### PR TITLE
refactor: honest shell/local/global scopes; add `self shell`

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,39 +35,68 @@ This repository's main entrypoint for starting ROS communication sessions is
 the checkout-local `rosotacom` command. Each checkout owns its own `.venv`,
 so multiple rosotacom versions can coexist without global symlink drift.
 
+#### Scopes: `shell` vs `global`
+
+rosotacom selects both *which version runs* and *which project is active* using
+the same vocabulary (borrowed from `pyenv`):
+
+| Scope | Means | Needs `source`/`eval`? | How |
+|---|---|---|---|
+| **shell** | just this terminal | yes — only your shell can change its own env | activate a venv / an env var |
+| **local** | this directory | no | a file discovered upward (a `rosotacom.yaml`) |
+| **global** | the whole machine | no | a PATH shim / a config file |
+
+The reason `shell` needs `source`/`eval`: a child process (like `rosotacom` or
+`./setup`) can never change its parent shell's `PATH` or environment. `global`
+sidesteps that by dropping a shim into `~/.local/bin` (already on your PATH).
+
 #### Install
 
-The front-door is `./setup`: it installs a version and selects it, with one
-consistent `--global`/`--local` model (`--local` = this terminal, `--global` =
-all terminals).
+`./setup` installs a version and selects it. The default scope is **shell**, so
+it never touches your global `rosotacom`:
 
 ```bash
 cd /path/to/ros_communication_devcontainer
-./setup                         # auto: from-source + this terminal
-source .venv/bin/activate
+./setup                         # auto (from-source here); builds .venv, prints the activate line
+source .venv/bin/activate       # use it in THIS terminal
 rosotacom --version
 python -m rosotacom --version
 rosotacom doctor
 ```
 
-`./setup` also takes an explicit version and scope:
+Use `--global` for the no-`source`, available-everywhere path:
 
 ```bash
-./setup --from-source --global  # editable install, shimmed into ~/.local/bin
-./setup 2.1.0 --global          # a PyPI release, for all terminals
-./setup latest --local          # newest release, this terminal only
+./setup --global                # editable install + shim in ~/.local/bin (all terminals)
+./setup 2.1.0 --global          # a PyPI release, machine-wide
+./setup latest                  # newest release, this terminal only (prints activate line)
 ```
 
-Manage installed versions afterwards with `rosotacom self`:
+Manage versions afterwards with `rosotacom self`:
 
 ```bash
-rosotacom self list             # installed versions + the global selection
-rosotacom self use 2.1.0 --global
+rosotacom self install 2.2.0    # add a release (managed venv; global untouched)
+rosotacom self use 2.2.0        # make it the machine-wide default (re-point the shim)
+rosotacom self shell 2.2.0      # use it in THIS terminal only (prints an activate line)
+rosotacom self list             # installed versions; * marks the global default
 rosotacom self which
 ```
 
-`./install.sh` (optionally `--global-symlink`) remains the low-level source
-installer that `./setup --from-source` builds on.
+**Use case — try a new version without disturbing a pinned one.** Keep a
+production checkout/global on its commit, and smoke-test the newest commit in
+one terminal:
+
+```bash
+cd ~/checkouts/rosotacom-newest   # a checkout (or git worktree) at the new commit
+./install.sh                      # builds .venv here; global rosotacom UNCHANGED
+source .venv/bin/activate         # this terminal now runs the new commit
+rosotacom smoke                   # built-in example, zero config
+deactivate                        # back to your global/production rosotacom
+```
+
+`./install.sh` (optionally `--global-symlink`) is the low-level source installer
+that `./setup --from-source` builds on; on its own it never touches the global
+shim, which is what makes the workflow above safe.
 
 ### Basic Setup
 
@@ -77,15 +106,17 @@ installer that `./setup --from-source` builds on.
 - A **session config** defines the communication behavior for one run: peers, addresses, topics, QoS, processing, and transport choices.
 - A **session instance** stores one concrete run: generated config, catmux pane logs, smoke debug output, and future rosbags.
 
-`rosotacom` resolves the active `rosotacom.yaml` in this order (first wins):
+`rosotacom` resolves the active `rosotacom.yaml` by scope (first wins) — the same
+`shell` / `local` / `global` model as versions:
 
 1. `--project <path>` (alias of `--rosotacom-config`) on the command
