### PR TITLE
docs: point CI/coverage badges at the default branch (volatile)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ROS Communication DevContainer
 
-[![CI](https://github.com/develNor/rosotacom/actions/workflows/pr-merge-gate.yml/badge.svg?branch=main&event=push)](https://github.com/develNor/rosotacom/actions/workflows/pr-merge-gate.yml)
-[![Coverage](https://codecov.io/gh/develNor/rosotacom/branch/main/graph/badge.svg)](https://codecov.io/gh/develNor/rosotacom)
+[![CI](https://github.com/develNor/rosotacom/actions/workflows/pr-merge-gate.yml/badge.svg?branch=volatile&event=push)](https://github.com/develNor/rosotacom/actions/workflows/pr-merge-gate.yml)
+[![Coverage](https://codecov.io/gh/develNor/rosotacom/branch/volatile/graph/badge.svg)](https://codecov.io/gh/develNor/rosotacom)
 [![PyPI](https://img.shields.io/pypi/v/rosotacom.svg)](https://pypi.org/project/rosotacom/)
 [![Python](https://img.shields.io/pypi/pyversions/rosotacom.svg)](https://pypi.org/project/rosotacom/)
 [![License](https://img.shields.io/pypi/l/rosotacom.svg)](https://pypi.org/project/rosotacom/)


### PR DESCRIPTION
## Summary

The README CI and Codecov badges referenced `main`, but the repository's default/integration branch is `volatile`, so the badges rendered stale status. This updates both badge URLs to track `volatile`.

Isolated, docs-only change (one file, two lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)