### PR TITLE
Add rosotacom session instance logging

### DIFF
--- a/.github/ISSUE_TEMPLATE/implementation-cleanup.md
+++ b/.github/ISSUE_TEMPLATE/implementation-cleanup.md
@@ -30,4 +30,4 @@ Improve implementation quality while preserving the current public contract.
 - [ ] `just test-unit`
 - [ ] `just test-contract`
 - [ ] `just docs`
-- [ ] `just test-e2e-fast`, if Docker/runtime behavior changed.
+- [ ] `just test-e2e-smoke`, if Docker/runtime behavior changed.

--- a/.github/ISSUE_TEMPLATE/release-process.md
+++ b/.github/ISSUE_TEMPLATE/release-process.md
@@ -33,4 +33,4 @@ Ship a validated, well-described `rosotacom` release.
 - [ ] `just test-contract`
 - [ ] `just docs`
 - [ ] `just package`
-- [ ] `just test-e2e-fast`
+- [ ] `just test-e2e-smoke`

--- a/.github/ISSUE_TEMPLATE/test-ci-audit.md
+++ b/.github/ISSUE_TEMPLATE/test-ci-audit.md
@@ -33,4 +33,4 @@ Audit and improve test coverage and test execution wiring.
 - [ ] `just test-contract`
 - [ ] `just docs`
 - [ ] `just check`
-- [ ] `just test-e2e-fast`
+- [ ] `just test-e2e-smoke`

--- a/.github/ISSUE_TEMPLATE/work-item.md
+++ b/.github/ISSUE_TEMPLATE/work-item.md
@@ -36,4 +36,4 @@ Describe the outcome this issue should achieve.
 - [ ] `just test-contract`
 - [ ] `just docs`
 - [ ] `just check`
-- [ ] `just test-e2e-fast`, if Docker/runtime behavior changed.
+- [ ] `just test-e2e-smoke`, if Docker/runtime behavior changed.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -27,7 +27,7 @@
 - [ ] `just docs`
 - [ ] `just package`
 - [ ] `just check`
-- [ ] `just test-e2e-fast`, if Docker/runtime behavior changed
+- [ ] `just test-e2e-smoke`, if Docker/runtime behavior changed
 
 ## Test Integrity
 

--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -41,5 +41,5 @@ jobs:
       - name: Show Docker environment
         run: docker info
 
-      - name: Run full E2E
-        run: just test-e2e-fast
+      - name: Run heartbeat smoke matrix
+        run: just test-e2e-smoke

--- a/.github/workflows/pr-merge-gate.yml
+++ b/.github/workflows/pr-merge-gate.yml
@@ -125,8 +125,8 @@ jobs:
       - name: Show Docker environment
         run: docker info
 
-      - name: Run fast E2E
-        run: just test-e2e-fast
+      - name: Run heartbeat smoke matrix
+        run: just test-e2e-smoke
 
   ci-success:
     name: ci-success

--- a/.github/workflows/pr-merge-gate.yml
+++ b/.github/workflows/pr-merge-gate.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, volatile]
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
   merge_group:
@@ -127,6 +127,14 @@ jobs:
 
       - name: Run heartbeat smoke matrix
         run: just test-e2e-smoke
+
+      - name: Upload smoke session artifacts
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: session-instances-smoke
+          path: session-instances/
+          if-no-files-found: ignore
 
   ci-success:
     name: ci-success

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,8 +118,8 @@ jobs:
       - name: Show Docker environment
         run: docker info
 
-      - name: Run fast E2E
-        run: just test-e2e-fast
+      - name: Run heartbeat smoke matrix
+        run: just test-e2e-smoke
 
   publish-pypi:
     name: publish-pypi

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /.devcontainer/devcontainer.json
 /data_dict.json
 /ros2docker.json
+/session-instances/
 /zenoh.json5
 
 # ignore temporary data

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,19 +31,19 @@ just test-contract
 just test-nondocker-cov
 just docs
 just package
-just test-e2e-fast
+just test-e2e-smoke
 ```
 
 Before opening or updating a ready PR, run:
 
 ```bash
 just check
-just test-e2e-fast
+just test-e2e-smoke
 ```
 
 `just check` runs linting, type checking, host tests under coverage, docs checks,
-and package validation. `just test-e2e-fast` runs the required Docker-backed
-smoke test separately so failures are easier to inspect.
+and package validation. `just test-e2e-smoke` runs the required Docker-backed
+heartbeat smoke matrix separately so failures are easier to inspect.
 
 ## Branch And Merge Policy
 

--- a/README.md
+++ b/README.md
@@ -91,10 +91,10 @@ Run `rosotacom` on each peer with the same active setup but a different identity
 
 ```bash
 # on peer "a"
-rosotacom start 1_heartbeat --identity a
+rosotacom start 1_heartbeat_fastdds --identity a
 
 # on peer "b"
-rosotacom start 1_heartbeat --identity b
+rosotacom start 1_heartbeat_fastdds --identity b
 ```
 
 `rosotacom` reads the session input and creates generated files in that session directory, including per-peer plugin/session specs, topic lists, optional QoS, and optional `domain_bridge.yaml`.
@@ -132,7 +132,12 @@ cd scripts/2_native_chatter/machine_a
 
 The `sessions/` directory contains the built-in session definitions:
 
-- `1_heartbeat`: minimal heartbeat exchange
+- `1_heartbeat_fastdds`: minimal heartbeat exchange over FastDDS
+- `1_heartbeat_cyclone-ota`: heartbeat with CycloneDDS OTA config
+- `1_heartbeat_zen-endpoints`: heartbeat with native Zenoh connected endpoints
+- `1_heartbeat_fastdds-local_cyclone-ota`: local FastDDS with CycloneDDS OTA config
+- `1_heartbeat_cyclone-local_fastdds-ota`: local CycloneDDS with FastDDS OTA
+- `1_heartbeat_cyclone-local_zenoh-ros2dds-ota`: local CycloneDDS with Zenoh-ROS2DDS OTA
 - `2_native_chatter`: bridge `/chatter` from `machine_b` to `machine_a`
 - `3_comp_occ_grid`: compressed occupancy grid over DDS
 - `4_comp_occ_grid_zen`: compressed occupancy grid through Zenoh

--- a/README.md
+++ b/README.md
@@ -128,10 +128,11 @@ latency (`delay_s`) so rate and latency regressions are visible. It prints the
 ### Live status / debugging overview
 
 Enable a continuously-updated, per-topic pipeline overview by setting
-`shared.use_status_overview: true` in the session definition. For every
-configured topic it tracks where the topic currently is in the communication
-pipeline (furthest stage reached and the first stage that is missing/broken),
-plus last-message age, Hz, mean size, and latency.
+`shared.use_status_overview: true` in the session definition (see the
+ready-made `1_heartbeat_status` example). For every configured topic it tracks
+where the topic currently is in the communication pipeline (furthest stage
+reached and the first stage that is missing/broken), plus last-message age, Hz,
+mean size, and latency.
 
 The running session writes, under
 `session-instances/.../logs/<peer>/status/`:
@@ -144,9 +145,9 @@ The running session writes, under
 Read it from the host with the `status` command:
 
 ```bash
-rosotacom status 1_heartbeat_cyclone-ota            # human-readable table
-rosotacom status 1_heartbeat_cyclone-ota --json     # machine-readable, for tools/agents
-rosotacom status 1_heartbeat_cyclone-ota --watch    # live refresh
+rosotacom status 1_heartbeat_status            # human-readable table
+rosotacom status 1_heartbeat_status --json     # machine-readable, for tools/agents
+rosotacom status 1_heartbeat_status --watch    # live refresh
 ```
 
 Phase 1 reports each peer's locally-observable stages (outbound up to the `/ota`

--- a/README.md
+++ b/README.md
@@ -53,10 +53,11 @@ Legacy global symlinks are still available when explicitly requested:
 
 ### Basic Setup
 
-`rosotacom` uses two layers of configuration:
+`rosotacom` uses three layers of configuration/runtime state:
 
-- A **project setup** file (`rosotacom.yaml`) points to host-local resources such as `ros2docker.json`, `sessions/`, and `data_dict.json`.
+- A **project setup** file (`rosotacom.yaml`) points to host-local resources such as `ros2docker.json`, static `sessions/`, ignored `session-instances/`, and `data_dict.json`.
 - A **session config** defines the communication behavior for one run: peers, addresses, topics, QoS, processing, and transport choices.
+- A **session instance** stores one concrete run: generated config, catmux pane logs, smoke debug output, and future rosbags.
 
 No `rosotacom.yaml` is discovered automatically. Wire one explicitly with a flag or with `ROSOTACOM_CONFIG`:
 
@@ -74,6 +75,7 @@ rosotacom.yaml
 ros2docker.json
 data_dict.json
 sessions/
+session-instances/
 scripts/
 ```
 
@@ -97,7 +99,7 @@ rosotacom start 1_heartbeat_cyclone-ota --identity a
 rosotacom start 1_heartbeat_cyclone-ota --identity b
 ```
 
-`rosotacom` reads the session input and creates generated files in that session directory, including per-peer plugin/session specs, topic lists, optional QoS, and optional `domain_bridge.yaml`.
+`rosotacom` reads the static session input and creates generated files under `session-instances/<date>/<session>_<timestamp>_<id>/config/`, including per-peer plugin/session specs, topic lists, optional QoS, and optional `domain_bridge.yaml`. Catmux pane output is logged under the same instance in `logs/<peer>/catmux/`.
 
 ## Usage Examples
 
@@ -117,7 +119,9 @@ rosotacom smoke
 
 The smoke test verifies both directions through the communication path: it waits
 for `/com/in/a/heartbeat_a` and `/heartbeat_a` in peer `b`, plus
-`/com/in/b/heartbeat_b` and `/heartbeat_b` in peer `a`.
+`/com/in/b/heartbeat_b` and `/heartbeat_b` in peer `a`. It prints the
+`session-instances/...` artifact path so failures can be inspected after the
+containers stop.
 
 Run the CI heartbeat smoke matrix locally:
 

--- a/README.md
+++ b/README.md
@@ -119,6 +119,12 @@ The smoke test verifies both directions through the communication path: it waits
 for `/com/in/a/heartbeat_a` and `/heartbeat_a` in peer `b`, plus
 `/com/in/b/heartbeat_b` and `/heartbeat_b` in peer `a`.
 
+Run the CI heartbeat smoke matrix locally:
+
+```bash
+just test-e2e-smoke
+```
+
 Run the heartbeat example manually:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -125,6 +125,35 @@ latency (`delay_s`) so rate and latency regressions are visible. It prints the
 `session-instances/...` artifact path so failures (and the per-peer
 `logs/<peer>/catmux/...` pane output) can be inspected after the containers stop.
 
+### Live status / debugging overview
+
+Enable a continuously-updated, per-topic pipeline overview by setting
+`shared.use_status_overview: true` in the session definition. For every
+configured topic it tracks where the topic currently is in the communication
+pipeline (furthest stage reached and the first stage that is missing/broken),
+plus last-message age, Hz, mean size, and latency.
+
+The running session writes, under
+`session-instances/.../logs/<peer>/status/`:
+
+- `status.json` — machine-readable snapshot (source of truth) for tools/agents,
+  refreshed on a short interval and on every state transition,
+- `status.txt` — a human-rendered table, and
+- `events.jsonl` — one line per state transition (when/where a topic stalled).
+
+Read it from the host with the `status` command:
+
+```bash
+rosotacom status 1_heartbeat_cyclone-ota            # human-readable table
+rosotacom status 1_heartbeat_cyclone-ota --json     # machine-readable, for tools/agents
+rosotacom status 1_heartbeat_cyclone-ota --watch    # live refresh
+```
+
+Phase 1 reports each peer's locally-observable stages (outbound up to the `/ota`
+topic this peer publishes; inbound from the received `/ota` topic through the
+republished application topic). Combine both peers' files for the full
+end-to-end picture; cross-peer confirmation is reserved for a later phase.
+
 Run the CI heartbeat smoke matrix locally:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -91,10 +91,10 @@ Run `rosotacom` on each peer with the same active setup but a different identity
 
 ```bash
 # on peer "a"
-rosotacom start 1_heartbeat_fastdds --identity a
+rosotacom start 1_heartbeat_cyclone-ota --identity a
 
 # on peer "b"
-rosotacom start 1_heartbeat_fastdds --identity b
+rosotacom start 1_heartbeat_cyclone-ota --identity b
 ```
 
 `rosotacom` reads the session input and creates generated files in that session directory, including per-peer plugin/session specs, topic lists, optional QoS, and optional `domain_bridge.yaml`.
@@ -114,6 +114,10 @@ Run the local heartbeat smoke test:
 ```bash
 rosotacom smoke
 ```
+
+The smoke test verifies both directions through the communication path: it waits
+for `/com/in/a/heartbeat_a` and `/heartbeat_a` in peer `b`, plus
+`/com/in/b/heartbeat_b` and `/heartbeat_b` in peer `a`.
 
 Run the heartbeat example manually:
 

--- a/README.md
+++ b/README.md
@@ -119,9 +119,11 @@ rosotacom smoke
 
 The smoke test verifies both directions through the communication path: it waits
 for `/com/in/a/heartbeat_a` and `/heartbeat_a` in peer `b`, plus
-`/com/in/b/heartbeat_b` and `/heartbeat_b` in peer `a`. It prints the
-`session-instances/...` artifact path so failures can be inspected after the
-containers stop.
+`/com/in/b/heartbeat_b` and `/heartbeat_b` in peer `a`. For each checked topic it
+also reports a `SMOKE_METRIC` line with the received rate (`hz`) and end-to-end
+latency (`delay_s`) so rate and latency regressions are visible. It prints the
+`session-instances/...` artifact path so failures (and the per-peer
+`logs/<peer>/catmux/...` pane output) can be inspected after the containers stop.
 
 Run the CI heartbeat smoke matrix locally:
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -22,7 +22,7 @@ ci-success
 ```
 
 The merge gate runs Python 3.10 through 3.14 non-Docker checks, package
-validation, and fast Docker smoke:
+validation, and the Docker heartbeat smoke matrix:
 
 ```bash
 just lint
@@ -30,7 +30,7 @@ just typecheck
 just test-nondocker-cov
 just docs
 just package
-just test-e2e-fast
+just test-e2e-smoke
 ```
 
 The Python 3.12 leg uploads `coverage.xml` to Codecov with the `nondocker` flag.
@@ -38,9 +38,9 @@ Docker E2E is not collected for coverage.
 
 ## Docker E2E
 
-`just test-e2e-fast` runs the local heartbeat smoke test through Docker. It is a
-required merge-gate job because `rosotacom` exists to orchestrate Docker-backed
-ROS communication sessions.
+`just test-e2e-smoke` runs the local heartbeat smoke matrix through Docker. It
+is a required merge-gate job because `rosotacom` exists to orchestrate
+Docker-backed ROS communication sessions.
 
 ## Nightly And Maintenance
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -40,7 +40,10 @@ Docker E2E is not collected for coverage.
 
 `just test-e2e-smoke` runs the local heartbeat smoke matrix through Docker. It
 is a required merge-gate job because `rosotacom` exists to orchestrate
-Docker-backed ROS communication sessions.
+Docker-backed ROS communication sessions. Each smoke run writes generated
+config, catmux pane logs, Docker logs when available, and the smoke verification
+log under `session-instances/`; collect that directory as the first debugging
+artifact when an E2E job fails.
 
 ## Nightly And Maintenance
 

--- a/docs/release-notes/TEMPLATE.md
+++ b/docs/release-notes/TEMPLATE.md
@@ -16,4 +16,4 @@
 - `just test-contract`
 - `just docs`
 - `just package`
-- `just test-e2e-fast`
+- `just test-e2e-smoke`

--- a/justfile
+++ b/justfile
@@ -37,8 +37,10 @@ coverage: test-nondocker-cov
 test-nondocker-cov:
 	{{python}} -m pytest -q tests/unit tests/contract --cov=rosotacom --cov-report=term-missing --cov-report=xml:coverage.xml
 
-test-e2e-fast:
-	ROSOTACOM_RUN_E2E=1 {{python}} -m pytest -q tests/e2e -m e2e
+test-e2e-smoke:
+	ROSOTACOM_RUN_E2E=1 {{python}} -m pytest -q tests/e2e/test_smoke.py -m e2e
+
+test-e2e-fast: test-e2e-smoke
 
 docs:
 	{{python}} -m pytest -q tests/contract/test_markdown_links.py tests/contract/test_readme_examples.py tests/contract/test_pytest_policy.py

--- a/justfile
+++ b/justfile
@@ -72,7 +72,7 @@ _package-smoke:
 	    "py.typed",
 	    "resources/ros2docker.json.example",
 	    "resources/examples/rosotacom.yaml",
-	    "resources/examples/sessions/1_heartbeat/session-definition.yaml",
+	    "resources/examples/sessions/1_heartbeat_fastdds/session-definition.yaml",
 	    "resources/ws/session/creation/run_session.py",
 	    "resources/ws/ros2src/com_msgs/msg/Heartbeat.msg",
 	)

--- a/rosotacom.yaml
+++ b/rosotacom.yaml
@@ -5,4 +5,5 @@
 #   eval "$(rosotacom setup-env ./rosotacom.yaml)"
 ros2docker_config: src/rosotacom/resources/examples/ros2docker.json
 session_configs_dir: src/rosotacom/resources/examples/sessions
+session_instances_dir: session-instances
 data_dict: src/rosotacom/resources/examples/data_dict.json

--- a/session-configuration.md
+++ b/session-configuration.md
@@ -416,7 +416,10 @@ zen_qos:
 ```
 
 ### What gets generated
-For a session directory containing a session configuration input file, the generator typically produces:
+For a session configuration input file, `rosotacom start` writes generated files
+to the active runtime instance under `session-instances/<date>/<run>/config/`.
+The static `sessions/<name>/` definition/template directory is left unchanged.
+The generator typically produces:
 
 - `*_to_*_topics.txt` (topic list files per direction)
 - Per peer directory:

--- a/session-configuration.md
+++ b/session-configuration.md
@@ -78,8 +78,9 @@ Address expressions are explicit:
 
 ```yaml
 shared:
-  use_topic_monitor: false   # default false
-  use_heartbeat: false       # default false
+  use_topic_monitor: false    # default false
+  use_status_overview: false  # default false
+  use_heartbeat: false        # default false
 
   # Unified RMW configuration. Covers both the local ROS graph and the
   # over-the-air (OTA) bridge processes. See "RMW configuration" below.
@@ -285,6 +286,46 @@ If `use_heartbeat: true`:
 Default heartbeat topic per peer: `/heartbeat_<com-name>`
 Override: `peer_settings.<peer>.heartbeat_topic`
 Placement in topic list: per direction via `shared.heartbeat_position` (default `prepend`).
+
+#### Status overview behavior
+If `use_status_overview: true`:
+- The generator emits a per-peer `pipeline_spec.yaml` enumerating, for each
+  configured topic, the ordered pipeline stages observable on that peer.
+- A `status_overview` node (catmux `STAT` window) tracks, per topic, the
+  furthest stage reached and the first stage that is missing/broken, plus live
+  metrics (last-message age, Hz, mean size, latency).
+- It writes, under `session-instances/.../logs/<peer>/status/`:
+  - `status.json` — machine-readable snapshot (source of truth), rewritten on a
+    short interval and on every state transition;
+  - `status.txt` — human-rendered table regenerated alongside the JSON;
+  - `events.jsonl` — append-only, one line per state transition.
+- Read it from the host with `rosotacom status [<session>] [--json] [--watch]`.
+
+Phase 1 observes only what the local peer's ROS graph exposes: outbound topics
+up to the `/ota` topic this peer publishes ("sent"), and inbound topics from the
+received `/ota` topic through the republished application topic. Remote-side
+confirmation is reserved for a later phase and reported as `unknown`. OTA-domain
+observation assumes same-host discovery of the OTA `ROS_DOMAIN_ID` (works for the
+bundled DDS / `zenoh_ros2dds` examples; native `rmw_zenoh` OTA is not observed in
+Phase 1).
+
+##### Phase 2 (planned, not implemented)
+
+Phase 1 is per-peer local observation. A complete end-to-end view
+(`source -> ... -> remote-republished`, including the remote's republish Hz and
+latency) requires the two peers to exchange compact per-topic status. The
+intended design, mirroring the bidirectional heartbeat path:
+
+- Each peer publishes a small per-topic status summary on a dedicated OTA topic
+  (e.g. `/ota/<peer>/__topic_status`, carried by the same transport), likely
+  backed by a new `com_msgs` message type.
+- The remote receives the source's "sent" view and the source receives the
+  remote's "received and republished" view, so each side can fill the
+  `remote_observation` field that Phase 1 leaves as `null` and render the full
+  pipeline locally.
+
+Until then, combine both peers' `status.json` files (read side by side by a
+human or an agent) to reconstruct the end-to-end picture.
 
 ### `peer_settings` (optional)
 

--- a/src/rosotacom/cli.py
+++ b/src/rosotacom/cli.py
@@ -2,7 +2,8 @@
 """rosotacom host CLI.
 
 This module owns rosotacom-specific concepts such as session config
-directories, data_dict wiring, multi-checkout names, and local smoke tests.
+directories, data_dict wiring, multi-checkout names, session instance
+lifecycle, and local smoke tests.
 ros2docker remains the generic Docker runner underneath.
 """
 

--- a/src/rosotacom/cli.py
+++ b/src/rosotacom/cli.py
@@ -1140,7 +1140,7 @@ def _smoke_needs_distinct_peer_addresses(session: ResolvedSession) -> bool:
     if not isinstance(shared, dict):
         return False
     rmw_spec = session_gen._parse_rmw_block(shared.get("rmw"), list(peers.keys()))
-    return bool(session_gen._is_native_zenoh_ota(rmw_spec.ota.impl))
+    return bool(session_gen._is_native_zenoh_ota(rmw_spec.ota.impl) or rmw_spec.ota.impl == "fastdds")
 
 
 def _smoke_peer_address_args(session: ResolvedSession, local_ip: str) -> list[str]:
