### PR TITLE
feat: built-in example runs from tmpfs, never writing to $HOME

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,11 @@ version manager.
 4. **global** — a machine-wide default (`rosotacom config set project ... --global`)
 5. a built-in example project, so a fresh install runs with zero setup
 
+The built-in example is used **in place** (read-only) and writes nothing to
+`$HOME`: its generated session output goes to a per-user tmpfs dir under
+`$XDG_RUNTIME_DIR` (printed on `start`/`smoke`), so it is ephemeral. For
+persistent, editable projects, create one with `rosotacom examples create`.
+
 So the simplest workflow is just to be in a project directory (the **local**
 scope — no command needed, just have the file):
 

--- a/src/rosotacom/cli.py
+++ b/src/rosotacom/cli.py
@@ -20,6 +20,7 @@ import shlex
 import shutil
 import subprocess
 import sys
+import tempfile
 import time
 from dataclasses import dataclass
 from datetime import datetime
@@ -162,8 +163,22 @@ def _user_config_file() -> Path:
     return _xdg_dir("XDG_CONFIG_HOME", ".config") / "rosotacom" / "config.yaml"
 
 
-def _user_state_dir() -> Path:
-    return _xdg_dir("XDG_STATE_HOME", ".local/state") / "rosotacom"
+def _runtime_dir() -> Path:
+    """A per-user, RAM-backed scratch dir for ephemeral runtime artifacts.
+
+    ``XDG_RUNTIME_DIR`` is tmpfs on Linux and auto-cleaned on logout, so it is the
+    correct home for generated session files (which must be real paths because
+    they are bind-mounted into the container) without touching ``$HOME``.
+    """
+    base = os.environ.get("XDG_RUNTIME_DIR")
+    if base:
+        return Path(base) / "rosotacom"
+    uid = getattr(os, "getuid", lambda: os.getpid())()
+    return Path(tempfile.gettempdir()) / f"rosotacom-{uid}"
+
+
+def _builtin_instances_dir() -> Path:
+    return _runtime_dir() / "example" / "session-instances"
 
 
 def _discover_project_config(start: Path | None = None) -> Path | None:
@@ -189,21 +204,17 @@ def _user_config_project() -> Path | None:
 
 
 def _builtin_example_config() -> Path | None:
-    """Materialize the packaged example into the user state dir (once) and return it.
+    """Return the packaged example project's rosotacom.yaml, used in place.
 
     This is the zero-config fallback: a fresh install can run sessions with no
