### PR TITLE
feat: unify single/multi-machine test verification behind capability markers

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -36,10 +36,23 @@ only thing standing between a local topic and the wire. Some transport setups
 (e.g. single-domain CycloneDDS topic hiding, or a split-domain `domain_bridge`)
 are therefore **only meaningful multi-machine**.
 
+The single-machine smoke test still *runs* the isolation assertion (publishing a
+local-only topic and confirming it does not cross) — there the distinct domain
+IDs make it hold trivially, but it exercises the same assertion code that proves
+the real guarantee multi-machine, so the two tiers cannot diverge.
+
 ## Per-session capability marker
 
 Every session under `examples/sessions/<name>/` is meaningful in some tiers and
-not others. Declare that with a marker so coverage cannot silently drift:
+not others. Each `session-definition.yaml` declares this with a `test_tiers`
+block (the **single source of truth** — both tiers derive their session list
+from it, so coverage cannot silently drift):
+
+```yaml
+test_tiers:
+  single_machine: ok       # ok | na
+  multi_machine: required  # ok | required | na
+```
 
 | Marker | Meaning |
 |---|---|
@@ -47,12 +60,15 @@ not others. Declare that with a marker so coverage cannot silently drift:
 | `single_machine: na` | not meaningful on one host (skip in smoke) |
 | `multi_machine: ok` | valid across two hosts |
 | `multi_machine: required` | the behavior can *only* be proven across two hosts |
+| `multi_machine: na` | not exercised by the multi-machine suite |
 
-Today the single-machine smoke set is the heartbeat-RMW matrix in
-`tests/e2e/test_smoke.py`, guarded by
-`tests/contract/test_security_maintenance_config.py` so the list cannot drift
-unnoticed. When a session's tier coverage changes, update that matrix (and its
-multi-machine counterpart, below) in the same change.
+The single-machine smoke matrix (`tests/e2e/test_smoke.py`) is derived from the
+sessions marked `single_machine: ok`; the multi-machine set is derived from
+`multi_machine in {ok, required}`. `rosotacom.cli.session_test_markers()` /
+`sessions_in_tier()` read the markers, and
+`tests/contract/test_security_maintenance_config.py` guards both directions so a
+new or changed session must carry a valid marker. **To change a session's tier
+coverage, edit its `test_tiers` marker** — the matrices follow automatically.
 
 ## Multi-machine tier (external)
 
@@ -75,3 +91,16 @@ A multi-machine run, generically:
 The set of sessions a multi-machine runner exercises is the sessions marked
 `multi_machine: ok` or `multi_machine: required`. Keeping the markers in this
 repo lets any external runner derive its scenario list without hardcoding it.
+
+Both assertions in step 4 are the **same code** the single-machine smoke test
+runs. After starting each peer, the runner calls, per host over SSH:
+
+- `rosotacom verify --identity <peer>` — delivery of the crossed topics within
+  the shared rate/latency bounds;
+- `rosotacom probe-publish --identity a` then `rosotacom probe-check --identity b
+  --expect absent` — isolation (a local-only topic must not cross).
+
+These verbs probe inside the running session container, so the host itself needs
+no ROS environment. The bounds and the probe topic live in `rosotacom` (single
+source), so both tiers assert identically — only the transport (one loopback host
+vs. two hosts over the wire) differs.