@@ -1211,7 +1211,10 @@ def _smoke_local_config_commands(config_container_dir: str, cfg: dict[str, Any],
     if local.impl == "cyclone":
         return [f"export CYCLONEDDS_URI={shlex.quote(f'file://{config_file}')}"]
     if local.impl == "fastdds":
-        return [f"export FASTDDS_DEFAULT_PROFILES_FILE={shlex.quote(config_file)}"]
+        return [
+            f"export FASTDDS_DEFAULT_PROFILES_FILE={shlex.quote(config_file)}",
+            "export RMW_FASTRTPS_USE_QOS_FROM_XML=1",
+        ]
     return []
 
 

--- a/src/rosotacom/cli.py
+++ b/src/rosotacom/cli.py
@@ -1125,6 +1125,36 @@ def _wait_for_topic_hz(container_name: str, ros_setup: str, topic: str, *, timeo
     return last_output
 
 
+def _measure_topic_delay(container_name: str, ros_setup: str, topic: str, *, timeout_s: int = 12) -> str:
+    result = _run_container_shell(
+        container_name,
+        f"{ros_setup} && timeout 8 ros2 topic delay {shlex.quote(topic)} || true",
+        timeout_s=timeout_s,
+    )
+    return (result.stdout or "") + (result.stderr or "")
+
+
+def _parse_topic_hz_rate(output: str) -> float | None:
+    match = re.search(r"average rate:\s*([0-9]+(?:\.[0-9]+)?)", output)
+    return float(match.group(1)) if match else None
+
+
+def _parse_topic_delay_seconds(output: str) -> float | None:
+    match = re.search(r"average delay:\s*([0-9]+(?:\.[0-9]+)?)", output)
+    return float(match.group(1)) if match else None
+
+
+def _format_metric_value(value: float | None) -> str:
+    return "nan" if value is None else f"{value:.6g}"
+
+
+def _smoke_metric_line(*, label: str, topic: str, container_name: str, hz: float | None, delay_s: float | None) -> str:
+    return (
+        f"SMOKE_METRIC topic={topic} container={container_name} "
+        f"hz={_format_metric_value(hz)} delay_s={_format_metric_value(delay_s)} label={label!r}"
+    )
+
+
 def _alternate_loopback_ip(local_ip: str) -> str:
     if local_ip == "127.0.0.2":
         return "127.0.0.3"
@@ -1300,6 +1330,20 @@ def smoke(args: argparse.Namespace) -> int:
             if "average rate" not in output:
                 raise RuntimeError(f"Smoke verification failed for {label} ({topic}) in {container_name}:\n{output}")
             log_line(f"OK: {label} ({topic}) is publishing in {container_name}")
+
+            hz = _parse_topic_hz_rate(output)
+            delay_output = _measure_topic_delay(container_name, ros_setup, topic)
+            _append_log(smoke_log, f"\n--- delay {label} ({topic}) in {container_name} ---\n{delay_output}")
+            delay_s = _parse_topic_delay_seconds(delay_output)
+            log_line(
+                _smoke_metric_line(
+                    label=label,
+                    topic=topic,
+                    container_name=container_name,
+                    hz=hz,
+                    delay_s=delay_s,
+                )
+            )
     except Exception as exc:
         _append_log(smoke_log, f"ERROR: {exc}")
         raise

--- a/src/rosotacom/cli.py
+++ b/src/rosotacom/cli.py
@@ -56,7 +56,7 @@ SESSION_CONFIG_CONTAINER_DIR = "/session/configs"
 EXTERNAL_SESSION_CONTAINER_DIR = "/session/current"
 CONTAINER_DATA_DICT_PATH = "/data_dict.json"
 RUN_SESSION_CONTAINER_PATH = "/ws/session/creation/run_session.py"
-DEFAULT_SMOKE_SESSION = "1_heartbeat_fastdds"
+DEFAULT_SMOKE_SESSION = "1_heartbeat_cyclone-ota"
 
 ws_creation_dir = WS_DIR / "session" / "creation"
 session_gen_path = ws_creation_dir / "generate_session_files.py"
@@ -842,6 +842,22 @@ def _run_container_shell(container_name: str, command: str, timeout_s: int = 30)
     )
 
 
+def _wait_for_topic_hz(container_name: str, ros_setup: str, topic: str, *, timeout_s: int = 60) -> str:
+    deadline = time.time() + timeout_s
+    last_output = ""
+    while time.time() < deadline:
+        result = _run_container_shell(
+            container_name,
+            f"{ros_setup} && timeout 8 ros2 topic hz {shlex.quote(topic)} || true",
+            timeout_s=12,
+        )
+        last_output = (result.stdout or "") + (result.stderr or "")
+        if "average rate" in last_output:
+            return last_output
+        time.sleep(2)
+    return last_output
+
+
 def _alternate_loopback_ip(local_ip: str) -> str:
     if local_ip == "127.0.0.2":
         return "127.0.0.3"
@@ -866,6 +882,92 @@ def _smoke_peer_address_args(session: ResolvedSession, local_ip: str) -> list[st
     return [f"a={local_ip}", f"b={local_ip}"]
 
 
+def _smoke_heartbeat_topic(cfg: dict[str, Any], peer_key: str) -> str:
+    peer_settings = cfg.get("peer_settings", {}) or {}
+    if isinstance(peer_settings, dict):
+        settings = peer_settings.get(peer_key, {}) or {}
+        if isinstance(settings, dict) and settings.get("heartbeat_topic"):
+            return str(settings["heartbeat_topic"])
+    peers = cfg.get("peers", {}) or {}
+    if not isinstance(peers, dict):
+        raise RuntimeError("Smoke verification requires a session config with peers.")
+    return f"/heartbeat_{_peer_com_name(peers, peer_key)}"
+
+
+def _smoke_inbound_bridge_topic(cfg: dict[str, Any], source_peer_key: str) -> str:
+    peers = cfg.get("peers", {}) or {}
+    if not isinstance(peers, dict):
+        raise RuntimeError("Smoke verification requires a session config with peers.")
+    source_name = _peer_com_name(peers, source_peer_key)
+    heartbeat_topic = _smoke_heartbeat_topic(cfg, source_peer_key).lstrip("/")
+    return f"/com/in/{source_name}/{heartbeat_topic}"
+
+
+def _smoke_rmw_spec(cfg: dict[str, Any]) -> Any:
+    peers = cfg.get("peers", {}) or {}
+    if not isinstance(peers, dict):
+        raise RuntimeError("Smoke verification requires a session config with peers.")
+    shared = cfg.get("shared", {}) or {}
+    if not isinstance(shared, dict):
+        shared = {}
+    return session_gen._parse_rmw_block(shared.get("rmw"), list(peers.keys()))
+
+
+def _smoke_rmw_env_value(cfg: dict[str, Any]) -> str | None:
+    rmw_spec = _smoke_rmw_spec(cfg)
+    local_impl = rmw_spec.local.impl
+    if local_impl is None:
+        return None
+    return session_gen.RMW_ALIASES.get(local_impl, local_impl)
+
+
+def _smoke_local_domain_id(cfg: dict[str, Any], receiver_peer_key: str) -> str | None:
+    shared = cfg.get("shared", {}) or {}
+    shared = shared if isinstance(shared, dict) else {}
+    peer_settings = cfg.get("peer_settings", {}) or {}
+    peer_settings = peer_settings if isinstance(peer_settings, dict) else {}
+    settings = peer_settings.get(receiver_peer_key, {}) or {}
+    settings = settings if isinstance(settings, dict) else {}
+    domain_id = settings.get("domain_id")
+    if domain_id is None:
+        domain_id = shared.get("local_domain_id")
+    if domain_id is None or domain_id == "":
+        return None
+    return str(session_gen._parse_optional_domain_id(domain_id, f"peer_settings.{receiver_peer_key}.domain_id"))
+
+
+def _smoke_local_config_commands(session: ResolvedSession, cfg: dict[str, Any], receiver_peer_key: str) -> list[str]:
+    local = _smoke_rmw_spec(cfg).local
+    if not local.dds_config:
+        return []
+    config_file = f"{session.container_dir}/{receiver_peer_key}/local_dds.xml"
+    if local.impl == "cyclone":
+        return [f"export CYCLONEDDS_URI={shlex.quote(f'file://{config_file}')}"]
+    if local.impl == "fastdds":
+        return [f"export FASTDDS_DEFAULT_PROFILES_FILE={shlex.quote(config_file)}"]
+    return []
+
+
+def _smoke_ros_setup(session: ResolvedSession, cfg: dict[str, Any], receiver_peer_key: str) -> str:
+    commands = [
+        'ros_distro="${ROS_DISTRO:-kilted}"',
+        'source "/opt/ros/${ros_distro}/setup.bash"',
+        "source /opt/ros_venv/bin/activate",
+        "{ [ ! -f /opt/custom_ws/install/setup.bash ] || source /opt/custom_ws/install/setup.bash; }",
+        "{ [ ! -f /ros2ws/install/setup.bash ] || source /ros2ws/install/setup.bash; }",
+    ]
+    rmw_env = _smoke_rmw_env_value(cfg)
+    if rmw_env:
+        commands.append(f"export RMW_IMPLEMENTATION={shlex.quote(rmw_env)}")
+        if rmw_env == "rmw_fastrtps_cpp":
+            commands.append("export FASTDDS_BUILTIN_TRANSPORTS=${FASTDDS_BUILTIN_TRANSPORTS:-UDPv4}")
+    local_domain_id = _smoke_local_domain_id(cfg, receiver_peer_key)
+    if local_domain_id:
+        commands.append(f"export ROS_DOMAIN_ID={shlex.quote(local_domain_id)}")
+    commands.extend(_smoke_local_config_commands(session, cfg, receiver_peer_key))
+    return " && ".join(commands)
+
+
 def smoke(args: argparse.Namespace) -> int:
     if not args.local:
         raise RuntimeError("Only --local smoke mode is implemented.")
@@ -874,6 +976,8 @@ def smoke(args: argparse.Namespace) -> int:
     runtime = _load_runtime_config(args)
     session = _resolve_session(session_dir, runtime)
     peer_address_args = _smoke_peer_address_args(session, local_ip)
+    peer_overrides = _parse_peer_address_overrides(peer_address_args)
+    cfg = _effective_session_config(session.host_dir, runtime, peer_address_overrides=peer_overrides)
     common = {
         "rosotacom_config": args.rosotacom_config,
         "ros2docker_config": args.ros2docker_config,
@@ -902,27 +1006,18 @@ def smoke(args: argparse.Namespace) -> int:
             raise RuntimeError("Smoke verification failed: generated plugin.yaml did not use literal CLI addresses.")
         print("OK: generated plugin.yaml files use literal CLI addresses")
 
-        ros_setup = (
-            'ros_distro="${ROS_DISTRO:-kilted}" && '
-            'source "/opt/ros/${ros_distro}/setup.bash" && '
-            "source /opt/ros_venv/bin/activate && "
-            "{ [ ! -f /opt/custom_ws/install/setup.bash ] || source /opt/custom_ws/install/setup.bash; } && "
-            "{ [ ! -f /ros2ws/install/setup.bash ] || source /ros2ws/install/setup.bash; }"
-        )
         checks = [
-            (b_container, "/heartbeat_a"),
-            (a_container, "/heartbeat_b"),
+            (b_container, _smoke_inbound_bridge_topic(cfg, "a"), "a->b inbound bridge heartbeat", "b"),
+            (b_container, _smoke_heartbeat_topic(cfg, "a"), "a->b final heartbeat", "b"),
+            (a_container, _smoke_inbound_bridge_topic(cfg, "b"), "b->a inbound bridge heartbeat", "a"),
+            (a_container, _smoke_heartbeat_topic(cfg, "b"), "b->a final heartbeat", "a"),
         ]
-        for container_name, topic in checks:
-            result = _run_container_shell(
-                container_name,
-                f"{ros_setup} && timeout 12 ros2 topic hz {topic} || true",
-                timeout_s=20,
-            )
-            output = (result.stdout or "") + (result.stderr or "")
+        for container_name, topic, label, receiver_peer_key in checks:
+            ros_setup = _smoke_ros_setup(session, cfg, receiver_peer_key)
+            output = _wait_for_topic_hz(container_name, ros_setup, topic)
             if "average rate" not in output:
-                raise RuntimeError(f"Smoke verification failed for {topic} in {container_name}:\n{output}")
-            print(f"OK: {topic} is publishing in {container_name}")
+                raise RuntimeError(f"Smoke verification failed for {label} ({topic}) in {container_name}:\n{output}")
+            print(f"OK: {label} ({topic}) is publishing in {container_name}")
     finally:
         if not args.keep_running:
             runtime = _load_runtime_config(args)

--- a/src/rosotacom/cli.py
+++ b/src/rosotacom/cli.py
@@ -20,6 +20,7 @@ import subprocess
 import sys
 import time
 from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
 from types import ModuleType
 from typing import Any
@@ -53,6 +54,8 @@ WS_DIR = RESOURCE_DIR / "ws"
 DEFAULT_ROS2DOCKER_CONFIG = RESOURCE_DIR / "ros2docker.json.example"
 EXAMPLE_PROJECT_DIR = RESOURCE_DIR / "examples"
 SESSION_CONFIG_CONTAINER_DIR = "/session/configs"
+SESSION_DEFINITION_CONTAINER_DIR = "/session/definitions"
+SESSION_INSTANCE_CONTAINER_DIR = "/session/instances"
 EXTERNAL_SESSION_CONTAINER_DIR = "/session/current"
 CONTAINER_DATA_DICT_PATH = "/data_dict.json"
 RUN_SESSION_CONTAINER_PATH = "/ws/session/creation/run_session.py"
@@ -86,6 +89,7 @@ class RuntimeConfig:
     session_configs_dir: Path | None
     data_dict: Path | None
     install_id: str
+    session_instances_dir: Path | None = None
 
 
 @dataclass(frozen=True)
@@ -93,6 +97,19 @@ class ResolvedSession:
     host_dir: Path
     container_dir: str
     source: str
+
+
+@dataclass(frozen=True)
+class SessionInstance:
+    instance_id: str
+    host_dir: Path
+    container_dir: str
+    config_host_dir: Path
+    config_container_dir: str
+    logs_host_dir: Path
+    logs_container_dir: str
+    rosbags_host_dir: Path
+    rosbags_container_dir: str
 
 
 def _load_yaml_file(path: Path | None) -> dict[str, Any]:
@@ -154,6 +171,12 @@ def _load_runtime_config(args: argparse.Namespace | None = None) -> RuntimeConfi
         os.environ.get("ROSOTACOM_SESSION_CONFIGS_DIR"),
         cfg.get("session_configs_dir"),
     )
+    session_instances_dir_raw = _first_value(
+        getattr(args, "session_instances_dir", None),
+        os.environ.get("ROSOTACOM_SESSION_INSTANCES_DIR"),
+        cfg.get("session_instances_dir"),
+        "session-instances",
+    )
     data_dict_raw = _first_value(
         getattr(args, "data_dict", None),
         os.environ.get("ROSOTACOM_DATA_DICT"),
@@ -170,6 +193,7 @@ def _load_runtime_config(args: argparse.Namespace | None = None) -> RuntimeConfi
         session_configs_dir=_resolve_path(session_configs_dir_raw, config_base, must_exist=True),
         data_dict=_resolve_path(data_dict_raw, config_base, must_exist=True),
         install_id=_install_id(rosotacom_config),
+        session_instances_dir=_resolve_path(session_instances_dir_raw, config_base, must_exist=False),
     )
 
 
@@ -201,6 +225,167 @@ def _scoped_image_name(runtime: RuntimeConfig) -> str:
 
 def _container_name(remote_peer_name: str, runtime: RuntimeConfig) -> str:
     return _sanitize_docker_name(f"rosotacom_{runtime.install_id}_com_to_{remote_peer_name}")
+
+
+def _safe_path_token(value: str) -> str:
+    token = re.sub(r"[^a-zA-Z0-9_.-]+", "_", value.strip())
+    token = token.strip("._-")
+    return token or "run"
+
+
+def _new_instance_id() -> str:
+    seed = f"{time.time_ns()}:{os.getpid()}:{Path.cwd()}"
+    return hashlib.sha1(seed.encode("utf-8")).hexdigest()[:8]
+
+
+def _session_instances_root(runtime: RuntimeConfig) -> Path:
+    return (runtime.session_instances_dir or (Path.cwd() / "session-instances")).resolve()
+
+
+def _session_instance_slug(session: ResolvedSession, runtime: RuntimeConfig) -> str:
+    if runtime.session_configs_dir:
+        rel = _relative_to(session.host_dir, runtime.session_configs_dir)
+        if rel is not None:
+            return _safe_path_token(rel.as_posix().replace("/", "_"))
+    return _safe_path_token(session.host_dir.name)
+
+
+def _resolve_session_instance(
+    runtime: RuntimeConfig,
+    session: ResolvedSession,
+    instance_id: str | None = None,
+) -> SessionInstance:
+    root = _session_instances_root(runtime)
+    root.mkdir(parents=True, exist_ok=True)
+    session_slug = _session_instance_slug(session, runtime)
+    resolved_instance_id = _safe_path_token(instance_id or _new_instance_id())
+
+    if instance_id:
+        matches = sorted(root.glob(f"*/{session_slug}_*_{resolved_instance_id}"))
+        if matches:
+            host_dir = matches[-1].resolve()
+        else:
+            now = datetime.now()
+            host_dir = (
+                root
+                / now.strftime("%Y-%m-%d")
+                / (f"{session_slug}_{now.strftime('%Y-%m-%d_%H-%M-%S')}_{resolved_instance_id}")
+            )
+    else:
+        now = datetime.now()
+        host_dir = (
+            root
+            / now.strftime("%Y-%m-%d")
+            / (f"{session_slug}_{now.strftime('%Y-%m-%d_%H-%M-%S')}_{resolved_instance_id}")
+        )
+
+    host_dir.mkdir(parents=True, exist_ok=True)
+    config_host_dir = host_dir / "config"
+    logs_host_dir = host_dir / "logs"
+    rosbags_host_dir = host_dir / "rosbags"
+    for path in (config_host_dir, logs_host_dir, rosbags_host_dir):
+        path.mkdir(parents=True, exist_ok=True)
+
+    rel = host_dir.resolve().relative_to(root.resolve())
+    container_dir = f"{SESSION_INSTANCE_CONTAINER_DIR}/{rel.as_posix()}"
+    return SessionInstance(
+        instance_id=resolved_instance_id,
+        host_dir=host_dir,
+        container_dir=container_dir,
+        config_host_dir=config_host_dir,
+        config_container_dir=f"{container_dir}/config",
+        logs_host_dir=logs_host_dir,
+        logs_container_dir=f"{container_dir}/logs",
+        rosbags_host_dir=rosbags_host_dir,
+        rosbags_container_dir=f"{container_dir}/rosbags",
+    )
+
+
+def _peer_catmux_log_container_dir(instance: SessionInstance, identity: str) -> str:
+    return f"{instance.logs_container_dir}/{_safe_path_token(identity)}/catmux"
+
+
+def _peer_rosbag_container_dir(instance: SessionInstance, identity: str) -> str:
+    return f"{instance.rosbags_container_dir}/{_safe_path_token(identity)}"
+
+
+def _peer_launcher_log(instance: SessionInstance, identity: str) -> Path:
+    return instance.logs_host_dir / _safe_path_token(identity) / "launcher.log"
+
+
+def _peer_docker_log(instance: SessionInstance, identity: str) -> Path:
+    return instance.logs_host_dir / _safe_path_token(identity) / "docker.log"
+
+
+def _append_log(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as fp:
+        fp.write(text)
+        if not text.endswith("\n"):
+            fp.write("\n")
+
+
+def _effective_config_sha256(cfg: dict[str, Any]) -> str:
+    text = yaml.safe_dump(cfg, sort_keys=True, default_flow_style=False, allow_unicode=True)
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _write_instance_manifest(
+    instance: SessionInstance,
+    session: ResolvedSession,
+    runtime: RuntimeConfig,
+    cfg: dict[str, Any],
+    *,
+    identity: str,
+    container_name: str,
+    mode: str,
+    peer_address: list[str],
+    overwrite_peers_via_remote_peer: str | None,
+) -> None:
+    manifest_path = instance.host_dir / "manifest.yaml"
+    manifest = _load_yaml_file(manifest_path)
+    now = datetime.now().isoformat(timespec="seconds")
+    if not manifest:
+        manifest = {
+            "schema_version": 1,
+            "created_at": now,
+            "instance_id": instance.instance_id,
+            "rosotacom_version": __version__,
+            "source_session_host_dir": str(session.host_dir),
+            "source_session_container_dir": session.container_dir,
+            "source": session.source,
+            "config_dir": str(instance.config_host_dir),
+            "logs_dir": str(instance.logs_host_dir),
+            "rosbags_dir": str(instance.rosbags_host_dir),
+            "rollout": None,
+            "starts": [],
+        }
+    manifest["updated_at"] = now
+    manifest["effective_config_sha256"] = _effective_config_sha256(cfg)
+    manifest.setdefault("starts", []).append(
+        {
+            "started_at": now,
+            "identity": identity,
+            "container_name": container_name,
+            "mode": mode,
+            "peer_address": list(peer_address),
+            "overwrite_peers_via_remote_peer": overwrite_peers_via_remote_peer,
+        }
+    )
+    manifest_path.write_text(
+        yaml.safe_dump(manifest, sort_keys=True, default_flow_style=False, allow_unicode=True),
+        encoding="utf-8",
+    )
+
+
+def _write_docker_log(container_name: str, instance: SessionInstance, identity: str) -> None:
+    try:
+        result = subprocess.run(["docker", "logs", container_name], text=True, capture_output=True, check=False)
+    except Exception:
+        return
+    logs = (result.stdout or "") + (result.stderr or "")
+    if logs:
+        _append_log(_peer_docker_log(instance, identity), logs)
 
 
 def _get_local_ipv4s() -> list[str]:
@@ -476,6 +661,9 @@ def _resolve_session(session_dir: str, runtime: RuntimeConfig) -> ResolvedSessio
     if raw.is_absolute():
         if str(raw).startswith("/ws/"):
             candidates.append((PROJECT_DIR / str(raw).lstrip("/"), "workspace"))
+        if str(raw).startswith(f"{SESSION_DEFINITION_CONTAINER_DIR}/") and runtime.session_configs_dir:
+            rel = Path(str(raw)[len(SESSION_DEFINITION_CONTAINER_DIR) :].lstrip("/"))
+            candidates.append((runtime.session_configs_dir / rel, "session_configs"))
         if str(raw).startswith(f"{SESSION_CONFIG_CONTAINER_DIR}/") and runtime.session_configs_dir:
             rel = Path(str(raw)[len(SESSION_CONFIG_CONTAINER_DIR) :].lstrip("/"))
             candidates.append((runtime.session_configs_dir / rel, "session_configs"))
@@ -496,7 +684,7 @@ def _resolve_session(session_dir: str, runtime: RuntimeConfig) -> ResolvedSessio
                 if cfg_rel is not None:
                     return ResolvedSession(
                         host_dir,
-                        f"{SESSION_CONFIG_CONTAINER_DIR}/{cfg_rel.as_posix()}",
+                        f"{SESSION_DEFINITION_CONTAINER_DIR}/{cfg_rel.as_posix()}",
                         "session_configs",
                     )
             return ResolvedSession(host_dir, EXTERNAL_SESSION_CONTAINER_DIR, source)
@@ -520,7 +708,12 @@ def _format_available_sessions(runtime: RuntimeConfig) -> str:
     )
 
 
-def _base_extra_run_args(runtime: RuntimeConfig, session: ResolvedSession, cfg: dict[str, Any]) -> list[str]:
+def _base_extra_run_args(
+    runtime: RuntimeConfig,
+    session: ResolvedSession,
+    cfg: dict[str, Any],
+    instance: SessionInstance,
+) -> list[str]:
     args: list[str] = []
     ros2docker_cfg = load_config(runtime.ros2docker_config)
 
@@ -530,13 +723,33 @@ def _base_extra_run_args(runtime: RuntimeConfig, session: ResolvedSession, cfg: 
         args.extend(
             [
                 "-v",
-                f"{runtime.session_configs_dir}:{SESSION_CONFIG_CONTAINER_DIR}",
+                f"{runtime.session_configs_dir}:{SESSION_DEFINITION_CONTAINER_DIR}:ro",
                 "-e",
-                f"SESSION_CONFIGS_DIR={SESSION_CONFIG_CONTAINER_DIR}",
+                f"SESSION_DEFINITIONS_DIR={SESSION_DEFINITION_CONTAINER_DIR}",
+                "-e",
+                f"SESSION_CONFIGS_DIR={SESSION_DEFINITION_CONTAINER_DIR}",
             ]
         )
     if session.container_dir == EXTERNAL_SESSION_CONTAINER_DIR:
-        args.extend(["-v", f"{session.host_dir}:{EXTERNAL_SESSION_CONTAINER_DIR}"])
+        args.extend(["-v", f"{session.host_dir}:{EXTERNAL_SESSION_CONTAINER_DIR}:ro"])
+    instances_root = _session_instances_root(runtime)
+    instances_root.mkdir(parents=True, exist_ok=True)
+    args.extend(
+        [
+            "-v",
+            f"{instances_root}:{SESSION_INSTANCE_CONTAINER_DIR}",
+            "-e",
+            f"ROSOTACOM_SESSION_INSTANCES_DIR={SESSION_INSTANCE_CONTAINER_DIR}",
+            "-e",
+            f"ROSOTACOM_INSTANCE_DIR={instance.container_dir}",
+            "-e",
+            f"ROSOTACOM_CONFIG_DIR={instance.config_container_dir}",
+            "-e",
+            f"ROSOTACOM_LOGS_DIR={instance.logs_container_dir}",
+            "-e",
+            f"ROSOTACOM_ROSBAGS_DIR={instance.rosbags_container_dir}",
+        ]
+    )
     if _contains_data_ref(cfg):
         data_dict = _load_host_data_dict(runtime)
         if not isinstance(data_dict, dict):
@@ -547,6 +760,7 @@ def _base_extra_run_args(runtime: RuntimeConfig, session: ResolvedSession, cfg: 
 
 def _session_command(
     session: ResolvedSession,
+    instance: SessionInstance,
     identity: str,
     *,
     force: bool,
@@ -555,7 +769,21 @@ def _session_command(
     peer_address_overrides: dict[str, str],
     attach_mode: str,
 ) -> list[str]:
-    parts = [RUN_SESSION_CONTAINER_PATH, "--session-dir", session.container_dir, "--identity", identity]
+    parts = [
+        RUN_SESSION_CONTAINER_PATH,
+        "--session-dir",
+        session.container_dir,
+        "--output-dir",
+        instance.config_container_dir,
+        "--instance-dir",
+        instance.container_dir,
+        "--catmux-log-dir",
+        _peer_catmux_log_container_dir(instance, identity),
+        "--rosbag-dir",
+        _peer_rosbag_container_dir(instance, identity),
+        "--identity",
+        identity,
+    ]
     if force:
         parts.append("--force")
     if rewrite_formatting:
@@ -636,11 +864,13 @@ def start_session(args: argparse.Namespace) -> str:
         print(f"Auto-selected identity: {identity}")
     remote_name = _remote_peer_name(cfg, identity)
     container_name = _container_name(remote_name, runtime)
+    instance = _resolve_session_instance(runtime, session, getattr(args, "instance_id", None))
     image_name = _scoped_image_name(runtime)
-    extra_run_args = _base_extra_run_args(runtime, session, cfg)
+    extra_run_args = _base_extra_run_args(runtime, session, cfg, instance)
     mode = _resolve_mode(args.mode)
     command = _session_command(
         session,
+        instance,
         identity,
         force=args.force,
         rewrite_formatting=args.rewrite_formatting,
@@ -650,6 +880,30 @@ def start_session(args: argparse.Namespace) -> str:
     )
 
     print("Command which will be run in container: " + shlex.join(command))
+    print(f"rosotacom session instance: {instance.host_dir}")
+    _append_log(
+        _peer_launcher_log(instance, identity),
+        "\n".join(
+            [
+                f"started_at: {datetime.now().isoformat(timespec='seconds')}",
+                f"container_name: {container_name}",
+                f"mode: {mode}",
+                "command: " + shlex.join(command),
+                "",
+            ]
+        ),
+    )
+    _write_instance_manifest(
+        instance,
+        session,
+        runtime,
+        cfg,
+        identity=identity,
+        container_name=container_name,
+        mode=mode,
+        peer_address=list(args.peer_address or []),
+        overwrite_peers_via_remote_peer=args.overwrite_peers_via_remote_peer,
+    )
     if args.force:
         _stop_container_name(container_name, runtime, quiet_missing=True)
 
@@ -668,6 +922,7 @@ def start_session(args: argparse.Namespace) -> str:
             command=command,
             interactive=False,
         )
+        _write_docker_log(container_name, instance, identity)
     else:
         ros2docker_build(config_file=runtime.ros2docker_config, override=common_override)
         ros2docker_run(
@@ -681,6 +936,7 @@ def start_session(args: argparse.Namespace) -> str:
             },
             extra_run_args=extra_run_args,
         )
+        _write_docker_log(container_name, instance, identity)
 
     print(f"rosotacom session started in container: {container_name}")
     return container_name
@@ -740,6 +996,15 @@ def _copy_example_resource_tree(source: Any, target: Path) -> None:
             destination.chmod(destination.stat().st_mode | 0o111)
 
 
+def _ensure_example_gitignore(target: Path) -> None:
+    gitignore = target / ".gitignore"
+    existing = gitignore.read_text(encoding="utf-8") if gitignore.exists() else ""
+    lines = existing.splitlines()
+    if "session-instances/" not in lines:
+        lines.append("session-instances/")
+    gitignore.write_text("\n".join(lines).strip() + "\n", encoding="utf-8")
+
+
 def examples_create_command(args: argparse.Namespace) -> int:
     target = Path(os.path.expandvars(os.path.expanduser(args.target))).resolve()
     if target.exists():
@@ -751,6 +1016,7 @@ def examples_create_command(args: argparse.Namespace) -> int:
             target.unlink()
     target.parent.mkdir(parents=True, exist_ok=True)
     _copy_example_resource_tree(_example_project_resource(), target)
+    _ensure_example_gitignore(target)
     print(f"Copied rosotacom examples to: {target}")
     print(f'Wire this shell with: eval "$(rosotacom setup-env {shlex.quote(str(target / "rosotacom.yaml"))})"')
     return 0
@@ -797,9 +1063,10 @@ def doctor(args: argparse.Namespace) -> int:
         line("OK", "install id", runtime.install_id)
         line("OK", "workspace mount", f"{WS_DIR} -> /ws")
         if runtime.session_configs_dir:
-            line("OK", "session configs", f"{runtime.session_configs_dir} -> {SESSION_CONFIG_CONTAINER_DIR}")
+            line("OK", "session definitions", f"{runtime.session_configs_dir} -> {SESSION_DEFINITION_CONTAINER_DIR}")
         else:
-            line("INFO", "session configs", "not configured")
+            line("INFO", "session definitions", "not configured")
+        line("OK", "session instances", f"{_session_instances_root(runtime)} -> {SESSION_INSTANCE_CONTAINER_DIR}")
         if runtime.data_dict:
             line("OK", "data dict", str(runtime.data_dict))
         else:
@@ -918,7 +1185,7 @@ def _smoke_rmw_env_value(cfg: dict[str, Any]) -> str | None:
     local_impl = rmw_spec.local.impl
     if local_impl is None:
         return None
-    return session_gen.RMW_ALIASES.get(local_impl, local_impl)
+    return str(session_gen.RMW_ALIASES.get(local_impl, local_impl))
 
 
 def _smoke_local_domain_id(cfg: dict[str, Any], receiver_peer_key: str) -> str | None:
@@ -936,11 +1203,11 @@ def _smoke_local_domain_id(cfg: dict[str, Any], receiver_peer_key: str) -> str |
     return str(session_gen._parse_optional_domain_id(domain_id, f"peer_settings.{receiver_peer_key}.domain_id"))
 
 
-def _smoke_local_config_commands(session: ResolvedSession, cfg: dict[str, Any], receiver_peer_key: str) -> list[str]:
+def _smoke_local_config_commands(config_container_dir: str, cfg: dict[str, Any], receiver_peer_key: str) -> list[str]:
     local = _smoke_rmw_spec(cfg).local
     if not local.dds_config:
         return []
-    config_file = f"{session.container_dir}/{receiver_peer_key}/local_dds.xml"
+    config_file = f"{config_container_dir}/{receiver_peer_key}/local_dds.xml"
     if local.impl == "cyclone":
         return [f"export CYCLONEDDS_URI={shlex.quote(f'file://{config_file}')}"]
     if local.impl == "fastdds":
@@ -948,7 +1215,7 @@ def _smoke_local_config_commands(session: ResolvedSession, cfg: dict[str, Any], 
     return []
 
 
-def _smoke_ros_setup(session: ResolvedSession, cfg: dict[str, Any], receiver_peer_key: str) -> str:
+def _smoke_ros_setup(config_container_dir: str, cfg: dict[str, Any], receiver_peer_key: str) -> str:
     commands = [
         'ros_distro="${ROS_DISTRO:-kilted}"',
         'source "/opt/ros/${ros_distro}/setup.bash"',
@@ -964,7 +1231,7 @@ def _smoke_ros_setup(session: ResolvedSession, cfg: dict[str, Any], receiver_pee
     local_domain_id = _smoke_local_domain_id(cfg, receiver_peer_key)
     if local_domain_id:
         commands.append(f"export ROS_DOMAIN_ID={shlex.quote(local_domain_id)}")
-    commands.extend(_smoke_local_config_commands(session, cfg, receiver_peer_key))
+    commands.extend(_smoke_local_config_commands(config_container_dir, cfg, receiver_peer_key))
     return " && ".join(commands)
 
 
@@ -975,6 +1242,14 @@ def smoke(args: argparse.Namespace) -> int:
     session_dir = args.session_dir or DEFAULT_SMOKE_SESSION
     runtime = _load_runtime_config(args)
     session = _resolve_session(session_dir, runtime)
+    instance_id = getattr(args, "instance_id", None) or _new_instance_id()
+    smoke_instance = _resolve_session_instance(runtime, session, instance_id)
+    smoke_log = smoke_instance.logs_host_dir / "smoke-verification.log"
+
+    def log_line(message: str) -> None:
+        print(message)
+        _append_log(smoke_log, message)
+
     peer_address_args = _smoke_peer_address_args(session, local_ip)
     peer_overrides = _parse_peer_address_overrides(peer_address_args)
     cfg = _effective_session_config(session.host_dir, runtime, peer_address_overrides=peer_overrides)
@@ -982,6 +1257,7 @@ def smoke(args: argparse.Namespace) -> int:
         "rosotacom_config": args.rosotacom_config,
         "ros2docker_config": args.ros2docker_config,
         "session_configs_dir": args.session_configs_dir,
+        "session_instances_dir": getattr(args, "session_instances_dir", None),
         "data_dict": args.data_dict,
         "session_dir": session_dir,
         "mode": "detached",
@@ -989,9 +1265,11 @@ def smoke(args: argparse.Namespace) -> int:
         "rewrite_formatting": False,
         "overwrite_peers_via_remote_peer": None,
         "peer_address": peer_address_args,
+        "instance_id": smoke_instance.instance_id,
     }
 
-    print(f"Starting local smoke test with PEER_ADDRESSES={', '.join(peer_address_args)}")
+    log_line(f"Starting local smoke test with PEER_ADDRESSES={', '.join(peer_address_args)}")
+    log_line(f"Smoke artifacts: {smoke_instance.host_dir}")
     a_container = None
     b_container = None
     try:
@@ -999,12 +1277,12 @@ def smoke(args: argparse.Namespace) -> int:
         b_container = start_session(argparse.Namespace(**common, identity="b", auto_identity=True))
 
         plugin_text = "\n".join(
-            (session.host_dir / peer / "plugin.yaml").read_text(encoding="utf-8") for peer in ("a", "b")
+            (smoke_instance.config_host_dir / peer / "plugin.yaml").read_text(encoding="utf-8") for peer in ("a", "b")
         )
         expected_addresses = {arg.split("=", 1)[1] for arg in peer_address_args}
         if any(address not in plugin_text for address in expected_addresses) or "data:" in plugin_text:
             raise RuntimeError("Smoke verification failed: generated plugin.yaml did not use literal CLI addresses.")
-        print("OK: generated plugin.yaml files use literal CLI addresses")
+        log_line("OK: generated plugin.yaml files use literal CLI addresses")
 
         checks = [
             (b_container, _smoke_inbound_bridge_topic(cfg, "a"), "a->b inbound bridge heartbeat", "b"),
@@ -1013,17 +1291,25 @@ def smoke(args: argparse.Namespace) -> int:
             (a_container, _smoke_heartbeat_topic(cfg, "b"), "b->a final heartbeat", "a"),
         ]
         for container_name, topic, label, receiver_peer_key in checks:
-            ros_setup = _smoke_ros_setup(session, cfg, receiver_peer_key)
+            ros_setup = _smoke_ros_setup(smoke_instance.config_container_dir, cfg, receiver_peer_key)
             output = _wait_for_topic_hz(container_name, ros_setup, topic)
+            _append_log(smoke_log, f"\n--- {label} ({topic}) in {container_name} ---\n{output}")
             if "average rate" not in output:
                 raise RuntimeError(f"Smoke verification failed for {label} ({topic}) in {container_name}:\n{output}")
-            print(f"OK: {label} ({topic}) is publishing in {container_name}")
+            log_line(f"OK: {label} ({topic}) is publishing in {container_name}")
+    except Exception as exc:
+        _append_log(smoke_log, f"ERROR: {exc}")
+        raise
     finally:
+        for started_container, peer in [(a_container, "a"), (b_container, "b")]:
+            if started_container:
+                _write_docker_log(started_container, smoke_instance, peer)
         if not args.keep_running:
             runtime = _load_runtime_config(args)
             for started_container in [a_container, b_container]:
                 if started_container:
                     _stop_container_name(started_container, runtime)
+        print(f"Smoke artifacts: {smoke_instance.host_dir}")
     return 0
 
 
@@ -1031,6 +1317,7 @@ def _add_common_config_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--rosotacom-config", help="Path to rosotacom.yaml.")
     parser.add_argument("-f", "--ros2docker-config", help="Path to ros2docker JSON config.")
     parser.add_argument("--session-configs-dir", help="Host directory containing named session configs.")
+    parser.add_argument("--session-instances-dir", help="Host directory for generated session instances and logs.")
     parser.add_argument("--data-dict", help="Host data_dict.json path for data:<key> address expressions.")
 
 
@@ -1046,6 +1333,7 @@ def _add_start_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--rewrite-formatting", action="store_true")
     parser.add_argument("--overwrite-peers-via-remote-peer")
     parser.add_argument("--peer-address", action="append", default=[], metavar="PEER=ADDRESS_EXPR")
+    parser.add_argument("--instance-id", help="Join or create a named runtime session instance.")
     parser.set_defaults(force=True, auto_identity=True)
 
 
@@ -1112,6 +1400,7 @@ def main(argv: list[str] | None = None) -> int:
     smoke_parser.add_argument("--local", action="store_true", default=True)
     smoke_parser.add_argument("--local-ip")
     smoke_parser.add_argument("--keep-running", action="store_true", help="Leave smoke-test containers running.")
+    smoke_parser.add_argument("--instance-id", help="Join or create a named runtime session instance.")
     smoke_parser.set_defaults(func=smoke)
 
     list_parser = subparsers.add_parser("list-sessions", help="List configured sessions.")

--- a/src/rosotacom/cli.py
+++ b/src/rosotacom/cli.py
@@ -56,6 +56,7 @@ SESSION_CONFIG_CONTAINER_DIR = "/session/configs"
 EXTERNAL_SESSION_CONTAINER_DIR = "/session/current"
 CONTAINER_DATA_DICT_PATH = "/data_dict.json"
 RUN_SESSION_CONTAINER_PATH = "/ws/session/creation/run_session.py"
+DEFAULT_SMOKE_SESSION = "1_heartbeat_fastdds"
 
 ws_creation_dir = WS_DIR / "session" / "creation"
 session_gen_path = ws_creation_dir / "generate_session_files.py"
@@ -841,11 +842,38 @@ def _run_container_shell(container_name: str, command: str, timeout_s: int = 30)
     )
 
 
+def _alternate_loopback_ip(local_ip: str) -> str:
+    if local_ip == "127.0.0.2":
+        return "127.0.0.3"
+    return "127.0.0.2"
+
+
+def _smoke_needs_distinct_peer_addresses(session: ResolvedSession) -> bool:
+    cfg = _load_session_config_from_host(session.host_dir)
+    peers = cfg.get("peers")
+    if not isinstance(peers, dict):
+        return False
+    shared = cfg.get("shared", {}) or {}
+    if not isinstance(shared, dict):
+        return False
+    rmw_spec = session_gen._parse_rmw_block(shared.get("rmw"), list(peers.keys()))
+    return bool(session_gen._is_native_zenoh_ota(rmw_spec.ota.impl))
+
+
+def _smoke_peer_address_args(session: ResolvedSession, local_ip: str) -> list[str]:
+    if _smoke_needs_distinct_peer_addresses(session):
+        return [f"a={local_ip}", f"b={_alternate_loopback_ip(local_ip)}"]
+    return [f"a={local_ip}", f"b={local_ip}"]
+
+
 def smoke(args: argparse.Namespace) -> int:
     if not args.local:
         raise RuntimeError("Only --local smoke mode is implemented.")
     local_ip = args.local_ip or _default_local_ip()
-    session_dir = args.session_dir or "1_heartbeat"
+    session_dir = args.session_dir or DEFAULT_SMOKE_SESSION
+    runtime = _load_runtime_config(args)
+    session = _resolve_session(session_dir, runtime)
+    peer_address_args = _smoke_peer_address_args(session, local_ip)
     common = {
         "rosotacom_config": args.rosotacom_config,
         "ros2docker_config": args.ros2docker_config,
@@ -856,30 +884,30 @@ def smoke(args: argparse.Namespace) -> int:
         "force": True,
         "rewrite_formatting": False,
         "overwrite_peers_via_remote_peer": None,
-        "peer_address": [f"a={local_ip}", f"b={local_ip}"],
+        "peer_address": peer_address_args,
     }
 
-    print(f"Starting local smoke test with LOCAL_IP={local_ip}")
+    print(f"Starting local smoke test with PEER_ADDRESSES={', '.join(peer_address_args)}")
     a_container = None
     b_container = None
     try:
         a_container = start_session(argparse.Namespace(**common, identity="a", auto_identity=True))
         b_container = start_session(argparse.Namespace(**common, identity="b", auto_identity=True))
 
-        runtime = _load_runtime_config(args)
-        session = _resolve_session(session_dir, runtime)
         plugin_text = "\n".join(
             (session.host_dir / peer / "plugin.yaml").read_text(encoding="utf-8") for peer in ("a", "b")
         )
-        if local_ip not in plugin_text or "data:" in plugin_text:
+        expected_addresses = {arg.split("=", 1)[1] for arg in peer_address_args}
+        if any(address not in plugin_text for address in expected_addresses) or "data:" in plugin_text:
             raise RuntimeError("Smoke verification failed: generated plugin.yaml did not use literal CLI addresses.")
         print("OK: generated plugin.yaml files use literal CLI addresses")
 
         ros_setup = (
-            "source /opt/ros/lyrical/setup.bash && "
+            'ros_distro="${ROS_DISTRO:-kilted}" && '
+            'source "/opt/ros/${ros_distro}/setup.bash" && '
             "source /opt/ros_venv/bin/activate && "
-            "source /opt/custom_ws/install/setup.bash && "
-            "source /ros2ws/install/setup.bash"
+            "{ [ ! -f /opt/custom_ws/install/setup.bash ] || source /opt/custom_ws/install/setup.bash; } && "
+            "{ [ ! -f /ros2ws/install/setup.bash ] || source /ros2ws/install/setup.bash; }"
         )
         checks = [
             (b_container, "/heartbeat_a"),
@@ -985,7 +1013,7 @@ def main(argv: list[str] | None = None) -> int:
 
     smoke_parser = subparsers.add_parser("smoke", help="Run a local smoke test.")
     _add_common_config_args(smoke_parser)
-    smoke_parser.add_argument("session_dir", nargs="?", default="1_heartbeat")
+    smoke_parser.add_argument("session_dir", nargs="?", default=DEFAULT_SMOKE_SESSION)
     smoke_parser.add_argument("--local", action="store_true", default=True)
     smoke_parser.add_argument("--local-ip")
     smoke_parser.add_argument("--keep-running", action="store_true", help="Leave smoke-test containers running.")

--- a/src/rosotacom/cli.py
+++ b/src/rosotacom/cli.py
@@ -12,6 +12,7 @@ import argparse
 import hashlib
 import importlib.resources as importlib_resources
 import importlib.util
+import json
 import os
 import re
 import shlex
@@ -867,6 +868,15 @@ def start_session(args: argparse.Namespace) -> str:
     instance = _resolve_session_instance(runtime, session, getattr(args, "instance_id", None))
     image_name = _scoped_image_name(runtime)
     extra_run_args = _base_extra_run_args(runtime, session, cfg, instance)
+    run_override: dict[str, object] = {}
+    network_name = getattr(args, "network_name", None)
+    if network_name:
+        base_run_args = load_config(runtime.ros2docker_config).get("run_args", []) or []
+        run_override["run_args"] = _isolated_network_run_args(
+            [str(arg) for arg in base_run_args],
+            network_name,
+            getattr(args, "network_ip", None),
+        )
     mode = _resolve_mode(args.mode)
     command = _session_command(
         session,
@@ -912,7 +922,7 @@ def start_session(args: argparse.Namespace) -> str:
         ros2docker_build(config_file=runtime.ros2docker_config, override=common_override)
         ros2docker_run(
             config_file=runtime.ros2docker_config,
-            override={**common_override, "run_type": "up"},
+            override={**common_override, "run_type": "up", **run_override},
             extra_run_args=extra_run_args,
         )
         _wait_for_container_ready(container_name)
@@ -933,6 +943,7 @@ def start_session(args: argparse.Namespace) -> str:
                 "command": command,
                 "tty": True,
                 "stdin_open": True,
+                **run_override,
             },
             extra_run_args=extra_run_args,
         )
@@ -1099,24 +1110,50 @@ def doctor(args: argparse.Namespace) -> int:
     return 1 if failures else 0
 
 
+# `ros2 topic hz`/`delay` never exit on their own, so we sample them for a fixed
+# window via `timeout` and then SIGKILL, otherwise a slow rmw shutdown can keep
+# the probe alive. The outer docker-exec timeout must stay well above the sample
+# window plus the kill grace; on a loaded CI runner the original 12s outer budget
+# could expire on an otherwise-healthy probe whose rmw teardown was slow, which
+# aborted the whole smoke run instead of letting the caller retry.
+_TOPIC_PROBE_WINDOW_S = 8
+_TOPIC_PROBE_KILL_GRACE_S = 2
+_TOPIC_PROBE_EXEC_TIMEOUT_S = 25
+
+
+def _topic_probe_command(ros_setup: str, ros2_command: str) -> str:
+    sampler = f"timeout -k {_TOPIC_PROBE_KILL_GRACE_S} {_TOPIC_PROBE_WINDOW_S} {ros2_command}"
+    return f"{ros_setup} && {sampler} || true"
+
+
 def _run_container_shell(container_name: str, command: str, timeout_s: int = 30) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(
-        ["docker", "exec", container_name, "bash", "-lc", command],
-        text=True,
-        capture_output=True,
-        timeout=timeout_s,
-        check=False,
-    )
+    try:
+        return subprocess.run(
+            ["docker", "exec", container_name, "bash", "-lc", command],
+            text=True,
+            capture_output=True,
+            timeout=timeout_s,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        # A docker-exec timeout must not abort the whole smoke run: callers poll
+        # and retry, so surface it as a non-fatal result with any partial output.
+        def _as_text(value: str | bytes | None) -> str:
+            if value is None:
+                return ""
+            return value.decode("utf-8", errors="replace") if isinstance(value, bytes) else value
+
+        return subprocess.CompletedProcess(exc.cmd, 124, _as_text(exc.stdout), _as_text(exc.stderr))
 
 
-def _wait_for_topic_hz(container_name: str, ros_setup: str, topic: str, *, timeout_s: int = 60) -> str:
+def _wait_for_topic_hz(container_name: str, ros_setup: str, topic: str, *, timeout_s: int = 90) -> str:
     deadline = time.time() + timeout_s
     last_output = ""
     while time.time() < deadline:
         result = _run_container_shell(
             container_name,
-            f"{ros_setup} && timeout 8 ros2 topic hz {shlex.quote(topic)} || true",
-            timeout_s=12,
+            _topic_probe_command(ros_setup, f"ros2 topic hz {shlex.quote(topic)}"),
+            timeout_s=_TOPIC_PROBE_EXEC_TIMEOUT_S,
         )
         last_output = (result.stdout or "") + (result.stderr or "")
         if "average rate" in last_output:
@@ -1125,10 +1162,12 @@ def _wait_for_topic_hz(container_name: str, ros_setup: str, topic: str, *, timeo
     return last_output
 
 
-def _measure_topic_delay(container_name: str, ros_setup: str, topic: str, *, timeout_s: int = 12) -> str:
+def _measure_topic_delay(
+    container_name: str, ros_setup: str, topic: str, *, timeout_s: int = _TOPIC_PROBE_EXEC_TIMEOUT_S
+) -> str:
     result = _run_container_shell(
         container_name,
-        f"{ros_setup} && timeout 8 ros2 topic delay {shlex.quote(topic)} || true",
+        _topic_probe_command(ros_setup, f"ros2 topic delay {shlex.quote(topic)}"),
         timeout_s=timeout_s,
     )
     return (result.stdout or "") + (result.stderr or "")
@@ -1155,28 +1194,64 @@ def _smoke_metric_line(*, label: str, topic: str, container_name: str, hz: float
     )
 
 
-def _alternate_loopback_ip(local_ip: str) -> str:
-    if local_ip == "127.0.0.2":
-        return "127.0.0.3"
-    return "127.0.0.2"
+# Smoke runs both peers on a single host. Sharing the host loopback
+# (`--network host`) lets the two peers' local- and OTA-domain DDS participants
+# cross-match over `lo`, which intermittently produces duplicate delivery
+# (inflated heartbeat rates) or no delivery at all. Instead we give each peer its
+# own network namespace on a dedicated docker bridge with distinct IPs, mirroring
+# a real two-machine deployment so the transports stay isolated.
+SMOKE_NETWORK_NAME = "rosotacom-smoke"
+SMOKE_NETWORK_SUBNET = "10.137.0.0/24"
+SMOKE_PEER_IPS: dict[str, str] = {"a": "10.137.0.2", "b": "10.137.0.3"}
 
 
-def _smoke_needs_distinct_peer_addresses(session: ResolvedSession) -> bool:
-    cfg = _load_session_config_from_host(session.host_dir)
-    peers = cfg.get("peers")
-    if not isinstance(peers, dict):
-        return False
-    shared = cfg.get("shared", {}) or {}
-    if not isinstance(shared, dict):
-        return False
-    rmw_spec = session_gen._parse_rmw_block(shared.get("rmw"), list(peers.keys()))
-    return bool(session_gen._is_native_zenoh_ota(rmw_spec.ota.impl) or rmw_spec.ota.impl == "fastdds")
+def _smoke_peer_address_args() -> list[str]:
+    return [f"{peer}={ip}" for peer, ip in SMOKE_PEER_IPS.items()]
 
 
-def _smoke_peer_address_args(session: ResolvedSession, local_ip: str) -> list[str]:
-    if _smoke_needs_distinct_peer_addresses(session):
-        return [f"a={local_ip}", f"b={_alternate_loopback_ip(local_ip)}"]
-    return [f"a={local_ip}", f"b={local_ip}"]
+def _ensure_smoke_network() -> None:
+    # Recreate from a clean slate so a leftover network from a crashed run cannot
+    # cause a subnet-overlap failure on create.
+    _remove_smoke_network()
+    result = subprocess.run(
+        ["docker", "network", "create", "--subnet", SMOKE_NETWORK_SUBNET, SMOKE_NETWORK_NAME],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"Failed to create smoke network {SMOKE_NETWORK_NAME} ({SMOKE_NETWORK_SUBNET}): "
+            f"{(result.stderr or result.stdout).strip()}"
+        )
+
+
+def _remove_smoke_network() -> None:
+    subprocess.run(
+        ["docker", "network", "rm", SMOKE_NETWORK_NAME],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def _isolated_network_run_args(run_args: list[str], network_name: str, ip: str | None) -> list[str]:
+    out: list[str] = []
+    i = 0
+    while i < len(run_args):
+        token = run_args[i]
+        if token in ("--network", "--net"):
+            i += 2
+            continue
+        if token.startswith("--network=") or token.startswith("--net="):
+            i += 1
+            continue
+        out.append(token)
+        i += 1
+    out.extend(["--network", network_name])
+    if ip:
+        out.extend(["--ip", ip])
+    return out
 
 
 def _smoke_heartbeat_topic(cfg: dict[str, Any], peer_key: str) -> str:
@@ -1271,7 +1346,6 @@ def _smoke_ros_setup(config_container_dir: str, cfg: dict[str, Any], receiver_pe
 def smoke(args: argparse.Namespace) -> int:
     if not args.local:
         raise RuntimeError("Only --local smoke mode is implemented.")
-    local_ip = args.local_ip or _default_local_ip()
     session_dir = args.session_dir or DEFAULT_SMOKE_SESSION
     runtime = _load_runtime_config(args)
     session = _resolve_session(session_dir, runtime)
@@ -1283,7 +1357,7 @@ def smoke(args: argparse.Namespace) -> int:
         print(message)
         _append_log(smoke_log, message)
 
-    peer_address_args = _smoke_peer_address_args(session, local_ip)
+    peer_address_args = _smoke_peer_address_args()
     peer_overrides = _parse_peer_address_overrides(peer_address_args)
     cfg = _effective_session_config(session.host_dir, runtime, peer_address_overrides=peer_overrides)
     common = {
@@ -1299,15 +1373,22 @@ def smoke(args: argparse.Namespace) -> int:
         "overwrite_peers_via_remote_peer": None,
         "peer_address": peer_address_args,
         "instance_id": smoke_instance.instance_id,
+        "network_name": SMOKE_NETWORK_NAME,
     }
 
     log_line(f"Starting local smoke test with PEER_ADDRESSES={', '.join(peer_address_args)}")
+    log_line(f"Smoke peers isolated on docker network {SMOKE_NETWORK_NAME} ({SMOKE_NETWORK_SUBNET})")
     log_line(f"Smoke artifacts: {smoke_instance.host_dir}")
     a_container = None
     b_container = None
     try:
-        a_container = start_session(argparse.Namespace(**common, identity="a", auto_identity=True))
-        b_container = start_session(argparse.Namespace(**common, identity="b", auto_identity=True))
+        _ensure_smoke_network()
+        a_container = start_session(
+            argparse.Namespace(**common, identity="a", auto_identity=True, network_ip=SMOKE_PEER_IPS["a"])
+        )
+        b_container = start_session(
+            argparse.Namespace(**common, identity="b", auto_identity=True, network_ip=SMOKE_PEER_IPS["b"])
+        )
 
         plugin_text = "\n".join(
             (smoke_instance.config_host_dir / peer / "plugin.yaml").read_text(encoding="utf-8") for peer in ("a", "b")
@@ -1356,8 +1437,113 @@ def smoke(args: argparse.Namespace) -> int:
             for started_container in [a_container, b_container]:
                 if started_container:
                     _stop_container_name(started_container, runtime)
+            _remove_smoke_network()
         print(f"Smoke artifacts: {smoke_instance.host_dir}")
     return 0
+
+
+def _find_latest_instance_dir(runtime: RuntimeConfig, session: ResolvedSession, instance_id: str | None) -> Path:
+    root = _session_instances_root(runtime)
+    session_slug = _session_instance_slug(session, runtime)
+    if instance_id:
+        pattern = f"*/{session_slug}_*_{_safe_path_token(instance_id)}"
+    else:
+        pattern = f"*/{session_slug}_*"
+    matches = sorted(p for p in root.glob(pattern) if p.is_dir())
+    if not matches:
+        raise RuntimeError(
+            f"No session instance found for '{session.host_dir.name}' under {root}. "
+            "Start a session with shared.use_status_overview=true first."
+        )
+    return matches[-1].resolve()
+
+
+def _status_identities(logs_dir: Path, identity: str | None) -> list[str]:
+    if identity:
+        return [identity]
+    if not logs_dir.is_dir():
+        return []
+    found = []
+    for peer_dir in sorted(logs_dir.iterdir()):
+        if (peer_dir / "status" / "status.json").exists():
+            found.append(peer_dir.name)
+    return found
+
+
+def _render_status_for_identities(logs_dir: Path, identities: list[str], as_json: bool) -> str:
+    if as_json:
+        combined: dict[str, Any] = {}
+        for identity in identities:
+            json_path = logs_dir / identity / "status" / "status.json"
+            if json_path.exists():
+                combined[identity] = json.loads(json_path.read_text(encoding="utf-8"))
+        return json.dumps(combined, indent=2)
+
+    chunks: list[str] = []
+    for identity in identities:
+        status_dir = logs_dir / identity / "status"
+        txt_path = status_dir / "status.txt"
+        json_path = status_dir / "status.json"
+        if txt_path.exists():
+            chunks.append(txt_path.read_text(encoding="utf-8").rstrip())
+        elif json_path.exists():
+            snapshot = json.loads(json_path.read_text(encoding="utf-8"))
+            chunks.append(_render_status_text_fallback(snapshot))
+        else:
+            chunks.append(f"(no status.json yet for identity '{identity}')")
+    return "\n\n".join(chunks)
+
+
+def _render_status_text_fallback(snapshot: dict[str, Any]) -> str:
+    summary = snapshot.get("summary", {})
+    lines = [
+        f"rosotacom status  peer={snapshot.get('peer')} remote={snapshot.get('remote')}  "
+        f"{snapshot.get('generated_at')}",
+        f"summary: OK={summary.get('OK', 0)} PARTIAL={summary.get('PARTIAL', 0)} "
+        f"STALLED={summary.get('STALLED', 0)} ABSENT={summary.get('ABSENT', 0)}",
+        "",
+    ]
+    for topic in snapshot.get("topics", []):
+        arrow = "->" if topic.get("direction") == "outbound" else "<-"
+        lines.append(
+            f"[{topic.get('overall'):<7}] {arrow} {topic.get('base')}  "
+            f"(reached: {topic.get('reached_stage')}, blocked: {topic.get('blocked_at')})"
+        )
+        if topic.get("diagnosis"):
+            lines.append(f"    -> {topic['diagnosis']}")
+    return "\n".join(lines)
+
+
+def status(args: argparse.Namespace) -> int:
+    runtime = _load_runtime_config(args)
+    session = _resolve_session(args.session_dir or DEFAULT_SMOKE_SESSION, runtime)
+    instance_dir = _find_latest_instance_dir(runtime, session, getattr(args, "instance_id", None))
+    logs_dir = instance_dir / "logs"
+
+    def render_once() -> str:
+        identities = _status_identities(logs_dir, getattr(args, "identity", None))
+        if not identities:
+            return (
+                f"No status.json found under {logs_dir}.\n"
+                "Ensure the session was started with shared.use_status_overview=true "
+                "and has had time to initialize."
+            )
+        return _render_status_for_identities(logs_dir, identities, bool(getattr(args, "json", False)))
+
+    if not getattr(args, "watch", False):
+        print(render_once())
+        return 0
+
+    interval = max(0.5, float(getattr(args, "watch_interval", 2.0)))
+    try:
+        while True:
+            # Clear screen for a live view.
+            print("\033[2J\033[H", end="")
+            print(f"(watching {instance_dir.name}; refresh {interval}s; Ctrl-C to stop)\n")
+            print(render_once(), flush=True)
+            time.sleep(interval)
+    except KeyboardInterrupt:
+        return 0
 
 
 def _add_common_config_args(parser: argparse.ArgumentParser) -> None:
@@ -1413,7 +1599,7 @@ def list_sessions_command(args: argparse.Namespace) -> int:
 
 def main(argv: list[str] | None = None) -> int:
     argv = list(sys.argv[1:] if argv is None else argv)
-    commands = {"start", "stop", "doctor", "smoke", "list-sessions", "examples", "setup-env"}
+    commands = {"start", "stop", "doctor", "smoke", "status", "list-sessions", "examples", "setup-env"}
     if not argv:
         argv = ["start"]
     elif argv[0] not in commands and not argv[0].startswith("-"):
@@ -1449,6 +1635,20 @@ def main(argv: list[str] | None = None) -> int:
     smoke_parser.add_argument("--keep-running", action="store_true", help="Leave smoke-test containers running.")
     smoke_parser.add_argument("--instance-id", help="Join or create a named runtime session instance.")
     smoke_parser.set_defaults(func=smoke)
+
+    status_parser = subparsers.add_parser(
+        "status", help="Show the live per-topic pipeline status for a session instance."
+    )
+    _add_common_config_args(status_parser)
+    status_parser.add_argument("session_dir", nargs="?", default=DEFAULT_SMOKE_SESSION)
+    status_parser.add_argument("--identity", help="Show only this peer identity (default: all available).")
+    status_parser.add_argument(
+        "--instance-id", help="Inspect a specific instance id (default: most recent for the session)."
+    )
+    status_parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
+    status_parser.add_argument("--watch", action="store_true", help="Continuously refresh the view.")
+    status_parser.add_argument("--watch-interval", type=float, default=2.0, help="Watch refresh interval (s).")
+    status_parser.set_defaults(func=status)
 
     list_parser = subparsers.add_parser("list-sessions", help="List configured sessions.")
     _add_common_config_args(list_parser)

--- a/src/rosotacom/resources/examples/.gitignore
+++ b/src/rosotacom/resources/examples/.gitignore
@@ -1,0 +1,1 @@
+session-instances/

--- a/src/rosotacom/resources/examples/README.md
+++ b/src/rosotacom/resources/examples/README.md
@@ -9,7 +9,7 @@ project setup, reusable session configs, and helper scripts.
 rosotacom examples create ./rosotacom_examples
 cd ./rosotacom_examples
 eval "$(rosotacom setup-env ./rosotacom.yaml)"
-rosotacom start 1_heartbeat_fastdds --identity a
+rosotacom start 1_heartbeat_cyclone-ota --identity a
 ```
 
 In another terminal on the same host:
@@ -17,7 +17,7 @@ In another terminal on the same host:
 ```bash
 cd ./rosotacom_examples
 eval "$(rosotacom setup-env ./rosotacom.yaml)"
-rosotacom start 1_heartbeat_fastdds --identity b
+rosotacom start 1_heartbeat_cyclone-ota --identity b
 ```
 
 ## Layout

--- a/src/rosotacom/resources/examples/README.md
+++ b/src/rosotacom/resources/examples/README.md
@@ -25,7 +25,8 @@ rosotacom start 1_heartbeat_cyclone-ota --identity b
 - `rosotacom.yaml`: project-local rosotacom setup
 - `ros2docker.json`: Docker runtime defaults used by the communication containers
 - `data_dict.json`: example machine address data used by `data:<key>` session entries
-- `sessions/`: session definitions
+- `sessions/`: tracked static session definitions/templates
+- `session-instances/`: ignored generated runtime configs, catmux logs, smoke logs, and rosbags
 - `scripts/`: convenience wrappers and external-node launchers
 
 `data_dict.json` intentionally uses `127.0.0.1` for both peers so the examples

--- a/src/rosotacom/resources/examples/README.md
+++ b/src/rosotacom/resources/examples/README.md
@@ -9,7 +9,7 @@ project setup, reusable session configs, and helper scripts.
 rosotacom examples create ./rosotacom_examples
 cd ./rosotacom_examples
 eval "$(rosotacom setup-env ./rosotacom.yaml)"
-rosotacom start 1_heartbeat --identity a
+rosotacom start 1_heartbeat_fastdds --identity a
 ```
 
 In another terminal on the same host:
@@ -17,7 +17,7 @@ In another terminal on the same host:
 ```bash
 cd ./rosotacom_examples
 eval "$(rosotacom setup-env ./rosotacom.yaml)"
-rosotacom start 1_heartbeat --identity b
+rosotacom start 1_heartbeat_fastdds --identity b
 ```
 
 ## Layout

--- a/src/rosotacom/resources/examples/ros2docker.json
+++ b/src/rosotacom/resources/examples/ros2docker.json
@@ -9,7 +9,7 @@
 
   // Extra docker run arguments
   "run_args": [
-    "-e", "ROS_DOMAIN_ID=47",
+    "-e", "ROS_DOMAIN_ID=48",
     "-e", "BUILD_ROS2WS=1",
     "-e", "CHECK_ROS2WS_DEPENDENCIES=1",
     "--network", "host"

--- a/src/rosotacom/resources/examples/ros2docker.json
+++ b/src/rosotacom/resources/examples/ros2docker.json
@@ -22,7 +22,7 @@
   "build_args": {
     "BASE_IMAGE": "osrf/ros:kilted-desktop-full-noble",
     "DIGEST": "@sha256:29eb6f48bb06549aba004a7a4b12c00ece23b156731df12cf1f3c1ae1b0fd178",
-    "APT_PACKAGES":                  "iputils-ping psmisc net-tools snmp iw nload iftop iproute2 tshark",
+    "APT_PACKAGES":                  "iputils-ping psmisc net-tools snmp iw nload iftop iproute2 tshark ros-kilted-domain-bridge",
     "PIP_PACKAGES":                  "numpy>=1.26,<2 lz4 pysnmp speedtest-cli psutil zstandard opencv-python"
   }
 }

--- a/src/rosotacom/resources/examples/ros2docker.json
+++ b/src/rosotacom/resources/examples/ros2docker.json
@@ -20,6 +20,8 @@
 
   // Build-time arguments — defaults shown; override if necessary
   "build_args": {
+    "BASE_IMAGE": "osrf/ros:kilted-desktop-full-noble",
+    "DIGEST": "@sha256:29eb6f48bb06549aba004a7a4b12c00ece23b156731df12cf1f3c1ae1b0fd178",
     "APT_PACKAGES":                  "iputils-ping psmisc net-tools snmp iw nload iftop iproute2 tshark",
     "PIP_PACKAGES":                  "numpy>=1.26,<2 lz4 pysnmp speedtest-cli psutil zstandard opencv-python"
   }

--- a/src/rosotacom/resources/examples/rosotacom.yaml
+++ b/src/rosotacom/resources/examples/rosotacom.yaml
@@ -5,4 +5,5 @@
 # `--rosotacom-config`.
 ros2docker_config: ros2docker.json
 session_configs_dir: sessions
+session_instances_dir: session-instances
 data_dict: data_dict.json

--- a/src/rosotacom/resources/examples/scripts/1_heartbeat/run_machine_a.sh
+++ b/src/rosotacom/resources/examples/scripts/1_heartbeat/run_machine_a.sh
@@ -6,4 +6,4 @@ SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 EXAMPLE_ROOT="$(cd -- "$SCRIPT_DIR/../.." && pwd)"
 CONFIG="${ROSOTACOM_CONFIG:-$EXAMPLE_ROOT/rosotacom.yaml}"
 
-rosotacom start --rosotacom-config "$CONFIG" 1_heartbeat_fastdds --identity a --force
+rosotacom start --rosotacom-config "$CONFIG" 1_heartbeat_cyclone-ota --identity a --force

--- a/src/rosotacom/resources/examples/scripts/1_heartbeat/run_machine_a.sh
+++ b/src/rosotacom/resources/examples/scripts/1_heartbeat/run_machine_a.sh
@@ -6,4 +6,4 @@ SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 EXAMPLE_ROOT="$(cd -- "$SCRIPT_DIR/../.." && pwd)"
 CONFIG="${ROSOTACOM_CONFIG:-$EXAMPLE_ROOT/rosotacom.yaml}"
 
-rosotacom start --rosotacom-config "$CONFIG" 1_heartbeat --identity a --force
+rosotacom start --rosotacom-config "$CONFIG" 1_heartbeat_fastdds --identity a --force

--- a/src/rosotacom/resources/examples/scripts/1_heartbeat/run_machine_b.sh
+++ b/src/rosotacom/resources/examples/scripts/1_heartbeat/run_machine_b.sh
@@ -6,4 +6,4 @@ SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 EXAMPLE_ROOT="$(cd -- "$SCRIPT_DIR/../.." && pwd)"
 CONFIG="${ROSOTACOM_CONFIG:-$EXAMPLE_ROOT/rosotacom.yaml}"
 
-rosotacom start --rosotacom-config "$CONFIG" 1_heartbeat_fastdds --identity b --force
+rosotacom start --rosotacom-config "$CONFIG" 1_heartbeat_cyclone-ota --identity b --force

--- a/src/rosotacom/resources/examples/scripts/1_heartbeat/run_machine_b.sh
+++ b/src/rosotacom/resources/examples/scripts/1_heartbeat/run_machine_b.sh
@@ -6,4 +6,4 @@ SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 EXAMPLE_ROOT="$(cd -- "$SCRIPT_DIR/../.." && pwd)"
 CONFIG="${ROSOTACOM_CONFIG:-$EXAMPLE_ROOT/rosotacom.yaml}"
 
-rosotacom start --rosotacom-config "$CONFIG" 1_heartbeat --identity b --force
+rosotacom start --rosotacom-config "$CONFIG" 1_heartbeat_fastdds --identity b --force

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_cyclone-local_fastdds-ota/a/plugin.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_cyclone-local_fastdds-ota/a/plugin.yaml
@@ -1,13 +1,13 @@
 parameters:
-  session_dir: /session/configs/1_heartbeat_fastdds
+  session_dir: /session/configs/1_heartbeat_cyclone-local_fastdds-ota
   peer_dir: ${session_dir}/a
 
-  ip_local: 192.168.178.66
+  ip_local: data:machine_a_ip
   local_name: a
-  ip_remote: 192.168.178.66
+  ip_remote: data:machine_b_ip
   remote_name: b
 
-  rmw_local: fastdds
+  rmw_local: cyclone
 
   in: true
   topic_list_paths_inbound: ${session_dir}/b_to_a_topics.txt

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_cyclone-local_fastdds-ota/a/session_specification.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_cyclone-local_fastdds-ota/a/session_specification.yaml
@@ -1,0 +1,3 @@
+session_plugins:
+  - ./plugin.yaml
+  - /ws/session/content/base/session_plugin_base.yaml

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_cyclone-local_fastdds-ota/a_to_b_topics.txt
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_cyclone-local_fastdds-ota/a_to_b_topics.txt
@@ -1,0 +1,1 @@
+/heartbeat_a

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_cyclone-local_fastdds-ota/b/plugin.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_cyclone-local_fastdds-ota/b/plugin.yaml
@@ -1,5 +1,5 @@
 parameters:
-  session_dir: /session/configs/1_heartbeat_zen-endpoints
+  session_dir: /session/configs/1_heartbeat_cyclone-local_fastdds-ota
   peer_dir: ${session_dir}/b
 
   ip_local: data:machine_b_ip
@@ -7,7 +7,7 @@ parameters:
   ip_remote: data:machine_a_ip
   remote_name: a
 
-  rmw_local: zenoh
+  rmw_local: cyclone
 
   in: true
   topic_list_paths_inbound: ${session_dir}/a_to_b_topics.txt
@@ -15,17 +15,8 @@ parameters:
   out: true
   topic_list_paths_outbound: ${session_dir}/b_to_a_topics.txt
 
-  use_domain_bridge: true
-  local_domain_id: 47
-  ota_domain_id: 48
-  domain_bridge_config_file: ${peer_dir}/domain_bridge.yaml
-
-  zen_main_ip: data:machine_a_ip
-  zen_main_port: 7447
-  zen_connect: true
-
-  rmw_ota: zenoh
-  use_zenoh_rmw: true
+  rmw_ota: fastdds
+  use_zenoh_rmw: false
   use_zenoh_ros2dds: false
 
   heartbeat: true

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_cyclone-local_fastdds-ota/b/session_specification.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_cyclone-local_fastdds-ota/b/session_specification.yaml
@@ -1,0 +1,3 @@
+session_plugins:
+  - ./plugin.yaml
+  - /ws/session/content/base/session_plugin_base.yaml

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_cyclone-local_fastdds-ota/b_to_a_topics.txt
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_cyclone-local_fastdds-ota/b_to_a_topics.txt
@@ -1,0 +1,1 @@
+/heartbeat_b

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_cyclone-local_fastdds-ota/session-definition.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_cyclone-local_fastdds-ota/session-definition.yaml
@@ -1,0 +1,12 @@
+peers:
+  a:
+    address: "data:machine_a_ip"
+  b:
+    address: "data:machine_b_ip"
+
+shared:
+  use_heartbeat: true
+  rmw:
+    local: cyclone
+    ota: fastdds
+  ota_domain_id: 48

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_cyclone-local_fastdds-ota/session-definition.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_cyclone-local_fastdds-ota/session-definition.yaml
@@ -4,6 +4,12 @@ peers:
   b:
     address: "data:machine_b_ip"
 
+peer_settings:
+  a:
+    domain_id: 46
+  b:
+    domain_id: 47
+
 shared:
   use_heartbeat: true
   rmw:

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_cyclone-local_fastdds-ota/session-definition.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_cyclone-local_fastdds-ota/session-definition.yaml
@@ -13,6 +13,10 @@ peer_settings:
 shared:
   use_heartbeat: true
   rmw:
-    local: cyclone
-    ota: fastdds
+    local:
+      cyclone:
+        config: cyclonedds_minimal.xml
+    ota:
+      fastdds:
+        config: fastdds_unicast.xml
   ota_domain_id: 48

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_cyclone-local_zenoh-ros2dds-ota/a/domain_bridge.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_cyclone-local_zenoh-ros2dds-ota/a/domain_bridge.yaml
@@ -1,0 +1,10 @@
+name: a_com_domain_bridge
+topics:
+  /com/in/b/heartbeat_b:
+    from_domain: 48
+    to_domain: 46
+    type: com_msgs/msg/Heartbeat
+  /com/out/a/heartbeat_a:
+    from_domain: 46
+    to_domain: 48
+    type: com_msgs/msg/Heartbeat

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_cyclone-local_zenoh-ros2dds-ota/a/plugin.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_cyclone-local_zenoh-ros2dds-ota/a/plugin.yaml
@@ -1,5 +1,5 @@
 parameters:
-  session_dir: /session/configs/1_heartbeat_zen-endpoints
+  session_dir: /session/configs/1_heartbeat_cyclone-local_zenoh-ros2dds-ota
   peer_dir: ${session_dir}/a
 
   ip_local: data:machine_a_ip
@@ -7,7 +7,7 @@ parameters:
   ip_remote: data:machine_b_ip
   remote_name: b
 
-  rmw_local: zenoh
+  rmw_local: cyclone
 
   in: true
   topic_list_paths_inbound: ${session_dir}/b_to_a_topics.txt
@@ -20,13 +20,17 @@ parameters:
   ota_domain_id: 48
   domain_bridge_config_file: ${peer_dir}/domain_bridge.yaml
 
+  zen_pub_allow: /ota/a/.*
+  zen_sub_allow: /ota/b/.*
+  zen_transport: udp
+  zen_mode: router
+  zen_endpoint_role: listen
   zen_main_ip: data:machine_a_ip
   zen_main_port: 7447
-  zen_connect: false
 
-  rmw_ota: zenoh
-  use_zenoh_rmw: true
-  use_zenoh_ros2dds: false
+  rmw_ota: zenoh_ros2dds
+  use_zenoh_rmw: false
+  use_zenoh_ros2dds: true
 
   heartbeat: true
   heartbeat_out_topics: /heartbeat_a

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_cyclone-local_zenoh-ros2dds-ota/a/session_specification.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_cyclone-local_zenoh-ros2dds-ota/a/session_specification.yaml
@@ -1,0 +1,3 @@
+session_plugins:
+  - ./plugin.yaml
+  - /ws/session/content/base/session_plugin_base.yaml

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_cyclone-local_zenoh-ros2dds-ota/a_to_b_topics.txt
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_cyclone-local_zenoh-ros2dds-ota/a_to_b_topics.txt
@@ -1,0 +1,1 @@
+/heartbeat_a

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_cyclone-local_zenoh-ros2dds-ota/b/domain_bridge.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_cyclone-local_zenoh-ros2dds-ota/b/domain_bridge.yaml
@@ -1,0 +1,10 @@
+name: b_com_domain_bridge
+topics:
+  /com/in/a/heartbeat_a:
+    from_domain: 48
+    to_domain: 47
+    type: com_msgs/msg/Heartbeat
+  /com/out/b/heartbeat_b:
+    from_domain: 47
+    to_domain: 48
+    type: com_msgs/msg/Heartbeat

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_cyclone-local_zenoh-ros2dds-ota/b/plugin.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_cyclone-local_zenoh-ros2dds-ota/b/plugin.yaml
@@ -1,5 +1,5 @@
 parameters:
-  session_dir: /session/configs/1_heartbeat_zen-endpoints
+  session_dir: /session/configs/1_heartbeat_cyclone-local_zenoh-ros2dds-ota
   peer_dir: ${session_dir}/b
 
   ip_local: data:machine_b_ip
@@ -7,7 +7,7 @@ parameters:
   ip_remote: data:machine_a_ip
   remote_name: a
 
-  rmw_local: zenoh
+  rmw_local: cyclone
 
   in: true
   topic_list_paths_inbound: ${session_dir}/a_to_b_topics.txt
@@ -20,13 +20,17 @@ parameters:
   ota_domain_id: 48
   domain_bridge_config_file: ${peer_dir}/domain_bridge.yaml
 
+  zen_pub_allow: /ota/b/.*
+  zen_sub_allow: /ota/a/.*
+  zen_transport: udp
+  zen_mode: router
+  zen_endpoint_role: connect
   zen_main_ip: data:machine_a_ip
   zen_main_port: 7447
-  zen_connect: true
 
-  rmw_ota: zenoh
-  use_zenoh_rmw: true
-  use_zenoh_ros2dds: false
+  rmw_ota: zenoh_ros2dds
+  use_zenoh_rmw: false
+  use_zenoh_ros2dds: true
 
   heartbeat: true
   heartbeat_out_topics: /heartbeat_b

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_cyclone-local_zenoh-ros2dds-ota/b/session_specification.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_cyclone-local_zenoh-ros2dds-ota/b/session_specification.yaml
@@ -1,0 +1,3 @@
+session_plugins:
+  - ./plugin.yaml
+  - /ws/session/content/base/session_plugin_base.yaml

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_cyclone-local_zenoh-ros2dds-ota/b_to_a_topics.txt
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_cyclone-local_zenoh-ros2dds-ota/b_to_a_topics.txt
@@ -1,0 +1,1 @@
+/heartbeat_b

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_cyclone-local_zenoh-ros2dds-ota/session-definition.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_cyclone-local_zenoh-ros2dds-ota/session-definition.yaml
@@ -16,3 +16,6 @@ shared:
   rmw:
     local: cyclone
     ota: zenoh_ros2dds
+
+# - why here local ips?
+# - here hz is way to much

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_cyclone-local_zenoh-ros2dds-ota/session-definition.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_cyclone-local_zenoh-ros2dds-ota/session-definition.yaml
@@ -1,0 +1,18 @@
+peers:
+  a:
+    address: "data:machine_a_ip"
+  b:
+    address: "data:machine_b_ip"
+
+peer_settings:
+  a:
+    domain_id: 46
+  b:
+    domain_id: 47
+
+shared:
+  use_heartbeat: true
+  ota_domain_id: 48
+  rmw:
+    local: cyclone
+    ota: zenoh_ros2dds

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_cyclone-ota/a/ota_dds.xml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_cyclone-ota/a/ota_dds.xml
@@ -1,0 +1,9 @@
+<CycloneDDS>
+    <Domain>
+        <General>
+            <Interfaces>
+                <NetworkInterface address="127.0.0.1"/>
+            </Interfaces>
+        </General>
+    </Domain>
+</CycloneDDS>

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_cyclone-ota/a/plugin.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_cyclone-ota/a/plugin.yaml
@@ -8,6 +8,8 @@ parameters:
   remote_name: b
 
   rmw_local: cyclone
+  local_config_template: cyclonedds_minimal.xml
+  local_config_file: ${peer_dir}/local_dds.xml
 
   in: true
   topic_list_paths_inbound: ${session_dir}/b_to_a_topics.txt

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_cyclone-ota/a/plugin.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_cyclone-ota/a/plugin.yaml
@@ -1,0 +1,26 @@
+parameters:
+  session_dir: /session/configs/1_heartbeat_cyclone-ota
+  peer_dir: ${session_dir}/a
+
+  ip_local: data:machine_a_ip
+  local_name: a
+  ip_remote: data:machine_b_ip
+  remote_name: b
+
+  rmw_local: cyclone
+
+  in: true
+  topic_list_paths_inbound: ${session_dir}/b_to_a_topics.txt
+
+  out: true
+  topic_list_paths_outbound: ${session_dir}/a_to_b_topics.txt
+
+  rmw_ota: cyclone
+  use_zenoh_rmw: false
+  use_zenoh_ros2dds: false
+  ota_config_template: cyclonedds_minimal.xml
+  ota_config_file: ${peer_dir}/ota_dds.xml
+
+  heartbeat: true
+  heartbeat_out_topics: /heartbeat_a
+  heartbeat_in_topic: /heartbeat_b

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_cyclone-ota/a/session_specification.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_cyclone-ota/a/session_specification.yaml
@@ -1,0 +1,3 @@
+session_plugins:
+  - ./plugin.yaml
+  - /ws/session/content/base/session_plugin_base.yaml

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_cyclone-ota/a_to_b_topics.txt
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_cyclone-ota/a_to_b_topics.txt
@@ -1,0 +1,1 @@
+/heartbeat_a

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_cyclone-ota/b/ota_dds.xml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_cyclone-ota/b/ota_dds.xml
@@ -1,0 +1,9 @@
+<CycloneDDS>
+    <Domain>
+        <General>
+            <Interfaces>
+                <NetworkInterface address="127.0.0.1"/>
+            </Interfaces>
+        </General>
+    </Domain>
+</CycloneDDS>

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_cyclone-ota/b/plugin.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_cyclone-ota/b/plugin.yaml
@@ -1,0 +1,26 @@
+parameters:
+  session_dir: /session/configs/1_heartbeat_cyclone-ota
+  peer_dir: ${session_dir}/b
+
+  ip_local: data:machine_b_ip
+  local_name: b
+  ip_remote: data:machine_a_ip
+  remote_name: a
+
+  rmw_local: cyclone
+
+  in: true
+  topic_list_paths_inbound: ${session_dir}/a_to_b_topics.txt
+
+  out: true
+  topic_list_paths_outbound: ${session_dir}/b_to_a_topics.txt
+
+  rmw_ota: cyclone
+  use_zenoh_rmw: false
+  use_zenoh_ros2dds: false
+  ota_config_template: cyclonedds_minimal.xml
+  ota_config_file: ${peer_dir}/ota_dds.xml
+
+  heartbeat: true
+  heartbeat_out_topics: /heartbeat_b
+  heartbeat_in_topic: /heartbeat_a

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_cyclone-ota/b/plugin.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_cyclone-ota/b/plugin.yaml
@@ -8,6 +8,8 @@ parameters:
   remote_name: a
 
   rmw_local: cyclone
+  local_config_template: cyclonedds_minimal.xml
+  local_config_file: ${peer_dir}/local_dds.xml
 
   in: true
   topic_list_paths_inbound: ${session_dir}/a_to_b_topics.txt

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_cyclone-ota/b/session_specification.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_cyclone-ota/b/session_specification.yaml
@@ -1,0 +1,3 @@
+session_plugins:
+  - ./plugin.yaml
+  - /ws/session/content/base/session_plugin_base.yaml

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_cyclone-ota/b_to_a_topics.txt
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_cyclone-ota/b_to_a_topics.txt
@@ -1,0 +1,1 @@
+/heartbeat_b

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_cyclone-ota/session-definition.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_cyclone-ota/session-definition.yaml
@@ -4,55 +4,11 @@ peers:
   b:
     address: "data:machine_b_ip"
 
-# peer_settings:
-#   a:
-#     domain_id: 46
-#   b:
-#     domain_id: 47
-
 shared:
   use_heartbeat: true
   rmw:
-    local:
-      cyclone:
-        config: cyclonedds_minimal.xml
+    local: cyclone
     ota:
       cyclone:
         config: cyclonedds_minimal.xml
   ota_domain_id: 48
-
-  # Tested Working RMW-Config Combinations:
-
-  # 1. FastDDS
-  # rmw: fastdds
-
-  # 2. Cyclone with OTA config
-  # rmw:
-  #   local:
-  #     cyclone:
-  #       config: cyclonedds_minimal.xml
-  #   ota:
-  #     cyclone:
-  #       config: cyclonedds_minimal.xml
-
-  # 3. Zenoh with connected endpoints
-  # rmw:
-  #   local: zenoh
-  #   ota: zenoh_connect_endpoints
-
-  # 4. Cyclone with OTA config and locally FastDDS
-  # rmw:
-  #   local: fastdds
-  #   ota:
-  #     cyclone:
-  #       config: cyclonedds_minimal.xml
-
-  # 5. FastDDS for OTA and locally Cyclone
-  # rmw:
-  #   local: cyclone
-  #   ota: fastdds
-
-  # 6. Zenoh-ROS2DDS for OTA and locally cyclone
-  # rmw:
-  #   local: cyclone
-  #   ota: zenoh_ros2dds

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_cyclone-ota/session-definition.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_cyclone-ota/session-definition.yaml
@@ -4,10 +4,22 @@ peers:
   b:
     address: "data:machine_b_ip"
 
+peer_settings:
+  a:
+    domain_id: 46
+    # inbound:
+    #   keep_source_prefix: true
+  b:
+    domain_id: 47
+    # inbound:
+    #   keep_source_prefix: true
+
 shared:
   use_heartbeat: true
   rmw:
-    local: cyclone
+    local:
+      cyclone:
+        config: cyclonedds_minimal.xml
     ota:
       cyclone:
         config: cyclonedds_minimal.xml

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_cyclone-ota/session-definition.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_cyclone-ota/session-definition.yaml
@@ -1,0 +1,54 @@
+peers:
+  a:
+    address: "data:machine_a_ip"
+  b:
+    address: "data:machine_b_ip"
+
+# peer_settings:
+#   a:
+#     domain_id: 46
+#   b:
+#     domain_id: 47
+
+shared:
+  use_heartbeat: true
+  rmw:
+    local: cyclone
+    ota:
+      cyclone:
+        config: cyclonedds_minimal.xml
+  ota_domain_id: 48
+
+  # Tested Working RMW-Config Combinations:
+
+  # 1. FastDDS
+  # rmw: fastdds
+
+  # 2. Cyclone with OTA config
+  # rmw:
+  #   local: cyclone
+  #   ota:
+  #     cyclone:
+  #       config: cyclonedds_minimal.xml
+
+  # 3. Zenoh with connected endpoints
+  # rmw:
+  #   local: zenoh
+  #   ota: zenoh_connect_endpoints
+
+  # 4. Cyclone with OTA config and locally FastDDS
+  # rmw:
+  #   local: fastdds
+  #   ota:
+  #     cyclone:
+  #       config: cyclonedds_minimal.xml
+
+  # 5. FastDDS for OTA and locally Cyclone
+  # rmw:
+  #   local: cyclone
+  #   ota: fastdds
+
+  # 6. Zenoh-ROS2DDS for OTA and locally cyclone
+  # rmw:
+  #   local: cyclone
+  #   ota: zenoh_ros2dds

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_cyclone-ota/session-definition.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_cyclone-ota/session-definition.yaml
@@ -13,7 +13,9 @@ peers:
 shared:
   use_heartbeat: true
   rmw:
-    local: cyclone
+    local:
+      cyclone:
+        config: cyclonedds_minimal.xml
     ota:
       cyclone:
         config: cyclonedds_minimal.xml
@@ -26,7 +28,9 @@ shared:
 
   # 2. Cyclone with OTA config
   # rmw:
-  #   local: cyclone
+  #   local:
+  #     cyclone:
+  #       config: cyclonedds_minimal.xml
   #   ota:
   #     cyclone:
   #       config: cyclonedds_minimal.xml

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_fastdds-local_cyclone-ota/a/plugin.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_fastdds-local_cyclone-ota/a/plugin.yaml
@@ -1,10 +1,10 @@
 parameters:
-  session_dir: /session/configs/1_heartbeat_fastdds
+  session_dir: /session/configs/1_heartbeat_fastdds-local_cyclone-ota
   peer_dir: ${session_dir}/a
 
-  ip_local: 192.168.178.66
+  ip_local: data:machine_a_ip
   local_name: a
-  ip_remote: 192.168.178.66
+  ip_remote: data:machine_b_ip
   remote_name: b
 
   rmw_local: fastdds
@@ -15,9 +15,11 @@ parameters:
   out: true
   topic_list_paths_outbound: ${session_dir}/a_to_b_topics.txt
 
-  rmw_ota: fastdds
+  rmw_ota: cyclone
   use_zenoh_rmw: false
   use_zenoh_ros2dds: false
+  ota_config_template: cyclonedds_minimal.xml
+  ota_config_file: ${peer_dir}/ota_dds.xml
 
   heartbeat: true
   heartbeat_out_topics: /heartbeat_a

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_fastdds-local_cyclone-ota/a/session_specification.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_fastdds-local_cyclone-ota/a/session_specification.yaml
@@ -1,0 +1,3 @@
+session_plugins:
+  - ./plugin.yaml
+  - /ws/session/content/base/session_plugin_base.yaml

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_fastdds-local_cyclone-ota/a_to_b_topics.txt
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_fastdds-local_cyclone-ota/a_to_b_topics.txt
@@ -1,0 +1,1 @@
+/heartbeat_a

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_fastdds-local_cyclone-ota/b/plugin.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_fastdds-local_cyclone-ota/b/plugin.yaml
@@ -1,5 +1,5 @@
 parameters:
-  session_dir: /session/configs/1_heartbeat_zen-endpoints
+  session_dir: /session/configs/1_heartbeat_fastdds-local_cyclone-ota
   peer_dir: ${session_dir}/b
 
   ip_local: data:machine_b_ip
@@ -7,7 +7,7 @@ parameters:
   ip_remote: data:machine_a_ip
   remote_name: a
 
-  rmw_local: zenoh
+  rmw_local: fastdds
 
   in: true
   topic_list_paths_inbound: ${session_dir}/a_to_b_topics.txt
@@ -15,18 +15,11 @@ parameters:
   out: true
   topic_list_paths_outbound: ${session_dir}/b_to_a_topics.txt
 
-  use_domain_bridge: true
-  local_domain_id: 47
-  ota_domain_id: 48
-  domain_bridge_config_file: ${peer_dir}/domain_bridge.yaml
-
-  zen_main_ip: data:machine_a_ip
-  zen_main_port: 7447
-  zen_connect: true
-
-  rmw_ota: zenoh
-  use_zenoh_rmw: true
+  rmw_ota: cyclone
+  use_zenoh_rmw: false
   use_zenoh_ros2dds: false
+  ota_config_template: cyclonedds_minimal.xml
+  ota_config_file: ${peer_dir}/ota_dds.xml
 
   heartbeat: true
   heartbeat_out_topics: /heartbeat_b

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_fastdds-local_cyclone-ota/b/session_specification.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_fastdds-local_cyclone-ota/b/session_specification.yaml
@@ -1,0 +1,3 @@
+session_plugins:
+  - ./plugin.yaml
+  - /ws/session/content/base/session_plugin_base.yaml

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_fastdds-local_cyclone-ota/b_to_a_topics.txt
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_fastdds-local_cyclone-ota/b_to_a_topics.txt
@@ -1,0 +1,1 @@
+/heartbeat_b

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_fastdds-local_cyclone-ota/session-definition.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_fastdds-local_cyclone-ota/session-definition.yaml
@@ -1,0 +1,14 @@
+peers:
+  a:
+    address: "data:machine_a_ip"
+  b:
+    address: "data:machine_b_ip"
+
+shared:
+  use_heartbeat: true
+  rmw:
+    local: fastdds
+    ota:
+      cyclone:
+        config: cyclonedds_minimal.xml
+  ota_domain_id: 48

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_fastdds-local_cyclone-ota/session-definition.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_fastdds-local_cyclone-ota/session-definition.yaml
@@ -4,6 +4,12 @@ peers:
   b:
     address: "data:machine_b_ip"
 
+peer_settings:
+  a:
+    domain_id: 46
+  b:
+    domain_id: 47
+
 shared:
   use_heartbeat: true
   rmw:

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_fastdds-local_cyclone-ota/session-definition.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_fastdds-local_cyclone-ota/session-definition.yaml
@@ -13,7 +13,9 @@ peer_settings:
 shared:
   use_heartbeat: true
   rmw:
-    local: fastdds
+    local:
+      fastdds:
+        config: fastdds_unicast.xml
     ota:
       cyclone:
         config: cyclonedds_minimal.xml

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_fastdds/a/domain_bridge.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_fastdds/a/domain_bridge.yaml
@@ -1,0 +1,10 @@
+name: a_com_domain_bridge
+topics:
+  /com/in/b/heartbeat_b:
+    from_domain: 48
+    to_domain: 46
+    type: com_msgs/msg/Heartbeat
+  /com/out/a/heartbeat_a:
+    from_domain: 46
+    to_domain: 48
+    type: com_msgs/msg/Heartbeat

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_fastdds/a/ota_dds.xml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_fastdds/a/ota_dds.xml
@@ -1,0 +1,9 @@
+<CycloneDDS>
+    <Domain>
+        <General>
+            <Interfaces>
+                <NetworkInterface address="127.0.0.1"/>
+            </Interfaces>
+        </General>
+    </Domain>
+</CycloneDDS>

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_fastdds/a/plugin.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_fastdds/a/plugin.yaml
@@ -8,6 +8,8 @@ parameters:
   remote_name: b
 
   rmw_local: fastdds
+  local_config_template: fastdds_unicast.xml
+  local_config_file: ${peer_dir}/local_dds.xml
 
   in: true
   topic_list_paths_inbound: ${session_dir}/b_to_a_topics.txt
@@ -15,9 +17,16 @@ parameters:
   out: true
   topic_list_paths_outbound: ${session_dir}/a_to_b_topics.txt
 
+  use_domain_bridge: true
+  local_domain_id: 46
+  ota_domain_id: 48
+  domain_bridge_config_file: ${peer_dir}/domain_bridge.yaml
+
   rmw_ota: fastdds
   use_zenoh_rmw: false
   use_zenoh_ros2dds: false
+  ota_config_template: fastdds_unicast.xml
+  ota_config_file: ${peer_dir}/ota_dds.xml
 
   heartbeat: true
   heartbeat_out_topics: /heartbeat_a

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_fastdds/a/plugin.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_fastdds/a/plugin.yaml
@@ -2,9 +2,9 @@ parameters:
   session_dir: /session/configs/1_heartbeat_fastdds
   peer_dir: ${session_dir}/a
 
-  ip_local: 192.168.178.66
+  ip_local: data:machine_a_ip
   local_name: a
-  ip_remote: 192.168.178.66
+  ip_remote: data:machine_b_ip
   remote_name: b
 
   rmw_local: fastdds

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_fastdds/a/plugin.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_fastdds/a/plugin.yaml
@@ -1,0 +1,24 @@
+parameters:
+  session_dir: /session/configs/1_heartbeat_fastdds
+  peer_dir: ${session_dir}/a
+
+  ip_local: data:machine_a_ip
+  local_name: a
+  ip_remote: data:machine_b_ip
+  remote_name: b
+
+  rmw_local: fastdds
+
+  in: true
+  topic_list_paths_inbound: ${session_dir}/b_to_a_topics.txt
+
+  out: true
+  topic_list_paths_outbound: ${session_dir}/a_to_b_topics.txt
+
+  rmw_ota: fastdds
+  use_zenoh_rmw: false
+  use_zenoh_ros2dds: false
+
+  heartbeat: true
+  heartbeat_out_topics: /heartbeat_a
+  heartbeat_in_topic: /heartbeat_b

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_fastdds/a/session_specification.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_fastdds/a/session_specification.yaml
@@ -1,0 +1,3 @@
+session_plugins:
+  - ./plugin.yaml
+  - /ws/session/content/base/session_plugin_base.yaml

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_fastdds/a_to_b_topics.txt
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_fastdds/a_to_b_topics.txt
@@ -1,0 +1,1 @@
+/heartbeat_a

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_fastdds/b/domain_bridge.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_fastdds/b/domain_bridge.yaml
@@ -1,0 +1,10 @@
+name: b_com_domain_bridge
+topics:
+  /com/in/a/heartbeat_a:
+    from_domain: 48
+    to_domain: 47
+    type: com_msgs/msg/Heartbeat
+  /com/out/b/heartbeat_b:
+    from_domain: 47
+    to_domain: 48
+    type: com_msgs/msg/Heartbeat

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_fastdds/b/ota_dds.xml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_fastdds/b/ota_dds.xml
@@ -1,0 +1,9 @@
+<CycloneDDS>
+    <Domain>
+        <General>
+            <Interfaces>
+                <NetworkInterface address="127.0.0.1"/>
+            </Interfaces>
+        </General>
+    </Domain>
+</CycloneDDS>

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_fastdds/b/ota_dds.xml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_fastdds/b/ota_dds.xml
@@ -1,9 +1,71 @@
-<CycloneDDS>
-    <Domain>
-        <General>
-            <Interfaces>
-                <NetworkInterface address="127.0.0.1"/>
-            </Interfaces>
-        </General>
-    </Domain>
-</CycloneDDS>
+<?xml version="1.0" encoding="UTF-8"?>
+<dds xmlns="http://www.eprosima.com/XMLSchemas/fastRTPS_Profiles">
+  <profiles>
+    <transport_descriptors>
+      <transport_descriptor>
+        <transport_id>rosotacom_udp</transport_id>
+        <type>UDPv4</type>
+      </transport_descriptor>
+    </transport_descriptors>
+
+    <participant profile_name="rosotacom_fastdds_unicast" is_default_profile="true">
+      <rtps>
+        <defaultUnicastLocatorList>
+          <locator>
+            <udpv4>
+              <address>127.0.0.2</address>
+              <port>0</port>
+            </udpv4>
+          </locator>
+        </defaultUnicastLocatorList>
+
+        <builtin>
+          <metatrafficUnicastLocatorList>
+            <locator>
+              <udpv4>
+                <address>127.0.0.2</address>
+                <port>0</port>
+              </udpv4>
+            </locator>
+          </metatrafficUnicastLocatorList>
+
+          <initialPeersList>
+            <locator>
+              <udpv4>
+                <address>127.0.0.2</address>
+                <port>0</port>
+              </udpv4>
+            </locator>
+            <locator>
+              <udpv4>
+                <address>127.0.0.1</address>
+                <port>0</port>
+              </udpv4>
+            </locator>
+          </initialPeersList>
+        </builtin>
+
+        <userTransports>
+          <transport_id>rosotacom_udp</transport_id>
+        </userTransports>
+        <useBuiltinTransports>false</useBuiltinTransports>
+      </rtps>
+    </participant>
+
+    <data_writer profile_name="rosotacom_fastdds_writer" is_default_profile="true">
+      <qos>
+        <data_sharing>
+          <kind>OFF</kind>
+        </data_sharing>
+      </qos>
+    </data_writer>
+
+    <data_reader profile_name="rosotacom_fastdds_reader" is_default_profile="true">
+      <qos>
+        <data_sharing>
+          <kind>OFF</kind>
+        </data_sharing>
+      </qos>
+    </data_reader>
+  </profiles>
+</dds>

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_fastdds/b/plugin.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_fastdds/b/plugin.yaml
@@ -1,0 +1,24 @@
+parameters:
+  session_dir: /session/configs/1_heartbeat_fastdds
+  peer_dir: ${session_dir}/b
+
+  ip_local: data:machine_b_ip
+  local_name: b
+  ip_remote: data:machine_a_ip
+  remote_name: a
+
+  rmw_local: fastdds
+
+  in: true
+  topic_list_paths_inbound: ${session_dir}/a_to_b_topics.txt
+
+  out: true
+  topic_list_paths_outbound: ${session_dir}/b_to_a_topics.txt
+
+  rmw_ota: fastdds
+  use_zenoh_rmw: false
+  use_zenoh_ros2dds: false
+
+  heartbeat: true
+  heartbeat_out_topics: /heartbeat_b
+  heartbeat_in_topic: /heartbeat_a

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_fastdds/b/plugin.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_fastdds/b/plugin.yaml
@@ -2,9 +2,9 @@ parameters:
   session_dir: /session/configs/1_heartbeat_fastdds
   peer_dir: ${session_dir}/b
 
-  ip_local: 192.168.178.66
+  ip_local: data:machine_b_ip
   local_name: b
-  ip_remote: 192.168.178.66
+  ip_remote: data:machine_a_ip
   remote_name: a
 
   rmw_local: fastdds

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_fastdds/b/plugin.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_fastdds/b/plugin.yaml
@@ -2,9 +2,9 @@ parameters:
   session_dir: /session/configs/1_heartbeat_fastdds
   peer_dir: ${session_dir}/b
 
-  ip_local: data:machine_b_ip
+  ip_local: 192.168.178.66
   local_name: b
-  ip_remote: data:machine_a_ip
+  ip_remote: 192.168.178.66
   remote_name: a
 
   rmw_local: fastdds

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_fastdds/b/plugin.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_fastdds/b/plugin.yaml
@@ -8,6 +8,8 @@ parameters:
   remote_name: a
 
   rmw_local: fastdds
+  local_config_template: fastdds_unicast.xml
+  local_config_file: ${peer_dir}/local_dds.xml
 
   in: true
   topic_list_paths_inbound: ${session_dir}/a_to_b_topics.txt
@@ -15,9 +17,16 @@ parameters:
   out: true
   topic_list_paths_outbound: ${session_dir}/b_to_a_topics.txt
 
+  use_domain_bridge: true
+  local_domain_id: 47
+  ota_domain_id: 48
+  domain_bridge_config_file: ${peer_dir}/domain_bridge.yaml
+
   rmw_ota: fastdds
   use_zenoh_rmw: false
   use_zenoh_ros2dds: false
+  ota_config_template: fastdds_unicast.xml
+  ota_config_file: ${peer_dir}/ota_dds.xml
 
   heartbeat: true
   heartbeat_out_topics: /heartbeat_b

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_fastdds/b/session_specification.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_fastdds/b/session_specification.yaml
@@ -1,0 +1,3 @@
+session_plugins:
+  - ./plugin.yaml
+  - /ws/session/content/base/session_plugin_base.yaml

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_fastdds/b_to_a_topics.txt
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_fastdds/b_to_a_topics.txt
@@ -1,0 +1,1 @@
+/heartbeat_b

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_fastdds/session-definition.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_fastdds/session-definition.yaml
@@ -13,7 +13,7 @@ peers:
 shared:
   use_heartbeat: true
   rmw: fastdds
-  # ota_domain_id: 48
+  ota_domain_id: 48
 
   # Tested Working RMW-Config Combinations:
 

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_fastdds/session-definition.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_fastdds/session-definition.yaml
@@ -14,37 +14,3 @@ shared:
   use_heartbeat: true
   rmw: fastdds
   ota_domain_id: 48
-
-  # Tested Working RMW-Config Combinations:
-
-  # 1. FastDDS
-  # rmw: fastdds
-
-  # 2. Cyclone with OTA config
-  # rmw:
-  #   local: cyclone
-  #   ota:
-  #     cyclone:
-  #       config: cyclonedds_minimal.xml
-
-  # 3. Zenoh with connected endpoints
-  # rmw:
-  #   local: zenoh
-  #   ota: zenoh_connect_endpoints
-
-  # 4. Cyclone with OTA config and locally FastDDS
-  # rmw:
-  #   local: fastdds
-  #   ota:
-  #     cyclone:
-  #       config: cyclonedds_minimal.xml
-
-  # 5. FastDDS for OTA and locally Cyclone
-  # rmw:
-  #   local: cyclone
-  #   ota: fastdds
-
-  # 6. Zenoh-ROS2DDS for OTA and locally cyclone
-  # rmw:
-  #   local: cyclone
-  #   ota: zenoh_ros2dds

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_fastdds/session-definition.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_fastdds/session-definition.yaml
@@ -12,5 +12,11 @@ peer_settings:
 
 shared:
   use_heartbeat: true
-  rmw: fastdds
+  rmw:
+    local:
+      fastdds:
+        config: fastdds_unicast.xml
+    ota:
+      fastdds:
+        config: fastdds_unicast.xml
   ota_domain_id: 48

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_fastdds/session-definition.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_fastdds/session-definition.yaml
@@ -4,11 +4,11 @@ peers:
   b:
     address: "data:machine_b_ip"
 
-# peer_settings:
-#   a:
-#     domain_id: 46
-#   b:
-#     domain_id: 47
+peer_settings:
+  a:
+    domain_id: 46
+  b:
+    domain_id: 47
 
 shared:
   use_heartbeat: true

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_status/a/domain_bridge.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_status/a/domain_bridge.yaml
@@ -1,0 +1,10 @@
+name: a_com_domain_bridge
+topics:
+  /com/in/b/heartbeat_b:
+    from_domain: 48
+    to_domain: 46
+    type: com_msgs/msg/Heartbeat
+  /com/out/a/heartbeat_a:
+    from_domain: 46
+    to_domain: 48
+    type: com_msgs/msg/Heartbeat

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_status/a/pipeline_spec.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_status/a/pipeline_spec.yaml
@@ -1,0 +1,45 @@
+local_domain_id: 46
+ota_domain_id: 48
+peer: a
+remote: b
+schema_version: 1
+topics:
+- base: /heartbeat_a
+  direction: outbound
+  expected_hz: null
+  source: a
+  stages:
+  - domain: local
+    produced_by: application
+    stage: native
+    topic: /heartbeat_a
+  - domain: local
+    produced_by: relay_out
+    stage: com_out
+    topic: /com/out/a/heartbeat_a
+  - domain: ota
+    produced_by: bridge_out
+    stage: ota_sent
+    topic: /ota/a/heartbeat_a
+  target: b
+  type: com_msgs/msg/Heartbeat
+- base: /heartbeat_b
+  direction: inbound
+  expected_hz: null
+  source: b
+  stages:
+  - domain: ota
+    produced_by: transport
+    stage: ota_recv
+    topic: /ota/b/heartbeat_b
+  - domain: local
+    produced_by: bridge_in
+    stage: com_in
+    topic: /com/in/b/heartbeat_b
+  - domain: local
+    produced_by: relay_in
+    stage: app_in
+    topic: /heartbeat_b
+  target: a
+  type: com_msgs/msg/Heartbeat
+uses_domain_bridge: true

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_status/a/plugin.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_status/a/plugin.yaml
@@ -1,0 +1,36 @@
+parameters:
+  session_dir: /session/configs/1_heartbeat_status
+  peer_dir: ${session_dir}/a
+
+  ip_local: data:machine_a_ip
+  local_name: a
+  ip_remote: data:machine_b_ip
+  remote_name: b
+
+  rmw_local: cyclone
+  local_config_template: cyclonedds_minimal.xml
+  local_config_file: ${peer_dir}/local_dds.xml
+
+  in: true
+  topic_list_paths_inbound: ${session_dir}/b_to_a_topics.txt
+
+  out: true
+  topic_list_paths_outbound: ${session_dir}/a_to_b_topics.txt
+
+  use_domain_bridge: true
+  local_domain_id: 46
+  ota_domain_id: 48
+  domain_bridge_config_file: ${peer_dir}/domain_bridge.yaml
+
+  rmw_ota: cyclone
+  use_zenoh_rmw: false
+  use_zenoh_ros2dds: false
+  ota_config_template: cyclonedds_minimal.xml
+  ota_config_file: ${peer_dir}/ota_dds.xml
+
+  status_overview: true
+  status_spec_file: ${peer_dir}/pipeline_spec.yaml
+
+  heartbeat: true
+  heartbeat_out_topics: /heartbeat_a
+  heartbeat_in_topic: /heartbeat_b

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_status/a/session_specification.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_status/a/session_specification.yaml
@@ -1,0 +1,3 @@
+session_plugins:
+  - ./plugin.yaml
+  - /ws/session/content/base/session_plugin_base.yaml

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_status/a_to_b_topics.txt
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_status/a_to_b_topics.txt
@@ -1,0 +1,1 @@
+/heartbeat_a

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_status/b/domain_bridge.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_status/b/domain_bridge.yaml
@@ -1,0 +1,10 @@
+name: b_com_domain_bridge
+topics:
+  /com/in/a/heartbeat_a:
+    from_domain: 48
+    to_domain: 47
+    type: com_msgs/msg/Heartbeat
+  /com/out/b/heartbeat_b:
+    from_domain: 47
+    to_domain: 48
+    type: com_msgs/msg/Heartbeat

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_status/b/pipeline_spec.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_status/b/pipeline_spec.yaml
@@ -1,0 +1,45 @@
+local_domain_id: 47
+ota_domain_id: 48
+peer: b
+remote: a
+schema_version: 1
+topics:
+- base: /heartbeat_b
+  direction: outbound
+  expected_hz: null
+  source: b
+  stages:
+  - domain: local
+    produced_by: application
+    stage: native
+    topic: /heartbeat_b
+  - domain: local
+    produced_by: relay_out
+    stage: com_out
+    topic: /com/out/b/heartbeat_b
+  - domain: ota
+    produced_by: bridge_out
+    stage: ota_sent
+    topic: /ota/b/heartbeat_b
+  target: a
+  type: com_msgs/msg/Heartbeat
+- base: /heartbeat_a
+  direction: inbound
+  expected_hz: null
+  source: a
+  stages:
+  - domain: ota
+    produced_by: transport
+    stage: ota_recv
+    topic: /ota/a/heartbeat_a
+  - domain: local
+    produced_by: bridge_in
+    stage: com_in
+    topic: /com/in/a/heartbeat_a
+  - domain: local
+    produced_by: relay_in
+    stage: app_in
+    topic: /heartbeat_a
+  target: b
+  type: com_msgs/msg/Heartbeat
+uses_domain_bridge: true

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_status/b/plugin.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_status/b/plugin.yaml
@@ -1,0 +1,36 @@
+parameters:
+  session_dir: /session/configs/1_heartbeat_status
+  peer_dir: ${session_dir}/b
+
+  ip_local: data:machine_b_ip
+  local_name: b
+  ip_remote: data:machine_a_ip
+  remote_name: a
+
+  rmw_local: cyclone
+  local_config_template: cyclonedds_minimal.xml
+  local_config_file: ${peer_dir}/local_dds.xml
+
+  in: true
+  topic_list_paths_inbound: ${session_dir}/a_to_b_topics.txt
+
+  out: true
+  topic_list_paths_outbound: ${session_dir}/b_to_a_topics.txt
+
+  use_domain_bridge: true
+  local_domain_id: 47
+  ota_domain_id: 48
+  domain_bridge_config_file: ${peer_dir}/domain_bridge.yaml
+
+  rmw_ota: cyclone
+  use_zenoh_rmw: false
+  use_zenoh_ros2dds: false
+  ota_config_template: cyclonedds_minimal.xml
+  ota_config_file: ${peer_dir}/ota_dds.xml
+
+  status_overview: true
+  status_spec_file: ${peer_dir}/pipeline_spec.yaml
+
+  heartbeat: true
+  heartbeat_out_topics: /heartbeat_b
+  heartbeat_in_topic: /heartbeat_a

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_status/b/session_specification.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_status/b/session_specification.yaml
@@ -1,0 +1,3 @@
+session_plugins:
+  - ./plugin.yaml
+  - /ws/session/content/base/session_plugin_base.yaml

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_status/b_to_a_topics.txt
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_status/b_to_a_topics.txt
@@ -1,0 +1,1 @@
+/heartbeat_b

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_status/session-definition.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_status/session-definition.yaml
@@ -1,0 +1,30 @@
+peers:
+  a:
+    address: "data:machine_a_ip"
+  b:
+    address: "data:machine_b_ip"
+
+peer_settings:
+  a:
+    domain_id: 46
+    # inbound:
+    #   keep_source_prefix: true
+  b:
+    domain_id: 47
+    # inbound:
+    #   keep_source_prefix: true
+
+shared:
+  use_heartbeat: true
+  # Maintain a continuously-updated per-topic pipeline status overview
+  # (status.json / status.txt / events.jsonl under logs/<peer>/status/).
+  # Inspect it from the host with: rosotacom status 1_heartbeat_status
+  use_status_overview: true
+  rmw:
+    local:
+      cyclone:
+        config: cyclonedds_minimal.xml
+    ota:
+      cyclone:
+        config: cyclonedds_minimal.xml
+  ota_domain_id: 48

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_zen-endpoints/a/domain_bridge.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_zen-endpoints/a/domain_bridge.yaml
@@ -1,0 +1,10 @@
+name: a_com_domain_bridge
+topics:
+  /com/in/b/heartbeat_b:
+    from_domain: 48
+    to_domain: 46
+    type: com_msgs/msg/Heartbeat
+  /com/out/a/heartbeat_a:
+    from_domain: 46
+    to_domain: 48
+    type: com_msgs/msg/Heartbeat

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_zen-endpoints/a/ota_dds.xml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_zen-endpoints/a/ota_dds.xml
@@ -1,0 +1,9 @@
+<CycloneDDS>
+    <Domain>
+        <General>
+            <Interfaces>
+                <NetworkInterface address="127.0.0.1"/>
+            </Interfaces>
+        </General>
+    </Domain>
+</CycloneDDS>

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_zen-endpoints/a/plugin.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_zen-endpoints/a/plugin.yaml
@@ -1,0 +1,26 @@
+parameters:
+  session_dir: /session/configs/1_heartbeat
+  peer_dir: ${session_dir}/a
+
+  ip_local: data:machine_a_ip
+  local_name: a
+  ip_remote: data:machine_b_ip
+  remote_name: b
+
+  rmw_local: cyclone
+
+  in: true
+  topic_list_paths_inbound: ${session_dir}/b_to_a_topics.txt
+
+  out: true
+  topic_list_paths_outbound: ${session_dir}/a_to_b_topics.txt
+
+  rmw_ota: cyclone
+  use_zenoh_rmw: false
+  use_zenoh_ros2dds: false
+  ota_config_template: cyclonedds_minimal.xml
+  ota_config_file: ${peer_dir}/ota_dds.xml
+
+  heartbeat: true
+  heartbeat_out_topics: /heartbeat_a
+  heartbeat_in_topic: /heartbeat_b

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_zen-endpoints/a/session_specification.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_zen-endpoints/a/session_specification.yaml
@@ -1,0 +1,3 @@
+session_plugins:
+  - ./plugin.yaml
+  - /ws/session/content/base/session_plugin_base.yaml

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_zen-endpoints/a_to_b_topics.txt
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_zen-endpoints/a_to_b_topics.txt
@@ -1,0 +1,1 @@
+/heartbeat_a

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_zen-endpoints/b/domain_bridge.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_zen-endpoints/b/domain_bridge.yaml
@@ -1,0 +1,10 @@
+name: b_com_domain_bridge
+topics:
+  /com/in/a/heartbeat_a:
+    from_domain: 48
+    to_domain: 47
+    type: com_msgs/msg/Heartbeat
+  /com/out/b/heartbeat_b:
+    from_domain: 47
+    to_domain: 48
+    type: com_msgs/msg/Heartbeat

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_zen-endpoints/b/ota_dds.xml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_zen-endpoints/b/ota_dds.xml
@@ -1,0 +1,9 @@
+<CycloneDDS>
+    <Domain>
+        <General>
+            <Interfaces>
+                <NetworkInterface address="127.0.0.1"/>
+            </Interfaces>
+        </General>
+    </Domain>
+</CycloneDDS>

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_zen-endpoints/b/plugin.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_zen-endpoints/b/plugin.yaml
@@ -1,0 +1,26 @@
+parameters:
+  session_dir: /session/configs/1_heartbeat
+  peer_dir: ${session_dir}/b
+
+  ip_local: data:machine_b_ip
+  local_name: b
+  ip_remote: data:machine_a_ip
+  remote_name: a
+
+  rmw_local: cyclone
+
+  in: true
+  topic_list_paths_inbound: ${session_dir}/a_to_b_topics.txt
+
+  out: true
+  topic_list_paths_outbound: ${session_dir}/b_to_a_topics.txt
+
+  rmw_ota: cyclone
+  use_zenoh_rmw: false
+  use_zenoh_ros2dds: false
+  ota_config_template: cyclonedds_minimal.xml
+  ota_config_file: ${peer_dir}/ota_dds.xml
+
+  heartbeat: true
+  heartbeat_out_topics: /heartbeat_b
+  heartbeat_in_topic: /heartbeat_a

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_zen-endpoints/b/session_specification.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_zen-endpoints/b/session_specification.yaml
@@ -1,0 +1,3 @@
+session_plugins:
+  - ./plugin.yaml
+  - /ws/session/content/base/session_plugin_base.yaml

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_zen-endpoints/b_to_a_topics.txt
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_zen-endpoints/b_to_a_topics.txt
@@ -1,0 +1,1 @@
+/heartbeat_b

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_zen-endpoints/session-definition.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_zen-endpoints/session-definition.yaml
@@ -7,8 +7,12 @@ peers:
 peer_settings:
   a:
     domain_id: 46
+    # inbound:
+    #   keep_source_prefix: true
   b:
     domain_id: 47
+    # inbound:
+    #   keep_source_prefix: true
 
 shared:
   use_heartbeat: true

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_zen-endpoints/session-definition.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_zen-endpoints/session-definition.yaml
@@ -1,0 +1,52 @@
+peers:
+  a:
+    address: "data:machine_a_ip"
+  b:
+    address: "data:machine_b_ip"
+
+# peer_settings:
+#   a:
+#     domain_id: 46
+#   b:
+#     domain_id: 47
+
+shared:
+  use_heartbeat: true
+  rmw:
+    local: zenoh
+    ota: zenoh_connect_endpoints
+  ota_domain_id: 48
+
+  # Tested Working RMW-Config Combinations:
+
+  # 1. FastDDS
+  # rmw: fastdds
+
+  # 2. Cyclone with OTA config
+  # rmw:
+  #   local: cyclone
+  #   ota:
+  #     cyclone:
+  #       config: cyclonedds_minimal.xml
+
+  # 3. Zenoh with connected endpoints
+  # rmw:
+  #   local: zenoh
+  #   ota: zenoh_connect_endpoints
+
+  # 4. Cyclone with OTA config and locally FastDDS
+  # rmw:
+  #   local: fastdds
+  #   ota:
+  #     cyclone:
+  #       config: cyclonedds_minimal.xml
+
+  # 5. FastDDS for OTA and locally Cyclone
+  # rmw:
+  #   local: cyclone
+  #   ota: fastdds
+
+  # 6. Zenoh-ROS2DDS for OTA and locally cyclone
+  # rmw:
+  #   local: cyclone
+  #   ota: zenoh_ros2dds

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_zen-endpoints/session-definition.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_zen-endpoints/session-definition.yaml
@@ -17,36 +17,6 @@ shared:
     ota: zenoh_connect_endpoints
   ota_domain_id: 48
 
-  # Tested Working RMW-Config Combinations:
-
-  # 1. FastDDS
-  # rmw: fastdds
-
-  # 2. Cyclone with OTA config
-  # rmw:
-  #   local: cyclone
-  #   ota:
-  #     cyclone:
-  #       config: cyclonedds_minimal.xml
-
-  # 3. Zenoh with connected endpoints
-  # rmw:
-  #   local: zenoh
-  #   ota: zenoh_connect_endpoints
-
-  # 4. Cyclone with OTA config and locally FastDDS
-  # rmw:
-  #   local: fastdds
-  #   ota:
-  #     cyclone:
-  #       config: cyclonedds_minimal.xml
-
-  # 5. FastDDS for OTA and locally Cyclone
-  # rmw:
-  #   local: cyclone
-  #   ota: fastdds
-
-  # 6. Zenoh-ROS2DDS for OTA and locally cyclone
-  # rmw:
-  #   local: cyclone
-  #   ota: zenoh_ros2dds
+# problems
+# - why here local ips?
+# - one zenoh dies

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_zen-endpoints/session-definition.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_zen-endpoints/session-definition.yaml
@@ -4,11 +4,11 @@ peers:
   b:
     address: "data:machine_b_ip"
 
-# peer_settings:
-#   a:
-#     domain_id: 46
-#   b:
-#     domain_id: 47
+peer_settings:
+  a:
+    domain_id: 46
+  b:
+    domain_id: 47
 
 shared:
   use_heartbeat: true

--- a/src/rosotacom/resources/ros2docker.json.example
+++ b/src/rosotacom/resources/ros2docker.json.example
@@ -20,7 +20,7 @@
 
   // Build-time arguments — defaults shown; override if necessary
   "build_args": {
-    "APT_PACKAGES":                  "iputils-ping psmisc net-tools snmp iw nload iftop iproute2 tshark",
+    "APT_PACKAGES":                  "iputils-ping psmisc net-tools snmp iw nload iftop iproute2 tshark ros-kilted-domain-bridge",
     "PIP_PACKAGES":                  "numpy>=1.26,<2 lz4 pysnmp speedtest-cli psutil zstandard opencv-python"
   }
 }

--- a/src/rosotacom/resources/ws/ota_configs/fastdds_unicast.xml.template
+++ b/src/rosotacom/resources/ws/ota_configs/fastdds_unicast.xml.template
@@ -13,7 +13,7 @@
         <defaultUnicastLocatorList>
           <locator>
             <udpv4>
-              <address>127.0.0.1</address>
+              <address>#host_ip</address>
               <port>0</port>
             </udpv4>
           </locator>
@@ -23,7 +23,7 @@
           <metatrafficUnicastLocatorList>
             <locator>
               <udpv4>
-                <address>127.0.0.1</address>
+                <address>#host_ip</address>
                 <port>0</port>
               </udpv4>
             </locator>
@@ -32,16 +32,16 @@
           <initialPeersList>
             <locator>
               <udpv4>
-                <address>127.0.0.1</address>
+                <address>#host_ip</address>
                 <port>0</port>
               </udpv4>
             </locator>
-            <locator>
+            <!--peer-block--><locator>
               <udpv4>
-                <address>127.0.0.2</address>
+                <address>#peer</address>
                 <port>0</port>
               </udpv4>
-            </locator>
+            </locator><!--/peer-block-->
           </initialPeersList>
         </builtin>
 

--- a/src/rosotacom/resources/ws/ros2src/com_py/com_py/status_overview.py
+++ b/src/rosotacom/resources/ws/ros2src/com_py/com_py/status_overview.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+
+# -- BEGIN LICENSE BLOCK ----------------------------------------------
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the {copyright_holder} nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+# -- END LICENSE BLOCK ------------------------------------------------
+#
+# ---------------------------------------------------------------------
+# !\file
+#
+# \brief  rosotacom status / debugging overview node.
+#
+# Tracks, for every configured topic, the furthest pipeline stage it has
+# reached and the first stage that is missing/broken, plus live metrics
+# (last-message age, Hz, mean size, latency). Writes a machine-readable
+# status.json (source of truth), a rendered status.txt, and an append-only
+# events.jsonl (one line per state transition).
+#
+# Phase 1 observes only what the local peer's ROS graph exposes:
+#   * outbound topics up to the /ota topic this peer publishes ("sent")
+#   * inbound topics from the received /ota topic through the republished
+#     application topic.
+# End-to-end remote confirmation is reserved for a later phase; remote-side
+# fields are reported as "unknown".
+#
+# The pure classification/rollup/rendering logic lives in
+# status_overview_core (ROS-independent, unit-tested on the host); this file
+# wires it to live ROS graph observers (one per ROS domain).
+# ---------------------------------------------------------------------
+
+from __future__ import annotations
+
+import os
+import threading
+from typing import Dict, Optional
+
+import yaml
+
+import rclpy
+from rclpy.context import Context
+from rclpy.executors import MultiThreadedExecutor
+from rclpy.node import Node
+from rclpy.qos import HistoryPolicy, QoSProfile, ReliabilityPolicy
+from rclpy.serialization import serialize_message
+from rosidl_runtime_py.utilities import get_message
+
+from com_py.status_overview_core import (
+    StageObservation,
+    StatusAggregator,
+    collect_stage_topics,
+)
+
+
+class StageObserver(Node):
+    """
+    Observes a set of stage topics within a single ROS domain context.
+
+    Performs periodic graph introspection (publisher/subscriber counts) and
+    dynamically subscribes to topics that have a publisher, measuring size and
+    header-based latency per message.
+    """
+
+    def __init__(self, node_name: str, context: Optional[Context],
+                 topics: Dict[str, Optional[str]], refresh_interval_s: float):
+        super().__init__(node_name, context=context)
+        self.observations: Dict[str, StageObservation] = {
+            t: StageObservation(type_str=hint) for t, hint in topics.items()
+        }
+        self._refresh_interval_s = refresh_interval_s
+        self.create_timer(self._refresh_interval_s, self._refresh)
+        self._refresh()
+
+    def _refresh(self) -> None:
+        try:
+            graph = {name: types for name, types in self.get_topic_names_and_types()}
+        except Exception:  # pragma: no cover - defensive
+            graph = {}
+
+        for topic, obs in self.observations.items():
+            try:
+                obs.pub_count = self.count_publishers(topic)
+                obs.sub_count = self.count_subscribers(topic)
+            except Exception:  # pragma: no cover - defensive
+                pass
+
+            if obs.subscribed:
+                continue
+            type_str = obs.type_str
+            if not type_str:
+                graph_types = graph.get(topic)
+                type_str = graph_types[0] if graph_types else None
+            if not type_str or obs.pub_count == 0:
+                continue
+            try:
+                msg_class = get_message(type_str)
+            except Exception:
+                msg_class = None
+            if msg_class is None:
+                continue
+            qos = QoSProfile(
+                reliability=ReliabilityPolicy.BEST_EFFORT,
+                history=HistoryPolicy.KEEP_LAST,
+                depth=10,
+            )
+            try:
+                self.create_subscription(msg_class, topic, self._make_cb(topic), qos)
+                obs.subscribed = True
+                obs.type_str = type_str
+            except Exception:  # pragma: no cover - defensive
+                continue
+
+    def _make_cb(self, topic: str):
+        def cb(msg):
+            try:
+                size = len(serialize_message(msg))
+            except Exception:
+                size = 0
+            delay_s: Optional[float] = None
+            header = getattr(msg, "header", None)
+            stamp = getattr(header, "stamp", None) if header is not None else None
+            if stamp is not None:
+                try:
+                    now = self.get_clock().now()
+                    msg_time = rclpy.time.Time.from_msg(stamp)
+                    d = (now - msg_time).nanoseconds / 1e9
+                    if -1.0 < d < 1000.0:  # guard unsynced clocks / zero stamps
+                        delay_s = d
+                except Exception:
+                    delay_s = None
+            self.observations[topic].record(size, delay_s)
+
+        return cb
+
+
+class StatusOverview(Node):
+    """Coordinator node: owns the local-domain observer, the aggregator timer,
+    and (when domains are split) a second observer running in the OTA context."""
+
+    def __init__(self) -> None:
+        super().__init__("status_overview")
+
+        self.declare_parameter("status_spec_file", "")
+        self.declare_parameter("output_dir", "")
+        self.declare_parameter("write_interval_s", 2.0)
+        self.declare_parameter("liveness_window_s", 3.0)
+        self.declare_parameter("stale_after_s", 3.0)
+        self.declare_parameter("refresh_interval_s", 5.0)
+        self.declare_parameter("delay_good_ms", 100.0)
+        self.declare_parameter("delay_bad_ms", 200.0)
+
+        spec_file = str(self.get_parameter("status_spec_file").value or "").strip()
+        output_dir = str(self.get_parameter("output_dir").value or "").strip()
+        if not spec_file:
+            raise ValueError("Parameter 'status_spec_file' is required")
+        if not output_dir:
+            output_dir = os.path.join(os.path.dirname(spec_file), "status")
+
+        with open(spec_file, "r", encoding="utf-8") as fp:
+            self.spec = yaml.safe_load(fp) or {}
+
+        self.write_interval_s = float(self.get_parameter("write_interval_s").value)
+        self.refresh_interval_s = float(self.get_parameter("refresh_interval_s").value)
+
+        local_domain_id = self.spec.get("local_domain_id")
+        ota_domain_id = self.spec.get("ota_domain_id")
+        need_ota_ctx = ota_domain_id is not None and ota_domain_id != local_domain_id
+
+        by_domain = collect_stage_topics(self.spec)
+
+        self._ota_context: Optional[Context] = None
+        self._ota_executor: Optional[MultiThreadedExecutor] = None
+        self._ota_thread: Optional[threading.Thread] = None
+        observers: Dict[str, StageObserver] = {}
+
+        # Local-domain observer shares this node's (default) context. When
+        # domains are not split, all stages are observed here.
+        local_topics = dict(by_domain.get("local", {}))
+        if not need_ota_ctx:
+            local_topics.update(by_domain.get("ota", {}))
+        self._local_observer = StageObserver(
+            "status_overview_local_obs", None, local_topics, self.refresh_interval_s
+        )
+        observers["local"] = self._local_observer
+
+        if need_ota_ctx:
+            self._ota_context = Context()
+            rclpy.init(context=self._ota_context, domain_id=int(ota_domain_id))
+            self._ota_observer = StageObserver(
+                "status_overview_ota_obs",
+                self._ota_context,
+                dict(by_domain.get("ota", {})),
+                self.refresh_interval_s,
+            )
+            observers["ota"] = self._ota_observer
+            self._ota_executor = MultiThreadedExecutor(num_threads=2, context=self._ota_context)
+            self._ota_executor.add_node(self._ota_observer)
+            self._ota_thread = threading.Thread(target=self._ota_executor.spin, daemon=True)
+            self._ota_thread.start()
+            self.get_logger().info(
+                f"status_overview: OTA observer running in domain {ota_domain_id}"
+            )
+
+        self.aggregator = StatusAggregator(
+            self.get_logger(),
+            self.spec,
+            output_dir,
+            observers,
+            liveness_window_s=float(self.get_parameter("liveness_window_s").value),
+            stale_after_s=float(self.get_parameter("stale_after_s").value),
+            delay_good_ms=float(self.get_parameter("delay_good_ms").value),
+            delay_bad_ms=float(self.get_parameter("delay_bad_ms").value),
+        )
+
+        self.create_timer(self.write_interval_s, self._on_write)
+        self.get_logger().info(
+            f"status_overview started: peer={self.spec.get('peer')} "
+            f"topics={len(self.spec.get('topics', []))} output={output_dir}"
+        )
+
+    def add_local_nodes(self, executor: MultiThreadedExecutor) -> None:
+        executor.add_node(self)
+        executor.add_node(self._local_observer)
+
+    def _on_write(self) -> None:
+        self.aggregator.write()
+
+    def shutdown(self) -> None:
+        if self._ota_executor is not None:
+            try:
+                self._ota_executor.shutdown()
+            except Exception:
+                pass
+        if self._ota_context is not None:
+            try:
+                self._ota_context.try_shutdown()
+            except Exception:
+                pass
+
+
+def main(args=None) -> None:
+    rclpy.init(args=args)
+    node = StatusOverview()
+    executor = MultiThreadedExecutor(num_threads=4)
+    node.add_local_nodes(executor)
+    try:
+        executor.spin()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.shutdown()
+        executor.shutdown()
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/rosotacom/resources/ws/ros2src/com_py/com_py/status_overview_core.py
+++ b/src/rosotacom/resources/ws/ros2src/com_py/com_py/status_overview_core.py
@@ -1,0 +1,452 @@
+#!/usr/bin/env python3
+
+# -- BEGIN LICENSE BLOCK ----------------------------------------------
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the {copyright_holder} nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+# -- END LICENSE BLOCK ------------------------------------------------
+#
+# ---------------------------------------------------------------------
+# !\file
+#
+# \brief  Pure (ROS-independent) logic for the rosotacom status overview.
+#
+# This module holds the per-stage observation accumulator, the stage/topic
+# classification, the rollup ("where is the topic now?") and the artifact
+# rendering. It deliberately has no rclpy dependency so it can be unit-tested
+# on the host. status_overview.py wires it to live ROS observers.
+# ---------------------------------------------------------------------
+
+from __future__ import annotations
+
+import datetime
+import json
+import os
+import threading
+import time
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Any, Deque, Dict, List, Optional, Tuple
+
+
+# --- State vocabulary (aligned with heartbeat_in_monitor) ---
+ABSENT = "ABSENT"        # no publisher and never received a message
+IDLE = "IDLE"            # publisher present but no message observed yet
+FLOWING = "FLOWING"      # messages within the liveness window
+STALE = "STALE"          # was flowing, last message older than stale threshold
+
+# Quality sub-classification while FLOWING
+GOOD = "GOOD"
+DEGRADED = "DEGRADED"
+BAD = "BAD"
+
+# Topic-level rollup
+OK = "OK"
+PARTIAL = "PARTIAL"
+STALLED = "STALLED"
+
+
+@dataclass
+class StageObservation:
+    """Live observation of a single stage topic within one ROS domain."""
+
+    type_str: Optional[str] = None
+    subscribed: bool = False
+    pub_count: int = 0
+    sub_count: int = 0
+    msg_total: int = 0
+    last_recv_mono: Optional[float] = None
+    last_recv_wall: Optional[float] = None
+    last_delay_s: Optional[float] = None
+    # (t_mono, size_bytes, delay_s_or_None)
+    events: Deque[Tuple[float, int, Optional[float]]] = field(default_factory=deque)
+    lock: threading.Lock = field(default_factory=threading.Lock)
+
+    def record(self, size: int, delay_s: Optional[float], now_mono: Optional[float] = None,
+               now_wall: Optional[float] = None) -> None:
+        now = time.monotonic() if now_mono is None else now_mono
+        with self.lock:
+            self.msg_total += 1
+            self.last_recv_mono = now
+            self.last_recv_wall = time.time() if now_wall is None else now_wall
+            self.last_delay_s = delay_s
+            self.events.append((now, size, delay_s))
+
+    def metrics(self, now_mono: float, window_s: float) -> Dict[str, Any]:
+        with self.lock:
+            cutoff = now_mono - window_s
+            while self.events and self.events[0][0] < cutoff:
+                self.events.popleft()
+            count = len(self.events)
+            total_bytes = sum(e[1] for e in self.events)
+            delays = [e[2] for e in self.events if e[2] is not None]
+            last_recv_mono = self.last_recv_mono
+            last_recv_wall = self.last_recv_wall
+            last_delay = self.last_delay_s
+            msg_total = self.msg_total
+        hz = count / window_s if window_s > 0 else 0.0
+        mean_size = (total_bytes / count) if count > 0 else 0.0
+        age = (now_mono - last_recv_mono) if last_recv_mono is not None else None
+        return {
+            "hz": hz,
+            "mean_size_bytes": mean_size,
+            "last_delay_s": last_delay,
+            "delays_in_window": delays,
+            "age_s": age,
+            "last_recv_wall": last_recv_wall,
+            "msg_total": msg_total,
+        }
+
+
+class StatusAggregator:
+    """
+    Merges observations from the per-domain observers with the static pipeline
+    spec into the unified status artifacts.
+
+    ``observers_by_domain`` maps a domain key ("local"/"ota") to any object that
+    exposes an ``observations`` dict mapping topic name -> StageObservation.
+    """
+
+    def __init__(self, logger, spec: Dict[str, Any], output_dir: str,
+                 observers_by_domain: Dict[str, Any],
+                 *, liveness_window_s: float = 3.0, stale_after_s: float = 3.0,
+                 delay_good_ms: float = 100.0, delay_bad_ms: float = 200.0):
+        self._log = logger
+        self._spec = spec
+        self._output_dir = output_dir
+        self._observers = observers_by_domain
+        self._liveness_window_s = liveness_window_s
+        self._stale_after_s = stale_after_s
+        self._delay_good_ms = delay_good_ms
+        self._delay_bad_ms = delay_bad_ms
+        self._prev_states: Dict[str, Dict[str, Any]] = {}
+        os.makedirs(self._output_dir, exist_ok=True)
+        self._json_path = os.path.join(self._output_dir, "status.json")
+        self._txt_path = os.path.join(self._output_dir, "status.txt")
+        self._events_path = os.path.join(self._output_dir, "events.jsonl")
+
+    # -- observation lookup --
+    def _obs_for(self, stage: Dict[str, Any]) -> Optional[StageObservation]:
+        domain = stage.get("domain", "local")
+        observer = self._observers.get(domain) or self._observers.get("local")
+        if observer is None:
+            return None
+        return observer.observations.get(stage["topic"])
+
+    # -- classification --
+    def classify_stage(self, stage: Dict[str, Any], expected_hz: Optional[float],
+                       now_mono: float) -> Dict[str, Any]:
+        obs = self._obs_for(stage)
+        result: Dict[str, Any] = {
+            "stage": stage["stage"],
+            "topic": stage["topic"],
+            "domain": stage.get("domain", "local"),
+            "produced_by": stage.get("produced_by"),
+            "publishers": 0,
+            "subscribers": 0,
+            "hz": 0.0,
+            "mean_size_bytes": 0.0,
+            "latency_ms": None,
+            "age_s": None,
+            "last_message_wall": None,
+            "messages_total": 0,
+            "state": ABSENT,
+            "quality": None,
+            "quality_reason": None,
+        }
+        if obs is None:
+            return result
+
+        m = obs.metrics(now_mono, self._liveness_window_s)
+        result["publishers"] = obs.pub_count
+        result["subscribers"] = obs.sub_count
+        result["hz"] = round(m["hz"], 3)
+        result["mean_size_bytes"] = round(m["mean_size_bytes"], 1)
+        result["messages_total"] = m["msg_total"]
+        result["age_s"] = round(m["age_s"], 3) if m["age_s"] is not None else None
+        if m["last_delay_s"] is not None:
+            result["latency_ms"] = round(m["last_delay_s"] * 1000.0, 1)
+        if m["last_recv_wall"] is not None:
+            result["last_message_wall"] = datetime.datetime.fromtimestamp(
+                m["last_recv_wall"]
+            ).isoformat(timespec="milliseconds")
+
+        if m["msg_total"] == 0:
+            result["state"] = IDLE if obs.pub_count > 0 else ABSENT
+            return result
+
+        age = m["age_s"]
+        if age is not None and age > self._stale_after_s:
+            result["state"] = STALE
+            return result
+
+        result["state"] = FLOWING
+        quality, reason = self._classify_quality(m, expected_hz)
+        result["quality"] = quality
+        result["quality_reason"] = reason
+        return result
+
+    def _classify_quality(self, m: Dict[str, Any], expected_hz: Optional[float]) -> Tuple[str, Optional[str]]:
+        delay_ms = (m["last_delay_s"] * 1000.0) if m["last_delay_s"] is not None else None
+        if delay_ms is not None:
+            if delay_ms >= self._delay_bad_ms:
+                return BAD, "latency"
+            if delay_ms > self._delay_good_ms:
+                return DEGRADED, "latency"
+        if expected_hz and expected_hz > 0:
+            hz = m["hz"]
+            if hz < 0.5 * expected_hz:
+                return BAD, "hz"
+            if hz < 0.8 * expected_hz:
+                return DEGRADED, "hz"
+        return GOOD, None
+
+    # -- rollup --
+    def rollup(self, topic_spec: Dict[str, Any], stage_results: List[Dict[str, Any]]) -> Dict[str, Any]:
+        states = [s["state"] for s in stage_results]
+        n = len(stage_results)
+        seen_idx = [i for i, st in enumerate(states) if st in (FLOWING, STALE)]
+        last_seen = max(seen_idx) if seen_idx else -1
+        any_publisher = any(s["publishers"] > 0 for s in stage_results)
+
+        reached_stage = stage_results[last_seen]["stage"] if last_seen >= 0 else None
+        blocked_at = None
+        next_topic = None
+        diagnosis = ""
+
+        final_idx = n - 1
+        if n == 0:
+            overall = ABSENT
+        elif last_seen == final_idx and states[final_idx] == FLOWING:
+            overall = OK
+            diagnosis = f"all observable stages flowing (reached '{reached_stage}')"
+        elif last_seen == -1:
+            blocked = stage_results[0]
+            blocked_at = blocked["stage"]
+            next_topic = blocked["topic"]
+            overall = ABSENT if not any_publisher else STALLED
+            diagnosis = self._stage_diagnosis(blocked)
+        else:
+            reached = stage_results[last_seen]
+            if reached["state"] == STALE:
+                overall = STALLED
+                age = reached.get("age_s")
+                diagnosis = (
+                    f"'{reached_stage}' ({reached['topic']}) stopped"
+                    + (f" {age:.1f}s ago" if isinstance(age, (int, float)) else "")
+                )
+                blocked_at = reached["stage"]
+                next_topic = reached["topic"]
+            else:
+                overall = PARTIAL
+                blocked = stage_results[last_seen + 1]
+                blocked_at = blocked["stage"]
+                next_topic = blocked["topic"]
+                diagnosis = (
+                    f"reached '{reached_stage}', but '{blocked_at}' is not getting it: "
+                    + self._stage_diagnosis(blocked)
+                )
+
+        if topic_spec.get("direction") == "outbound" and overall == OK:
+            diagnosis += " | sent to transport; remote delivery not observed locally (Phase 1)"
+
+        return {
+            "overall": overall,
+            "reached_stage": reached_stage,
+            "blocked_at": blocked_at,
+            "next_missing_topic": next_topic,
+            "diagnosis": diagnosis,
+        }
+
+    def _stage_diagnosis(self, stage_result: Dict[str, Any]) -> str:
+        st = stage_result["state"]
+        topic = stage_result["topic"]
+        producer = stage_result.get("produced_by") or "producer"
+        if st == ABSENT:
+            return f"{producer} is not producing {topic} (no publisher)"
+        if st == IDLE:
+            return f"{topic} has a publisher but no messages observed yet"
+        if st == STALE:
+            return f"{topic} stopped receiving messages"
+        return f"{topic}: {st}"
+
+    # -- snapshot + write --
+    def build_snapshot(self, now_mono: Optional[float] = None) -> Dict[str, Any]:
+        if now_mono is None:
+            now_mono = time.monotonic()
+        now_wall = datetime.datetime.now().isoformat(timespec="milliseconds")
+        topics_out: List[Dict[str, Any]] = []
+        counts = {OK: 0, PARTIAL: 0, STALLED: 0, ABSENT: 0}
+
+        for topic_spec in self._spec.get("topics", []):
+            expected_hz = topic_spec.get("expected_hz")
+            stage_results = [
+                self.classify_stage(stage, expected_hz, now_mono)
+                for stage in topic_spec.get("stages", [])
+            ]
+            roll = self.rollup(topic_spec, stage_results)
+            counts[roll["overall"]] = counts.get(roll["overall"], 0) + 1
+            topics_out.append(
+                {
+                    "base": topic_spec.get("base"),
+                    "direction": topic_spec.get("direction"),
+                    "source": topic_spec.get("source"),
+                    "target": topic_spec.get("target"),
+                    "type": topic_spec.get("type"),
+                    "expected_hz": expected_hz,
+                    "overall": roll["overall"],
+                    "reached_stage": roll["reached_stage"],
+                    "blocked_at": roll["blocked_at"],
+                    "next_missing_topic": roll["next_missing_topic"],
+                    "diagnosis": roll["diagnosis"],
+                    "remote_observation": None,  # Phase 1: not observed
+                    "stages": stage_results,
+                }
+            )
+
+        return {
+            "schema_version": 1,
+            "phase": 1,
+            "generated_at": now_wall,
+            "peer": self._spec.get("peer"),
+            "remote": self._spec.get("remote"),
+            "local_domain_id": self._spec.get("local_domain_id"),
+            "ota_domain_id": self._spec.get("ota_domain_id"),
+            "uses_domain_bridge": self._spec.get("uses_domain_bridge"),
+            "summary": counts,
+            "topics": topics_out,
+        }
+
+    def detect_transitions(self, snapshot: Dict[str, Any]) -> List[Dict[str, Any]]:
+        events: List[Dict[str, Any]] = []
+        for t in snapshot["topics"]:
+            key = f"{t['direction']}:{t['base']}"
+            cur = {
+                "overall": t["overall"],
+                "reached_stage": t["reached_stage"],
+                "blocked_at": t["blocked_at"],
+                "stages": {s["stage"]: s["state"] for s in t["stages"]},
+            }
+            prev = self._prev_states.get(key)
+            if prev != cur:
+                if prev is not None:
+                    events.append(
+                        {
+                            "at": snapshot["generated_at"],
+                            "peer": snapshot["peer"],
+                            "topic": t["base"],
+                            "direction": t["direction"],
+                            "from": {
+                                "overall": prev.get("overall"),
+                                "reached_stage": prev.get("reached_stage"),
+                                "blocked_at": prev.get("blocked_at"),
+                            },
+                            "to": {
+                                "overall": cur["overall"],
+                                "reached_stage": cur["reached_stage"],
+                                "blocked_at": cur["blocked_at"],
+                            },
+                            "diagnosis": t["diagnosis"],
+                        }
+                    )
+                self._prev_states[key] = cur
+        return events
+
+    def render_text(self, snapshot: Dict[str, Any]) -> str:
+        lines: List[str] = []
+        s = snapshot["summary"]
+        lines.append(
+            f"rosotacom status  peer={snapshot['peer']} remote={snapshot['remote']}  "
+            f"{snapshot['generated_at']}"
+        )
+        lines.append(
+            f"summary: OK={s.get('OK', 0)} PARTIAL={s.get('PARTIAL', 0)} "
+            f"STALLED={s.get('STALLED', 0)} ABSENT={s.get('ABSENT', 0)}   (Phase 1: local observation)"
+        )
+        lines.append("")
+        for t in snapshot["topics"]:
+            arrow = "->" if t["direction"] == "outbound" else "<-"
+            lines.append(
+                f"[{t['overall']:<7}] {arrow} {t['base']}  "
+                f"(reached: {t['reached_stage']}, blocked: {t['blocked_at']})"
+            )
+            for st in t["stages"]:
+                state = st["state"]
+                if state == FLOWING and st.get("quality") and st["quality"] != GOOD:
+                    state = f"{state}/{st['quality']}"
+                metric = ""
+                if st["state"] in (FLOWING, STALE):
+                    parts = [f"{st['hz']:.1f}Hz"]
+                    if st["latency_ms"] is not None:
+                        parts.append(f"{st['latency_ms']:.0f}ms")
+                    if st["mean_size_bytes"]:
+                        parts.append(f"{st['mean_size_bytes']:.0f}B")
+                    if st["age_s"] is not None:
+                        parts.append(f"age {st['age_s']:.1f}s")
+                    metric = "  " + " ".join(parts)
+                lines.append(
+                    f"    {st['stage']:<10} {state:<14} "
+                    f"pub={st['publishers']} sub={st['subscribers']}  {st['topic']}{metric}"
+                )
+            if t["diagnosis"]:
+                lines.append(f"    -> {t['diagnosis']}")
+            lines.append("")
+        return "\n".join(lines) + "\n"
+
+    @staticmethod
+    def _atomic_write(path: str, text: str) -> None:
+        tmp = f"{path}.tmp"
+        with open(tmp, "w", encoding="utf-8") as fp:
+            fp.write(text)
+        os.replace(tmp, path)
+
+    def write(self, now_mono: Optional[float] = None) -> int:
+        """Build a snapshot, write artifacts, and return number of transition events."""
+        snapshot = self.build_snapshot(now_mono)
+        events = self.detect_transitions(snapshot)
+        try:
+            self._atomic_write(self._json_path, json.dumps(snapshot, indent=2) + "\n")
+            self._atomic_write(self._txt_path, self.render_text(snapshot))
+            if events:
+                with open(self._events_path, "a", encoding="utf-8") as fp:
+                    for ev in events:
+                        fp.write(json.dumps(ev) + "\n")
+        except Exception as exc:  # pragma: no cover - defensive
+            if self._log is not None:
+                self._log.warning(f"status_overview: failed to write artifacts: {exc}")
+        return len(events)
+
+
+def collect_stage_topics(spec: Dict[str, Any]) -> Dict[str, Dict[str, Optional[str]]]:
+    """Return {domain: {topic: type_hint}} from the pipeline spec."""
+    by_domain: Dict[str, Dict[str, Optional[str]]] = {"local": {}, "ota": {}}
+    for topic_spec in spec.get("topics", []):
+        type_hint = topic_spec.get("type")
+        for stage in topic_spec.get("stages", []):
+            domain = stage.get("domain", "local")
+            by_domain.setdefault(domain, {})
+            existing = by_domain[domain].get(stage["topic"])
+            by_domain[domain][stage["topic"]] = existing or type_hint
+    return by_domain

--- a/src/rosotacom/resources/ws/ros2src/com_py/setup.py
+++ b/src/rosotacom/resources/ws/ros2src/com_py/setup.py
@@ -33,6 +33,7 @@ setup(
             'heartbeat_out_publisher = com_py.heartbeat_out_publisher:main',
             'heartbeat_in_monitor = com_py.heartbeat_in_monitor:main',
             'topic_monitor = com_py.topic_monitor:main',
+            'status_overview = com_py.status_overview:main',
             'bridge_in = com_py.bridge_in:main',
             'bridge_out = com_py.bridge_out:main',
             'relay_in = com_py.relay_in:main',

--- a/src/rosotacom/resources/ws/session/content/base/session_plugin_base.yaml
+++ b/src/rosotacom/resources/ws/session/content/base/session_plugin_base.yaml
@@ -225,7 +225,7 @@ parameters:
 common:
   before_commands:
     - if [ '${local_domain_id}' != "None" ] && [ -n '${local_domain_id}' ]; then export ROS_DOMAIN_ID='${local_domain_id}'; fi
-    - if [ '${rmw_local}' != "None" ]; then case ${rmw_local} in cyclone) export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp;; fastdds) export RMW_IMPLEMENTATION=rmw_fastrtps_cpp;; zenoh) export RMW_IMPLEMENTATION=rmw_zenoh_cpp;; *) export RMW_IMPLEMENTATION='${rmw_local}';; esac; fi
+    - if [ '${rmw_local}' != "None" ]; then case ${rmw_local} in cyclone) export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp;; fastdds) export RMW_IMPLEMENTATION=rmw_fastrtps_cpp; export FASTDDS_BUILTIN_TRANSPORTS=${FASTDDS_BUILTIN_TRANSPORTS:-UDPv4};; zenoh) export RMW_IMPLEMENTATION=rmw_zenoh_cpp;; *) export RMW_IMPLEMENTATION='${rmw_local}';; esac; fi
     - if [ '${local_config_template}' != "None" ] && [ -n '${local_config_template}' ]; then local_args=(--config "${local_config_template}" --host-ip "${ip_local}" --peer "${ip_remote}"); [ '${local_easy_mode_ip_key}' != "None" ] && [ -n '${local_easy_mode_ip_key}' ] && local_args+=(--easy-mode-ip "${local_easy_mode_ip_key}"); /ws/ota_configs/get_ota_xml.py "${local_args[@]}" > "${local_config_file}"; case ${rmw_local} in cyclone) export CYCLONEDDS_URI="file://${local_config_file}";; fastdds) export FASTDDS_DEFAULT_PROFILES_FILE="${local_config_file}";; esac; fi
     - if [ '${before_command}' != "None" ]; then ${before_command}; fi
 
