### PR TITLE
release: add v2.1 release notes and make PyPI publish idempotent

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,6 +144,8 @@ jobs:
 
       - name: Publish distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true
 
   publish-testpypi:
     name: publish-testpypi

--- a/docs/release-notes/v2.1.md
+++ b/docs/release-notes/v2.1.md
@@ -1,0 +1,22 @@
+# v2.1
+
+## Summary
+
+- Add rosotacom session instance logging (#1).
+- Fix `zenoh_ros2dds` OTA double-delivery in the smoke matrix (#3).
+- Point CI/coverage badges at the default branch (`volatile`) (#4).
+- Bring rosotacom packaging and quality gates up to date.
+
+## Compatibility And Migration
+
+- No breaking changes.
+
+## Validation
+
+- `just lint`
+- `just typecheck`
+- `just test-unit`
+- `just test-contract`
+- `just docs`
+- `just package`
+- `just test-e2e-smoke`


### PR DESCRIPTION
## What

- Add `docs/release-notes/v2.1.md` so the `github-release` job's "Verify release notes" check passes for the v2.1 tag.
- Set `skip-existing: true` on the PyPI publish step so re-running the release workflow for an already-published version no longer fails on a duplicate upload.

## Why

The v2.1 release reached PyPI and a GitHub Release was created, but the `github-release` CI job kept failing on re-run: the tag's tree had no release-notes file, and `publish-pypi` had no idempotency guard. These two changes make the release workflow re-runnable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)