-2. `ROSOTACOM_CONFIG` in the environment
-3. the nearest `rosotacom.yaml` discovered upward from the current directory
-4. a machine-wide default set with `rosotacom config set project ... --global`
+2. **shell** — `ROSOTACOM_CONFIG` in the environment
+3. **local** — the nearest `rosotacom.yaml` discovered upward from the cwd
+4. **global** — a machine-wide default (`rosotacom config set project ... --global`)
 5. a built-in example project, so a fresh install runs with zero setup
 
-So the simplest workflow is just to be in a project directory:
+So the simplest workflow is just to be in a project directory (the **local**
+scope — no command needed, just have the file):
 
 ```bash
 rosotacom examples create ./rosotacom_examples
@@ -96,12 +127,12 @@ rosotacom doctor                # picks up ./rosotacom.yaml automatically
 Inspect or pin the selection with `rosotacom config`:
 
 ```bash
-rosotacom config show                                            # every layer + the winner
+rosotacom config show                                            # every scope + the winner
 rosotacom config set project ./rosotacom.yaml --global           # machine-wide default
-eval "$(rosotacom config set project ./rosotacom.yaml --local)"  # this terminal only
+eval "$(rosotacom config set project ./rosotacom.yaml --shell)"  # this terminal only
 ```
 
-(`rosotacom setup-env ./rosotacom.yaml` is a deprecated alias for the `--local` form.)
+(`rosotacom setup-env ./rosotacom.yaml` is a deprecated alias for the `--shell` form.)
 
 The copied packaged example project uses this layout:
 

--- a/justfile
+++ b/justfile
@@ -8,8 +8,9 @@ venv:
 	python3 -m venv .venv
 	{{python}} -m pip install --upgrade pip
 
-setup:
-	./setup --from-source --local --dev
+setup: venv
+	{{python}} -m pip install -e ".[dev]"
+	{{python}} -m pre_commit install
 
 format:
 	{{python}} -m ruff check --fix .

--- a/setup
+++ b/setup
@@ -1,11 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# rosotacom front-door: install a version and select it, with one consistent
-# `--global`/`--local` model. See `./setup --help`.
+# rosotacom front-door: install a version and select it. Two honest scopes:
+#   --shell  (default) usable in THIS terminal; leaves your global rosotacom
+#            untouched. Activation is a shell action, so it prints a `source`
+#            line for you to run (a script cannot change its parent shell).
+#   --global usable in ALL terminals via a PATH shim in ~/.local/bin; no source.
 #
 # Usage:
-#   ./setup [VERSION] [--global|--local] [--dev]
+#   ./setup [VERSION] [--shell|--global] [--dev]
 #
 # VERSION (pick one; default = auto):
 #   --from-source   editable install of THIS checkout (developer mode)
@@ -13,27 +16,27 @@ set -euo pipefail
 #   latest          the newest PyPI release
 #   (auto)          --from-source when run inside a checkout, else latest
 #
-# SELECTION (default = --local):
-#   --local         usable in THIS terminal (prints a `source .../activate` line)
-#   --global        usable in ALL terminals (shims in ~/.local/bin)
-#
 #   --dev           also install dev tooling (.[dev] + pre-commit); source only
+#
+# The default scope never touches your global rosotacom, so you can install and
+# smoke-test a new version in one terminal while production stays put. Make it
+# the machine-wide default later (or now) with --global, or `rosotacom self use`.
 #
 # Env: VENV_DIR, ROSOTACOM_BIN_DIR, XDG_DATA_HOME honored as elsewhere.
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 
 version=""          # "", "--from-source", "latest", or a tag
-scope="local"
+scope="shell"
 dev=false
 
 for arg in "$@"; do
   case "$arg" in
     --from-source) version="--from-source" ;;
     --global) scope="global" ;;
-    --local) scope="local" ;;
+    --shell) scope="shell" ;;
     --dev) dev=true ;;
-    -h|--help) sed -n '4,22p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    -h|--help) sed -n '4,25p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
     --*) echo "ERROR: unknown option: $arg" >&2; exit 2 ;;
     *)
       if [[ -n "$version" && "$version" != "--from-source" ]]; then
@@ -51,23 +54,28 @@ fi
 bin_dir="${ROSOTACOM_BIN_DIR:-$HOME/.local/bin}"
 data_home="${XDG_DATA_HOME:-$HOME/.local/share}"
 
+print_activate() {  # $1 = venv dir
+  echo
+  echo "Use it in THIS terminal (global default untouched):"
+  echo "  source \"$1/bin/activate\""
+}
+
 install_from_source() {
+  local venv="${VENV_DIR:-$SCRIPT_DIR/.venv}"
   if [[ "$scope" == "global" ]]; then
     "$SCRIPT_DIR/install.sh" --global-symlink
   else
     "$SCRIPT_DIR/install.sh"
   fi
-  local venv="${VENV_DIR:-$SCRIPT_DIR/.venv}"
   if [[ "$dev" == true ]]; then
     "$venv/bin/python" -m pip install -e "$SCRIPT_DIR[dev]"
     "$venv/bin/pre-commit" install || true
   fi
-  echo
   if [[ "$scope" == "global" ]]; then
+    echo
     echo "Global rosotacom shims installed in: $bin_dir (ensure it is on your PATH)"
   else
-    echo "Activate this terminal with:"
-    echo "  source \"$venv/bin/activate\""
+    print_activate "$venv"
   fi
 }
 
@@ -78,13 +86,11 @@ install_release() {
   python3 -m venv "$venv"
   "$venv/bin/python" -m pip install --upgrade pip
   "$venv/bin/python" -m pip install "$spec"
-  # Reuse the CLI's own shim/activate logic for selection.
   if [[ "$scope" == "global" ]]; then
-    "$venv/bin/rosotacom" self use "$tag" --global
+    # Reuse the CLI's own shim logic for the machine-wide default.
+    "$venv/bin/rosotacom" self use "$tag"
   else
-    echo
-    echo "Activate this terminal with:"
-    echo "  source \"$venv/bin/activate\""
+    print_activate "$venv"
   fi
 }
 

--- a/src/rosotacom/cli.py
+++ b/src/rosotacom/cli.py
@@ -217,26 +217,28 @@ def _builtin_example_config() -> Path | None:
 
 
 def _resolve_project_config_source(args: argparse.Namespace) -> tuple[str | None, str | None]:
-    """Resolve which rosotacom.yaml is active and which layer it came from.
+    """Resolve which rosotacom.yaml is active and which scope it came from.
 
-    Precedence (highest first): explicit flag, ROSOTACOM_CONFIG env, cwd/ancestor
-    auto-discovery, machine-wide user default, packaged built-in example.
+    Precedence (highest first), in the shared shell/local/global vocabulary:
+    explicit ``--project`` flag, ``shell`` (ROSOTACOM_CONFIG env), ``local`` (a
+    rosotacom.yaml discovered upward from the cwd), ``global`` (machine-wide user
+    default), then the packaged ``built-in`` example.
     """
     flag = getattr(args, "rosotacom_config", None)
     if flag:
         return str(flag), "flag"
     env = os.environ.get("ROSOTACOM_CONFIG")
     if env:
-        return env, "env"
+        return env, "shell"
     discovered = _discover_project_config()
     if discovered:
-        return str(discovered), "cwd"
+        return str(discovered), "local"
     user = _user_config_project()
     if user:
         return str(user), "global"
     builtin = _builtin_example_config()
     if builtin:
-        return str(builtin), "builtin"
+        return str(builtin), "built-in"
     return None, None
 
 
@@ -1153,9 +1155,10 @@ def config_command(args: argparse.Namespace) -> int:
         if args.key != "project":
             raise RuntimeError(f"unknown config key: {args.key}")
         config = _require_project_file(args.value)
-        # --global persists machine-wide; --local (default) emits a shell export to
-        # eval in the current terminal. A child process cannot mutate the parent
-        # shell, so the per-terminal path stays an `eval "$(...)"` escape hatch.
+        # --global persists machine-wide; --shell (default) emits an export to eval
+        # in the current terminal. A child process cannot mutate the parent shell,
+        # so the per-terminal path stays an `eval "$(...)"` escape hatch. The third
+        # scope, "local", needs no command: just keep a rosotacom.yaml in the dir.
         if args.scope == "global":
             path = _write_user_project(config)
             print(f"Set global default project: {config}")
@@ -1187,13 +1190,13 @@ def config_command(args: argparse.Namespace) -> int:
         print(f"{label:>9}: {value}")
 
     line("flag", getattr(args, "rosotacom_config", None) or "-")
-    line("env", os.environ.get("ROSOTACOM_CONFIG") or "-")
-    line("cwd", str(_discover_project_config() or "-"))
+    line("shell", os.environ.get("ROSOTACOM_CONFIG") or "-")
+    line("local", str(_discover_project_config() or "-"))
     line("global", str(_user_config_project() or "-"))
-    line("builtin", str(_user_state_dir() / "example" / "rosotacom.yaml"))
+    line("built-in", str(_user_state_dir() / "example" / "rosotacom.yaml"))
     if raw:
         active = _resolve_path(raw, Path.cwd(), must_exist=True)
-        line("active", f"{active}  (source: {source})")
+        line("active", f"{active}  (scope: {source})")
     else:
         line("active", "none configured")
     return 0
@@ -1270,18 +1273,25 @@ def self_command(args: argparse.Namespace) -> int:
         venv_dir = _version_venv_dir(args.tag)
         _create_version_venv(venv_dir, spec)
         print(f"Installed {spec} into: {venv_dir}")
-        print(f"Select it with: rosotacom self use {args.tag} --global")
+        print(f"Make it the default:    rosotacom self use {args.tag}")
+        print(f'Use only this terminal: eval "$(rosotacom self shell {args.tag})"')
         return 0
 
     if action == "use":
+        # "use" = set the machine-wide default (re-point the ~/.local/bin shim).
         venv_dir = _resolve_self_venv(args, require_exists=True)
-        if args.scope == "global":
-            _link_global_shims(venv_dir)
-            _write_user_version(venv_dir)
-            print(f"Global rosotacom now points at: {venv_dir}")
-            print(f"  shims in {_user_bin_dir()} (ensure it is on your PATH)")
-        else:
-            print(f"source {shlex.quote(str(venv_dir / 'bin' / 'activate'))}")
+        _link_global_shims(venv_dir)
+        _write_user_version(venv_dir)
+        print(f"Global rosotacom now points at: {venv_dir}")
+        print(f"  shims in {_user_bin_dir()} (ensure it is on your PATH)")
+        return 0
+
+    if action == "shell":
+        # "shell" = use this version in the current terminal only, leaving the
+        # global default untouched. Activation is a shell action, so we print a
+        # line to eval/source (a child process cannot change the parent shell).
+        venv_dir = _resolve_self_venv(args, require_exists=True)
+        print(f"source {shlex.quote(str(venv_dir / 'bin' / 'activate'))}")
         return 0
 
     if action == "uninstall":
@@ -1961,7 +1971,7 @@ def main(argv: list[str] | None = None) -> int:
 
     setup_env_parser = subparsers.add_parser(
         "setup-env",
-        help="[deprecated] Alias for `config set project --local`. Print shell exports for a rosotacom.yaml.",
+        help="[deprecated] Alias for `config set project --shell`. Print shell exports for a rosotacom.yaml.",
     )
     setup_env_parser.add_argument("rosotacom_config", help="Path to rosotacom.yaml.")
     setup_env_parser.set_defaults(func=setup_env_command)
@@ -1969,7 +1979,9 @@ def main(argv: list[str] | None = None) -> int:
     config_parser = subparsers.add_parser("config", help="Inspect or set the active rosotacom project.")
     config_subparsers = config_parser.add_subparsers(dest="config_action", required=True)
 
-    config_set_parser = config_subparsers.add_parser("set", help="Set the active project (--global or --local).")
+    config_set_parser = config_subparsers.add_parser(
+        "set", help="Set the active project (--global, or --shell for this terminal)."
+    )
     config_set_parser.add_argument("key", choices=["project"])
     config_set_parser.add_argument("value", help="Path to rosotacom.yaml.")
     config_set_scope = config_set_parser.add_mutually_exclusive_group()
@@ -1981,19 +1993,20 @@ def main(argv: list[str] | None = None) -> int:
         help="Persist as the machine-wide default for all terminals.",
     )
     config_set_scope.add_argument(
-        "--local",
+        "--shell",
         dest="scope",
         action="store_const",
-        const="local",
-        help="Print a shell export to eval in the current terminal (default).",
+        const="shell",
+        help="Print an export to eval in the current terminal only (default). "
+        "For a directory ('local') scope, just keep a rosotacom.yaml in it.",
     )
-    config_set_parser.set_defaults(func=config_command, scope="local")
+    config_set_parser.set_defaults(func=config_command, scope="shell")
 
     config_get_parser = config_subparsers.add_parser("get", help="Print the resolved active project path.")
     config_get_parser.add_argument("key", choices=["project"], nargs="?", default="project")
     config_get_parser.set_defaults(func=config_command)
 
-    config_show_parser = config_subparsers.add_parser("show", help="Show every project-selection layer and the winner.")
+    config_show_parser = config_subparsers.add_parser("show", help="Show every project-selection scope and the winner.")
     config_show_parser.set_defaults(func=config_command)
 
     config_unset_parser = config_subparsers.add_parser("unset", help="Clear the machine-wide default project.")
@@ -2011,33 +2024,21 @@ def main(argv: list[str] | None = None) -> int:
     self_parser = subparsers.add_parser("self", help="Install and select rosotacom versions.")
     self_subparsers = self_parser.add_subparsers(dest="self_action", required=True)
 
-    def _add_scope_group(p: argparse.ArgumentParser) -> None:
-        scope = p.add_mutually_exclusive_group()
-        scope.add_argument(
-            "--global",
-            dest="scope",
-            action="store_const",
-            const="global",
-            help="Point ~/.local/bin at this version for all terminals.",
-        )
-        scope.add_argument(
-            "--local",
-            dest="scope",
-            action="store_const",
-            const="local",
-            help="Print a `source .../activate` line for the current terminal (default).",
-        )
-        p.set_defaults(scope="local")
-
     self_install_parser = self_subparsers.add_parser("install", help="Install a release into a managed venv.")
     self_install_parser.add_argument("tag", help="PyPI release tag (e.g. 2.1.0) or 'latest'.")
     self_install_parser.set_defaults(func=self_command)
 
-    self_use_parser = self_subparsers.add_parser("use", help="Select an installed version (--global or --local).")
+    self_use_parser = self_subparsers.add_parser("use", help="Make a version the machine-wide default (PATH shim).")
     self_use_parser.add_argument("tag", nargs="?", help="A release tag previously installed.")
     self_use_parser.add_argument("--from-source", help="Use the .venv of a source checkout at this path.")
-    _add_scope_group(self_use_parser)
     self_use_parser.set_defaults(func=self_command)
+
+    self_shell_parser = self_subparsers.add_parser(
+        "shell", help="Use a version in THIS terminal only (prints a line to eval); global default untouched."
+    )
+    self_shell_parser.add_argument("tag", nargs="?", help="A release tag previously installed.")
+    self_shell_parser.add_argument("--from-source", help="Use the .venv of a source checkout at this path.")
+    self_shell_parser.set_defaults(func=self_command)
 
     self_list_parser = self_subparsers.add_parser("list", help="List managed versions and the global selection.")
     self_list_parser.set_defaults(func=self_command)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -38,7 +38,7 @@ def test_cwd_rosotacom_yaml_is_auto_discovered(tmp_path: Path, monkeypatch: pyte
     runtime = rosotacom._load_runtime_config(argparse.Namespace())
 
     assert runtime.rosotacom_config == config
-    assert runtime.project_source == "cwd"
+    assert runtime.project_source == "local"
     assert runtime.ros2docker_config == tmp_path / "ros2docker.json"
     assert runtime.session_instances_dir == tmp_path / "session-instances"
 
@@ -69,7 +69,7 @@ def test_builtin_example_used_when_nothing_configured(tmp_path: Path, monkeypatc
     runtime = rosotacom._load_runtime_config(argparse.Namespace())
 
     builtin = (rosotacom._user_state_dir() / "example" / "rosotacom.yaml").resolve()
-    assert runtime.project_source == "builtin"
+    assert runtime.project_source == "built-in"
     assert runtime.rosotacom_config == builtin
     # The materialized built-in ships runnable sessions, so zero-config works.
     assert runtime.session_configs_dir is not None
@@ -90,11 +90,11 @@ def test_config_set_project_global_roundtrip(tmp_path: Path, monkeypatch: pytest
     assert rosotacom._user_config_project() is None
 
 
-def test_config_set_project_local_prints_export(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+def test_config_set_project_shell_prints_export(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     config = tmp_path / "rosotacom.yaml"
     config.write_text("ros2docker_config: ros2docker.json\n", encoding="utf-8")
 
-    rosotacom.config_command(argparse.Namespace(config_action="set", key="project", value=str(config), scope="local"))
+    rosotacom.config_command(argparse.Namespace(config_action="set", key="project", value=str(config), scope="shell"))
 
     assert capsys.readouterr().out.strip() == f"export ROSOTACOM_CONFIG={rosotacom.shlex.quote(str(config))}"
 
@@ -108,10 +108,10 @@ def _fake_version_venv(tag: str) -> Path:
     return venv
 
 
-def test_self_use_global_links_shims_and_records(tmp_path: Path) -> None:
+def test_self_use_sets_global_default(tmp_path: Path) -> None:
     venv = _fake_version_venv("2.1.0")
 
-    rc = rosotacom.self_command(argparse.Namespace(self_action="use", tag="2.1.0", from_source=None, scope="global"))
+    rc = rosotacom.self_command(argparse.Namespace(self_action="use", tag="2.1.0", from_source=None))
 
     assert rc == 0
     bin_dir = rosotacom._user_bin_dir()
@@ -120,18 +120,21 @@ def test_self_use_global_links_shims_and_records(tmp_path: Path) -> None:
     assert rosotacom._global_version_dir() == venv
 
 
-def test_self_use_local_prints_activate(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+def test_self_shell_prints_activate_without_touching_global(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     venv = _fake_version_venv("2.1.0")
 
-    rosotacom.self_command(argparse.Namespace(self_action="use", tag="2.1.0", from_source=None, scope="local"))
+    rosotacom.self_command(argparse.Namespace(self_action="shell", tag="2.1.0", from_source=None))
 
     expected = f"source {rosotacom.shlex.quote(str(venv / 'bin' / 'activate'))}"
     assert capsys.readouterr().out.strip() == expected
+    # shell scope must not change the global default
+    assert rosotacom._global_version_dir() is None
+    assert not (rosotacom._user_bin_dir() / "rosotacom").exists()
 
 
 def test_self_uninstall_removes_venv_and_shims(tmp_path: Path) -> None:
     venv = _fake_version_venv("2.1.0")
-    rosotacom.self_command(argparse.Namespace(self_action="use", tag="2.1.0", from_source=None, scope="global"))
+    rosotacom.self_command(argparse.Namespace(self_action="use", tag="2.1.0", from_source=None))
 
     rosotacom.self_command(argparse.Namespace(self_action="uninstall", tag="2.1.0"))
 
@@ -142,7 +145,7 @@ def test_self_uninstall_removes_venv_and_shims(tmp_path: Path) -> None:
 
 def test_self_use_unknown_tag_errors(tmp_path: Path) -> None:
     with pytest.raises(RuntimeError, match="self install"):
-        rosotacom.self_command(argparse.Namespace(self_action="use", tag="9.9.9", from_source=None, scope="local"))
+        rosotacom.self_command(argparse.Namespace(self_action="use", tag="9.9.9", from_source=None))
 
 
 def test_rosotacom_yaml_relative_paths_resolve_from_config_dir(tmp_path: Path) -> None:


### PR DESCRIPTION
Follow-up to #10. Makes the version- and project-selection vocabulary consistent and honest, before any of it ships.

## Why
`#10` shipped `--global`/`--local` on `setup`/`self`/`config`, but that was a false symmetry: `setup --global` ≈ `install.sh + symlink`, while `--local` was really "install, don't select" and couldn't actually activate a shell. This aligns everything on one model (borrowed from `pyenv`).