@@ -268,7 +268,7 @@ windows:
     splits:
       - commands:
         - if [ '${ota_domain_id}' != "None" ] && [ -n '${ota_domain_id}' ]; then export ROS_DOMAIN_ID='${ota_domain_id}'; fi
-        - case ${rmw_ota} in cyclone) export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp;; fastdds) export RMW_IMPLEMENTATION=rmw_fastrtps_cpp;; zenoh) export RMW_IMPLEMENTATION=rmw_zenoh_cpp;; esac
+        - case ${rmw_ota} in cyclone) export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp;; fastdds) export RMW_IMPLEMENTATION=rmw_fastrtps_cpp; export FASTDDS_BUILTIN_TRANSPORTS=${FASTDDS_BUILTIN_TRANSPORTS:-UDPv4};; zenoh) export RMW_IMPLEMENTATION=rmw_zenoh_cpp;; esac
         - if [ '${ota_config_template}' != "None" ] && [ -n '${ota_config_template}' ]; then ota_args=(--config "${ota_config_template}" --host-ip "${ip_local}" --peer "${ip_remote}"); [ '${ota_easy_mode_ip_key}' != "None" ] && [ -n '${ota_easy_mode_ip_key}' ] && ota_args+=(--easy-mode-ip "${ota_easy_mode_ip_key}"); /ws/ota_configs/get_ota_xml.py "${ota_args[@]}" > "${ota_config_file}"; case ${rmw_ota} in cyclone) export CYCLONEDDS_URI="file://${ota_config_file}";; fastdds) export FASTDDS_DEFAULT_PROFILES_FILE="${ota_config_file}";; esac; fi
         - export ROS_STATIC_PEERS=$(/ws/session/content/get_data_dict_entries.py -k "${ip_remote}")
         - ros2 run com_py bridge_in --ros-args