--- a/src/rosotacom/cli.py
+++ b/src/rosotacom/cli.py
@@ -22,6 +22,7 @@ import subprocess
 import sys
 import tempfile
 import time
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
@@ -1512,6 +1513,232 @@ def _smoke_ros_setup(config_container_dir: str, cfg: dict[str, Any], receiver_pe
     return " && ".join(commands)
 
 
+# --- Shared verification primitives (used by `smoke` and the `verify`/`probe-*`
+# CLI verbs that the external multi-machine runner calls over SSH) --------------
+# Single source of truth for the heartbeat delivery bounds and the isolation
+# probe topic, so both test tiers assert the same thing. See docs/testing.md.
+VERIFY_HZ_MIN = 5.0
+VERIFY_HZ_MAX = 20.0
+VERIFY_MAX_DELAY_S = 1.0
+ISOLATION_PROBE_TOPIC = "/local_only"
+
+
+def _other_peer_key(cfg: dict[str, Any], identity: str) -> str:
+    peers = cfg.get("peers") or {}
+    if identity not in peers:
+        raise RuntimeError(f"--identity must be one of peers={sorted(peers)}")
+    return str(next(k for k in peers if k != identity))
+
+
+def _received_crossed_topics(cfg: dict[str, Any], receiver_peer_key: str) -> list[tuple[str, str, bool]]:
+    """(topic, label, enforce_bounds) the receiver must get from the other peer:
+    the inbound-bridge topic (presence only) and the final remapped heartbeat
+    (presence + rate/latency bounds)."""
+    source = _other_peer_key(cfg, receiver_peer_key)
+    return [
+        (_smoke_inbound_bridge_topic(cfg, source), f"{source}->{receiver_peer_key} inbound bridge heartbeat", False),
+        (_smoke_heartbeat_topic(cfg, source), f"{source}->{receiver_peer_key} final heartbeat", True),
+    ]
+
+
+def _verify_received_topics(
+    container_name: str,
+    ros_setup: str,
+    cfg: dict[str, Any],
+    receiver_peer_key: str,
+    *,
+    hz_min: float = VERIFY_HZ_MIN,
+    hz_max: float = VERIFY_HZ_MAX,
+    max_delay_s: float = VERIFY_MAX_DELAY_S,
+    log_line: Callable[[str], None] = print,
+    detail_log: Callable[[str], None] | None = None,
+) -> list[str]:
+    """Assert the receiver's crossed topics publish (and the final heartbeat does
+    so within rate/latency bounds). Emits the OK/SMOKE_METRIC lines smoke has
+    always produced; returns a list of failures (empty == all good)."""
+    errors: list[str] = []
+    for topic, label, enforce_bounds in _received_crossed_topics(cfg, receiver_peer_key):
+        output = _wait_for_topic_hz(container_name, ros_setup, topic)
+        if detail_log:
+            detail_log(f"\n--- {label} ({topic}) in {container_name} ---\n{output}")
+        if "average rate" not in output:
+            errors.append(f"{label} ({topic}) not publishing in {container_name}")
+            continue
+        log_line(f"OK: {label} ({topic}) is publishing in {container_name}")
+        hz = _parse_topic_hz_rate(output)
+        delay_output = _measure_topic_delay(container_name, ros_setup, topic)
+        if detail_log:
+            detail_log(f"\n--- delay {label} ({topic}) in {container_name} ---\n{delay_output}")
+        delay_s = _parse_topic_delay_seconds(delay_output)
+        log_line(_smoke_metric_line(label=label, topic=topic, container_name=container_name, hz=hz, delay_s=delay_s))
+        if enforce_bounds:
+            if hz is None or not (hz_min <= hz <= hz_max):
+                errors.append(f"{label} ({topic}) rate {hz} Hz outside [{hz_min}, {hz_max}] in {container_name}")
+            if delay_s is None or delay_s >= max_delay_s:
+                errors.append(f"{label} ({topic}) latency {delay_s}s >= {max_delay_s}s in {container_name}")
+    return errors
+
+
+def _publish_isolation_probe(
+    container_name: str, ros_setup: str, topic: str, *, rate: float = 5.0, duration: float = 30.0
+) -> None:
+    """Publish a local-only topic in the container's local application domain,
+    detached, for `duration` seconds (self-stops via `timeout`)."""
+    cmd = f"{ros_setup} && timeout {duration} ros2 topic pub {shlex.quote(topic)} std_msgs/msg/Empty '{{}}' -r {rate}"
+    subprocess.run(
+        ["docker", "exec", "-d", container_name, "bash", "-lc", cmd], capture_output=True, text=True, check=False
+    )
+
+
+def _stop_isolation_probe(container_name: str, topic: str) -> None:
+    """Stop any probe publisher for `topic` (so it cannot linger into a later
+    check or session teardown)."""
+    subprocess.run(
+        ["docker", "exec", container_name, "pkill", "-f", f"ros2 topic pub {topic}"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _topic_present(container_name: str, ros_setup: str, topic: str) -> bool:
+    result = _run_container_shell(
+        container_name, f"{ros_setup} && timeout -k 2 8 ros2 topic list", timeout_s=_TOPIC_PROBE_EXEC_TIMEOUT_S
+    )
+    names = {ln.strip() for ln in (result.stdout or "").splitlines() if ln.strip().startswith("/")}
+    return topic in names
+
+
+def _verify_isolation(
+    pub_container: str,
+    pub_setup: str,
+    check_container: str,
+    check_setup: str,
+    topic: str,
+    *,
+    log_line: Callable[[str], None] = print,
+) -> list[str]:
+    """Publish a local-only topic in pub_container's local domain and assert it
+    never appears in check_container's local domain."""
+    _publish_isolation_probe(pub_container, pub_setup, topic)
+    try:
+        live = False
+        for _ in range(8):
+            if _topic_present(pub_container, pub_setup, topic):
+                live = True
+                break
+            time.sleep(1)
+        if not live:
+            return [f"isolation check inconclusive: {topic} never advertised in {pub_container}"]
+        if _topic_present(check_container, check_setup, topic):
+            return [f"isolation breach: {topic} from {pub_container} leaked to {check_container}"]
+        log_line(f"OK: isolation holds ({topic} from {pub_container} not visible in {check_container})")
+        return []
+    finally:
+        _stop_isolation_probe(pub_container, topic)
+
+
+# --- Test-tier capability markers (single source of truth for both tiers) -----
+_VALID_SINGLE_MACHINE = {"ok", "na"}
+_VALID_MULTI_MACHINE = {"ok", "required", "na"}
+
+
+def _session_markers(session_host_dir: Path) -> dict[str, str]:
+    name = session_host_dir.name
+    cfg = _load_session_config_from_host(session_host_dir)
+    tiers = cfg.get("test_tiers")
+    if not isinstance(tiers, dict):
+        raise RuntimeError(f"{name}: missing 'test_tiers' mapping (see docs/testing.md)")
+    single, multi = tiers.get("single_machine"), tiers.get("multi_machine")
+    if single not in _VALID_SINGLE_MACHINE:
+        raise RuntimeError(f"{name}: test_tiers.single_machine={single!r} not in {sorted(_VALID_SINGLE_MACHINE)}")
+    if multi not in _VALID_MULTI_MACHINE:
+        raise RuntimeError(f"{name}: test_tiers.multi_machine={multi!r} not in {sorted(_VALID_MULTI_MACHINE)}")
+    return {"single_machine": single, "multi_machine": multi}
+
+
+def session_test_markers(sessions_dir: Path | None = None) -> dict[str, dict[str, str]]:
+    """Map session name -> {single_machine, multi_machine} for every session.
+    Defaults to the packaged example sessions (the repo's source of truth)."""
+    base = sessions_dir or (EXAMPLE_PROJECT_DIR / "sessions")
+    out: dict[str, dict[str, str]] = {}
+    for child in sorted(base.iterdir()):
+        if child.is_dir() and _is_session_dir(child):
+            out[child.name] = _session_markers(child)
+    return out
+
+
+def sessions_in_tier(tier: str, values: set[str], sessions_dir: Path | None = None) -> list[str]:
+    return [name for name, m in session_test_markers(sessions_dir).items() if m.get(tier) in values]
+
+
+def _running_instance_config_container_dir(
+    runtime: RuntimeConfig, session: ResolvedSession, instance_id: str | None
+) -> str:
+    """Container-side config dir of the session instance currently running on this
+    host (the instances root is bind-mounted at SESSION_INSTANCE_CONTAINER_DIR)."""
+    instance_dir = _find_latest_instance_dir(runtime, session, instance_id)
+    rel = instance_dir.relative_to(_session_instances_root(runtime))
+    return f"{SESSION_INSTANCE_CONTAINER_DIR}/{rel}/config"
+
+
+def _resolve_running_peer(args: argparse.Namespace, identity: str) -> tuple[str, str, dict[str, Any]]:
+    """Resolve (container, ros_setup, cfg) for `identity`'s already-running peer."""
+    runtime = _load_runtime_config(args)
+    session = _resolve_session(getattr(args, "session_dir", None) or DEFAULT_SMOKE_SESSION, runtime)
+    peer_overrides = _parse_peer_address_overrides(getattr(args, "peer_address", None))
+    cfg = _effective_session_config(session.host_dir, runtime, peer_address_overrides=peer_overrides)
+    containers = _identity_container_names(cfg, runtime, identity)
+    if not containers:
+        raise RuntimeError(f"No container resolved for identity {identity!r}")
+    config_container_dir = _running_instance_config_container_dir(runtime, session, getattr(args, "instance_id", None))
+    ros_setup = _smoke_ros_setup(config_container_dir, cfg, identity)
+    return containers[0], ros_setup, cfg
+
+
+def verify_command(args: argparse.Namespace) -> int:
+    """Assert an already-running peer receives its crossed topics within bounds."""
+    container, ros_setup, cfg = _resolve_running_peer(args, args.identity)
+    errors = _verify_received_topics(
+        container, ros_setup, cfg, args.identity, hz_min=args.hz_min, hz_max=args.hz_max, max_delay_s=args.max_delay
+    )
+    for err in errors:
+        print(f"VERIFY FAIL: {err}", file=sys.stderr)
+    if errors:
+        return 1
+    print(f"VERIFY OK: identity {args.identity} receives its crossed topics within bounds")
+    return 0
+
+
+def probe_publish_command(args: argparse.Namespace) -> int:
+    """Publish (or --stop) a local-only probe topic in a running peer's local domain."""
+    container, ros_setup, _ = _resolve_running_peer(args, args.identity)
+    if args.stop:
+        _stop_isolation_probe(container, args.topic)
+        print(f"Stopped probe publisher for {args.topic} in {container} (identity {args.identity})")
+        return 0
+    _publish_isolation_probe(container, ros_setup, args.topic, rate=args.rate, duration=args.duration)
+    # Block until the topic is actually advertised so a caller's subsequent
+    # absence check on the other peer is meaningful (not a false pass on a
+    # publisher that never came up).
+    for _ in range(10):
+        if _topic_present(container, ros_setup, args.topic):
+            print(f"Publishing {args.topic} in {container} (identity {args.identity}); advertised.")
+            return 0
+        time.sleep(1)
+    print(f"ERROR: {args.topic} did not advertise in {container} (identity {args.identity})", file=sys.stderr)
+    return 1
+
+
+def probe_check_command(args: argparse.Namespace) -> int:
+    """Assert a topic is present/absent in a running peer's local domain (isolation)."""
+    container, ros_setup, _ = _resolve_running_peer(args, args.identity)
+    present = _topic_present(container, ros_setup, args.topic)
+    state = "present" if present else "absent"
+    print(f"{args.topic} is {state} in {container} (identity {args.identity}); expected {args.expect}")
+    return 0 if present == (args.expect == "present") else 1
+
+
 def smoke(args: argparse.Namespace) -> int:
     if not args.local:
         raise RuntimeError("Only --local smoke mode is implemented.")
@@ -1567,33 +1794,23 @@ def smoke(args: argparse.Namespace) -> int:
             raise RuntimeError("Smoke verification failed: generated plugin.yaml did not use literal CLI addresses.")
         log_line("OK: generated plugin.yaml files use literal CLI addresses")
 
-        checks = [
-            (b_container, _smoke_inbound_bridge_topic(cfg, "a"), "a->b inbound bridge heartbeat", "b"),
-            (b_container, _smoke_heartbeat_topic(cfg, "a"), "a->b final heartbeat", "b"),
-            (a_container, _smoke_inbound_bridge_topic(cfg, "b"), "b->a inbound bridge heartbeat", "a"),
-            (a_container, _smoke_heartbeat_topic(cfg, "b"), "b->a final heartbeat", "a"),
-        ]
-        for container_name, topic, label, receiver_peer_key in checks:
-            ros_setup = _smoke_ros_setup(smoke_instance.config_container_dir, cfg, receiver_peer_key)
-            output = _wait_for_topic_hz(container_name, ros_setup, topic)
-            _append_log(smoke_log, f"\n--- {label} ({topic}) in {container_name} ---\n{output}")
-            if "average rate" not in output:
-                raise RuntimeError(f"Smoke verification failed for {label} ({topic}) in {container_name}:\n{output}")
-            log_line(f"OK: {label} ({topic}) is publishing in {container_name}")
+        def detail(msg: str) -> None:
+            _append_log(smoke_log, msg)
 
-            hz = _parse_topic_hz_rate(output)
-            delay_output = _measure_topic_delay(container_name, ros_setup, topic)
-            _append_log(smoke_log, f"\n--- delay {label} ({topic}) in {container_name} ---\n{delay_output}")
-            delay_s = _parse_topic_delay_seconds(delay_output)
-            log_line(
-                _smoke_metric_line(
-                    label=label,
-                    topic=topic,
-                    container_name=container_name,
-                    hz=hz,
-                    delay_s=delay_s,
-                )
-            )
+        ros_setup_a = _smoke_ros_setup(smoke_instance.config_container_dir, cfg, "a")
+        ros_setup_b = _smoke_ros_setup(smoke_instance.config_container_dir, cfg, "b")
+        errors: list[str] = []
+        # Delivery: each peer must receive the other's crossed topics within bounds.
+        errors += _verify_received_topics(b_container, ros_setup_b, cfg, "b", log_line=log_line, detail_log=detail)
+        errors += _verify_received_topics(a_container, ros_setup_a, cfg, "a", log_line=log_line, detail_log=detail)
+        # Isolation: a local-only topic published on a must not cross to b. On a
+        # single host the distinct test domain IDs make this hold; it exercises the
+        # same assertion that proves the real OTA guarantee multi-machine.
+        errors += _verify_isolation(
+            a_container, ros_setup_a, b_container, ros_setup_b, ISOLATION_PROBE_TOPIC, log_line=log_line
+        )
+        if errors:
+            raise RuntimeError("Smoke verification failed:\n  - " + "\n  - ".join(errors))
     except Exception as exc:
         _append_log(smoke_log, f"ERROR: {exc}")
         raise
@@ -1779,6 +1996,9 @@ def main(argv: list[str] | None = None) -> int:
         "doctor",
         "smoke",
         "status",
+        "verify",
+        "probe-publish",
+        "probe-check",
         "list-sessions",
         "examples",
         "setup-env",
@@ -1833,6 +2053,50 @@ def main(argv: list[str] | None = None) -> int:
     status_parser.add_argument("--watch", action="store_true", help="Continuously refresh the view.")
     status_parser.add_argument("--watch-interval", type=float, default=2.0, help="Watch refresh interval (s).")
     status_parser.set_defaults(func=status)
+
+    # Verification verbs operate on an already-running session per identity, so the
+    # external multi-machine runner can call them over SSH (one peer per host) with
+    # the exact same logic the local smoke test uses.
+    verify_parser = subparsers.add_parser(
+        "verify", help="Assert a running peer receives its crossed topics within rate/latency bounds."
+    )
+    _add_common_config_args(verify_parser)
+    verify_parser.add_argument("session_dir", nargs="?", default=DEFAULT_SMOKE_SESSION)
+    verify_parser.add_argument("--identity", required=True)
+    verify_parser.add_argument("--peer-address", action="append", default=[], metavar="PEER=ADDRESS_EXPR")
+    verify_parser.add_argument("--instance-id", help="Inspect a specific instance id (default: most recent).")
+    verify_parser.add_argument("--hz-min", type=float, default=VERIFY_HZ_MIN)
+    verify_parser.add_argument("--hz-max", type=float, default=VERIFY_HZ_MAX)
+    verify_parser.add_argument("--max-delay", type=float, default=VERIFY_MAX_DELAY_S)
+    verify_parser.set_defaults(func=verify_command)
+
+    probe_publish_parser = subparsers.add_parser(
+        "probe-publish", help="Publish a local-only probe topic in a running peer's local domain (isolation)."
+    )
+    _add_common_config_args(probe_publish_parser)
+    probe_publish_parser.add_argument("session_dir", nargs="?", default=DEFAULT_SMOKE_SESSION)
+    probe_publish_parser.add_argument("--identity", required=True)
+    probe_publish_parser.add_argument("--peer-address", action="append", default=[], metavar="PEER=ADDRESS_EXPR")
+    probe_publish_parser.add_argument("--instance-id")
+    probe_publish_parser.add_argument("--topic", default=ISOLATION_PROBE_TOPIC)
+    probe_publish_parser.add_argument("--rate", type=float, default=5.0)
+    probe_publish_parser.add_argument("--duration", type=float, default=30.0)
+    probe_publish_parser.add_argument(
+        "--stop", action="store_true", help="Stop a running probe publisher instead of starting one."
+    )
+    probe_publish_parser.set_defaults(func=probe_publish_command)
+
+    probe_check_parser = subparsers.add_parser(
+        "probe-check", help="Assert a topic is present/absent in a running peer's local domain (isolation)."
+    )
+    _add_common_config_args(probe_check_parser)
+    probe_check_parser.add_argument("session_dir", nargs="?", default=DEFAULT_SMOKE_SESSION)
+    probe_check_parser.add_argument("--identity", required=True)
+    probe_check_parser.add_argument("--peer-address", action="append", default=[], metavar="PEER=ADDRESS_EXPR")
+    probe_check_parser.add_argument("--instance-id")
+    probe_check_parser.add_argument("--topic", default=ISOLATION_PROBE_TOPIC)
+    probe_check_parser.add_argument("--expect", choices=["present", "absent"], default="absent")
+    probe_check_parser.set_defaults(func=probe_check_command)
 
     list_parser = subparsers.add_parser("list-sessions", help="List configured sessions.")
     _add_common_config_args(list_parser)

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_cyclone-local_fastdds-ota/session-definition.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_cyclone-local_fastdds-ota/session-definition.yaml
@@ -1,3 +1,8 @@
+# Test-tier capability markers (see docs/testing.md).
+test_tiers:
+  single_machine: ok
+  multi_machine: ok
+
 peers:
   a:
     address: "data:machine_a_ip"

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_cyclone-local_zenoh-ros2dds-ota/session-definition.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_cyclone-local_zenoh-ros2dds-ota/session-definition.yaml
@@ -1,3 +1,9 @@
+# Test-tier capability markers (see docs/testing.md). Split-domain zenoh bridge:
+# isolation is only meaningful across two hosts.
+test_tiers:
+  single_machine: ok
+  multi_machine: required
+
 peers:
   a:
     address: "data:machine_a_ip"

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_cyclone-ota-tuned/session-definition.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_cyclone-ota-tuned/session-definition.yaml
@@ -1,0 +1,21 @@
+# Test-tier capability markers (see docs/testing.md). This config hides local
+# topics on a shared domain (no per-peer domain split), so it cannot be proven
+# on one host: single_machine na, multi_machine required.
+test_tiers:
+  single_machine: na
+  multi_machine: required
+
+peers:
+  a:
+    address: "data:machine_a_ip"
+  b:
+    address: "data:machine_b_ip"
+
+shared:
+  use_heartbeat: true
+  rmw:
+    local: cyclone # default cyclone config
+    ota:
+      cyclone:
+        config: cyclonedds_tuned.xml
+  ota_domain_id: 48

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_cyclone-ota/session-definition.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_cyclone-ota/session-definition.yaml
@@ -1,3 +1,8 @@
+# Test-tier capability markers (see docs/testing.md).
+test_tiers:
+  single_machine: ok
+  multi_machine: required
+
 peers:
   a:
     address: "data:machine_a_ip"

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_fastdds-local_cyclone-ota/session-definition.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_fastdds-local_cyclone-ota/session-definition.yaml
@@ -1,3 +1,8 @@
+# Test-tier capability markers (see docs/testing.md).
+test_tiers:
+  single_machine: ok
+  multi_machine: ok
+
 peers:
   a:
     address: "data:machine_a_ip"

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_fastdds/session-definition.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_fastdds/session-definition.yaml
@@ -1,3 +1,8 @@
+# Test-tier capability markers (see docs/testing.md).
+test_tiers:
+  single_machine: ok
+  multi_machine: ok
+
 peers:
   a:
     address: "data:machine_a_ip"

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_status/session-definition.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_status/session-definition.yaml
@@ -1,3 +1,9 @@
+# Test-tier capability markers (see docs/testing.md). Status-overview demo, not
+# part of the automated test tiers.
+test_tiers:
+  single_machine: na
+  multi_machine: na
+
 peers:
   a:
     address: "data:machine_a_ip"

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_zen-endpoints/session-definition.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_zen-endpoints/session-definition.yaml
@@ -1,3 +1,8 @@
+# Test-tier capability markers (see docs/testing.md).
+test_tiers:
+  single_machine: ok
+  multi_machine: ok
+
 peers:
   a:
     address: "data:machine_a_ip"

--- a/src/rosotacom/resources/examples/sessions/2_native_chatter/session-definition.yaml
+++ b/src/rosotacom/resources/examples/sessions/2_native_chatter/session-definition.yaml
@@ -1,3 +1,9 @@
+# Test-tier capability markers (see docs/testing.md). Teaching example, not part
+# of the automated test tiers yet.
+test_tiers:
+  single_machine: na
+  multi_machine: na
+
 peers:
   a:
     address: "data:machine_a_ip"

--- a/src/rosotacom/resources/examples/sessions/3_comp_occ_grid/session-definition.yaml
+++ b/src/rosotacom/resources/examples/sessions/3_comp_occ_grid/session-definition.yaml
@@ -1,3 +1,9 @@
+# Test-tier capability markers (see docs/testing.md). Teaching example, not part
+# of the automated test tiers yet.
+test_tiers:
+  single_machine: na
+  multi_machine: na
+
 peers:
   a:
     address: "data:machine_a_ip"

--- a/src/rosotacom/resources/examples/sessions/4_comp_occ_grid_zen/session-definition.yaml
+++ b/src/rosotacom/resources/examples/sessions/4_comp_occ_grid_zen/session-definition.yaml
@@ -1,3 +1,9 @@
+# Test-tier capability markers (see docs/testing.md). Teaching example, not part
+# of the automated test tiers yet.
+test_tiers:
+  single_machine: na
+  multi_machine: na
+
 peers:
   a:
     address: "data:machine_a_ip"

--- a/src/rosotacom/resources/examples/sessions/5_sized_payload/session-definition.yaml
+++ b/src/rosotacom/resources/examples/sessions/5_sized_payload/session-definition.yaml
@@ -1,3 +1,9 @@
+# Test-tier capability markers (see docs/testing.md). Teaching example, not part
+# of the automated test tiers yet.
+test_tiers:
+  single_machine: na
+  multi_machine: na
+
 peers:
   a:
     address: "data:machine_a_ip"

--- a/src/rosotacom/resources/examples/sessions/6_sized_payload_zen/session-definition.yaml
+++ b/src/rosotacom/resources/examples/sessions/6_sized_payload_zen/session-definition.yaml
@@ -1,3 +1,9 @@
+# Test-tier capability markers (see docs/testing.md). Teaching example, not part
+# of the automated test tiers yet.
+test_tiers:
+  single_machine: na
+  multi_machine: na
+
 peers:
   a:
     address: "data:machine_a_ip"

--- a/src/rosotacom/resources/ws/session/creation/generate_session_files.py
+++ b/src/rosotacom/resources/ws/session/creation/generate_session_files.py
@@ -894,6 +894,9 @@ def _validate_session_template_cfg(cfg: Dict[str, Any]) -> None:
             "shared",
             "peer_settings",
             "topics",
+            # Test-tier capability markers (single_machine/multi_machine). Consumed
+            # by the test suites (see docs/testing.md); ignored by generation.
+            "test_tiers",
         },
     )
 

--- a/tests/contract/test_security_maintenance_config.py
+++ b/tests/contract/test_security_maintenance_config.py
@@ -43,16 +43,31 @@ def test_merge_gate_requires_non_docker_package_and_docker_smoke() -> None:
     assert "just test-e2e-smoke" in merge_gate
 
 
-def test_e2e_smoke_matrix_covers_all_heartbeat_rmw_examples() -> None:
-    e2e_smoke = (PACKAGE_ROOT / "tests" / "e2e" / "test_smoke.py").read_text(encoding="utf-8")
+def test_session_test_tier_markers_drive_both_test_matrices() -> None:
+    """Every session declares test_tiers; the single-machine smoke matrix and the
+    multi-machine set are derived from those markers (the single source of truth),
+    so neither tier can silently drift. See docs/testing.md."""
+    from rosotacom.cli import session_test_markers, sessions_in_tier
 
-    expected_sessions = [
-        "1_heartbeat_fastdds",
+    markers = session_test_markers()  # raises if any session lacks valid markers
+    assert markers, "no example sessions found"
+
+    # Anti-drift guard: the heartbeat-RMW matrix is exactly the single-machine
+    # smoke set. Adding/removing an RMW example must update its marker accordingly.
+    assert set(sessions_in_tier("single_machine", {"ok"})) == {
         "1_heartbeat_cyclone-ota",
+        "1_heartbeat_fastdds",
         "1_heartbeat_zen-endpoints",
         "1_heartbeat_fastdds-local_cyclone-ota",
         "1_heartbeat_cyclone-local_fastdds-ota",
         "1_heartbeat_cyclone-local_zenoh-ros2dds-ota",
-    ]
-    for session in expected_sessions:
-        assert session in e2e_smoke
+    }
+
+    # cyclone-ota-tuned hides local topics on a shared domain (no per-peer domain
+    # split), so it is only provable multi-machine.
+    assert markers["1_heartbeat_cyclone-ota-tuned"] == {"single_machine": "na", "multi_machine": "required"}
+    assert "1_heartbeat_cyclone-ota-tuned" in sessions_in_tier("multi_machine", {"ok", "required"})
+
+    # The smoke test must derive its matrix from the markers, not hardcode it.
+    e2e_smoke = (PACKAGE_ROOT / "tests" / "e2e" / "test_smoke.py").read_text(encoding="utf-8")
+    assert 'sessions_in_tier("single_machine", {"ok"})' in e2e_smoke

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -8,6 +8,8 @@ from pathlib import Path
 
 import pytest
 
+from rosotacom.cli import VERIFY_HZ_MAX, VERIFY_HZ_MIN, VERIFY_MAX_DELAY_S, sessions_in_tier
+
 PACKAGE_ROOT = Path(__file__).resolve().parents[2]
 pytestmark = [
     pytest.mark.e2e,
@@ -17,13 +19,16 @@ pytestmark = [
     ),
 ]
 
+
+# The single-machine smoke matrix is derived from the per-session capability
+# markers (single_machine: ok) so it cannot drift from the source of truth; the
+# contract test guards both directions. See docs/testing.md.
+def _smoke_id(session_name: str) -> str:
+    return session_name.removeprefix("1_heartbeat_").replace("_", "-")
+
+
 HEARTBEAT_SMOKE_SESSIONS = [
-    pytest.param("1_heartbeat_cyclone-ota", id="cyclone-ota"),
-    pytest.param("1_heartbeat_zen-endpoints", id="zen-endpoints"),
-    pytest.param("1_heartbeat_cyclone-local_zenoh-ros2dds-ota", id="cyclone-local-zenoh-ros2dds-ota"),
-    pytest.param("1_heartbeat_fastdds", id="fastdds"),
-    pytest.param("1_heartbeat_fastdds-local_cyclone-ota", id="fastdds-local-cyclone-ota"),
-    pytest.param("1_heartbeat_cyclone-local_fastdds-ota", id="cyclone-local-fastdds-ota"),
+    pytest.param(name, id=_smoke_id(name)) for name in sessions_in_tier("single_machine", {"ok"})
 ]
 
 EXPECTED_HEARTBEAT_CHECKS = (
@@ -32,14 +37,17 @@ EXPECTED_HEARTBEAT_CHECKS = (
     "OK: a->b final heartbeat (/heartbeat_a)",
     "OK: b->a inbound bridge heartbeat (/com/in/b/heartbeat_b)",
     "OK: b->a final heartbeat (/heartbeat_b)",
+    # Isolation is now asserted in smoke too (local-only topic must not cross);
+    # container names vary, so match the stable prefix.
+    "OK: isolation holds (/local_only",
 )
 
 # Heartbeat publishers emit at 10 Hz; received rate should stay close to that.
+# The bounds are the shared single source of truth from rosotacom.
 EXPECTED_HEARTBEAT_HZ = 10.0
-HEARTBEAT_HZ_MIN = 5.0
-HEARTBEAT_HZ_MAX = 20.0
-# End-to-end heartbeat latency must stay well below one second.
-MAX_HEARTBEAT_DELAY_S = 1.0
+HEARTBEAT_HZ_MIN = VERIFY_HZ_MIN
+HEARTBEAT_HZ_MAX = VERIFY_HZ_MAX
+MAX_HEARTBEAT_DELAY_S = VERIFY_MAX_DELAY_S
 
 _ANSI_RE = re.compile(r"\x1b\[[0-9;?]*[ -/]*[@-~]")
 _ERROR_PATTERNS = (

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import subprocess
 import sys
+from collections.abc import Callable
 from pathlib import Path
 
 import pytest
@@ -233,6 +234,30 @@ def test_positional_session_defaults_to_start(monkeypatch: pytest.MonkeyPatch) -
     assert calls
     assert calls[0].session_dir == "1_heartbeat"
     assert calls[0].identity == "a"
+
+
+def test_new_verification_verbs_dispatch_not_wrapped_in_start(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Regression guard: verify/probe-* must be in main()'s command set, otherwise
+    # the "bare positional -> start" shim rewrites them as `start <verb> ...`.
+    seen: list[tuple[str, argparse.Namespace]] = []
+
+    def record(name: str) -> Callable[[argparse.Namespace], int]:
+        def _cmd(args: argparse.Namespace) -> int:
+            seen.append((name, args))
+            return 0
+
+        return _cmd
+
+    for name in ("verify_command", "probe_publish_command", "probe_check_command"):
+        monkeypatch.setattr(rosotacom, name, record(name))
+
+    assert rosotacom.main(["verify", "1_heartbeat", "--identity", "a"]) == 0
+    assert rosotacom.main(["probe-publish", "1_heartbeat", "--identity", "a"]) == 0
+    assert rosotacom.main(["probe-check", "1_heartbeat", "--identity", "b", "--expect", "absent"]) == 0
+
+    assert [n for n, _ in seen] == ["verify_command", "probe_publish_command", "probe_check_command"]
+    assert all(args.session_dir == "1_heartbeat" for _, args in seen)
+    assert seen[2][1].expect == "absent"
 
 
 def test_start_and_stop_compat_entrypoints_prefix_commands(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -566,11 +591,11 @@ def test_stop_list_doctor_and_smoke_host_flows(
     monkeypatch.setattr(rosotacom, "start_session", lambda args: f"container_{args.identity}")
     monkeypatch.setattr(rosotacom, "_ensure_smoke_network", lambda: None)
     monkeypatch.setattr(rosotacom, "_remove_smoke_network", lambda: None)
-    monkeypatch.setattr(
-        rosotacom,
-        "_run_container_shell",
-        lambda *args, **kwargs: subprocess.CompletedProcess(args, 0, "average rate: 1.0", ""),
-    )
+    # Smoke's per-container delivery + isolation verification is exercised
+    # end-to-end in tests/e2e; this unit test only drives the host flow
+    # (start/stop/network), so stub the shared verification helpers as passing.
+    monkeypatch.setattr(rosotacom, "_verify_received_topics", lambda *args, **kwargs: [])
+    monkeypatch.setattr(rosotacom, "_verify_isolation", lambda *args, **kwargs: [])
     assert (
         rosotacom.smoke(
             argparse.Namespace(


### PR DESCRIPTION
## Why

The single-machine smoke test (`rosotacom smoke`) and the external multi-machine
runner duplicated intent with divergent verification code, and **smoke never
asserted the OTA isolation guarantee at all**. This unifies the verification and
makes per-session test-tier coverage a single source of truth — the shape
`docs/testing.md` already prescribed.

## What

- **`test_tiers` markers** on every `session-definition.yaml` (`single_machine` /
  `multi_machine`); the strict session-template validator now allows the key
  (generation ignores it). Both tiers derive their session list from the markers
  via `session_test_markers()` / `sessions_in_tier()`.
- **Shared verification** — `_verify_received_topics` (delivery within
  rate/latency bounds) and `_verify_isolation` (a local-only topic must not
  cross) — exposed as thin CLI verbs the external multi-machine runner calls per
  host over SSH:
  - `rosotacom verify --identity <peer>` — delivery
  - `rosotacom probe-publish --identity a` (blocks until advertised; `--stop`) and
    `rosotacom probe-check --identity b --expect absent` — isolation
  - The bounds and probe topic are single-sourced in `rosotacom`.
- **`smoke()`** delegates to the shared functions and now also asserts isolation.
  On one host the distinct test domain IDs make it hold; it exercises the same
  assertion that proves the real guarantee multi-machine.
- **`1_heartbeat_cyclone-ota-tuned`** (hides local topics on a shared domain via
  `EnableTopicDiscoveryEndpoints=false`) is `single_machine: na`,
  `multi_machine: required`.
- Contract test is markers-driven; `test_smoke.py` derives its matrix from
  markers; added a verb-dispatch regression test; `docs/testing.md` updated.

## Validation

- `just lint typecheck` clean; **53** contract + unit tests pass
- Full **6-session Docker smoke** (`just test-e2e-smoke`) — delivery + the new
  isolation assertion, across cyclone / fastdds / zenoh
- Manual `verify` / `probe-*` sanity against a live session, including the
  negative cases (out-of-bounds rate fails; a leaked topic fails)

## Follow-up (separate change)

The FZI-internal multi-machine runner will be rewritten to derive its scenario
list from these markers and call `verify` / `probe-*` per host, replacing its own
embedded probe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