## Scopes (same words for versions and projects)
| Scope | Means | Needs source/eval? | How |
|---|---|---|---|
| **shell** | this terminal | yes (only your shell can change its own env) | activate a venv / env var |
| **local** | this directory | no | a `rosotacom.yaml` discovered upward |
| **global** | the machine | no | a PATH shim / config file |

## Changes
- **`setup`**: scopes are `--shell` (default; never touches the global shim) and `--global`. Drops the misleading `--local`.
- **`rosotacom self`**: `use <tag>` now always = machine-wide default; new **`self shell <tag>`** selects a version for the current terminal only, leaving global untouched.
- **`config set project`**: `--global` or `--shell` (was `--local`); the per-directory scope needs no flag — just keep a `rosotacom.yaml` there.
- `config show`/`doctor` relabel sources: `cwd`→`local`, `env`→`shell`, `builtin`→`built-in`.
- `justfile setup` is dev-local again.

## Use case this unlocks
Keep a pinned/production version global, and smoke-test the newest commit in one terminal without disturbing it:
```bash
cd ~/checkouts/rosotacom-newest && ./install.sh && source .venv/bin/activate
rosotacom smoke      # global/production rosotacom untouched
```

## Verification
`just check` green: ruff, mypy, 56 unit/contract + 7 docs tests, wheel build, twine, package smoke. `self shell` confirmed to leave the global default in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)