### PR TITLE
docs: fix broken README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # ROS Communication DevContainer
 
-[![CI](https://github.com/develNor/rosotacom/actions/workflows/pr-merge-gate.yml/badge.svg?branch=develop&event=push)](https://github.com/develNor/rosotacom/actions/workflows/pr-merge-gate.yml)
-[![Coverage](https://codecov.io/gh/develNor/rosotacom/branch/develop/graph/badge.svg)](https://codecov.io/gh/develNor/rosotacom)
+[![CI](https://github.com/develNor/ros_communication_devcontainer/actions/workflows/pr-merge-gate.yml/badge.svg?branch=develop&event=push)](https://github.com/develNor/ros_communication_devcontainer/actions/workflows/pr-merge-gate.yml)
+[![Coverage](https://codecov.io/gh/develNor/ros_communication_devcontainer/branch/develop/graph/badge.svg)](https://codecov.io/gh/develNor/ros_communication_devcontainer)
 [![PyPI](https://img.shields.io/pypi/v/rosotacom.svg)](https://pypi.org/project/rosotacom/)
 [![Python](https://img.shields.io/pypi/pyversions/rosotacom.svg)](https://pypi.org/project/rosotacom/)
-[![License](https://img.shields.io/pypi/l/rosotacom.svg)](https://pypi.org/project/rosotacom/)
+[![License](https://img.shields.io/github/license/develNor/ros_communication_devcontainer.svg)](https://github.com/develNor/ros_communication_devcontainer/blob/HEAD/LICENSE.txt)
 
 The ROS Communication DevContainer is a Docker-based solution designed to streamline the bidirectional synchronization of ROS2 topics between two Linux machines. It provides built-in compression and routing capabilities for over-the-air (OTA) data transfer: selected topics are remapped into an OTA namespace and transmitted either via direct DDS (CycloneDDS) or through a Zenoh router. When desired, the session can also place local application nodes and OTA-facing bridge nodes into separate ROS 2 domain IDs and automatically generate a standard ROS 2 `domain_bridge` configuration for the `/com/...` boundary. This project aligns with the publication *“Scalable Remote Operation for Autonomous Vehicles: Integration of Cooperative Perception and Open Source Communication.”*
 


### PR DESCRIPTION
## What

Fix the three broken status badges at the top of the README.

| Badge | Problem | Fix |
|---|---|---|
| **CI** | Pointed at `github.com/develNor/rosotacom/…` — a repo that doesn't exist (this repo is `ros_communication_devcontainer`), so the image 404'd | Point at the correct repo |
| **Coverage** | Same wrong repo on `codecov.io/gh/develNor/rosotacom/…` → rendered "unknown" | Point at the correct repo |
| **License** | `shields.io/pypi/l/rosotacom` renders "unknown": the package declares its license as a PEP 639 `License-Expression`, which `pypi/l` can't read | Switch to `github/license` (auto-detects **BSD-3-Clause** from `LICENSE.txt`), linked to the license file |

The PyPI **version** and **Python** badges are unchanged — `rosotacom` is the correct PyPI package name, and they weren't broken.

## Notes
- CI/Coverage badges still track `branch=develop`, matching the merge-gate workflow.
- Docs-only change; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)