@@ -290,7 +290,7 @@ windows:
     splits:
       - commands:
         - if [ '${ota_domain_id}' != "None" ] && [ -n '${ota_domain_id}' ]; then export ROS_DOMAIN_ID='${ota_domain_id}'; fi
-        - case ${rmw_ota} in cyclone) export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp;; fastdds) export RMW_IMPLEMENTATION=rmw_fastrtps_cpp;; zenoh) export RMW_IMPLEMENTATION=rmw_zenoh_cpp;; esac
+        - case ${rmw_ota} in cyclone) export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp;; fastdds) export RMW_IMPLEMENTATION=rmw_fastrtps_cpp; export FASTDDS_BUILTIN_TRANSPORTS=${FASTDDS_BUILTIN_TRANSPORTS:-UDPv4};; zenoh) export RMW_IMPLEMENTATION=rmw_zenoh_cpp;; esac
         - if [ '${ota_config_template}' != "None" ] && [ -n '${ota_config_template}' ]; then ota_args=(--config "${ota_config_template}" --host-ip "${ip_local}" --peer "${ip_remote}"); [ '${ota_easy_mode_ip_key}' != "None" ] && [ -n '${ota_easy_mode_ip_key}' ] && ota_args+=(--easy-mode-ip "${ota_easy_mode_ip_key}"); /ws/ota_configs/get_ota_xml.py "${ota_args[@]}" > "${ota_config_file}"; case ${rmw_ota} in cyclone) export CYCLONEDDS_URI="file://${ota_config_file}";; fastdds) export FASTDDS_DEFAULT_PROFILES_FILE="${ota_config_file}";; esac; fi
         - export ROS_STATIC_PEERS=$(/ws/session/content/get_data_dict_entries.py -k "${ip_remote}")
         - ros2 run com_py bridge_out --ros-args

