### PR TITLE
feat: streamline version setup and project selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # ROS Communication DevContainer
 
-[![CI](https://github.com/develNor/rosotacom/actions/workflows/pr-merge-gate.yml/badge.svg?branch=develop&event=push)](https://github.com/develNor/rosotacom/actions/workflows/pr-merge-gate.yml)
-[![Coverage](https://codecov.io/gh/develNor/rosotacom/branch/develop/graph/badge.svg)](https://codecov.io/gh/develNor/rosotacom)
+[![CI](https://github.com/develNor/ros_communication_devcontainer/actions/workflows/pr-merge-gate.yml/badge.svg?branch=develop&event=push)](https://github.com/develNor/ros_communication_devcontainer/actions/workflows/pr-merge-gate.yml)
+[![Coverage](https://codecov.io/gh/develNor/ros_communication_devcontainer/branch/develop/graph/badge.svg)](https://codecov.io/gh/develNor/ros_communication_devcontainer)
 [![PyPI](https://img.shields.io/pypi/v/rosotacom.svg)](https://pypi.org/project/rosotacom/)
 [![Python](https://img.shields.io/pypi/pyversions/rosotacom.svg)](https://pypi.org/project/rosotacom/)
-[![License](https://img.shields.io/pypi/l/rosotacom.svg)](https://pypi.org/project/rosotacom/)
+[![License](https://img.shields.io/github/license/develNor/ros_communication_devcontainer.svg)](https://github.com/develNor/ros_communication_devcontainer/blob/HEAD/LICENSE.txt)
 
 The ROS Communication DevContainer is a Docker-based solution designed to streamline the bidirectional synchronization of ROS2 topics between two Linux machines. It provides built-in compression and routing capabilities for over-the-air (OTA) data transfer: selected topics are remapped into an OTA namespace and transmitted either via direct DDS (CycloneDDS) or through a Zenoh router. When desired, the session can also place local application nodes and OTA-facing bridge nodes into separate ROS 2 domain IDs and automatically generate a standard ROS 2 `domain_bridge` configuration for the `/com/...` boundary. This project aligns with the publication *“Scalable Remote Operation for Autonomous Vehicles: Integration of Cooperative Perception and Open Source Communication.”*
 
@@ -37,19 +37,37 @@ so multiple rosotacom versions can coexist without global symlink drift.
 
 #### Install
 
+The front-door is `./setup`: it installs a version and selects it, with one
+consistent `--global`/`--local` model (`--local` = this terminal, `--global` =
+all terminals).
+
 ```bash
-cd /path/to/ros_communication_devcontainer && ./install.sh
+cd /path/to/ros_communication_devcontainer
+./setup                         # auto: from-source + this terminal
 source .venv/bin/activate
 rosotacom --version
 python -m rosotacom --version
 rosotacom doctor
 ```
 
-Legacy global symlinks are still available when explicitly requested:
+`./setup` also takes an explicit version and scope:
 
 ```bash
-./install.sh --global-symlink
+./setup --from-source --global  # editable install, shimmed into ~/.local/bin
+./setup 2.1.0 --global          # a PyPI release, for all terminals
+./setup latest --local          # newest release, this terminal only
 ```
+
+Manage installed versions afterwards with `rosotacom self`:
+
+```bash
+rosotacom self list             # installed versions + the global selection
+rosotacom self use 2.1.0 --global
+rosotacom self which
+```
+
+`./install.sh` (optionally `--global-symlink`) remains the low-level source
+installer that `./setup --from-source` builds on.
 
 ### Basic Setup
 
@@ -59,14 +77,31 @@ Legacy global symlinks are still available when explicitly requested:
 - A **session config** defines the communication behavior for one run: peers, addresses, topics, QoS, processing, and transport choices.
 - A **session instance** stores one concrete run: generated config, catmux pane logs, smoke debug output, and future rosbags.
 
-No `rosotacom.yaml` is discovered automatically. Wire one explicitly with a flag or with `ROSOTACOM_CONFIG`:
+`rosotacom` resolves the active `rosotacom.yaml` in this order (first wins):
+
+1. `--project <path>` (alias of `--rosotacom-config`) on the command
+2. `ROSOTACOM_CONFIG` in the environment
+3. the nearest `rosotacom.yaml` discovered upward from the current directory
+4. a machine-wide default set with `rosotacom config set project ... --global`
+5. a built-in example project, so a fresh install runs with zero setup
+
+So the simplest workflow is just to be in a project directory:
 
 ```bash
 rosotacom examples create ./rosotacom_examples
 cd ./rosotacom_examples
-eval "$(rosotacom setup-env ./rosotacom.yaml)"
-rosotacom doctor
+rosotacom doctor                # picks up ./rosotacom.yaml automatically
 ```
+
+Inspect or pin the selection with `rosotacom config`:
+
+```bash
+rosotacom config show                                            # every layer + the winner
+rosotacom config set project ./rosotacom.yaml --global           # machine-wide default
+eval "$(rosotacom config set project ./rosotacom.yaml --local)"  # this terminal only
+```
+
+(`rosotacom setup-env ./rosotacom.yaml` is a deprecated alias for the `--local` form.)
 
 The copied packaged example project uses this layout:
 
@@ -103,12 +138,12 @@ rosotacom start 1_heartbeat_cyclone-ota --identity b
 
 ## Usage Examples
 
-Create and wire the example project first:
+Create the example project first (cwd discovery wires it automatically once you
+`cd` in):
 
 ```bash
 rosotacom examples create ./rosotacom_examples
 cd ./rosotacom_examples
-eval "$(rosotacom setup-env ./rosotacom.yaml)"
 ```
 
 Run the local heartbeat smoke test:

--- a/install.sh
+++ b/install.sh
@@ -54,10 +54,14 @@ echo "Try:"
 echo "  rosotacom --version"
 echo "  python -m rosotacom --version"
 echo "  rosotacom doctor"
-echo "  rosotacom examples create ./rosotacom_examples"
-echo "  eval \"\$(rosotacom setup-env ./rosotacom_examples/rosotacom.yaml)\""
-echo "  rosotacom smoke"
+echo "  rosotacom examples create ./rosotacom_examples && cd ./rosotacom_examples"
+echo "  rosotacom smoke    # ./rosotacom.yaml is auto-discovered from the current dir"
 echo
+echo "With no project nearby, rosotacom falls back to a built-in example, so"
+echo "'rosotacom smoke' works with zero setup. Pin a default with:"
+echo "  rosotacom config set project ./rosotacom.yaml --global"
+echo
+echo "Tip: './setup' wraps this installer and also selects releases (./setup 2.1.0 --global)."
 echo "For contributor checks, install dev tooling with:"
 echo "  just setup"
 

--- a/justfile
+++ b/justfile
@@ -8,9 +8,8 @@ venv:
 	python3 -m venv .venv
 	{{python}} -m pip install --upgrade pip
 
-setup: venv
-	{{python}} -m pip install -e ".[dev]"
-	{{python}} -m pre_commit install
+setup:
+	./setup --from-source --local --dev
 
 format:
 	{{python}} -m ruff check --fix .

--- a/setup
+++ b/setup
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# rosotacom front-door: install a version and select it, with one consistent
+# `--global`/`--local` model. See `./setup --help`.
+#
+# Usage:
+#   ./setup [VERSION] [--global|--local] [--dev]
+#
+# VERSION (pick one; default = auto):
+#   --from-source   editable install of THIS checkout (developer mode)
+#   <tag>           a PyPI release, e.g. 2.1.0
+#   latest          the newest PyPI release
+#   (auto)          --from-source when run inside a checkout, else latest
+#
+# SELECTION (default = --local):
+#   --local         usable in THIS terminal (prints a `source .../activate` line)
+#   --global        usable in ALL terminals (shims in ~/.local/bin)
+#
+#   --dev           also install dev tooling (.[dev] + pre-commit); source only
+#
+# Env: VENV_DIR, ROSOTACOM_BIN_DIR, XDG_DATA_HOME honored as elsewhere.
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+
+version=""          # "", "--from-source", "latest", or a tag
+scope="local"
+dev=false
+
+for arg in "$@"; do
+  case "$arg" in
+    --from-source) version="--from-source" ;;
+    --global) scope="global" ;;
+    --local) scope="local" ;;
+    --dev) dev=true ;;
+    -h|--help) sed -n '4,22p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    --*) echo "ERROR: unknown option: $arg" >&2; exit 2 ;;
+    *)
+      if [[ -n "$version" && "$version" != "--from-source" ]]; then
+        echo "ERROR: multiple versions given: $version and $arg" >&2; exit 2
+      fi
+      version="$arg" ;;
+  esac
+done
+
+# Auto-detect source vs release when no version was requested.
+if [[ -z "$version" ]]; then
+  if [[ -f "$SCRIPT_DIR/pyproject.toml" ]]; then version="--from-source"; else version="latest"; fi
+fi
+
+bin_dir="${ROSOTACOM_BIN_DIR:-$HOME/.local/bin}"
+data_home="${XDG_DATA_HOME:-$HOME/.local/share}"
+
+install_from_source() {
+  if [[ "$scope" == "global" ]]; then
+    "$SCRIPT_DIR/install.sh" --global-symlink
+  else
+    "$SCRIPT_DIR/install.sh"
+  fi
+  local venv="${VENV_DIR:-$SCRIPT_DIR/.venv}"
+  if [[ "$dev" == true ]]; then
+    "$venv/bin/python" -m pip install -e "$SCRIPT_DIR[dev]"
+    "$venv/bin/pre-commit" install || true
+  fi
+  echo
+  if [[ "$scope" == "global" ]]; then
+    echo "Global rosotacom shims installed in: $bin_dir (ensure it is on your PATH)"
+  else
+    echo "Activate this terminal with:"
+    echo "  source \"$venv/bin/activate\""
+  fi
+}
+
+install_release() {
+  local tag="$version" spec="rosotacom"
+  [[ "$tag" != "latest" ]] && spec="rosotacom==$tag"
+  local venv="$data_home/rosotacom/versions/$tag"
+  python3 -m venv "$venv"
+  "$venv/bin/python" -m pip install --upgrade pip
+  "$venv/bin/python" -m pip install "$spec"
+  # Reuse the CLI's own shim/activate logic for selection.
+  if [[ "$scope" == "global" ]]; then
+    "$venv/bin/rosotacom" self use "$tag" --global
+  else
+    echo
+    echo "Activate this terminal with:"
+    echo "  source \"$venv/bin/activate\""
+  fi
+}
+
+if [[ "$version" == "--from-source" ]]; then
+  install_from_source
+else
+  install_release
+fi

--- a/src/rosotacom/cli.py
+++ b/src/rosotacom/cli.py
@@ -92,6 +92,7 @@ class RuntimeConfig:
     data_dict: Path | None
     install_id: str
     session_instances_dir: Path | None = None
+    project_source: str | None = None
 
 
 @dataclass(frozen=True)
@@ -152,12 +153,96 @@ def _install_id(scope_path: Path | None = None) -> str:
     return hashlib.sha1(str(scope).encode("utf-8")).hexdigest()[:8]
 
 
+def _xdg_dir(env_var: str, default_suffix: str) -> Path:
+    base = os.environ.get(env_var)
+    return Path(base) if base else Path.home() / default_suffix
+
+
+def _user_config_file() -> Path:
+    return _xdg_dir("XDG_CONFIG_HOME", ".config") / "rosotacom" / "config.yaml"
+
+
+def _user_state_dir() -> Path:
+    return _xdg_dir("XDG_STATE_HOME", ".local/state") / "rosotacom"
+
+
+def _user_data_dir() -> Path:
+    return _xdg_dir("XDG_DATA_HOME", ".local/share") / "rosotacom"
+
+
+def _user_bin_dir() -> Path:
+    raw = os.environ.get("ROSOTACOM_BIN_DIR")
+    return Path(raw) if raw else Path.home() / ".local" / "bin"
+
+
+def _discover_project_config(start: Path | None = None) -> Path | None:
+    """Walk up from ``start`` (default cwd) for the nearest ``rosotacom.yaml``."""
+    current = (start or Path.cwd()).resolve()
+    for directory in (current, *current.parents):
+        candidate = directory / "rosotacom.yaml"
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def _user_config_project() -> Path | None:
+    """Return the machine-wide default project from the user config file, if set."""
+    raw = _load_yaml_file(_user_config_file()).get("project")
+    if not raw:
+        return None
+    path = Path(os.path.expandvars(os.path.expanduser(str(raw))))
+    if not path.is_absolute():
+        path = _user_config_file().parent / path
+    path = path.resolve()
+    return path if path.is_file() else None
+
+
+def _builtin_example_config() -> Path | None:
+    """Materialize the packaged example into the user state dir (once) and return it.
+
+    This is the zero-config fallback: a fresh install can run sessions with no
+    setup. The copy is writable (unlike the in-package resources) so its
+    ``data_dict.json`` and ``session-instances/`` work normally.
+    """
+    target = _user_state_dir() / "example"
+    config = target / "rosotacom.yaml"
+    if config.is_file():
+        return config
+    try:
+        source = _example_project_resource()
+        _copy_example_resource_tree(source, target)
+    except (RuntimeError, OSError):
+        return None
+    return config if config.is_file() else None
+
+
+def _resolve_project_config_source(args: argparse.Namespace) -> tuple[str | None, str | None]:
+    """Resolve which rosotacom.yaml is active and which layer it came from.
+
+    Precedence (highest first): explicit flag, ROSOTACOM_CONFIG env, cwd/ancestor
+    auto-discovery, machine-wide user default, packaged built-in example.
+    """
+    flag = getattr(args, "rosotacom_config", None)
+    if flag:
+        return str(flag), "flag"
+    env = os.environ.get("ROSOTACOM_CONFIG")
+    if env:
+        return env, "env"
+    discovered = _discover_project_config()
+    if discovered:
+        return str(discovered), "cwd"
+    user = _user_config_project()
+    if user:
+        return str(user), "global"
+    builtin = _builtin_example_config()
+    if builtin:
+        return str(builtin), "builtin"
+    return None, None
+
+
 def _load_runtime_config(args: argparse.Namespace | None = None) -> RuntimeConfig:
     args = args or argparse.Namespace()
-    rosotacom_config_raw = _first_value(
-        getattr(args, "rosotacom_config", None),
-        os.environ.get("ROSOTACOM_CONFIG"),
-    )
+    rosotacom_config_raw, project_source = _resolve_project_config_source(args)
     rosotacom_config = _resolve_path(rosotacom_config_raw, Path.cwd(), must_exist=True)
     config_base = rosotacom_config.parent if rosotacom_config else Path.cwd()
     cfg = _load_yaml_file(rosotacom_config)
@@ -196,6 +281,7 @@ def _load_runtime_config(args: argparse.Namespace | None = None) -> RuntimeConfi
         data_dict=_resolve_path(data_dict_raw, config_base, must_exist=True),
         install_id=_install_id(rosotacom_config),
         session_instances_dir=_resolve_path(session_instances_dir_raw, config_base, must_exist=False),
+        project_source=project_source,
     )
 
 
@@ -1030,15 +1116,210 @@ def examples_create_command(args: argparse.Namespace) -> int:
     _copy_example_resource_tree(_example_project_resource(), target)
     _ensure_example_gitignore(target)
     print(f"Copied rosotacom examples to: {target}")
-    print(f'Wire this shell with: eval "$(rosotacom setup-env {shlex.quote(str(target / "rosotacom.yaml"))})"')
+    print(f"Use it by entering the directory (auto-discovered):  cd {shlex.quote(str(target))}")
+    print(f"Or pin it everywhere:  rosotacom config set project {shlex.quote(str(target / 'rosotacom.yaml'))} --global")
     return 0
 
 
-def setup_env_command(args: argparse.Namespace) -> int:
-    config = _resolve_path(args.rosotacom_config, Path.cwd(), must_exist=True)
+def _require_project_file(raw: str | None) -> Path:
+    config = _resolve_path(raw, Path.cwd(), must_exist=True)
     if not config or not config.is_file():
-        raise RuntimeError(f"rosotacom config must be a file: {args.rosotacom_config}")
+        raise RuntimeError(f"rosotacom config must be a file: {raw}")
+    return config
+
+
+def _print_project_export(config: Path) -> None:
     print(f"export ROSOTACOM_CONFIG={shlex.quote(str(config))}")
+
+
+def setup_env_command(args: argparse.Namespace) -> int:
+    _print_project_export(_require_project_file(args.rosotacom_config))
+    return 0
+
+
+def _write_user_project(config: Path) -> Path:
+    """Persist the machine-wide default project to the user config file."""
+    path = _user_config_file()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    cfg = _load_yaml_file(path)
+    cfg["project"] = str(config)
+    path.write_text(yaml.safe_dump(cfg, default_flow_style=False, sort_keys=True), encoding="utf-8")
+    return path
+
+
+def config_command(args: argparse.Namespace) -> int:
+    action = args.config_action
+    if action == "set":
+        if args.key != "project":
+            raise RuntimeError(f"unknown config key: {args.key}")
+        config = _require_project_file(args.value)
+        # --global persists machine-wide; --local (default) emits a shell export to
+        # eval in the current terminal. A child process cannot mutate the parent
+        # shell, so the per-terminal path stays an `eval "$(...)"` escape hatch.
+        if args.scope == "global":
+            path = _write_user_project(config)
+            print(f"Set global default project: {config}")
+            print(f"  written to {path}")
+        else:
+            _print_project_export(config)
+        return 0
+
+    if action == "unset":
+        path = _user_config_file()
+        cfg = _load_yaml_file(path)
+        if cfg.pop("project", None) is None:
+            print("No global default project was set.")
+            return 0
+        if cfg:
+            path.write_text(yaml.safe_dump(cfg, default_flow_style=False, sort_keys=True), encoding="utf-8")
+        else:
+            path.unlink()
+        print("Cleared global default project.")
+        return 0
+
+    # action in {"get", "show"}
+    raw, source = _resolve_project_config_source(args)
+    if action == "get":
+        print(str(_resolve_path(raw, Path.cwd(), must_exist=True)) if raw else "")
+        return 0
+
+    def line(label: str, value: str) -> None:
+        print(f"{label:>9}: {value}")
+
+    line("flag", getattr(args, "rosotacom_config", None) or "-")
+    line("env", os.environ.get("ROSOTACOM_CONFIG") or "-")
+    line("cwd", str(_discover_project_config() or "-"))
+    line("global", str(_user_config_project() or "-"))
+    line("builtin", str(_user_state_dir() / "example" / "rosotacom.yaml"))
+    if raw:
+        active = _resolve_path(raw, Path.cwd(), must_exist=True)
+        line("active", f"{active}  (source: {source})")
+    else:
+        line("active", "none configured")
+    return 0
+
+
+# --- version management (`rosotacom self`) -----------------------------------
+
+SHIM_NAMES = ("rosotacom", "start_rosotacom", "stop_rosotacom")
+
+
+def _versions_dir() -> Path:
+    return _user_data_dir() / "versions"
+
+
+def _version_venv_dir(tag: str) -> Path:
+    return _versions_dir() / _safe_path_token(tag)
+
+
+def _link_global_shims(venv_dir: Path) -> Path:
+    """Point ~/.local/bin/{rosotacom,start_,stop_} at ``venv_dir``'s console scripts."""
+    bin_dir = _user_bin_dir()
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    for name in SHIM_NAMES:
+        link = bin_dir / name
+        if link.is_symlink() or link.exists():
+            link.unlink()
+        link.symlink_to(venv_dir / "bin" / name)
+    return bin_dir
+
+
+def _write_user_version(venv_dir: Path) -> Path:
+    path = _user_config_file()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    cfg = _load_yaml_file(path)
+    cfg["version"] = str(venv_dir)
+    path.write_text(yaml.safe_dump(cfg, default_flow_style=False, sort_keys=True), encoding="utf-8")
+    return path
+
+
+def _global_version_dir() -> Path | None:
+    raw = _load_yaml_file(_user_config_file()).get("version")
+    return Path(str(raw)) if raw else None
+
+
+def _create_version_venv(venv_dir: Path, spec: str) -> None:
+    venv_dir.parent.mkdir(parents=True, exist_ok=True)
+    subprocess.run([sys.executable, "-m", "venv", str(venv_dir)], check=True)
+    pip = venv_dir / "bin" / "pip"
+    subprocess.run([str(pip), "install", "--upgrade", "pip"], check=True)
+    subprocess.run([str(pip), "install", spec], check=True)
+
+
+def _resolve_self_venv(args: argparse.Namespace, *, require_exists: bool) -> Path:
+    from_source = getattr(args, "from_source", None)
+    if from_source:
+        venv_dir = Path(os.path.expanduser(from_source)).resolve() / ".venv"
+        hint = "run `./setup --from-source` (or `./install.sh`) in that checkout first"
+    else:
+        tag = getattr(args, "tag", None)
+        if not tag:
+            raise RuntimeError("specify a release tag or --from-source <checkout>.")
+        venv_dir = _version_venv_dir(tag)
+        hint = f"run `rosotacom self install {tag}` first"
+    if require_exists and not (venv_dir / "bin" / "rosotacom").exists():
+        raise RuntimeError(f"no rosotacom found in {venv_dir}; {hint}.")
+    return venv_dir
+
+
+def self_command(args: argparse.Namespace) -> int:
+    action = args.self_action
+
+    if action == "install":
+        spec = "rosotacom" if args.tag == "latest" else f"rosotacom=={args.tag}"
+        venv_dir = _version_venv_dir(args.tag)
+        _create_version_venv(venv_dir, spec)
+        print(f"Installed {spec} into: {venv_dir}")
+        print(f"Select it with: rosotacom self use {args.tag} --global")
+        return 0
+
+    if action == "use":
+        venv_dir = _resolve_self_venv(args, require_exists=True)
+        if args.scope == "global":
+            _link_global_shims(venv_dir)
+            _write_user_version(venv_dir)
+            print(f"Global rosotacom now points at: {venv_dir}")
+            print(f"  shims in {_user_bin_dir()} (ensure it is on your PATH)")
+        else:
+            print(f"source {shlex.quote(str(venv_dir / 'bin' / 'activate'))}")
+        return 0
+
+    if action == "uninstall":
+        venv_dir = _version_venv_dir(args.tag)
+        if not venv_dir.exists():
+            print(f"Nothing to uninstall at: {venv_dir}")
+            return 0
+        if _global_version_dir() == venv_dir:
+            for name in SHIM_NAMES:
+                link = _user_bin_dir() / name
+                if link.is_symlink() or link.exists():
+                    link.unlink()
+            cfg = _load_yaml_file(_user_config_file())
+            cfg.pop("version", None)
+            _user_config_file().write_text(
+                yaml.safe_dump(cfg, default_flow_style=False, sort_keys=True), encoding="utf-8"
+            )
+        shutil.rmtree(venv_dir)
+        print(f"Uninstalled: {venv_dir}")
+        return 0
+
+    if action == "list":
+        active = _global_version_dir()
+        versions = _versions_dir()
+        rows = sorted(p for p in versions.iterdir() if p.is_dir()) if versions.is_dir() else []
+        if not rows:
+            print("No managed versions installed. Try: rosotacom self install latest")
+            return 0
+        for venv_dir in rows:
+            marker = "*" if active and active == venv_dir else " "
+            print(f"{marker} {venv_dir.name:20} {venv_dir}")
+        return 0
+
+    # action == "which"
+    resolved = shutil.which("rosotacom")
+    print(f"on PATH : {resolved or 'not found'}")
+    print(f"this run: {sys.executable} (rosotacom {__version__})")
+    print(f"global  : {_global_version_dir() or 'not set'}")
     return 0
 
 
@@ -1068,9 +1349,9 @@ def doctor(args: argparse.Namespace) -> int:
     try:
         runtime = _load_runtime_config(args)
         if runtime.rosotacom_config:
-            line("OK", "rosotacom config", str(runtime.rosotacom_config))
+            line("OK", "rosotacom config", f"{runtime.rosotacom_config} (source: {runtime.project_source})")
         else:
-            line("INFO", "rosotacom config", "not configured; use --rosotacom-config or ROSOTACOM_CONFIG")
+            line("INFO", "rosotacom config", "not configured; use --project or `rosotacom config set`")
         line("OK", "ros2docker config", str(runtime.ros2docker_config))
         line("OK", "install id", runtime.install_id)
         line("OK", "workspace mount", f"{WS_DIR} -> /ws")
@@ -1548,7 +1829,12 @@ def status(args: argparse.Namespace) -> int:
 
 
 def _add_common_config_args(parser: argparse.ArgumentParser) -> None:
-    parser.add_argument("--rosotacom-config", help="Path to rosotacom.yaml.")
+    parser.add_argument(
+        "--rosotacom-config",
+        "--project",
+        dest="rosotacom_config",
+        help="Path to rosotacom.yaml (overrides cwd discovery and the global default).",
+    )
     parser.add_argument("-f", "--ros2docker-config", help="Path to ros2docker JSON config.")
     parser.add_argument("--session-configs-dir", help="Host directory containing named session configs.")
     parser.add_argument("--session-instances-dir", help="Host directory for generated session instances and logs.")
@@ -1600,7 +1886,18 @@ def list_sessions_command(args: argparse.Namespace) -> int:
 
 def main(argv: list[str] | None = None) -> int:
     argv = list(sys.argv[1:] if argv is None else argv)
-    commands = {"start", "stop", "doctor", "smoke", "status", "list-sessions", "examples", "setup-env"}
+    commands = {
+        "start",
+        "stop",
+        "doctor",
+        "smoke",
+        "status",
+        "list-sessions",
+        "examples",
+        "setup-env",
+        "config",
+        "self",
+    }
     if not argv:
         argv = ["start"]
     elif argv[0] not in commands and not argv[0].startswith("-"):
@@ -1662,9 +1959,95 @@ def main(argv: list[str] | None = None) -> int:
     examples_create_parser.add_argument("--force", action="store_true", help="Replace the target if it exists.")
     examples_create_parser.set_defaults(func=examples_create_command)
 
-    setup_env_parser = subparsers.add_parser("setup-env", help="Print shell exports for a rosotacom setup file.")
+    setup_env_parser = subparsers.add_parser(
+        "setup-env",
+        help="[deprecated] Alias for `config set project --local`. Print shell exports for a rosotacom.yaml.",
+    )
     setup_env_parser.add_argument("rosotacom_config", help="Path to rosotacom.yaml.")
     setup_env_parser.set_defaults(func=setup_env_command)
+
+    config_parser = subparsers.add_parser("config", help="Inspect or set the active rosotacom project.")
+    config_subparsers = config_parser.add_subparsers(dest="config_action", required=True)
+
+    config_set_parser = config_subparsers.add_parser("set", help="Set the active project (--global or --local).")
+    config_set_parser.add_argument("key", choices=["project"])
+    config_set_parser.add_argument("value", help="Path to rosotacom.yaml.")
+    config_set_scope = config_set_parser.add_mutually_exclusive_group()
+    config_set_scope.add_argument(
+        "--global",
+        dest="scope",
+        action="store_const",
+        const="global",
+        help="Persist as the machine-wide default for all terminals.",
+    )
+    config_set_scope.add_argument(
+        "--local",
+        dest="scope",
+        action="store_const",
+        const="local",
+        help="Print a shell export to eval in the current terminal (default).",
+    )
+    config_set_parser.set_defaults(func=config_command, scope="local")
+
+    config_get_parser = config_subparsers.add_parser("get", help="Print the resolved active project path.")
+    config_get_parser.add_argument("key", choices=["project"], nargs="?", default="project")
+    config_get_parser.set_defaults(func=config_command)
+
+    config_show_parser = config_subparsers.add_parser("show", help="Show every project-selection layer and the winner.")
+    config_show_parser.set_defaults(func=config_command)
+
+    config_unset_parser = config_subparsers.add_parser("unset", help="Clear the machine-wide default project.")
+    config_unset_parser.add_argument("key", choices=["project"], nargs="?", default="project")
+    config_unset_parser.add_argument(
+        "--global",
+        dest="scope",
+        action="store_const",
+        const="global",
+        default="global",
+        help="Clear the machine-wide default (the only persisted scope).",
+    )
+    config_unset_parser.set_defaults(func=config_command)
+
+    self_parser = subparsers.add_parser("self", help="Install and select rosotacom versions.")
+    self_subparsers = self_parser.add_subparsers(dest="self_action", required=True)
+
+    def _add_scope_group(p: argparse.ArgumentParser) -> None:
+        scope = p.add_mutually_exclusive_group()
+        scope.add_argument(
+            "--global",
+            dest="scope",
+            action="store_const",
+            const="global",
+            help="Point ~/.local/bin at this version for all terminals.",
+        )
+        scope.add_argument(
+            "--local",
+            dest="scope",
+            action="store_const",
+            const="local",
+            help="Print a `source .../activate` line for the current terminal (default).",
+        )
+        p.set_defaults(scope="local")
+
+    self_install_parser = self_subparsers.add_parser("install", help="Install a release into a managed venv.")
+    self_install_parser.add_argument("tag", help="PyPI release tag (e.g. 2.1.0) or 'latest'.")
+    self_install_parser.set_defaults(func=self_command)
+
+    self_use_parser = self_subparsers.add_parser("use", help="Select an installed version (--global or --local).")
+    self_use_parser.add_argument("tag", nargs="?", help="A release tag previously installed.")
+    self_use_parser.add_argument("--from-source", help="Use the .venv of a source checkout at this path.")
+    _add_scope_group(self_use_parser)
+    self_use_parser.set_defaults(func=self_command)
+
+    self_list_parser = self_subparsers.add_parser("list", help="List managed versions and the global selection.")
+    self_list_parser.set_defaults(func=self_command)
+
+    self_which_parser = self_subparsers.add_parser("which", help="Show the active rosotacom binary and version.")
+    self_which_parser.set_defaults(func=self_command)
+
+    self_uninstall_parser = self_subparsers.add_parser("uninstall", help="Remove a managed release venv.")
+    self_uninstall_parser.add_argument("tag", help="A release tag previously installed.")
+    self_uninstall_parser.set_defaults(func=self_command)
 
     args = parser.parse_args(argv)
     try:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -12,7 +12,7 @@ import rosotacom.cli as rosotacom
 
 
 @pytest.fixture(autouse=True)
-def clear_config_env(monkeypatch: pytest.MonkeyPatch) -> None:
+def clear_config_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     for key in (
         "ROSOTACOM_CONFIG",
         "ROSOTACOM_ROS2DOCKER_CONFIG",
@@ -21,17 +21,128 @@ def clear_config_env(monkeypatch: pytest.MonkeyPatch) -> None:
         "ROSOTACOM_DATA_DICT",
     ):
         monkeypatch.delenv(key, raising=False)
+    # Keep the global user config, version venvs, shims, and the built-in-example
+    # materialization out of the real $HOME so tests stay hermetic.
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / ".config"))
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / ".state"))
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / ".data"))
+    monkeypatch.setenv("ROSOTACOM_BIN_DIR", str(tmp_path / ".bin"))
 
 
-def test_no_rosotacom_yaml_auto_discovery(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    (tmp_path / "rosotacom.yaml").write_text("ros2docker_config: missing.json\n", encoding="utf-8")
+def test_cwd_rosotacom_yaml_is_auto_discovered(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    (tmp_path / "ros2docker.json").write_text('{"image_name": "cwd"}\n', encoding="utf-8")
+    config = tmp_path / "rosotacom.yaml"
+    config.write_text("ros2docker_config: ros2docker.json\n", encoding="utf-8")
     monkeypatch.chdir(tmp_path)
 
     runtime = rosotacom._load_runtime_config(argparse.Namespace())
 
-    assert runtime.rosotacom_config is None
-    assert runtime.ros2docker_config == rosotacom.DEFAULT_ROS2DOCKER_CONFIG.resolve()
+    assert runtime.rosotacom_config == config
+    assert runtime.project_source == "cwd"
+    assert runtime.ros2docker_config == tmp_path / "ros2docker.json"
     assert runtime.session_instances_dir == tmp_path / "session-instances"
+
+
+def test_global_user_config_project_is_used(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    (proj / "ros2docker.json").write_text('{"image_name": "global"}\n', encoding="utf-8")
+    config = proj / "rosotacom.yaml"
+    config.write_text("ros2docker_config: ros2docker.json\n", encoding="utf-8")
+    rosotacom._write_user_project(config.resolve())
+
+    work = tmp_path / "work"
+    work.mkdir()
+    monkeypatch.chdir(work)
+
+    runtime = rosotacom._load_runtime_config(argparse.Namespace())
+
+    assert runtime.rosotacom_config == config.resolve()
+    assert runtime.project_source == "global"
+
+
+def test_builtin_example_used_when_nothing_configured(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    work = tmp_path / "work"
+    work.mkdir()
+    monkeypatch.chdir(work)
+
+    runtime = rosotacom._load_runtime_config(argparse.Namespace())
+
+    builtin = (rosotacom._user_state_dir() / "example" / "rosotacom.yaml").resolve()
+    assert runtime.project_source == "builtin"
+    assert runtime.rosotacom_config == builtin
+    # The materialized built-in ships runnable sessions, so zero-config works.
+    assert runtime.session_configs_dir is not None
+
+
+def test_config_set_project_global_roundtrip(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    config = tmp_path / "rosotacom.yaml"
+    config.write_text("ros2docker_config: ros2docker.json\n", encoding="utf-8")
+
+    rc = rosotacom.config_command(
+        argparse.Namespace(config_action="set", key="project", value=str(config), scope="global")
+    )
+
+    assert rc == 0
+    assert rosotacom._user_config_project() == config.resolve()
+
+    rosotacom.config_command(argparse.Namespace(config_action="unset", key="project", scope="global"))
+    assert rosotacom._user_config_project() is None
+
+
+def test_config_set_project_local_prints_export(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    config = tmp_path / "rosotacom.yaml"
+    config.write_text("ros2docker_config: ros2docker.json\n", encoding="utf-8")
+
+    rosotacom.config_command(argparse.Namespace(config_action="set", key="project", value=str(config), scope="local"))
+
+    assert capsys.readouterr().out.strip() == f"export ROSOTACOM_CONFIG={rosotacom.shlex.quote(str(config))}"
+
+
+def _fake_version_venv(tag: str) -> Path:
+    """Create a managed-version venv layout with stand-in console scripts."""
+    venv = rosotacom._version_venv_dir(tag)
+    (venv / "bin").mkdir(parents=True)
+    for name in (*rosotacom.SHIM_NAMES, "activate"):
+        (venv / "bin" / name).write_text("#!/bin/sh\n", encoding="utf-8")
+    return venv
+
+
+def test_self_use_global_links_shims_and_records(tmp_path: Path) -> None:
+    venv = _fake_version_venv("2.1.0")
+
+    rc = rosotacom.self_command(argparse.Namespace(self_action="use", tag="2.1.0", from_source=None, scope="global"))
+
+    assert rc == 0
+    bin_dir = rosotacom._user_bin_dir()
+    for name in rosotacom.SHIM_NAMES:
+        assert (bin_dir / name).resolve() == (venv / "bin" / name).resolve()
+    assert rosotacom._global_version_dir() == venv
+
+
+def test_self_use_local_prints_activate(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    venv = _fake_version_venv("2.1.0")
+
+    rosotacom.self_command(argparse.Namespace(self_action="use", tag="2.1.0", from_source=None, scope="local"))
+
+    expected = f"source {rosotacom.shlex.quote(str(venv / 'bin' / 'activate'))}"
+    assert capsys.readouterr().out.strip() == expected
+
+
+def test_self_uninstall_removes_venv_and_shims(tmp_path: Path) -> None:
+    venv = _fake_version_venv("2.1.0")
+    rosotacom.self_command(argparse.Namespace(self_action="use", tag="2.1.0", from_source=None, scope="global"))
+
+    rosotacom.self_command(argparse.Namespace(self_action="uninstall", tag="2.1.0"))
+
+    assert not venv.exists()
+    assert not (rosotacom._user_bin_dir() / "rosotacom").exists()
+    assert rosotacom._global_version_dir() is None
+
+
+def test_self_use_unknown_tag_errors(tmp_path: Path) -> None:
+    with pytest.raises(RuntimeError, match="self install"):
+        rosotacom.self_command(argparse.Namespace(self_action="use", tag="9.9.9", from_source=None, scope="local"))
 
 
 def test_rosotacom_yaml_relative_paths_resolve_from_config_dir(tmp_path: Path) -> None:


### PR DESCRIPTION
## What & why

Two awkward, inconsistent "selection" steps get one shared `--global`/`--local` model:

- **Project selection** previously required `eval "$(rosotacom setup-env ./rosotacom.yaml)"` in every new terminal — no cwd discovery, no machine-wide default.
- **Version selection** could only mean "activate this one checkout's `.venv`"; there was no path to install/select a PyPI release, locally or globally.

## Project selection

`_load_runtime_config` now resolves the active `rosotacom.yaml` by precedence (first wins):

1. `--project` / `--rosotacom-config` flag
2. `ROSOTACOM_CONFIG` env
3. **cwd/ancestor auto-discovery** of `rosotacom.yaml`
4. **machine-wide default** in `~/.config/rosotacom/config.yaml`
5. **built-in example**, materialized into `~/.local/state/rosotacom/example`, so a fresh install runs sessions with zero setup

New `rosotacom config show|get|set|unset`. `--project` is an alias for `--rosotacom-config`; `doctor` reports the resolved source; `setup-env` stays as a deprecated alias of `config set project --local`.

## Version setup

- New dependency-free `./setup [VERSION] [--global|--local] [--dev]` front-door (smart default: from-source in a checkout, else latest release).
- `rosotacom self install|use|list|which|uninstall` manage release venvs under `~/.local/share/rosotacom/versions/<tag>` and `~/.local/bin` shims.
- `just setup` now delegates to `./setup --from-source --local --dev`.

## Tests / verification

- New unit tests cover all five precedence layers, `config` round-trips, and `self` shim/version layout (hermetic via redirected XDG dirs).
- `just check` is green: ruff, mypy, 56 unit/contract + 7 docs tests, wheel build, twine, package smoke.
- The release path was verified live: `rosotacom self install latest --global` installed `rosotacom 2.1` into a managed venv and ran via the global shim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)