-    setup. The copy is writable (unlike the in-package resources) so its
-    ``data_dict.json`` and ``session-instances/`` work normally.
+    setup. Nothing is copied — the config, ``sessions/`` and ``data_dict.json``
+    are read-only (and mounted read-only). Only the writable runtime output is
+    redirected, to tmpfs; see ``_builtin_instances_dir`` and where
+    ``project_source == "built-in"`` overrides ``session_instances_dir``.
     """
-    target = _user_state_dir() / "example"
-    config = target / "rosotacom.yaml"
-    if config.is_file():
-        return config
-    try:
-        source = _example_project_resource()
-        _copy_example_resource_tree(source, target)
-    except (RuntimeError, OSError):
+    if not EXAMPLE_PROJECT_DIR.is_dir():
         return None
+    config = EXAMPLE_PROJECT_DIR / "rosotacom.yaml"
     return config if config.is_file() else None
 
 
@@ -267,13 +278,19 @@ def _load_runtime_config(args: argparse.Namespace | None = None) -> RuntimeConfi
     if ros2docker_config is None:
         raise RuntimeError("ros2docker config could not be resolved.")
 
+    session_instances_dir = _resolve_path(session_instances_dir_raw, config_base, must_exist=False)
+    if project_source == "built-in":
+        # The packaged example is read-only; redirect only its writable runtime
+        # output to tmpfs so the built-in fallback never writes into $HOME.
+        session_instances_dir = _builtin_instances_dir()
+
     return RuntimeConfig(
         rosotacom_config=rosotacom_config,
         ros2docker_config=ros2docker_config,
         session_configs_dir=_resolve_path(session_configs_dir_raw, config_base, must_exist=True),
         data_dict=_resolve_path(data_dict_raw, config_base, must_exist=True),
         install_id=_install_id(rosotacom_config),
-        session_instances_dir=_resolve_path(session_instances_dir_raw, config_base, must_exist=False),
+        session_instances_dir=session_instances_dir,
         project_source=project_source,
     )
 
@@ -1184,7 +1201,7 @@ def config_command(args: argparse.Namespace) -> int:
     line("shell", os.environ.get("ROSOTACOM_CONFIG") or "-")
     line("local", str(_discover_project_config() or "-"))
     line("global", str(_user_config_project() or "-"))
-    line("built-in", str(_user_state_dir() / "example" / "rosotacom.yaml"))
+    line("built-in", str(_builtin_example_config() or "-"))
     if raw:
         active = _resolve_path(raw, Path.cwd(), must_exist=True)
         line("active", f"{active}  (scope: {source})")

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -21,10 +21,10 @@ def clear_config_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         "ROSOTACOM_DATA_DICT",
     ):
         monkeypatch.delenv(key, raising=False)
-    # Keep the global user config and the built-in-example materialization out of
-    # the real $HOME so tests stay hermetic.
+    # Keep the global user config and the built-in example's tmpfs instances dir
+    # off the real $HOME / runtime dir so tests stay hermetic.
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / ".config"))
-    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / ".state"))
+    monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path / ".run"))
 
 
 def test_cwd_rosotacom_yaml_is_auto_discovered(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -66,11 +66,13 @@ def test_builtin_example_used_when_nothing_configured(tmp_path: Path, monkeypatc
 
     runtime = rosotacom._load_runtime_config(argparse.Namespace())
 
-    builtin = (rosotacom._user_state_dir() / "example" / "rosotacom.yaml").resolve()
     assert runtime.project_source == "built-in"
-    assert runtime.rosotacom_config == builtin
-    # The materialized built-in ships runnable sessions, so zero-config works.
-    assert runtime.session_configs_dir is not None
+    # The packaged example is used in place (read-only), not copied into $HOME.
+    assert runtime.rosotacom_config == (rosotacom.EXAMPLE_PROJECT_DIR / "rosotacom.yaml").resolve()
+    assert runtime.session_configs_dir is not None  # ships runnable sessions
+    # Only the writable runtime output is redirected, to tmpfs (no $HOME writes).
+    assert runtime.session_instances_dir == rosotacom._builtin_instances_dir()
+    assert str(runtime.session_instances_dir).startswith(str(tmp_path / ".run"))
 
 
 def test_config_set_project_global_roundtrip(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Makes the built-in zero-config example clean: it no longer copies anything into `$HOME`.

## Why
The built-in fallback used to materialize the whole packaged example into `~/.local/state` on first use. But the generated session files are **bind-mounted into the container** (so they must be real paths — fully in-memory isn't possible), and that's the *only* thing that needs to be writable. The config / `sessions/` / `data_dict.json` are read-only and already mounted read-only.

## Change
- Use the packaged example **in place** (no copy).
- Redirect **only** `session_instances_dir` to a per-user **tmpfs** dir under `$XDG_RUNTIME_DIR` (RAM-backed, auto-cleaned on logout; falls back to a temp dir). On Linux this is the closest practical thing to "in memory."
- Result: the built-in writes **nothing** to `$HOME`; its run artifacts are ephemeral.
- Real projects (`rosotacom examples create ./x`) are unchanged — their instances stay under the project dir.

Removes the copy-on-first-use path and `_user_state_dir`; adds `_runtime_dir` / `_builtin_instances_dir` and a `project_source == "built-in"` override of `session_instances_dir`.

## Verification
`just check` green (ruff, mypy, 52 + 7 tests, wheel, twine, package smoke). Manually confirmed from a neutral dir: `config show` → active `built-in` (in-package path), `doctor` → `session instances: $XDG_RUNTIME_DIR/rosotacom/example/session-instances`, and **nothing created under `$HOME`**.

## Tradeoff
Built-in logs are ephemeral (gone on logout/reboot) — the right call for a "just try it" path. Use `examples create` when you want durable, editable projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)