--- a/src/rosotacom/resources/ws/session/content/base/session_plugin_base.yaml
+++ b/src/rosotacom/resources/ws/session/content/base/session_plugin_base.yaml
@@ -226,7 +226,7 @@ common:
   before_commands:
     - if [ '${local_domain_id}' != "None" ] && [ -n '${local_domain_id}' ]; then export ROS_DOMAIN_ID='${local_domain_id}'; fi
     - if [ '${rmw_local}' != "None" ]; then case ${rmw_local} in cyclone) export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp;; fastdds) export RMW_IMPLEMENTATION=rmw_fastrtps_cpp; export FASTDDS_BUILTIN_TRANSPORTS=${FASTDDS_BUILTIN_TRANSPORTS:-UDPv4};; zenoh) export RMW_IMPLEMENTATION=rmw_zenoh_cpp;; *) export RMW_IMPLEMENTATION='${rmw_local}';; esac; fi
-    - if [ '${local_config_template}' != "None" ] && [ -n '${local_config_template}' ]; then local_args=(--config "${local_config_template}" --host-ip "${ip_local}" --peer "${ip_remote}"); [ '${local_easy_mode_ip_key}' != "None" ] && [ -n '${local_easy_mode_ip_key}' ] && local_args+=(--easy-mode-ip "${local_easy_mode_ip_key}"); /ws/ota_configs/get_ota_xml.py "${local_args[@]}" > "${local_config_file}"; case ${rmw_local} in cyclone) export CYCLONEDDS_URI="file://${local_config_file}";; fastdds) export FASTDDS_DEFAULT_PROFILES_FILE="${local_config_file}";; esac; fi
+    - if [ '${local_config_template}' != "None" ] && [ -n '${local_config_template}' ]; then local_args=(--config "${local_config_template}" --host-ip "${ip_local}" --peer "${ip_remote}"); [ '${local_easy_mode_ip_key}' != "None" ] && [ -n '${local_easy_mode_ip_key}' ] && local_args+=(--easy-mode-ip "${local_easy_mode_ip_key}"); /ws/ota_configs/get_ota_xml.py "${local_args[@]}" > "${local_config_file}"; case ${rmw_local} in cyclone) export CYCLONEDDS_URI="file://${local_config_file}";; fastdds) export FASTDDS_DEFAULT_PROFILES_FILE="${local_config_file}"; export RMW_FASTRTPS_USE_QOS_FROM_XML=1;; esac; fi
     - if [ '${before_command}' != "None" ]; then ${before_command}; fi
 
 windows:
@@ -269,7 +269,7 @@ windows:
       - commands:
         - if [ '${ota_domain_id}' != "None" ] && [ -n '${ota_domain_id}' ]; then export ROS_DOMAIN_ID='${ota_domain_id}'; fi
         - case ${rmw_ota} in cyclone) export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp;; fastdds) export RMW_IMPLEMENTATION=rmw_fastrtps_cpp; export FASTDDS_BUILTIN_TRANSPORTS=${FASTDDS_BUILTIN_TRANSPORTS:-UDPv4};; zenoh) export RMW_IMPLEMENTATION=rmw_zenoh_cpp;; esac
-        - if [ '${ota_config_template}' != "None" ] && [ -n '${ota_config_template}' ]; then ota_args=(--config "${ota_config_template}" --host-ip "${ip_local}" --peer "${ip_remote}"); [ '${ota_easy_mode_ip_key}' != "None" ] && [ -n '${ota_easy_mode_ip_key}' ] && ota_args+=(--easy-mode-ip "${ota_easy_mode_ip_key}"); /ws/ota_configs/get_ota_xml.py "${ota_args[@]}" > "${ota_config_file}"; case ${rmw_ota} in cyclone) export CYCLONEDDS_URI="file://${ota_config_file}";; fastdds) export FASTDDS_DEFAULT_PROFILES_FILE="${ota_config_file}";; esac; fi
+        - if [ '${ota_config_template}' != "None" ] && [ -n '${ota_config_template}' ]; then ota_args=(--config "${ota_config_template}" --host-ip "${ip_local}" --peer "${ip_remote}"); [ '${ota_easy_mode_ip_key}' != "None" ] && [ -n '${ota_easy_mode_ip_key}' ] && ota_args+=(--easy-mode-ip "${ota_easy_mode_ip_key}"); /ws/ota_configs/get_ota_xml.py "${ota_args[@]}" > "${ota_config_file}"; case ${rmw_ota} in cyclone) export CYCLONEDDS_URI="file://${ota_config_file}";; fastdds) export FASTDDS_DEFAULT_PROFILES_FILE="${ota_config_file}"; export RMW_FASTRTPS_USE_QOS_FROM_XML=1;; esac; fi
         - export ROS_STATIC_PEERS=$(/ws/session/content/get_data_dict_entries.py -k "${ip_remote}")
         - ros2 run com_py bridge_in --ros-args
             -p base_topic_files:=[${topic_list_paths_inbound}]
@@ -291,7 +291,7 @@ windows:
       - commands:
         - if [ '${ota_domain_id}' != "None" ] && [ -n '${ota_domain_id}' ]; then export ROS_DOMAIN_ID='${ota_domain_id}'; fi
         - case ${rmw_ota} in cyclone) export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp;; fastdds) export RMW_IMPLEMENTATION=rmw_fastrtps_cpp; export FASTDDS_BUILTIN_TRANSPORTS=${FASTDDS_BUILTIN_TRANSPORTS:-UDPv4};; zenoh) export RMW_IMPLEMENTATION=rmw_zenoh_cpp;; esac
-        - if [ '${ota_config_template}' != "None" ] && [ -n '${ota_config_template}' ]; then ota_args=(--config "${ota_config_template}" --host-ip "${ip_local}" --peer "${ip_remote}"); [ '${ota_easy_mode_ip_key}' != "None" ] && [ -n '${ota_easy_mode_ip_key}' ] && ota_args+=(--easy-mode-ip "${ota_easy_mode_ip_key}"); /ws/ota_configs/get_ota_xml.py "${ota_args[@]}" > "${ota_config_file}"; case ${rmw_ota} in cyclone) export CYCLONEDDS_URI="file://${ota_config_file}";; fastdds) export FASTDDS_DEFAULT_PROFILES_FILE="${ota_config_file}";; esac; fi
+        - if [ '${ota_config_template}' != "None" ] && [ -n '${ota_config_template}' ]; then ota_args=(--config "${ota_config_template}" --host-ip "${ip_local}" --peer "${ip_remote}"); [ '${ota_easy_mode_ip_key}' != "None" ] && [ -n '${ota_easy_mode_ip_key}' ] && ota_args+=(--easy-mode-ip "${ota_easy_mode_ip_key}"); /ws/ota_configs/get_ota_xml.py "${ota_args[@]}" > "${ota_config_file}"; case ${rmw_ota} in cyclone) export CYCLONEDDS_URI="file://${ota_config_file}";; fastdds) export FASTDDS_DEFAULT_PROFILES_FILE="${ota_config_file}"; export RMW_FASTRTPS_USE_QOS_FROM_XML=1;; esac; fi
         - export ROS_STATIC_PEERS=$(/ws/session/content/get_data_dict_entries.py -k "${ip_remote}")
         - ros2 run com_py bridge_out --ros-args
             -p base_topic_files:=[${topic_list_paths_outbound}]

--- a/src/rosotacom/resources/ws/session/content/base/session_plugin_base.yaml
+++ b/src/rosotacom/resources/ws/session/content/base/session_plugin_base.yaml
@@ -55,6 +55,12 @@ parameters:
   tm_out_to_adressant: '""'
   tm_link_duration_buffer_s: 1.0
 
+  status_overview: false
+  status_spec_file: ${peer_dir}/pipeline_spec.yaml
+  status_write_interval_s: 2.0
+  status_liveness_window_s: 3.0
+  status_stale_after_s: 3.0
+
   network_monitor: false
 
   heartbeat: false
@@ -318,6 +324,18 @@ windows:
         - interface=$(ip -o addr | awk '/'${ip_local_resolved//./\\.}'\/[0-9]+/ {print $2; exit}')
         - ip_remote_resolved=$(/ws/session/content/get_data_dict_entries.py -k "${ip_remote}")
         - ros2 run com_py topic_monitor --ros-args -p sourcename:=${local_name} -p direction:=out -p to_adressant:='${tm_out_to_adressant}' -p ip_local:=${ip_local_resolved} -p ip_remote:=${ip_remote_resolved} -p interface:=${interface} -p link_duration_buffer_s:=${tm_link_duration_buffer_s}
+  - name: STAT
+    if: status_overview
+    splits:
+      - commands:
+        - status_out_dir="$(dirname "${ROSOTACOM_CATMUX_LOG_DIR:-/tmp/rosotacom_logs/catmux}")/status"
+        - mkdir -p "$status_out_dir"
+        - ros2 run com_py status_overview --ros-args
+            -p status_spec_file:=${status_spec_file}
+            -p output_dir:="$status_out_dir"
+            -p write_interval_s:=${status_write_interval_s}
+            -p liveness_window_s:=${status_liveness_window_s}
+            -p stale_after_s:=${status_stale_after_s}
   - name: NET
     if: network_monitor
     splits:

--- a/src/rosotacom/resources/ws/session/creation/catmux_log_setup.sh
+++ b/src/rosotacom/resources/ws/session/creation/catmux_log_setup.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Mirror the current catmux/tmux pane to a per-instance log file.
+#
+# This file is sourced from catmux common.before_commands. It must be tolerant:
+# logging should never prevent a pane command from starting.
+
+if [[ -z "${TMUX_PANE:-}" ]]; then
+  echo "[rosotacom_catmux_log] no TMUX_PANE; skipping pane logging" >&2
+  return 0 2>/dev/null || exit 0
+fi
+
+export RCUTILS_COLORIZED_OUTPUT="${RCUTILS_COLORIZED_OUTPUT:-0}"
+
+ROSOTACOM_CATMUX_LOG_DIR="${ROSOTACOM_CATMUX_LOG_DIR:-${ROSOTACOM_LOGS_DIR:-/tmp/rosotacom_logs}/catmux}"
+ROSOTACOM_ROSBAG_DIR="${ROSOTACOM_ROSBAG_DIR:-${ROSOTACOM_INSTANCE_DIR:-/tmp/rosotacom_instance}/rosbags}"
+export ROSOTACOM_INSTANCE_DIR ROSOTACOM_CONFIG_DIR ROSOTACOM_CATMUX_LOG_DIR ROSOTACOM_ROSBAG_DIR
+
+if ! command -v tmux >/dev/null 2>&1; then
+  echo "[rosotacom_catmux_log] tmux not on PATH; pane logging disabled" >&2
+  return 0 2>/dev/null || exit 0
+fi
+
+__rosotacom_window="$(tmux display-message -p -t "${TMUX_PANE}" '#{window_name}' 2>/dev/null)"
+__rosotacom_window_index="$(tmux display-message -p -t "${TMUX_PANE}" '#{window_index}' 2>/dev/null)"
+__rosotacom_pane="$(tmux display-message -p -t "${TMUX_PANE}" '#{pane_index}' 2>/dev/null)"
+if [[ -z "${__rosotacom_window}" || -z "${__rosotacom_window_index}" || -z "${__rosotacom_pane}" ]]; then
+  echo "[rosotacom_catmux_log] could not query tmux pane id; skipping" >&2
+  return 0 2>/dev/null || exit 0
+fi
+
+__rosotacom_window_safe="$(printf '%s' "${__rosotacom_window}" | tr -c 'A-Za-z0-9_.-' '_')"
+printf -v __rosotacom_window_prefix '%02d' "${__rosotacom_window_index}"
+__rosotacom_pane_log_dir="${ROSOTACOM_CATMUX_LOG_DIR}/${__rosotacom_window_prefix}-${__rosotacom_window_safe}"
+__rosotacom_pane_log_file="${__rosotacom_pane_log_dir}/${__rosotacom_pane}.log"
+export ROSOTACOM_CATMUX_PANE_LOG_DIR="${__rosotacom_pane_log_dir}"
+export ROSOTACOM_CATMUX_PANE_LOG_FILE="${__rosotacom_pane_log_file}"
+
+if ! mkdir -p "${__rosotacom_pane_log_dir}" 2>/dev/null; then
+  echo "[rosotacom_catmux_log] cannot create ${__rosotacom_pane_log_dir}; skipping" >&2
+  return 0 2>/dev/null || exit 0
+fi
+
+__rosotacom_strip_ansi="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)/strip_ansi.py"
+if [[ -x "${__rosotacom_strip_ansi}" ]] && command -v python3 >/dev/null 2>&1; then
+  __rosotacom_pipe_filter="python3 '${__rosotacom_strip_ansi//\'/\'\\\'\'}'"
+else
+  echo "[rosotacom_catmux_log] strip_ansi.py unavailable; logging raw pane output" >&2
+  __rosotacom_pipe_filter="cat"
+fi
+
+tmux pipe-pane -o -t "${TMUX_PANE}" \
+  "${__rosotacom_pipe_filter} >> '${__rosotacom_pane_log_file//\'/\'\\\'\'}'"
+
+{
+  printf '\n--- rosotacom catmux pipe-pane started %s ---\n' "$(date -Iseconds)"
+  printf '    window=%s (#%s) pane=%s\n' \
+    "${__rosotacom_window}" "${__rosotacom_window_index}" "${__rosotacom_pane}"
+  printf '    log_file=%s\n' "${__rosotacom_pane_log_file}"
+} >&2
+
+unset __rosotacom_window __rosotacom_window_index __rosotacom_pane \
+  __rosotacom_window_safe __rosotacom_window_prefix \
+  __rosotacom_pane_log_dir __rosotacom_pane_log_file \
+  __rosotacom_strip_ansi __rosotacom_pipe_filter

--- a/src/rosotacom/resources/ws/session/creation/create_session_yaml.py
+++ b/src/rosotacom/resources/ws/session/creation/create_session_yaml.py
@@ -40,9 +40,32 @@
 import yaml
 import argparse
 import os
+import shlex
 import stat
 
-def main(peer_dir):
+
+def _logging_before_command(instance_dir=None, config_dir=None, catmux_log_dir=None, rosbag_dir=None):
+    exports = {
+        "ROSOTACOM_INSTANCE_DIR": instance_dir,
+        "ROSOTACOM_CONFIG_DIR": config_dir,
+        "ROSOTACOM_CATMUX_LOG_DIR": catmux_log_dir,
+        "ROSOTACOM_ROSBAG_DIR": rosbag_dir,
+    }
+    parts = [f"export {key}={shlex.quote(str(value))}" for key, value in exports.items() if value]
+    parts.append("source /ws/session/creation/catmux_log_setup.sh")
+    return "; ".join(parts)
+
+
+def _inject_logging_command(merged_config, logging_command):
+    common = merged_config.setdefault('common', {})
+    before_commands = common.get('before_commands') or []
+    if not isinstance(before_commands, list):
+        before_commands = [before_commands]
+    before_commands = [cmd for cmd in before_commands if cmd != logging_command]
+    common['before_commands'] = [logging_command, *before_commands]
+
+
+def main(peer_dir, instance_dir=None, config_dir=None, catmux_log_dir=None, rosbag_dir=None):
     spec_file = os.path.join(peer_dir, 'session_specification.yaml')
 
     with open(spec_file, 'r') as f:
@@ -80,6 +103,16 @@ def main(peer_dir):
     if parameters:
         merged_config['parameters'] = {**merged_config['parameters'], **parameters}
 
+    _inject_logging_command(
+        merged_config,
+        _logging_before_command(
+            instance_dir=instance_dir,
+            config_dir=config_dir,
+            catmux_log_dir=catmux_log_dir,
+            rosbag_dir=rosbag_dir,
+        ),
+    )
+
     # Output file path
     output_file = os.path.join(peer_dir, '.session_readonly.yaml')
 
@@ -97,6 +130,16 @@ def main(peer_dir):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Merge multiple YAML plugin files into a full session configuration.")
     parser.add_argument('-p', '--peer-dir', required=True, help='Peer directory containing the session_specification.yaml file')
+    parser.add_argument('--instance-dir')
+    parser.add_argument('--config-dir')
+    parser.add_argument('--catmux-log-dir')
+    parser.add_argument('--rosbag-dir')
     args = parser.parse_args()
 
-    main(args.peer_dir)
+    main(
+        args.peer_dir,
+        instance_dir=args.instance_dir,
+        config_dir=args.config_dir,
+        catmux_log_dir=args.catmux_log_dir,
+        rosbag_dir=args.rosbag_dir,
+    )

--- a/src/rosotacom/resources/ws/session/creation/generate_session_files.py
+++ b/src/rosotacom/resources/ws/session/creation/generate_session_files.py
@@ -937,6 +937,7 @@ def _validate_session_template_cfg(cfg: Dict[str, Any]) -> None:
             shared,
             {
                 "use_topic_monitor",
+                "use_status_overview",
                 "use_heartbeat",
                 "use_in",
                 "use_out",
@@ -949,6 +950,12 @@ def _validate_session_template_cfg(cfg: Dict[str, Any]) -> None:
                 "qos",
             },
         )
+        if (
+            "use_status_overview" in shared
+            and shared["use_status_overview"] is not None
+            and not isinstance(shared["use_status_overview"], bool)
+        ):
+            raise RuntimeError("shared.use_status_overview must be boolean if provided.")
         if "use_in" in shared and shared["use_in"] is not None and not isinstance(shared["use_in"], bool):
             raise RuntimeError("shared.use_in must be boolean if provided.")
         if "use_out" in shared and shared["use_out"] is not None and not isinstance(shared["use_out"], bool):
@@ -1198,6 +1205,168 @@ def _final_topic_type(entry: TopicEntry, pipe: Dict[str, Any]) -> str:
             f"Topic '{entry.base}' requires a 'type' when peer_settings.<peer>.domain_id/shared.ota_domain_id are used."
         )
     return msg_type
+
+
+def _build_status_pipeline_spec(
+    *,
+    local: str,
+    remote: str,
+    peer_name: Dict[str, str],
+    out_entries: List["TopicEntry"],
+    out_pipes: List[Dict[str, Any]],
+    in_entries: List["TopicEntry"],
+    in_pipes: List[Dict[str, Any]],
+    use_target_prefix: bool,
+    remote_uses_target_prefix: bool,
+    native_have_source_prefix: bool,
+    inbound_keep_source_prefix: bool,
+    local_domain_id: Optional[int],
+    ota_domain_id: Optional[int],
+    uses_domain_bridge: bool,
+    hb_topic: Dict[str, str],
+    use_heartbeat: bool,
+    out_enabled: bool,
+    in_enabled: bool,
+    final_topic_type,
+) -> str:
+    """
+    Build the per-peer pipeline_spec.yaml consumed by the status_overview node.
+
+    For each configured topic it enumerates the ordered, locally-observable
+    pipeline stages (Phase 1): outbound stages reach up to the /ota topic the
+    local peer publishes ("sent"); inbound stages cover the /ota topic the local
+    peer receives through to the republished application topic.
+
+    Stage topic names mirror the runtime resolution in topic_resolution.py so the
+    node can subscribe directly without recomputing names.
+    """
+    local_name = peer_name[local]
+    remote_name = peer_name[remote]
+
+    def _safe_type(entry: "TopicEntry", pipe: Dict[str, Any], fallback_base_type: bool = False) -> Optional[str]:
+        if fallback_base_type:
+            base_type = str(entry.msg_type or "").strip()
+            if base_type:
+                return base_type
+        try:
+            return final_topic_type(entry, pipe)
+        except Exception:
+            t = str(entry.msg_type or "").strip()
+            return t or None
+
+    def _expected_hz(pipe: Dict[str, Any]) -> Optional[float]:
+        if pipe.get("throttle") is not None:
+            return float(pipe["throttle"])
+        if pipe.get("trickle_hz") is not None:
+            return float(pipe["trickle_hz"])
+        return None
+
+    def _relay_in_local_topic(topic: str) -> str:
+        if inbound_keep_source_prefix:
+            return f"/{remote_name}{topic}"
+        return topic
+
+    topics: List[Dict[str, Any]] = []
+
+    # --- Outbound: local peer is the source ---
+    if out_enabled:
+        outbound_items: List[Tuple["TopicEntry", Dict[str, Any]]] = []
+        hb_local = hb_topic.get(local, "")
+        for e, p in zip(out_entries, out_pipes):
+            if use_heartbeat and hb_local and e.base == hb_local:
+                continue
+            outbound_items.append((e, p))
+        if use_heartbeat and hb_local:
+            hb_entry = TopicEntry(base=hb_local, msg_type=HEARTBEAT_MSG_TYPE, processing={}, qos=None, zen_qos=None, index=-1)
+            hb_pipe = {"final": hb_local}
+            outbound_items.insert(0, (hb_entry, hb_pipe))
+
+        for e, p in outbound_items:
+            base = e.base
+            final = p.get("final", base)
+            forward_final = f"/to_{remote_name}{final}" if use_target_prefix else final
+            forward_ns = forward_final.lstrip("/")
+            app_native = f"/{local_name}{base}" if native_have_source_prefix else base
+            app_processed = f"/{local_name}{final}" if native_have_source_prefix else final
+
+            stages: List[Dict[str, Any]] = [
+                {"stage": "native", "topic": app_native, "domain": "local", "produced_by": "application"},
+            ]
+            if final != base:
+                stages.append(
+                    {"stage": "processed", "topic": app_processed, "domain": "local", "produced_by": "preprocessing"}
+                )
+            stages.append(
+                {"stage": "com_out", "topic": f"/com/out/{local_name}/{forward_ns}", "domain": "local", "produced_by": "relay_out"}
+            )
+            stages.append(
+                {"stage": "ota_sent", "topic": f"/ota/{local_name}/{forward_ns}", "domain": "ota", "produced_by": "bridge_out"}
+            )
+
+            topics.append(
+                {
+                    "base": base,
+                    "direction": "outbound",
+                    "source": local_name,
+                    "target": remote_name,
+                    "type": _safe_type(e, p),
+                    "expected_hz": _expected_hz(p),
+                    "stages": stages,
+                }
+            )
+
+    # --- Inbound: remote peer is the source, local peer is the target ---
+    if in_enabled:
+        inbound_items: List[Tuple["TopicEntry", Dict[str, Any]]] = []
+        hb_remote = hb_topic.get(remote, "")
+        for e, p in zip(in_entries, in_pipes):
+            if use_heartbeat and hb_remote and e.base == hb_remote:
+                continue
+            inbound_items.append((e, p))
+        if use_heartbeat and hb_remote:
+            hb_entry = TopicEntry(base=hb_remote, msg_type=HEARTBEAT_MSG_TYPE, processing={}, qos=None, zen_qos=None, index=-1)
+            hb_pipe = {"final": hb_remote}
+            inbound_items.insert(0, (hb_entry, hb_pipe))
+
+        for e, p in inbound_items:
+            base = e.base
+            final = p.get("final", base)
+            forward_final = f"/to_{local_name}{final}" if remote_uses_target_prefix else final
+            forward_ns = forward_final.lstrip("/")
+            app_in = _relay_in_local_topic(final)
+
+            stages = [
+                {"stage": "ota_recv", "topic": f"/ota/{remote_name}/{forward_ns}", "domain": "ota", "produced_by": "transport"},
+                {"stage": "com_in", "topic": f"/com/in/{remote_name}/{forward_ns}", "domain": "local", "produced_by": "bridge_in"},
+                {"stage": "app_in", "topic": app_in, "domain": "local", "produced_by": "relay_in"},
+            ]
+            if final != base:
+                stages.append(
+                    {"stage": "native_in", "topic": _relay_in_local_topic(base), "domain": "local", "produced_by": "postprocessing"}
+                )
+
+            topics.append(
+                {
+                    "base": base,
+                    "direction": "inbound",
+                    "source": remote_name,
+                    "target": local_name,
+                    "type": _safe_type(e, p),
+                    "expected_hz": _expected_hz(p),
+                    "stages": stages,
+                }
+            )
+
+    spec: Dict[str, Any] = {
+        "schema_version": 1,
+        "peer": local_name,
+        "remote": remote_name,
+        "local_domain_id": local_domain_id,
+        "ota_domain_id": ota_domain_id,
+        "uses_domain_bridge": uses_domain_bridge,
+        "topics": topics,
+    }
+    return _yaml_canonical_dump(spec)
 
 
 def _dedup_topic_type_items(items: List[Tuple[str, str]]) -> List[Tuple[str, str]]:
