### PR TITLE
docs: use static license badge to stop intermittent breakage

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Coverage](https://codecov.io/gh/develNor/ros_communication_devcontainer/branch/develop/graph/badge.svg)](https://codecov.io/gh/develNor/ros_communication_devcontainer)
 [![PyPI](https://img.shields.io/pypi/v/rosotacom.svg)](https://pypi.org/project/rosotacom/)
 [![Python](https://img.shields.io/pypi/pyversions/rosotacom.svg)](https://pypi.org/project/rosotacom/)
-[![License](https://img.shields.io/github/license/develNor/ros_communication_devcontainer.svg)](https://github.com/develNor/ros_communication_devcontainer/blob/HEAD/LICENSE.txt)
+[![License](https://img.shields.io/badge/license-BSD--3--Clause-blue.svg)](https://github.com/develNor/ros_communication_devcontainer/blob/HEAD/LICENSE.txt)
 
 The ROS Communication DevContainer is a Docker-based solution designed to streamline the bidirectional synchronization of ROS2 topics between two Linux machines. It provides built-in compression and routing capabilities for over-the-air (OTA) data transfer: selected topics are remapped into an OTA namespace and transmitted either via direct DDS (CycloneDDS) or through a Zenoh router. When desired, the session can also place local application nodes and OTA-facing bridge nodes into separate ROS 2 domain IDs and automatically generate a standard ROS 2 `domain_bridge` configuration for the `/com/...` boundary. This project aligns with the publication *“Scalable Remote Operation for Autonomous Vehicles: Integration of Cooperative Perception and Open Source Communication.”*
 


### PR DESCRIPTION
## What

Replace the dynamic License badge with a static one:

```diff
-[![License](https://img.shields.io/github/license/develNor/ros_communication_devcontainer.svg)](...LICENSE.txt)
+[![License](https://img.shields.io/badge/license-BSD--3--Clause-blue.svg)](...LICENSE.txt)
```

## Why it kept breaking

`img.shields.io/github/license/...` is a **dynamic** badge: shields.io calls the GitHub REST API on every render to detect the license. That API is rate-limited against shields.io's shared token, so it intermittently returns 429/errors. GitHub's camo image proxy then caches the failed response, so the badge shows as a broken image for everyone until the cache expires — even though the LICENSE file and GitHub's detection are both fine.

This is the same badge that #7 switched *to* (from the unreadable `pypi/l` badge). Rather than swap one flaky source for another, this uses a **static** badge.

## Why static is the right fix

The license is fixed and known (`BSD-3-Clause`, declared in `pyproject.toml` and `LICENSE.txt`). A static `badge/license-BSD--3--Clause-blue` hits no API, so it can't be rate-limited or cached-broken. The badge still links to `LICENSE.txt`. Renders identically: `license: BSD-3-Clause`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)