@@ -1508,6 +1677,7 @@ def func(
 
     # Optional shared toggles
     use_topic_monitor = bool(shared.get("use_topic_monitor", False))
+    use_status_overview = bool(shared.get("use_status_overview", False))
     use_heartbeat = bool(shared.get("use_heartbeat", False))
     shared_use_in = shared.get("use_in", None)
     shared_use_out = shared.get("use_out", None)
@@ -2047,6 +2217,7 @@ def func(
     per_peer_otaw_yaml: Dict[str, Optional[str]] = {p: None for p in peer_keys}
     per_peer_otau_yaml: Dict[str, Optional[str]] = {p: None for p in peer_keys}
     per_peer_domain_bridge_yaml: Dict[str, Optional[str]] = {p: None for p in peer_keys}
+    per_peer_status_spec_yaml: Dict[str, Optional[str]] = {p: None for p in peer_keys}
 
     def _prefix_with_source_name_if_needed(target_peer: str, source_peer: str, topic: str) -> str:
         ps = peer_settings_all.get(target_peer, {}) or {}
@@ -2353,6 +2524,38 @@ def func(
                 )
             )
 
+        if use_status_overview:
+            per_peer_status_spec_yaml[local] = _build_status_pipeline_spec(
+                local=local,
+                remote=remote,
+                peer_name=peer_name,
+                out_entries=out_entries,
+                out_pipes=out_pipes,
+                in_entries=in_entries,
+                in_pipes=in_pipes,
+                use_target_prefix=use_target_prefix,
+                remote_uses_target_prefix=remote_uses_target_prefix,
+                native_have_source_prefix=native_have_source_prefix,
+                inbound_keep_source_prefix=bool(inbound_cfg.get("keep_source_prefix", False)),
+                local_domain_id=peer_local_domain_id[local],
+                ota_domain_id=ota_domain_id,
+                uses_domain_bridge=_use_domain_bridge(local),
+                hb_topic=hb_topic,
+                use_heartbeat=use_heartbeat,
+                out_enabled=out_enabled,
+                in_enabled=in_enabled,
+                final_topic_type=_final_topic_type,
+            )
+            blocks.append(
+                PluginBlock(
+                    "status_overview",
+                    [
+                        ("status_overview", True),
+                        ("status_spec_file", "${peer_dir}/pipeline_spec.yaml"),
+                    ],
+                )
+            )
+
         if use_heartbeat:
             # Heartbeat topics are base topics, but may be explicitly targeted on outbound and/or source-prefixed on inbound.
             hb_out = hb_topic[local]
@@ -2595,6 +2798,8 @@ def func(
             generated.append((os.path.join(param_dir, p, "ota_unwrapper.yaml"), per_peer_otau_yaml[p] or ""))
         if per_peer_domain_bridge_yaml.get(p):
             generated.append((os.path.join(param_dir, p, "domain_bridge.yaml"), per_peer_domain_bridge_yaml[p] or ""))
+        if per_peer_status_spec_yaml.get(p):
+            generated.append((os.path.join(param_dir, p, "pipeline_spec.yaml"), per_peer_status_spec_yaml[p] or ""))
 
     _write_generated_files(generated, force=force, rewrite_formatting=rewrite_formatting)
 

--- a/src/rosotacom/resources/ws/session/creation/generate_session_files.py
+++ b/src/rosotacom/resources/ws/session/creation/generate_session_files.py
@@ -755,6 +755,16 @@ def _render_session_dir(param_dir: str) -> str:
       session directory works when mounted into the container.
     """
     d = os.path.abspath(param_dir)
+
+    session_configs_root = os.environ.get("SESSION_CONFIGS_DIR")
+    if session_configs_root:
+        root = os.path.abspath(session_configs_root)
+        rel = os.path.relpath(d, root)
+        if rel == ".":
+            return "/session/configs"
+        if not rel.startswith(f"..{os.sep}") and rel != "..":
+            return f"/session/configs/{rel}"
+
     session_root = None
     cur = d
     while True:

--- a/src/rosotacom/resources/ws/session/creation/run_session.py
+++ b/src/rosotacom/resources/ws/session/creation/run_session.py
@@ -242,6 +242,7 @@ def _apply_session_overrides(
 
 def _resolve_peer_dir(
     session_dir: str,
+    output_dir: Optional[str],
     identity: Optional[str],
     force: bool,
     rewrite_formatting: bool,
@@ -258,15 +259,19 @@ def _resolve_peer_dir(
       plus: --identity <peer_key>
     """
     if not os.path.isabs(session_dir):
-        base = os.environ.get("SESSION_CONFIGS_DIR")
-        if base:
+        for base in (os.environ.get("SESSION_DEFINITIONS_DIR"), os.environ.get("SESSION_CONFIGS_DIR")):
+            if not base:
+                continue
             candidate = os.path.join(base, session_dir)
             if os.path.isdir(candidate):
                 session_dir = candidate
+                break
 
     p = os.path.abspath(session_dir)
     if not os.path.isdir(p):
         raise RuntimeError(f"--session-dir must be a directory, got: {p}")
+    out = os.path.abspath(output_dir) if output_dir else p
+    os.makedirs(out, exist_ok=True)
 
     if not identity:
         raise RuntimeError(
@@ -300,22 +305,21 @@ def _resolve_peer_dir(
         overwrite_peers_via_remote_peer,
         peer_address,
     )
+    cfg_for_generation = cfg_override if cfg_override is not None else _load_session_config_input(param_yaml)
     session_gen.func(
         session_config_yaml=param_yaml,
         force=force,
         rewrite_formatting=rewrite_formatting,
-        session_config_obj=cfg_override,
-        output_dir=p,
-        write_resolved_definition=False if cfg_override is not None else None,
+        session_config_obj=cfg_for_generation,
+        output_dir=out,
+        write_resolved_definition=True,
     )
-    peer_dir = os.path.join(p, identity)
+    peer_dir = os.path.join(out, identity)
     spec_file = os.path.join(peer_dir, "session_specification.yaml")
     if not os.path.exists(spec_file):
         # Try to help with a quick "what identities exist" hint.
         try:
-            subdirs = sorted(
-                d for d in os.listdir(p) if os.path.isdir(os.path.join(p, d)) and not d.startswith(".")
-            )
+            subdirs = sorted(d for d in os.listdir(out) if os.path.isdir(os.path.join(out, d)) and not d.startswith("."))
         except Exception:
             subdirs = []
         hint = f" Available subdirs: {subdirs}" if subdirs else ""
@@ -326,6 +330,10 @@ def _resolve_peer_dir(
 def main(
     session_dir: str,
     identity: Optional[str] = None,
+    output_dir: Optional[str] = None,
+    instance_dir: Optional[str] = None,
+    catmux_log_dir: Optional[str] = None,
+    rosbag_dir: Optional[str] = None,
     force: bool = False,
     rewrite_formatting: bool = False,
     overwrite_peers_via_remote_peer: Optional[str] = None,
@@ -335,6 +343,7 @@ def main(
 
     peer_dir = _resolve_peer_dir(
         session_dir,
+        output_dir,
         identity,
         force,
         rewrite_formatting,
@@ -343,7 +352,14 @@ def main(
     )
 
     # Ensure merged .session_readonly.yaml exists for catmux
-    create_session_yaml(peer_dir)
+    config_dir = output_dir or os.path.dirname(peer_dir)
+    create_session_yaml(
+        peer_dir,
+        instance_dir=instance_dir or os.environ.get("ROSOTACOM_INSTANCE_DIR"),
+        config_dir=config_dir,
+        catmux_log_dir=catmux_log_dir or os.environ.get("ROSOTACOM_CATMUX_LOG_DIR"),
+        rosbag_dir=rosbag_dir or os.environ.get("ROSOTACOM_ROSBAG_DIR"),
+    )
 
     # Define the command and arguments
     command = "catmux_create_session"
@@ -387,6 +403,22 @@ if __name__ == "__main__":
         "--session-dir",
         required=True,
         help="Directory containing session-definition.yaml or session-parametrization.yaml.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        help="Directory where generated runtime session files are written.",
+    )
+    parser.add_argument(
+        "--instance-dir",
+        help="Runtime session instance directory.",
+    )
+    parser.add_argument(
+        "--catmux-log-dir",
+        help="Directory where catmux pane logs for this peer are written.",
+    )
+    parser.add_argument(
+        "--rosbag-dir",
+        help="Directory where rosbags for this peer should be written.",
     )
     parser.add_argument(
         "--identity",

--- a/src/rosotacom/resources/ws/session/creation/strip_ansi.py
+++ b/src/rosotacom/resources/ws/session/creation/strip_ansi.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Strip ANSI/VT100 control sequences from stdin to stdout."""
+
+from __future__ import annotations
+
+import re
+import sys
+
+
+_ANSI_PATTERN = re.compile(
+    rb"\x1b\[[0-9;?]*[ -/]*[@-~]"
+    rb"|\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)"
+    rb"|\x1b[@-Z\\-_]"
+)
+
+
+def _strip(chunk: bytes) -> bytes:
+    return _ANSI_PATTERN.sub(b"", chunk)
+
+
+def main() -> None:
+    src = sys.stdin.buffer
+    dst = sys.stdout.buffer
+    pending = b""
+    while True:
+        chunk = src.read1(4096)
+        if not chunk:
+            break
+        pending += chunk
+        cut = pending.rfind(b"\n")
+        if cut < 0:
+            continue
+        dst.write(_strip(pending[: cut + 1]))
+        dst.flush()
+        pending = pending[cut + 1:]
+    if pending:
+        dst.write(_strip(pending))
+        dst.flush()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/contract/test_packaged_resources.py
+++ b/tests/contract/test_packaged_resources.py
@@ -20,11 +20,13 @@ def test_packaged_resources_include_cli_marker_examples_and_runtime_workspace() 
         "resources/examples/ros2docker.json",
         "resources/examples/data_dict.json",
         "resources/examples/sessions/1_heartbeat_fastdds/session-definition.yaml",
+        "resources/examples/sessions/1_heartbeat_fastdds/a/domain_bridge.yaml",
         "resources/ws/session/creation/run_session.py",
         "resources/ws/session/creation/catmux_log_setup.sh",
         "resources/ws/session/creation/strip_ansi.py",
         "resources/ws/session/content/address_resolution.py",
         "resources/ws/ota_configs/cyclonedds_tuned.xml.template",
+        "resources/ws/ota_configs/fastdds_unicast.xml.template",
         "resources/ws/ros2src/com_msgs/msg/Heartbeat.msg",
     )
 

--- a/tests/contract/test_packaged_resources.py
+++ b/tests/contract/test_packaged_resources.py
@@ -16,10 +16,13 @@ def test_packaged_resources_include_cli_marker_examples_and_runtime_workspace() 
         "py.typed",
         "resources/ros2docker.json.example",
         "resources/examples/rosotacom.yaml",
+        "resources/examples/.gitignore",
         "resources/examples/ros2docker.json",
         "resources/examples/data_dict.json",
         "resources/examples/sessions/1_heartbeat_fastdds/session-definition.yaml",
         "resources/ws/session/creation/run_session.py",
+        "resources/ws/session/creation/catmux_log_setup.sh",
+        "resources/ws/session/creation/strip_ansi.py",
         "resources/ws/session/content/address_resolution.py",
         "resources/ws/ota_configs/cyclonedds_tuned.xml.template",
         "resources/ws/ros2src/com_msgs/msg/Heartbeat.msg",
@@ -41,3 +44,9 @@ def test_shell_entrypoints_pass_syntax_check() -> None:
     assert scripts
     for script in scripts:
         subprocess.run(["bash", "-n", str(script)], check=True)
+
+    subprocess.run(["bash", "-n", str(cli.WS_DIR / "session" / "creation" / "catmux_log_setup.sh")], check=True)
+    subprocess.run(
+        ["python3", "-m", "py_compile", str(cli.WS_DIR / "session" / "creation" / "strip_ansi.py")],
+        check=True,
+    )

--- a/tests/contract/test_packaged_resources.py
+++ b/tests/contract/test_packaged_resources.py
@@ -18,7 +18,7 @@ def test_packaged_resources_include_cli_marker_examples_and_runtime_workspace() 
         "resources/examples/rosotacom.yaml",
         "resources/examples/ros2docker.json",
         "resources/examples/data_dict.json",
-        "resources/examples/sessions/1_heartbeat/session-definition.yaml",
+        "resources/examples/sessions/1_heartbeat_fastdds/session-definition.yaml",
         "resources/ws/session/creation/run_session.py",
         "resources/ws/session/content/address_resolution.py",
         "resources/ws/ota_configs/cyclonedds_tuned.xml.template",

--- a/tests/contract/test_readme_examples.py
+++ b/tests/contract/test_readme_examples.py
@@ -40,6 +40,6 @@ def test_packaged_example_setup_paths_are_relative_to_example_root() -> None:
 def test_packaged_example_project_contains_documented_heartbeat_session() -> None:
     readme = (PACKAGE_ROOT / "README.md").read_text(encoding="utf-8")
 
-    assert "`1_heartbeat`" in readme
-    assert (cli.EXAMPLE_PROJECT_DIR / "sessions" / "1_heartbeat" / "session-definition.yaml").is_file()
+    assert "`1_heartbeat_fastdds`" in readme
+    assert (cli.EXAMPLE_PROJECT_DIR / "sessions" / "1_heartbeat_fastdds" / "session-definition.yaml").is_file()
     assert (cli.EXAMPLE_PROJECT_DIR / "scripts" / "1_heartbeat" / "run_machine_a.sh").is_file()

--- a/tests/contract/test_readme_examples.py
+++ b/tests/contract/test_readme_examples.py
@@ -24,6 +24,7 @@ def test_source_checkout_rosotacom_yaml_loads() -> None:
 
     assert runtime.ros2docker_config == cli.EXAMPLE_PROJECT_DIR / "ros2docker.json"
     assert runtime.session_configs_dir == cli.EXAMPLE_PROJECT_DIR / "sessions"
+    assert runtime.session_instances_dir == PACKAGE_ROOT / "session-instances"
     assert runtime.data_dict == cli.EXAMPLE_PROJECT_DIR / "data_dict.json"
 
 
@@ -33,6 +34,7 @@ def test_packaged_example_setup_paths_are_relative_to_example_root() -> None:
     assert setup == {
         "ros2docker_config": "ros2docker.json",
         "session_configs_dir": "sessions",
+        "session_instances_dir": "session-instances",
         "data_dict": "data_dict.json",
     }
 

--- a/tests/contract/test_security_maintenance_config.py
+++ b/tests/contract/test_security_maintenance_config.py
@@ -40,4 +40,19 @@ def test_merge_gate_requires_non_docker_package_and_docker_smoke() -> None:
     assert "ci-success" in merge_gate
     assert "just test-nondocker-cov" in merge_gate
     assert "just package" in merge_gate
-    assert "just test-e2e-fast" in merge_gate
+    assert "just test-e2e-smoke" in merge_gate
+
+
+def test_e2e_smoke_matrix_covers_all_heartbeat_rmw_examples() -> None:
+    e2e_smoke = (PACKAGE_ROOT / "tests" / "e2e" / "test_smoke.py").read_text(encoding="utf-8")
+
+    expected_sessions = [
+        "1_heartbeat_fastdds",
+        "1_heartbeat_cyclone-ota",
+        "1_heartbeat_zen-endpoints",
+        "1_heartbeat_fastdds-local_cyclone-ota",
+        "1_heartbeat_cyclone-local_fastdds-ota",
+        "1_heartbeat_cyclone-local_zenoh-ros2dds-ota",
+    ]
+    for session in expected_sessions:
+        assert session in e2e_smoke

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -48,6 +48,27 @@ EXPECTED_HEARTBEAT_CHECKS = (
     "OK: b->a final heartbeat (/heartbeat_b)",
 )
 
+# Heartbeat publishers emit at 10 Hz; received rate should stay close to that.
+EXPECTED_HEARTBEAT_HZ = 10.0
+HEARTBEAT_HZ_MIN = 5.0
+HEARTBEAT_HZ_MAX = 20.0
+# End-to-end heartbeat latency must stay well below one second.
+MAX_HEARTBEAT_DELAY_S = 1.0
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;?]*[ -/]*[@-~]")
+_ERROR_PATTERNS = (
+    re.compile(r"\[ERROR\]"),
+    re.compile(r"\[FATAL\]"),
+    re.compile(r"Traceback \(most recent call last\)"),
+    re.compile(r"terminate called"),
+    re.compile(r"Segmentation fault"),
+    re.compile(r"core dumped"),
+)
+_METRIC_RE = re.compile(
+    r"SMOKE_METRIC topic=(?P<topic>\S+) container=(?P<container>\S+) "
+    r"hz=(?P<hz>\S+) delay_s=(?P<delay>\S+) label=(?P<label>.+)"
+)
+
 
 def _run(command: list[str], *, timeout: int) -> subprocess.CompletedProcess[str]:
     result = subprocess.run(
@@ -74,32 +95,112 @@ def copied_example_project(tmp_path_factory: pytest.TempPathFactory) -> Path:
     return project
 
 
+def _smoke_command(project: Path, session_name: str) -> list[str]:
+    return [
+        sys.executable,
+        "-m",
+        "rosotacom",
+        "smoke",
+        session_name,
+        "--rosotacom-config",
+        str(project / "rosotacom.yaml"),
+        "--local-ip",
+        "127.0.0.1",
+    ]
+
+
+def _artifact_dir(stdout: str) -> Path:
+    matches = re.findall(r"Smoke artifacts: (.+)", stdout)
+    assert matches, f"no 'Smoke artifacts:' line in smoke output:\n{stdout}"
+    return Path(matches[-1].strip())
+
+
+def _strip_ansi(text: str) -> str:
+    return _ANSI_RE.sub("", text)
+
+
+def _collect_log_files(artifact_dir: Path) -> list[Path]:
+    logs_dir = artifact_dir / "logs"
+    files = list(logs_dir.glob("*/catmux/*/*.log"))
+    files += list(logs_dir.glob("*/docker.log"))
+    return sorted(files)
+
+
+def _scan_logs_for_errors(artifact_dir: Path) -> list[str]:
+    hits: list[str] = []
+    for path in _collect_log_files(artifact_dir):
+        text = _strip_ansi(path.read_text(encoding="utf-8", errors="replace"))
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            if any(pattern.search(line) for pattern in _ERROR_PATTERNS):
+                rel = path.relative_to(artifact_dir)
+                hits.append(f"{rel}:{lineno}: {line.strip()}")
+    return hits
+
+
+def _parse_metrics(stdout: str) -> list[dict[str, object]]:
+    metrics: list[dict[str, object]] = []
+    for line in stdout.splitlines():
+        match = _METRIC_RE.search(line)
+        if not match:
+            continue
+        metrics.append(
+            {
+                "topic": match["topic"],
+                "container": match["container"],
+                "hz": None if match["hz"] == "nan" else float(match["hz"]),
+                "delay_s": None if match["delay"] == "nan" else float(match["delay"]),
+                "label": match["label"].strip().strip("'\""),
+            }
+        )
+    return metrics
+
+
+def _assert_no_ros_or_catmux_errors(session_name: str, artifact_dir: Path) -> None:
+    log_files = _collect_log_files(artifact_dir)
+    assert log_files, f"no catmux/docker logs found under {artifact_dir}"
+
+    errors = _scan_logs_for_errors(artifact_dir)
+    assert not errors, f"ROS/catmux logs for {session_name} contain errors:\n" + "\n".join(errors)
+
+
+def _assert_heartbeat_rate_and_latency_within_bounds(session_name: str, stdout: str) -> None:
+    metrics = _parse_metrics(stdout)
+    final_heartbeat_metrics = [m for m in metrics if "final heartbeat" in str(m["label"])]
+    assert final_heartbeat_metrics, f"no final heartbeat metrics in smoke output for {session_name}:\n{stdout}"
+
+    hz_problems: list[str] = []
+    delay_problems: list[str] = []
+    for metric in final_heartbeat_metrics:
+        hz = metric["hz"]
+        delay_s = metric["delay_s"]
+        if not isinstance(hz, float) or not (HEARTBEAT_HZ_MIN <= hz <= HEARTBEAT_HZ_MAX):
+            hz_problems.append(f"{metric['label']} ({metric['topic']}): hz={hz}")
+        if not isinstance(delay_s, float) or delay_s >= MAX_HEARTBEAT_DELAY_S:
+            delay_problems.append(f"{metric['label']} ({metric['topic']}): delay_s={delay_s}")
+
+    assert not hz_problems, (
+        f"{session_name} heartbeat rate outside [{HEARTBEAT_HZ_MIN}, {HEARTBEAT_HZ_MAX}] Hz "
+        f"(expected ~{EXPECTED_HEARTBEAT_HZ} Hz):\n" + "\n".join(hz_problems)
+    )
+    assert not delay_problems, f"{session_name} heartbeat latency >= {MAX_HEARTBEAT_DELAY_S}s:\n" + "\n".join(
+        delay_problems
+    )
+
+
 @pytest.mark.parametrize("session_name", HEARTBEAT_SMOKE_SESSIONS)
 def test_local_heartbeat_smoke_matrix_from_copied_example_project(
     copied_example_project: Path,
     session_name: str,
 ) -> None:
-    result = _run(
-        [
-            sys.executable,
-            "-m",
-            "rosotacom",
-            "smoke",
-            session_name,
-            "--rosotacom-config",
-            str(copied_example_project / "rosotacom.yaml"),
-            "--local-ip",
-            "127.0.0.1",
-        ],
-        timeout=900,
-    )
+    result = _run(_smoke_command(copied_example_project, session_name), timeout=900)
 
     for expected in EXPECTED_HEARTBEAT_CHECKS:
         assert expected in result.stdout
 
-    artifact_matches = re.findall(r"Smoke artifacts: (.+)", result.stdout)
-    assert artifact_matches
-    artifact_dir = Path(artifact_matches[-1].strip())
+    artifact_dir = _artifact_dir(result.stdout)
     assert (artifact_dir / "config" / "a" / "plugin.yaml").is_file()
     assert (artifact_dir / "config" / "b" / "plugin.yaml").is_file()
     assert list((artifact_dir / "logs").glob("*/catmux/*/*.log"))
+
+    _assert_no_ros_or_catmux_errors(session_name, artifact_dir)
+    _assert_heartbeat_rate_and_latency_within_bounds(session_name, result.stdout)

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -7,7 +8,51 @@ from pathlib import Path
 import pytest
 
 PACKAGE_ROOT = Path(__file__).resolve().parents[2]
-pytestmark = pytest.mark.e2e
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.skipif(
+        os.environ.get("ROSOTACOM_RUN_E2E") != "1",
+        reason="Docker-backed E2E tests require ROSOTACOM_RUN_E2E=1.",
+    ),
+]
+
+HEARTBEAT_SMOKE_SESSIONS = [
+    pytest.param("1_heartbeat_cyclone-ota", id="cyclone-ota"),
+    pytest.param("1_heartbeat_zen-endpoints", id="zen-endpoints"),
+    pytest.param("1_heartbeat_cyclone-local_zenoh-ros2dds-ota", id="cyclone-local-zenoh-ros2dds-ota"),
+    pytest.param(
+        "1_heartbeat_fastdds",
+        marks=pytest.mark.xfail(
+            reason="Strict heartbeat smoke currently fails at the a->b inbound bridge topic.",
+            strict=True,
+        ),
+        id="fastdds",
+    ),
+    pytest.param(
+        "1_heartbeat_fastdds-local_cyclone-ota",
+        marks=pytest.mark.xfail(
+            reason="Strict heartbeat smoke currently fails at the a->b inbound bridge topic.",
+            strict=True,
+        ),
+        id="fastdds-local-cyclone-ota",
+    ),
+    pytest.param(
+        "1_heartbeat_cyclone-local_fastdds-ota",
+        marks=pytest.mark.xfail(
+            reason="Strict heartbeat smoke currently fails at the a->b inbound bridge topic.",
+            strict=True,
+        ),
+        id="cyclone-local-fastdds-ota",
+    ),
+]
+
+EXPECTED_HEARTBEAT_CHECKS = (
+    "OK: generated plugin.yaml files use literal CLI addresses",
+    "OK: a->b inbound bridge heartbeat (/com/in/a/heartbeat_a)",
+    "OK: a->b final heartbeat (/heartbeat_a)",
+    "OK: b->a inbound bridge heartbeat (/com/in/b/heartbeat_b)",
+    "OK: b->a final heartbeat (/heartbeat_b)",
+)
 
 
 def _run(command: list[str], *, timeout: int) -> subprocess.CompletedProcess[str]:
@@ -27,22 +72,33 @@ def _run(command: list[str], *, timeout: int) -> subprocess.CompletedProcess[str
     return result
 
 
-def test_local_heartbeat_smoke_from_copied_example_project(tmp_path: Path) -> None:
-    project = tmp_path / "rosotacom_examples"
+@pytest.fixture(scope="session")
+def copied_example_project(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    project = tmp_path_factory.mktemp("rosotacom") / "examples"
 
     _run([sys.executable, "-m", "rosotacom", "examples", "create", str(project)], timeout=60)
+    return project
+
+
+@pytest.mark.parametrize("session_name", HEARTBEAT_SMOKE_SESSIONS)
+def test_local_heartbeat_smoke_matrix_from_copied_example_project(
+    copied_example_project: Path,
+    session_name: str,
+) -> None:
     result = _run(
         [
             sys.executable,
             "-m",
             "rosotacom",
             "smoke",
+            session_name,
             "--rosotacom-config",
-            str(project / "rosotacom.yaml"),
+            str(copied_example_project / "rosotacom.yaml"),
             "--local-ip",
             "127.0.0.1",
         ],
         timeout=900,
     )
 
-    assert "OK: generated plugin.yaml files use literal CLI addresses" in result.stdout
+    for expected in EXPECTED_HEARTBEAT_CHECKS:
+        assert expected in result.stdout

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -102,3 +103,10 @@ def test_local_heartbeat_smoke_matrix_from_copied_example_project(
 
     for expected in EXPECTED_HEARTBEAT_CHECKS:
         assert expected in result.stdout
+
+    artifact_matches = re.findall(r"Smoke artifacts: (.+)", result.stdout)
+    assert artifact_matches
+    artifact_dir = Path(artifact_matches[-1].strip())
+    assert (artifact_dir / "config" / "a" / "plugin.yaml").is_file()
+    assert (artifact_dir / "config" / "b" / "plugin.yaml").is_file()
+    assert list((artifact_dir / "logs").glob("*/catmux/*/*.log"))

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -21,14 +21,7 @@ HEARTBEAT_SMOKE_SESSIONS = [
     pytest.param("1_heartbeat_cyclone-ota", id="cyclone-ota"),
     pytest.param("1_heartbeat_zen-endpoints", id="zen-endpoints"),
     pytest.param("1_heartbeat_cyclone-local_zenoh-ros2dds-ota", id="cyclone-local-zenoh-ros2dds-ota"),
-    pytest.param(
-        "1_heartbeat_fastdds",
-        marks=pytest.mark.xfail(
-            reason="Strict heartbeat smoke currently fails at the a->b inbound bridge topic.",
-            strict=True,
-        ),
-        id="fastdds",
-    ),
+    pytest.param("1_heartbeat_fastdds", id="fastdds"),
     pytest.param(
         "1_heartbeat_fastdds-local_cyclone-ota",
         marks=pytest.mark.xfail(

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -20,24 +20,21 @@ pytestmark = [
 HEARTBEAT_SMOKE_SESSIONS = [
     pytest.param("1_heartbeat_cyclone-ota", id="cyclone-ota"),
     pytest.param("1_heartbeat_zen-endpoints", id="zen-endpoints"),
-    pytest.param("1_heartbeat_cyclone-local_zenoh-ros2dds-ota", id="cyclone-local-zenoh-ros2dds-ota"),
+    pytest.param(
+        "1_heartbeat_cyclone-local_zenoh-ros2dds-ota",
+        marks=pytest.mark.xfail(
+            reason=(
+                "zenoh_ros2dds OTA double-bridges the heartbeat (~2x, ~21 Hz) over OTA domain 48, "
+                "exceeding the rate bound. Network-namespace isolation did not resolve it; "
+                "tracked as a follow-up to fix the zenoh-bridge-ros2dds / domain_bridge scoping."
+            ),
+            strict=True,
+        ),
+        id="cyclone-local-zenoh-ros2dds-ota",
+    ),
     pytest.param("1_heartbeat_fastdds", id="fastdds"),
-    pytest.param(
-        "1_heartbeat_fastdds-local_cyclone-ota",
-        marks=pytest.mark.xfail(
-            reason="Strict heartbeat smoke currently fails at the a->b inbound bridge topic.",
-            strict=True,
-        ),
-        id="fastdds-local-cyclone-ota",
-    ),
-    pytest.param(
-        "1_heartbeat_cyclone-local_fastdds-ota",
-        marks=pytest.mark.xfail(
-            reason="Strict heartbeat smoke currently fails at the a->b inbound bridge topic.",
-            strict=True,
-        ),
-        id="cyclone-local-fastdds-ota",
-    ),
+    pytest.param("1_heartbeat_fastdds-local_cyclone-ota", id="fastdds-local-cyclone-ota"),
+    pytest.param("1_heartbeat_cyclone-local_fastdds-ota", id="cyclone-local-fastdds-ota"),
 ]
 
 EXPECTED_HEARTBEAT_CHECKS = (
@@ -95,6 +92,12 @@ def copied_example_project(tmp_path_factory: pytest.TempPathFactory) -> Path:
     return project
 
 
+# Force smoke artifacts into the repo workspace instead of the pytest tmp dir so
+# CI's "Upload smoke session artifacts" step (path: session-instances/) actually
+# captures catmux/domain-bridge logs when a smoke check fails.
+SESSION_INSTANCES_DIR = PACKAGE_ROOT / "session-instances"
+
+
 def _smoke_command(project: Path, session_name: str) -> list[str]:
     return [
         sys.executable,
@@ -104,6 +107,8 @@ def _smoke_command(project: Path, session_name: str) -> list[str]:
         session_name,
         "--rosotacom-config",
         str(project / "rosotacom.yaml"),
+        "--session-instances-dir",
+        str(SESSION_INSTANCES_DIR),
         "--local-ip",
         "127.0.0.1",
     ]

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -6,6 +6,7 @@ import sys
 from pathlib import Path
 
 import pytest
+import yaml
 
 import rosotacom.cli as rosotacom
 
@@ -16,6 +17,7 @@ def clear_config_env(monkeypatch: pytest.MonkeyPatch) -> None:
         "ROSOTACOM_CONFIG",
         "ROSOTACOM_ROS2DOCKER_CONFIG",
         "ROSOTACOM_SESSION_CONFIGS_DIR",
+        "ROSOTACOM_SESSION_INSTANCES_DIR",
         "ROSOTACOM_DATA_DICT",
     ):
         monkeypatch.delenv(key, raising=False)
@@ -29,6 +31,7 @@ def test_no_rosotacom_yaml_auto_discovery(tmp_path: Path, monkeypatch: pytest.Mo
 
     assert runtime.rosotacom_config is None
     assert runtime.ros2docker_config == rosotacom.DEFAULT_ROS2DOCKER_CONFIG.resolve()
+    assert runtime.session_instances_dir == tmp_path / "session-instances"
 
 
 def test_rosotacom_yaml_relative_paths_resolve_from_config_dir(tmp_path: Path) -> None:
@@ -41,6 +44,7 @@ def test_rosotacom_yaml_relative_paths_resolve_from_config_dir(tmp_path: Path) -
             [
                 "ros2docker_config: ros2docker.json",
                 "session_configs_dir: sessions",
+                "session_instances_dir: session-instances",
                 "data_dict: data_dict.json",
                 "",
             ]
@@ -53,6 +57,7 @@ def test_rosotacom_yaml_relative_paths_resolve_from_config_dir(tmp_path: Path) -
     assert runtime.rosotacom_config == config
     assert runtime.ros2docker_config == tmp_path / "ros2docker.json"
     assert runtime.session_configs_dir == tmp_path / "sessions"
+    assert runtime.session_instances_dir == tmp_path / "session-instances"
     assert runtime.data_dict == tmp_path / "data_dict.json"
 
 
@@ -71,6 +76,7 @@ def test_environment_config_is_used_when_no_config_arg(tmp_path: Path, monkeypat
     assert runtime.rosotacom_config == config
     assert runtime.ros2docker_config == tmp_path / "ros2docker.json"
     assert runtime.session_configs_dir == tmp_path / "sessions"
+    assert runtime.session_instances_dir == tmp_path / "session-instances"
 
 
 def test_examples_create_copies_project_and_refuses_overwrite(
@@ -85,6 +91,7 @@ def test_examples_create_copies_project_and_refuses_overwrite(
     assert (target / "rosotacom.yaml").is_file()
     assert (target / "ros2docker.json").is_file()
     assert (target / "data_dict.json").is_file()
+    assert "session-instances/" in (target / ".gitignore").read_text(encoding="utf-8")
     assert (target / "sessions" / "1_heartbeat_fastdds" / "session-definition.yaml").is_file()
     assert not (target / "__init__.py").exists()
     assert "Copied rosotacom examples" in capsys.readouterr().out
@@ -121,7 +128,7 @@ def test_session_name_resolves_through_configured_sessions_dir(tmp_path: Path) -
     resolved = rosotacom._resolve_session("1_heartbeat", runtime)
 
     assert resolved.host_dir == session.resolve()
-    assert resolved.container_dir == "/session/configs/1_heartbeat"
+    assert resolved.container_dir == "/session/definitions/1_heartbeat"
     assert resolved.source == "session_configs"
 
 
@@ -246,8 +253,20 @@ def test_peer_override_identity_and_command_helpers(tmp_path: Path, monkeypatch:
     assert rosotacom._identity_container_names(overridden, runtime, "a") == ["rosotacom_abc_com_to_remote_unit"]
 
     session = rosotacom.ResolvedSession(tmp_path, "/session/current", "absolute")
+    instance = rosotacom.SessionInstance(
+        instance_id="run1",
+        host_dir=tmp_path / "instances" / "2026-01-01" / "1_heartbeat_run1",
+        container_dir="/session/instances/2026-01-01/1_heartbeat_run1",
+        config_host_dir=tmp_path / "instances" / "2026-01-01" / "1_heartbeat_run1" / "config",
+        config_container_dir="/session/instances/2026-01-01/1_heartbeat_run1/config",
+        logs_host_dir=tmp_path / "instances" / "2026-01-01" / "1_heartbeat_run1" / "logs",
+        logs_container_dir="/session/instances/2026-01-01/1_heartbeat_run1/logs",
+        rosbags_host_dir=tmp_path / "instances" / "2026-01-01" / "1_heartbeat_run1" / "rosbags",
+        rosbags_container_dir="/session/instances/2026-01-01/1_heartbeat_run1/rosbags",
+    )
     assert rosotacom._session_command(
         session,
+        instance,
         "a",
         force=True,
         rewrite_formatting=True,
@@ -258,6 +277,14 @@ def test_peer_override_identity_and_command_helpers(tmp_path: Path, monkeypatch:
         "/ws/session/creation/run_session.py",
         "--session-dir",
         "/session/current",
+        "--output-dir",
+        "/session/instances/2026-01-01/1_heartbeat_run1/config",
+        "--instance-dir",
+        "/session/instances/2026-01-01/1_heartbeat_run1",
+        "--catmux-log-dir",
+        "/session/instances/2026-01-01/1_heartbeat_run1/logs/a/catmux",
+        "--rosbag-dir",
+        "/session/instances/2026-01-01/1_heartbeat_run1/rosbags/a",
         "--identity",
         "a",
         "--force",
@@ -285,15 +312,23 @@ def test_resolve_session_and_base_extra_run_args(tmp_path: Path, monkeypatch: py
         session_configs_dir=tmp_path / "sessions",
         data_dict=data_dict,
         install_id="id",
+        session_instances_dir=tmp_path / "session-instances",
     )
 
     resolved = rosotacom._resolve_session("1_heartbeat", runtime)
-    monkeypatch.setattr(rosotacom, "load_config", lambda config: {"mount_ws": False})
-    args = rosotacom._base_extra_run_args(runtime, resolved, {"peers": {"a": {"address": "data:machine_a_ip"}}})
+    instance = rosotacom._resolve_session_instance(runtime, resolved, "test-run")
+    monkeypatch.setattr(rosotacom, "load_config", lambda config: {"mount_ws": False}, raising=False)
+    args = rosotacom._base_extra_run_args(
+        runtime,
+        resolved,
+        {"peers": {"a": {"address": "data:machine_a_ip"}}},
+        instance,
+    )
 
-    assert resolved.container_dir == "/session/configs/1_heartbeat"
+    assert resolved.container_dir == "/session/definitions/1_heartbeat"
     assert f"{rosotacom.WS_DIR.resolve()}:/ws" in args
-    assert f"{runtime.session_configs_dir}:/session/configs" in args
+    assert f"{runtime.session_configs_dir}:/session/definitions:ro" in args
+    assert f"{runtime.session_instances_dir}:/session/instances" in args
     assert f"{data_dict}:/data_dict.json:ro" in args
     assert "Configured sessions:" in rosotacom._format_available_sessions(runtime)
 
@@ -307,7 +342,7 @@ def test_container_helpers_use_docker_and_ros2docker_stop(tmp_path: Path, monkey
     assert not rosotacom._stop_container_name("missing", runtime, quiet_missing=True)
 
     monkeypatch.setattr(rosotacom, "_container_exists", lambda name: True)
-    monkeypatch.setattr(rosotacom, "ros2docker_stop", lambda **kwargs: calls.append(kwargs))
+    monkeypatch.setattr(rosotacom, "ros2docker_stop", lambda **kwargs: calls.append(kwargs), raising=False)
     assert rosotacom._stop_container_name("running", runtime)
     assert calls == [{"config_file": runtime.ros2docker_config, "override": {"container_name": "running"}}]
 
@@ -323,22 +358,28 @@ def test_container_helpers_use_docker_and_ros2docker_stop(tmp_path: Path, monkey
 
 
 def test_start_session_detached_dispatches_ros2docker(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    runtime = rosotacom.RuntimeConfig(None, tmp_path / "ros2docker.json", None, None, "id")
+    runtime = rosotacom.RuntimeConfig(None, tmp_path / "ros2docker.json", None, None, "id", tmp_path / "instances")
     session = rosotacom.ResolvedSession(tmp_path, "/session/current", "absolute")
     cfg = {"peers": {"a": {}, "b": {"com-name": "remote"}}}
     calls: list[tuple[str, dict[str, object]]] = []
 
+    monkeypatch.setattr(rosotacom, "_require_ros2docker", lambda: None)
     monkeypatch.setattr(rosotacom, "_load_runtime_config", lambda args: runtime)
     monkeypatch.setattr(rosotacom, "_resolve_session", lambda session_dir, runtime: session)
     monkeypatch.setattr(rosotacom, "_effective_session_config", lambda *args, **kwargs: cfg)
     monkeypatch.setattr(rosotacom, "_scoped_image_name", lambda runtime: "image:id")
-    monkeypatch.setattr(rosotacom, "_base_extra_run_args", lambda runtime, session, cfg: ["--network", "host"])
+    monkeypatch.setattr(
+        rosotacom,
+        "_base_extra_run_args",
+        lambda runtime, session, cfg, instance: ["--network", "host"],
+    )
     monkeypatch.setattr(rosotacom, "_resolve_mode", lambda mode: "detached")
     monkeypatch.setattr(rosotacom, "_stop_container_name", lambda *args, **kwargs: True)
     monkeypatch.setattr(rosotacom, "_wait_for_container_ready", lambda name: None)
-    monkeypatch.setattr(rosotacom, "ros2docker_build", lambda **kwargs: calls.append(("build", kwargs)))
-    monkeypatch.setattr(rosotacom, "ros2docker_run", lambda **kwargs: calls.append(("run", kwargs)))
-    monkeypatch.setattr(rosotacom, "ros2docker_exec", lambda **kwargs: calls.append(("exec", kwargs)))
+    monkeypatch.setattr(rosotacom, "_write_docker_log", lambda *args, **kwargs: None)
+    monkeypatch.setattr(rosotacom, "ros2docker_build", lambda **kwargs: calls.append(("build", kwargs)), raising=False)
+    monkeypatch.setattr(rosotacom, "ros2docker_run", lambda **kwargs: calls.append(("run", kwargs)), raising=False)
+    monkeypatch.setattr(rosotacom, "ros2docker_exec", lambda **kwargs: calls.append(("exec", kwargs)), raising=False)
 
     container = rosotacom.start_session(
         argparse.Namespace(
@@ -350,6 +391,7 @@ def test_start_session_detached_dispatches_ros2docker(monkeypatch: pytest.Monkey
             mode="detached",
             force=True,
             rewrite_formatting=False,
+            instance_id="unit",
         )
     )
 
@@ -357,24 +399,27 @@ def test_start_session_detached_dispatches_ros2docker(monkeypatch: pytest.Monkey
     assert [name for name, _ in calls] == ["build", "run", "exec"]
     assert calls[1][1]["override"]["run_type"] == "up"
     assert calls[2][1]["interactive"] is False
+    assert "--output-dir" in calls[2][1]["command"]
 
 
 def test_start_session_attach_dispatches_command_run(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    runtime = rosotacom.RuntimeConfig(None, tmp_path / "ros2docker.json", None, None, "id")
+    runtime = rosotacom.RuntimeConfig(None, tmp_path / "ros2docker.json", None, None, "id", tmp_path / "instances")
     session = rosotacom.ResolvedSession(tmp_path, "/session/current", "absolute")
     cfg = {"peers": {"a": {}, "b": {}}}
     calls: list[tuple[str, dict[str, object]]] = []
 
+    monkeypatch.setattr(rosotacom, "_require_ros2docker", lambda: None)
     monkeypatch.setattr(rosotacom, "_load_runtime_config", lambda args: runtime)
     monkeypatch.setattr(rosotacom, "_resolve_session", lambda session_dir, runtime: session)
     monkeypatch.setattr(rosotacom, "_effective_session_config", lambda *args, **kwargs: cfg)
     monkeypatch.setattr(rosotacom, "_auto_identity", lambda *args: "a")
     monkeypatch.setattr(rosotacom, "_scoped_image_name", lambda runtime: "image:id")
-    monkeypatch.setattr(rosotacom, "_base_extra_run_args", lambda runtime, session, cfg: [])
+    monkeypatch.setattr(rosotacom, "_base_extra_run_args", lambda runtime, session, cfg, instance: [])
     monkeypatch.setattr(rosotacom, "_resolve_mode", lambda mode: "attach")
     monkeypatch.setattr(rosotacom, "_stop_container_name", lambda *args, **kwargs: True)
-    monkeypatch.setattr(rosotacom, "ros2docker_build", lambda **kwargs: calls.append(("build", kwargs)))
-    monkeypatch.setattr(rosotacom, "ros2docker_run", lambda **kwargs: calls.append(("run", kwargs)))
+    monkeypatch.setattr(rosotacom, "_write_docker_log", lambda *args, **kwargs: None)
+    monkeypatch.setattr(rosotacom, "ros2docker_build", lambda **kwargs: calls.append(("build", kwargs)), raising=False)
+    monkeypatch.setattr(rosotacom, "ros2docker_run", lambda **kwargs: calls.append(("run", kwargs)), raising=False)
 
     rosotacom.start_session(
         argparse.Namespace(
@@ -386,6 +431,7 @@ def test_start_session_attach_dispatches_command_run(monkeypatch: pytest.MonkeyP
             mode="attach",
             force=True,
             rewrite_formatting=False,
+            instance_id="unit",
         )
     )
 
@@ -405,17 +451,43 @@ def test_stop_list_doctor_and_smoke_host_flows(
     (session_dir / "session-definition.yaml").write_text("peers: {}\n", encoding="utf-8")
     (session_dir / "a" / "plugin.yaml").write_text("127.0.0.1\n", encoding="utf-8")
     (session_dir / "b" / "plugin.yaml").write_text("127.0.0.1\n", encoding="utf-8")
-    runtime = rosotacom.RuntimeConfig(None, tmp_path / "ros2docker.json", tmp_path / "sessions", None, "id")
-    session = rosotacom.ResolvedSession(session_dir, "/session/configs/1_heartbeat", "session_configs")
+    runtime = rosotacom.RuntimeConfig(
+        None,
+        tmp_path / "ros2docker.json",
+        tmp_path / "sessions",
+        None,
+        "id",
+        tmp_path / "session-instances",
+    )
+    session = rosotacom.ResolvedSession(session_dir, "/session/definitions/1_heartbeat", "session_configs")
+    instance = rosotacom.SessionInstance(
+        instance_id="smoke",
+        host_dir=tmp_path / "session-instances" / "2026-01-01" / "1_heartbeat_smoke",
+        container_dir="/session/instances/2026-01-01/1_heartbeat_smoke",
+        config_host_dir=tmp_path / "session-instances" / "2026-01-01" / "1_heartbeat_smoke" / "config",
+        config_container_dir="/session/instances/2026-01-01/1_heartbeat_smoke/config",
+        logs_host_dir=tmp_path / "session-instances" / "2026-01-01" / "1_heartbeat_smoke" / "logs",
+        logs_container_dir="/session/instances/2026-01-01/1_heartbeat_smoke/logs",
+        rosbags_host_dir=tmp_path / "session-instances" / "2026-01-01" / "1_heartbeat_smoke" / "rosbags",
+        rosbags_container_dir="/session/instances/2026-01-01/1_heartbeat_smoke/rosbags",
+    )
+    (instance.config_host_dir / "a").mkdir(parents=True)
+    (instance.config_host_dir / "b").mkdir()
+    (instance.config_host_dir / "a" / "plugin.yaml").write_text("127.0.0.1\n", encoding="utf-8")
+    (instance.config_host_dir / "b" / "plugin.yaml").write_text("127.0.0.1\n", encoding="utf-8")
     cfg = {"peers": {"a": {}, "b": {}}}
     stopped: list[str] = []
 
     monkeypatch.setattr(rosotacom, "_load_runtime_config", lambda args: runtime)
     monkeypatch.setattr(rosotacom, "_resolve_session", lambda session_dir, runtime: session)
+    monkeypatch.setattr(rosotacom, "_resolve_session_instance", lambda runtime, session, instance_id=None: instance)
     monkeypatch.setattr(rosotacom, "_effective_session_config", lambda *args, **kwargs: cfg)
     monkeypatch.setattr(rosotacom, "_identity_container_names", lambda cfg, runtime, identity=None: ["c1", "c2"])
     monkeypatch.setattr(rosotacom, "_stop_container_name", lambda name, runtime, **kwargs: stopped.append(name) or True)
-    monkeypatch.setattr(rosotacom, "load_config", lambda config: {"mount_ws": True})
+    monkeypatch.setattr(rosotacom, "_ROS2DOCKER_IMPORT_ERROR", None)
+    fake_ros2docker = type("FakeRos2Docker", (), {"__version__": "test", "__file__": __file__})
+    monkeypatch.setattr(rosotacom, "ros2docker", fake_ros2docker)
+    monkeypatch.setattr(rosotacom, "load_config", lambda config: {"mount_ws": True}, raising=False)
     monkeypatch.setattr(rosotacom, "_scoped_image_name", lambda runtime: "image:id")
 
     rosotacom.stop_session(argparse.Namespace(session_dir="1_heartbeat", identity=None, auto_identity=False))
@@ -441,7 +513,9 @@ def test_stop_list_doctor_and_smoke_host_flows(
                 rosotacom_config=None,
                 ros2docker_config=None,
                 session_configs_dir=None,
+                session_instances_dir=None,
                 data_dict=None,
+                instance_id="smoke",
                 keep_running=False,
             )
         )
@@ -470,6 +544,84 @@ def test_native_zenoh_smoke_uses_distinct_loopback_addresses(tmp_path: Path) -> 
         ),
         encoding="utf-8",
     )
-    session = rosotacom.ResolvedSession(session_dir, "/session/configs/1_heartbeat_zen-endpoints", "session_configs")
+    session = rosotacom.ResolvedSession(
+        session_dir,
+        "/session/definitions/1_heartbeat_zen-endpoints",
+        "session_configs",
+    )
 
     assert rosotacom._smoke_peer_address_args(session, "127.0.0.1") == ["a=127.0.0.1", "b=127.0.0.2"]
+
+
+def test_run_session_generates_into_instance_config_without_touching_static_source(tmp_path: Path) -> None:
+    from session.creation import run_session
+
+    source = tmp_path / "sessions" / "1_heartbeat"
+    output = tmp_path / "session-instances" / "2026-01-01" / "1_heartbeat_run" / "config"
+    source.mkdir(parents=True)
+    (source / "session-definition.yaml").write_text(
+        "\n".join(
+            [
+                "peers:",
+                "  a:",
+                "    address: 127.0.0.1",
+                "  b:",
+                "    address: 127.0.0.1",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    peer_dir = run_session._resolve_peer_dir(
+        str(source),
+        str(output),
+        "a",
+        force=True,
+        rewrite_formatting=False,
+    )
+
+    assert Path(peer_dir) == output / "a"
+    assert (output / "session-definition.yaml").is_file()
+    assert (output / "a" / "plugin.yaml").is_file()
+    assert not (source / "a").exists()
+
+
+def test_create_session_yaml_injects_catmux_logging_command(tmp_path: Path) -> None:
+    from session.creation import create_session_yaml
+
+    peer_dir = tmp_path / "config" / "a"
+    peer_dir.mkdir(parents=True)
+    (peer_dir / "plugin.yaml").write_text(
+        "\n".join(
+            [
+                "parameters:",
+                "  example: true",
+                "common:",
+                "  before_commands:",
+                "    - echo existing",
+                "windows:",
+                "  - name: TEST",
+                "    splits:",
+                "      - commands:",
+                "        - echo run",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (peer_dir / "session_specification.yaml").write_text("session_plugins:\n  - ./plugin.yaml\n", encoding="utf-8")
+
+    create_session_yaml.main(
+        str(peer_dir),
+        instance_dir="/session/instances/run",
+        config_dir="/session/instances/run/config",
+        catmux_log_dir="/session/instances/run/logs/a/catmux",
+        rosbag_dir="/session/instances/run/rosbags/a",
+    )
+
+    merged = yaml.safe_load((peer_dir / ".session_readonly.yaml").read_text(encoding="utf-8"))
+    before_commands = merged["common"]["before_commands"]
+    assert "catmux_log_setup.sh" in before_commands[0]
+    assert "ROSOTACOM_CATMUX_LOG_DIR=/session/instances/run/logs/a/catmux" in before_commands[0]
+    assert before_commands[1] == "echo existing"

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -473,8 +473,8 @@ def test_stop_list_doctor_and_smoke_host_flows(
     )
     (instance.config_host_dir / "a").mkdir(parents=True)
     (instance.config_host_dir / "b").mkdir()
-    (instance.config_host_dir / "a" / "plugin.yaml").write_text("127.0.0.1\n", encoding="utf-8")
-    (instance.config_host_dir / "b" / "plugin.yaml").write_text("127.0.0.1\n", encoding="utf-8")
+    (instance.config_host_dir / "a" / "plugin.yaml").write_text("10.137.0.2\n", encoding="utf-8")
+    (instance.config_host_dir / "b" / "plugin.yaml").write_text("10.137.0.3\n", encoding="utf-8")
     cfg = {"peers": {"a": {}, "b": {}}}
     stopped: list[str] = []
 
@@ -499,6 +499,8 @@ def test_stop_list_doctor_and_smoke_host_flows(
     assert "OK: ros2docker validation: config loads" in capsys.readouterr().out
 
     monkeypatch.setattr(rosotacom, "start_session", lambda args: f"container_{args.identity}")
+    monkeypatch.setattr(rosotacom, "_ensure_smoke_network", lambda: None)
+    monkeypatch.setattr(rosotacom, "_remove_smoke_network", lambda: None)
     monkeypatch.setattr(
         rosotacom,
         "_run_container_shell",
@@ -524,60 +526,20 @@ def test_stop_list_doctor_and_smoke_host_flows(
     assert stopped[-2:] == ["container_a", "container_b"]
 
 
-def test_native_zenoh_smoke_uses_distinct_loopback_addresses(tmp_path: Path) -> None:
-    session_dir = tmp_path / "sessions" / "1_heartbeat_zen-endpoints"
-    session_dir.mkdir(parents=True)
-    (session_dir / "session-definition.yaml").write_text(
-        "\n".join(
-            [
-                "peers:",
-                "  a:",
-                "    address: data:machine_a_ip",
-                "  b:",
-                "    address: data:machine_b_ip",
-                "shared:",
-                "  rmw:",
-                "    local: zenoh",
-                "    ota: zenoh_connect_endpoints",
-                "",
-            ]
-        ),
-        encoding="utf-8",
-    )
-    session = rosotacom.ResolvedSession(
-        session_dir,
-        "/session/definitions/1_heartbeat_zen-endpoints",
-        "session_configs",
-    )
-
-    assert rosotacom._smoke_peer_address_args(session, "127.0.0.1") == ["a=127.0.0.1", "b=127.0.0.2"]
+def test_smoke_peer_addresses_use_isolated_bridge_ips() -> None:
+    # Smoke isolates the two peers in their own network namespaces on a dedicated
+    # docker bridge with distinct IPs, instead of sharing the host loopback.
+    assert rosotacom._smoke_peer_address_args() == ["a=10.137.0.2", "b=10.137.0.3"]
+    assert rosotacom.SMOKE_PEER_IPS == {"a": "10.137.0.2", "b": "10.137.0.3"}
 
 
-def test_fastdds_smoke_uses_distinct_loopback_addresses(tmp_path: Path) -> None:
-    session_dir = tmp_path / "sessions" / "1_heartbeat_fastdds"
-    session_dir.mkdir(parents=True)
-    (session_dir / "session-definition.yaml").write_text(
-        "\n".join(
-            [
-                "peers:",
-                "  a:",
-                "    address: data:machine_a_ip",
-                "  b:",
-                "    address: data:machine_b_ip",
-                "shared:",
-                "  rmw: fastdds",
-                "",
-            ]
-        ),
-        encoding="utf-8",
-    )
-    session = rosotacom.ResolvedSession(
-        session_dir,
-        "/session/definitions/1_heartbeat_fastdds",
-        "session_configs",
-    )
-
-    assert rosotacom._smoke_peer_address_args(session, "127.0.0.1") == ["a=127.0.0.1", "b=127.0.0.2"]
+def test_isolated_network_run_args_swaps_host_networking() -> None:
+    base = ["-e", "ROS_DOMAIN_ID=48", "--network", "host"]
+    swapped = rosotacom._isolated_network_run_args(base, "rosotacom-smoke", "10.137.0.2")
+    assert "host" not in swapped
+    assert swapped == ["-e", "ROS_DOMAIN_ID=48", "--network", "rosotacom-smoke", "--ip", "10.137.0.2"]
+    # A config that already pins --network=... form is also replaced.
+    assert rosotacom._isolated_network_run_args(["--network=host"], "net", None) == ["--network", "net"]
 
 
 def test_run_session_generates_into_instance_config_without_touching_static_source(tmp_path: Path) -> None:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -553,6 +553,33 @@ def test_native_zenoh_smoke_uses_distinct_loopback_addresses(tmp_path: Path) -> 
     assert rosotacom._smoke_peer_address_args(session, "127.0.0.1") == ["a=127.0.0.1", "b=127.0.0.2"]
 
 
+def test_fastdds_smoke_uses_distinct_loopback_addresses(tmp_path: Path) -> None:
+    session_dir = tmp_path / "sessions" / "1_heartbeat_fastdds"
+    session_dir.mkdir(parents=True)
+    (session_dir / "session-definition.yaml").write_text(
+        "\n".join(
+            [
+                "peers:",
+                "  a:",
+                "    address: data:machine_a_ip",
+                "  b:",
+                "    address: data:machine_b_ip",
+                "shared:",
+                "  rmw: fastdds",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    session = rosotacom.ResolvedSession(
+        session_dir,
+        "/session/definitions/1_heartbeat_fastdds",
+        "session_configs",
+    )
+
+    assert rosotacom._smoke_peer_address_args(session, "127.0.0.1") == ["a=127.0.0.1", "b=127.0.0.2"]
+
+
 def test_run_session_generates_into_instance_config_without_touching_static_source(tmp_path: Path) -> None:
     from session.creation import run_session
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -85,7 +85,7 @@ def test_examples_create_copies_project_and_refuses_overwrite(
     assert (target / "rosotacom.yaml").is_file()
     assert (target / "ros2docker.json").is_file()
     assert (target / "data_dict.json").is_file()
-    assert (target / "sessions" / "1_heartbeat" / "session-definition.yaml").is_file()
+    assert (target / "sessions" / "1_heartbeat_fastdds" / "session-definition.yaml").is_file()
     assert not (target / "__init__.py").exists()
     assert "Copied rosotacom examples" in capsys.readouterr().out
 
@@ -448,3 +448,28 @@ def test_stop_list_doctor_and_smoke_host_flows(
         == 0
     )
     assert stopped[-2:] == ["container_a", "container_b"]
+
+
+def test_native_zenoh_smoke_uses_distinct_loopback_addresses(tmp_path: Path) -> None:
+    session_dir = tmp_path / "sessions" / "1_heartbeat_zen-endpoints"
+    session_dir.mkdir(parents=True)
+    (session_dir / "session-definition.yaml").write_text(
+        "\n".join(
+            [
+                "peers:",
+                "  a:",
+                "    address: data:machine_a_ip",
+                "  b:",
+                "    address: data:machine_b_ip",
+                "shared:",
+                "  rmw:",
+                "    local: zenoh",
+                "    ota: zenoh_connect_endpoints",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    session = rosotacom.ResolvedSession(session_dir, "/session/configs/1_heartbeat_zen-endpoints", "session_configs")
+
+    assert rosotacom._smoke_peer_address_args(session, "127.0.0.1") == ["a=127.0.0.1", "b=127.0.0.2"]

--- a/tests/unit/test_status_overview.py
+++ b/tests/unit/test_status_overview.py
@@ -1,0 +1,343 @@
+"""Unit tests for the rosotacom status / debugging overview.
+
+Covers three layers:
+  * pipeline_spec.yaml generation (generate_session_files._build_status_pipeline_spec
+    exercised end-to-end via func()),
+  * state classification + rollup (status_overview_core, ROS-independent),
+  * the `rosotacom status` host CLI rendering.
+
+The in-container modules live under resources/ws and are loaded by file path so
+the host test suite (which has no rclpy) can import the pure parts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+import rosotacom.cli as rosotacom
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WS = REPO_ROOT / "src" / "rosotacom" / "resources" / "ws"
+GENERATOR_PY = WS / "session" / "creation" / "generate_session_files.py"
+STATUS_CORE_PY = WS / "ros2src" / "com_py" / "com_py" / "status_overview_core.py"
+
+
+def _load_module(path: Path, name: str) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    # Register before exec so dataclasses can resolve the module's namespace.
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+generator = _load_module(GENERATOR_PY, "rosotacom_generate_session_files")
+core = _load_module(STATUS_CORE_PY, "rosotacom_status_overview_core")
+
+
+# ---------------------------------------------------------------------------
+# pipeline_spec generation
+# ---------------------------------------------------------------------------
+
+
+def _heartbeat_cfg() -> dict:
+    return {
+        "peers": {"a": {"address": "127.0.0.1"}, "b": {"address": "127.0.0.1"}},
+        "peer_settings": {"a": {"domain_id": 46}, "b": {"domain_id": 47}},
+        "shared": {
+            "use_heartbeat": True,
+            "use_status_overview": True,
+            "rmw": {
+                "local": {"cyclone": {"config": "cyclonedds_minimal.xml"}},
+                "ota": {"cyclone": {"config": "cyclonedds_minimal.xml"}},
+            },
+            "ota_domain_id": 48,
+        },
+    }
+
+
+def test_pipeline_spec_generated_for_heartbeat(tmp_path: Path) -> None:
+    import yaml
+
+    generator.func(session_config_obj=_heartbeat_cfg(), output_dir=str(tmp_path), force=True)
+
+    spec_path = tmp_path / "a" / "pipeline_spec.yaml"
+    assert spec_path.exists(), "pipeline_spec.yaml should be generated for peer a"
+    spec = yaml.safe_load(spec_path.read_text(encoding="utf-8"))
+
+    assert spec["peer"] == "a"
+    assert spec["remote"] == "b"
+    assert spec["local_domain_id"] == 46
+    assert spec["ota_domain_id"] == 48
+    assert spec["uses_domain_bridge"] is True
+
+    by_dir = {(t["base"], t["direction"]): t for t in spec["topics"]}
+    out = by_dir[("/heartbeat_a", "outbound")]
+    out_stages = {s["stage"]: s for s in out["stages"]}
+    assert out_stages["native"]["topic"] == "/heartbeat_a"
+    assert out_stages["native"]["domain"] == "local"
+    assert out_stages["com_out"]["topic"] == "/com/out/a/heartbeat_a"
+    assert out_stages["ota_sent"]["topic"] == "/ota/a/heartbeat_a"
+    assert out_stages["ota_sent"]["domain"] == "ota"
+
+    inb = by_dir[("/heartbeat_b", "inbound")]
+    in_stages = {s["stage"]: s for s in inb["stages"]}
+    assert in_stages["ota_recv"]["topic"] == "/ota/b/heartbeat_b"
+    assert in_stages["ota_recv"]["domain"] == "ota"
+    assert in_stages["com_in"]["topic"] == "/com/in/b/heartbeat_b"
+    assert in_stages["app_in"]["topic"] == "/heartbeat_b"
+
+
+def test_pipeline_spec_absent_when_flag_off(tmp_path: Path) -> None:
+    cfg = _heartbeat_cfg()
+    cfg["shared"]["use_status_overview"] = False
+    generator.func(session_config_obj=cfg, output_dir=str(tmp_path), force=True)
+    assert not (tmp_path / "a" / "pipeline_spec.yaml").exists()
+
+
+def test_use_status_overview_must_be_bool() -> None:
+    cfg = _heartbeat_cfg()
+    cfg["shared"]["use_status_overview"] = "yes"
+    with pytest.raises(RuntimeError):
+        generator._validate_session_template_cfg(cfg)
+
+
+# ---------------------------------------------------------------------------
+# state classification + rollup
+# ---------------------------------------------------------------------------
+
+
+class _FakeObserver:
+    def __init__(self) -> None:
+        self.observations: dict = {}
+
+
+def _outbound_spec() -> dict:
+    return {
+        "peer": "a",
+        "remote": "b",
+        "local_domain_id": 46,
+        "ota_domain_id": 48,
+        "uses_domain_bridge": True,
+        "topics": [
+            {
+                "base": "/heartbeat_a",
+                "direction": "outbound",
+                "source": "a",
+                "target": "b",
+                "type": "com_msgs/msg/Heartbeat",
+                "expected_hz": None,
+                "stages": [
+                    {"stage": "native", "topic": "/heartbeat_a", "domain": "local", "produced_by": "application"},
+                    {
+                        "stage": "com_out",
+                        "topic": "/com/out/a/heartbeat_a",
+                        "domain": "local",
+                        "produced_by": "relay_out",
+                    },
+                    {"stage": "ota_sent", "topic": "/ota/a/heartbeat_a", "domain": "ota", "produced_by": "bridge_out"},
+                ],
+            }
+        ],
+    }
+
+
+def _build(observers: dict, output_dir: Path) -> core.StatusAggregator:
+    return core.StatusAggregator(
+        logger=None,
+        spec=_outbound_spec(),
+        output_dir=str(output_dir),
+        observers_by_domain=observers,
+        liveness_window_s=3.0,
+        stale_after_s=3.0,
+    )
+
+
+def _obs(pub: int = 0, last_msg_at: float | None = None) -> core.StageObservation:
+    o = core.StageObservation()
+    o.pub_count = pub
+    o.sub_count = 1 if pub else 0
+    if last_msg_at is not None:
+        o.record(size=64, delay_s=0.01, now_mono=last_msg_at, now_wall=1_700_000_000.0)
+    return o
+
+
+def test_rollup_ok_when_all_stages_flow(tmp_path: Path) -> None:
+    now = 100.0
+    local = _FakeObserver()
+    ota = _FakeObserver()
+    local.observations["/heartbeat_a"] = _obs(pub=1, last_msg_at=now)
+    local.observations["/com/out/a/heartbeat_a"] = _obs(pub=1, last_msg_at=now)
+    ota.observations["/ota/a/heartbeat_a"] = _obs(pub=1, last_msg_at=now)
+
+    agg = _build({"local": local, "ota": ota}, tmp_path)
+    snap = agg.build_snapshot(now_mono=now)
+    topic = snap["topics"][0]
+    assert topic["overall"] == core.OK
+    assert topic["reached_stage"] == "ota_sent"
+    assert topic["blocked_at"] is None
+    assert "Phase 1" in topic["diagnosis"]
+    assert snap["summary"]["OK"] == 1
+
+
+def test_rollup_partial_identifies_first_broken_stage(tmp_path: Path) -> None:
+    now = 100.0
+    local = _FakeObserver()
+    ota = _FakeObserver()
+    local.observations["/heartbeat_a"] = _obs(pub=1, last_msg_at=now)
+    # com_out has a publisher but no messages observed -> IDLE
+    local.observations["/com/out/a/heartbeat_a"] = _obs(pub=1, last_msg_at=None)
+    ota.observations["/ota/a/heartbeat_a"] = _obs(pub=0, last_msg_at=None)
+
+    agg = _build({"local": local, "ota": ota}, tmp_path)
+    snap = agg.build_snapshot(now_mono=now)
+    topic = snap["topics"][0]
+    assert topic["overall"] == core.PARTIAL
+    assert topic["reached_stage"] == "native"
+    assert topic["blocked_at"] == "com_out"
+    stages = {s["stage"]: s for s in topic["stages"]}
+    assert stages["com_out"]["state"] == core.IDLE
+    assert stages["ota_sent"]["state"] == core.ABSENT
+
+
+def test_rollup_absent_when_nothing_publishes(tmp_path: Path) -> None:
+    now = 100.0
+    local = _FakeObserver()
+    ota = _FakeObserver()
+    local.observations["/heartbeat_a"] = _obs(pub=0)
+    local.observations["/com/out/a/heartbeat_a"] = _obs(pub=0)
+    ota.observations["/ota/a/heartbeat_a"] = _obs(pub=0)
+
+    agg = _build({"local": local, "ota": ota}, tmp_path)
+    snap = agg.build_snapshot(now_mono=now)
+    topic = snap["topics"][0]
+    assert topic["overall"] == core.ABSENT
+    assert topic["reached_stage"] is None
+    assert topic["blocked_at"] == "native"
+
+
+def test_rollup_stalled_when_last_stage_goes_stale(tmp_path: Path) -> None:
+    now = 100.0
+    local = _FakeObserver()
+    ota = _FakeObserver()
+    local.observations["/heartbeat_a"] = _obs(pub=1, last_msg_at=now)
+    local.observations["/com/out/a/heartbeat_a"] = _obs(pub=1, last_msg_at=now)
+    # ota stage last received 10s ago -> STALE (stale_after=3)
+    ota.observations["/ota/a/heartbeat_a"] = _obs(pub=1, last_msg_at=now - 10.0)
+
+    agg = _build({"local": local, "ota": ota}, tmp_path)
+    snap = agg.build_snapshot(now_mono=now)
+    topic = snap["topics"][0]
+    assert topic["overall"] == core.STALLED
+    assert topic["reached_stage"] == "ota_sent"
+    stages = {s["stage"]: s for s in topic["stages"]}
+    assert stages["ota_sent"]["state"] == core.STALE
+
+
+def test_write_produces_artifacts_and_transition_events(tmp_path: Path) -> None:
+    now = 100.0
+    local = _FakeObserver()
+    ota = _FakeObserver()
+    local.observations["/heartbeat_a"] = _obs(pub=1, last_msg_at=now)
+    local.observations["/com/out/a/heartbeat_a"] = _obs(pub=1, last_msg_at=now)
+    ota.observations["/ota/a/heartbeat_a"] = _obs(pub=0)
+
+    agg = _build({"local": local, "ota": ota}, tmp_path)
+    # First write establishes baseline (no transition events emitted).
+    assert agg.write(now_mono=now) == 0
+    assert (tmp_path / "status.json").exists()
+    assert (tmp_path / "status.txt").exists()
+    assert not (tmp_path / "events.jsonl").exists()
+
+    # Now the ota stage starts flowing -> overall changes -> one event row.
+    ota.observations["/ota/a/heartbeat_a"] = _obs(pub=1, last_msg_at=now)
+    assert agg.write(now_mono=now) == 1
+    events_text = (tmp_path / "events.jsonl").read_text(encoding="utf-8").strip().splitlines()
+    assert len(events_text) == 1
+
+
+# ---------------------------------------------------------------------------
+# `rosotacom status` CLI rendering
+# ---------------------------------------------------------------------------
+
+
+def _make_project(tmp_path: Path) -> tuple[argparse.Namespace, Path]:
+    (tmp_path / "ros2docker.json").write_text('{"image_name": "test"}\n', encoding="utf-8")
+    sessions = tmp_path / "sessions" / "mysess"
+    sessions.mkdir(parents=True)
+    (sessions / "session-definition.yaml").write_text("peers: {}\n", encoding="utf-8")
+    (tmp_path / "session-instances").mkdir()
+    config = tmp_path / "rosotacom.yaml"
+    config.write_text(
+        "ros2docker_config: ros2docker.json\nsession_configs_dir: sessions\nsession_instances_dir: session-instances\n",
+        encoding="utf-8",
+    )
+    instance = tmp_path / "session-instances" / "2026-01-01" / "mysess_2026-01-01_00-00-00_abcd1234"
+    status_dir = instance / "logs" / "a" / "status"
+    status_dir.mkdir(parents=True)
+    import json
+
+    snapshot = {
+        "schema_version": 1,
+        "phase": 1,
+        "generated_at": "2026-01-01T00:00:01.000",
+        "peer": "a",
+        "remote": "b",
+        "summary": {"OK": 1, "PARTIAL": 0, "STALLED": 0, "ABSENT": 0},
+        "topics": [
+            {
+                "base": "/heartbeat_a",
+                "direction": "outbound",
+                "overall": "OK",
+                "reached_stage": "ota_sent",
+                "blocked_at": None,
+                "diagnosis": "all observable stages flowing",
+                "stages": [],
+            }
+        ],
+    }
+    (status_dir / "status.json").write_text(json.dumps(snapshot), encoding="utf-8")
+    (status_dir / "status.txt").write_text("RENDERED STATUS TEXT\n", encoding="utf-8")
+
+    args = argparse.Namespace(
+        rosotacom_config=str(config),
+        ros2docker_config=None,
+        session_configs_dir=None,
+        session_instances_dir=None,
+        data_dict=None,
+        session_dir="mysess",
+        identity=None,
+        instance_id=None,
+        json=False,
+        watch=False,
+        watch_interval=2.0,
+    )
+    return args, instance
+
+
+def test_status_cli_human_output(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    args, _ = _make_project(tmp_path)
+    rc = rosotacom.status(args)
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "RENDERED STATUS TEXT" in out
+
+
+def test_status_cli_json_output(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    import json
+
+    args, _ = _make_project(tmp_path)
+    args.json = True
+    rc = rosotacom.status(args)
+    assert rc == 0
+    out = capsys.readouterr().out
+    payload = json.loads(out)
+    assert "a" in payload
+    assert payload["a"]["topics"][0]["base"] == "/heartbeat_a"


### PR DESCRIPTION
## Summary
- split static session definitions from generated runtime session instances
- add always-on catmux pane logging, smoke artifacts, manifests, and rosbag/log directories
- update smoke/E2E/docs/CI to retain session-instances artifacts for debugging

## Verification
- .venv/bin/ruff check src/rosotacom tests
- .venv/bin/mypy src/rosotacom
- .venv/bin/python -m pytest -q tests/unit tests/contract
- just docs
- just package

Note: Docker-backed E2E smoke was not run locally.