### PR TITLE
fix: avoid OTA payload subscriptions in status overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,10 +196,11 @@ rosotacom status 1_heartbeat_status --json     # machine-readable, for tools/age
 rosotacom status 1_heartbeat_status --watch    # live refresh
 ```
 
-Phase 1 reports each peer's locally-observable stages (outbound up to the `/ota`
-topic this peer publishes; inbound from the received `/ota` topic through the
-republished application topic). Combine both peers' files for the full
-end-to-end picture; cross-peer confirmation is reserved for a later phase.
+Phase 1 samples local-domain stages directly. OTA stages are graph-only and
+their activity is inferred from adjacent local flow, so the status overview
+never creates an additional OTA payload subscription. Combine both peers' files
+for the full end-to-end picture; cross-peer confirmation is reserved for a later
+phase.
 
 Run the CI heartbeat smoke matrix locally:
 

--- a/session-configuration.md
+++ b/session-configuration.md
@@ -301,13 +301,14 @@ If `use_status_overview: true`:
   - `events.jsonl` — append-only, one line per state transition.
 - Read it from the host with `rosotacom status [<session>] [--json] [--watch]`.
 
-Phase 1 observes only what the local peer's ROS graph exposes: outbound topics
-up to the `/ota` topic this peer publishes ("sent"), and inbound topics from the
-received `/ota` topic through the republished application topic. Remote-side
-confirmation is reserved for a later phase and reported as `unknown`. OTA-domain
-observation assumes same-host discovery of the OTA `ROS_DOMAIN_ID` (works for the
-bundled DDS / `zenoh_ros2dds` examples; native `rmw_zenoh` OTA is not observed in
-Phase 1).
+Phase 1 samples local-domain stages directly. OTA-domain observation is
+graph-only: the status node never subscribes to OTA payload topics, so enabling
+the overview cannot create an additional OTA data stream. OTA activity is
+inferred from the adjacent local stage plus publisher discovery and is marked as
+inferred in the status output. Remote-side confirmation is reserved for a later
+phase and reported as `unknown`. OTA graph observation assumes same-host
+discovery of the OTA `ROS_DOMAIN_ID` (works for the bundled DDS /
+`zenoh_ros2dds` examples; native `rmw_zenoh` OTA is not observed in Phase 1).
 
 ##### Phase 2 (planned, not implemented)
 

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_status/session-definition.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_status/session-definition.yaml
@@ -24,6 +24,7 @@ shared:
   use_heartbeat: true
   # Maintain a continuously-updated per-topic pipeline status overview
   # (status.json / status.txt / events.jsonl under logs/<peer>/status/).
+  # OTA stages are graph-only; this does not add OTA payload subscriptions.
   # Inspect it from the host with: rosotacom status 1_heartbeat_status
   use_status_overview: true
   rmw:

--- a/src/rosotacom/resources/ws/ros2src/com_py/com_py/status_overview.py
+++ b/src/rosotacom/resources/ws/ros2src/com_py/com_py/status_overview.py
@@ -40,9 +40,9 @@
 # events.jsonl (one line per state transition).
 #
 # Phase 1 observes only what the local peer's ROS graph exposes:
-#   * outbound topics up to the /ota topic this peer publishes ("sent")
-#   * inbound topics from the received /ota topic through the republished
-#     application topic.
+#   * local-domain stages are sampled directly for live metrics
+#   * OTA-domain stages use graph metadata only and never create DataReaders;
+#     activity is inferred from the adjacent local stage where possible
 # End-to-end remote confirmation is reserved for a later phase; remote-side
 # fields are reported as "unknown".
 #
@@ -78,18 +78,22 @@ class StageObserver(Node):
     """
     Observes a set of stage topics within a single ROS domain context.
 
-    Performs periodic graph introspection (publisher/subscriber counts) and
-    dynamically subscribes to topics that have a publisher, measuring size and
-    header-based latency per message.
+    Performs periodic graph introspection (publisher/subscriber counts). For
+    local-domain topics it also dynamically subscribes to measure size and
+    header-based latency. OTA observers are graph-only so status monitoring can
+    never create an additional OTA payload stream.
     """
 
     def __init__(self, node_name: str, context: Optional[Context],
-                 topics: Dict[str, Optional[str]], refresh_interval_s: float):
+                 topics: Dict[str, Optional[str]], refresh_interval_s: float,
+                 *, subscribe_to_messages: bool = True):
         super().__init__(node_name, context=context)
         self.observations: Dict[str, StageObservation] = {
-            t: StageObservation(type_str=hint) for t, hint in topics.items()
+            t: StageObservation(type_str=hint, graph_only=not subscribe_to_messages)
+            for t, hint in topics.items()
         }
         self._refresh_interval_s = refresh_interval_s
+        self._subscribe_to_messages = subscribe_to_messages
         self.create_timer(self._refresh_interval_s, self._refresh)
         self._refresh()
 
@@ -106,6 +110,8 @@ class StageObserver(Node):
             except Exception:  # pragma: no cover - defensive
                 pass
 
+            if not self._subscribe_to_messages:
+                continue
             if obs.subscribed:
                 continue
             type_str = obs.type_str
@@ -193,34 +199,48 @@ class StatusOverview(Node):
         self._ota_context: Optional[Context] = None
         self._ota_executor: Optional[MultiThreadedExecutor] = None
         self._ota_thread: Optional[threading.Thread] = None
+        self._ota_observer: Optional[StageObserver] = None
+        self._ota_observer_uses_separate_context = False
         observers: Dict[str, StageObserver] = {}
 
-        # Local-domain observer shares this node's (default) context. When
-        # domains are not split, all stages are observed here.
+        # Local-domain stages are sampled for payload metrics.
         local_topics = dict(by_domain.get("local", {}))
-        if not need_ota_ctx:
-            local_topics.update(by_domain.get("ota", {}))
         self._local_observer = StageObserver(
             "status_overview_local_obs", None, local_topics, self.refresh_interval_s
         )
         observers["local"] = self._local_observer
 
-        if need_ota_ctx:
-            self._ota_context = Context()
-            rclpy.init(context=self._ota_context, domain_id=int(ota_domain_id))
+        # OTA stages always have a distinct graph-only observer, even if the
+        # local and OTA domain IDs are equal. This makes the no-OTA-DataReader
+        # guarantee independent of session topology.
+        ota_topics = dict(by_domain.get("ota", {}))
+        if ota_topics:
+            ota_context: Optional[Context] = None
+            if need_ota_ctx:
+                self._ota_context = Context()
+                rclpy.init(context=self._ota_context, domain_id=int(ota_domain_id))
+                ota_context = self._ota_context
+                self._ota_observer_uses_separate_context = True
             self._ota_observer = StageObserver(
                 "status_overview_ota_obs",
-                self._ota_context,
-                dict(by_domain.get("ota", {})),
+                ota_context,
+                ota_topics,
                 self.refresh_interval_s,
+                subscribe_to_messages=False,
             )
             observers["ota"] = self._ota_observer
-            self._ota_executor = MultiThreadedExecutor(num_threads=2, context=self._ota_context)
-            self._ota_executor.add_node(self._ota_observer)
-            self._ota_thread = threading.Thread(target=self._ota_executor.spin, daemon=True)
-            self._ota_thread.start()
+            if self._ota_observer_uses_separate_context:
+                self._ota_executor = MultiThreadedExecutor(
+                    num_threads=2, context=self._ota_context
+                )
+                self._ota_executor.add_node(self._ota_observer)
+                self._ota_thread = threading.Thread(
+                    target=self._ota_executor.spin, daemon=True
+                )
+                self._ota_thread.start()
             self.get_logger().info(
-                f"status_overview: OTA observer running in domain {ota_domain_id}"
+                f"status_overview: graph-only OTA observer running in domain "
+                f"{ota_domain_id} (no payload subscriptions)"
             )
 
         self.aggregator = StatusAggregator(
@@ -243,6 +263,11 @@ class StatusOverview(Node):
     def add_local_nodes(self, executor: MultiThreadedExecutor) -> None:
         executor.add_node(self)
         executor.add_node(self._local_observer)
+        if (
+            self._ota_observer is not None
+            and not self._ota_observer_uses_separate_context
+        ):
+            executor.add_node(self._ota_observer)
 
     def _on_write(self) -> None:
         self.aggregator.write()

--- a/src/rosotacom/resources/ws/ros2src/com_py/com_py/status_overview_core.py
+++ b/src/rosotacom/resources/ws/ros2src/com_py/com_py/status_overview_core.py
@@ -73,6 +73,7 @@ class StageObservation:
     """Live observation of a single stage topic within one ROS domain."""
 
     type_str: Optional[str] = None
+    graph_only: bool = False
     subscribed: bool = False
     pub_count: int = 0
     sub_count: int = 0
@@ -175,6 +176,8 @@ class StatusAggregator:
             "state": ABSENT,
             "quality": None,
             "quality_reason": None,
+            "observation": "graph" if obs is not None and obs.graph_only else "payload",
+            "inferred_from": None,
         }
         if obs is None:
             return result
@@ -207,6 +210,53 @@ class StatusAggregator:
         result["quality"] = quality
         result["quality_reason"] = reason
         return result
+
+    @staticmethod
+    def _copy_inferred_activity(target: Dict[str, Any], source: Dict[str, Any]) -> None:
+        """Copy payload-derived activity while retaining OTA graph counts/topic."""
+        for key in (
+            "hz",
+            "mean_size_bytes",
+            "latency_ms",
+            "age_s",
+            "last_message_wall",
+            "messages_total",
+            "state",
+            "quality",
+            "quality_reason",
+        ):
+            target[key] = source[key]
+        target["inferred_from"] = source["topic"]
+
+    def infer_graph_only_ota_stages(
+        self, topic_spec: Dict[str, Any], stage_results: List[Dict[str, Any]]
+    ) -> None:
+        """
+        Infer OTA activity without creating an OTA DataReader.
+
+        Outbound activity requires both an OTA publisher endpoint and flowing
+        input at the preceding local stage. Inbound receipt is proven by flow at
+        the following local stage, which can only exist after the OTA sample has
+        passed through bridge_in/domain_bridge.
+        """
+        direction = topic_spec.get("direction")
+        for idx, stage_result in enumerate(stage_results):
+            if (
+                stage_result.get("domain") != "ota"
+                or stage_result.get("observation") != "graph"
+            ):
+                continue
+
+            source: Optional[Dict[str, Any]] = None
+            if direction == "outbound":
+                if stage_result["publishers"] == 0 or idx == 0:
+                    continue
+                source = stage_results[idx - 1]
+            elif direction == "inbound" and idx + 1 < len(stage_results):
+                source = stage_results[idx + 1]
+
+            if source is not None and source["state"] in (FLOWING, STALE):
+                self._copy_inferred_activity(stage_result, source)
 
     def _classify_quality(self, m: Dict[str, Any], expected_hz: Optional[float]) -> Tuple[str, Optional[str]]:
         delay_ms = (m["last_delay_s"] * 1000.0) if m["last_delay_s"] is not None else None
@@ -270,7 +320,14 @@ class StatusAggregator:
                 )
 
         if topic_spec.get("direction") == "outbound" and overall == OK:
-            diagnosis += " | sent to transport; remote delivery not observed locally (Phase 1)"
+            diagnosis += " | OTA activity inferred locally; remote delivery not observed (Phase 1)"
+
+        inferred = [s for s in stage_results if s.get("inferred_from")]
+        if inferred:
+            detail = ", ".join(
+                f"{s['stage']} from {s['inferred_from']}" for s in inferred
+            )
+            diagnosis += f" | inferred without OTA payload subscription: {detail}"
 
         return {
             "overall": overall,
@@ -287,6 +344,11 @@ class StatusAggregator:
         if st == ABSENT:
             return f"{producer} is not producing {topic} (no publisher)"
         if st == IDLE:
+            if stage_result.get("observation") == "graph":
+                return (
+                    f"{topic} has a publisher; payload is intentionally not "
+                    "subscribed and adjacent local flow is not observed"
+                )
             return f"{topic} has a publisher but no messages observed yet"
         if st == STALE:
             return f"{topic} stopped receiving messages"
@@ -306,6 +368,7 @@ class StatusAggregator:
                 self.classify_stage(stage, expected_hz, now_mono)
                 for stage in topic_spec.get("stages", [])
             ]
+            self.infer_graph_only_ota_stages(topic_spec, stage_results)
             roll = self.rollup(topic_spec, stage_results)
             counts[roll["overall"]] = counts.get(roll["overall"], 0) + 1
             topics_out.append(
@@ -394,7 +457,11 @@ class StatusAggregator:
             )
             for st in t["stages"]:
                 state = st["state"]
-                if state == FLOWING and st.get("quality") and st["quality"] != GOOD:
+                if st.get("inferred_from"):
+                    state = f"{state}/INFERRED"
+                elif st.get("observation") == "graph":
+                    state = f"{state}/GRAPH"
+                elif state == FLOWING and st.get("quality") and st["quality"] != GOOD:
                     state = f"{state}/{st['quality']}"
                 metric = ""
                 if st["state"] in (FLOWING, STALE):
@@ -405,6 +472,8 @@ class StatusAggregator:
                         parts.append(f"{st['mean_size_bytes']:.0f}B")
                     if st["age_s"] is not None:
                         parts.append(f"age {st['age_s']:.1f}s")
+                    if st.get("inferred_from"):
+                        parts.append(f"from {st['inferred_from']}")
                     metric = "  " + " ".join(parts)
                 lines.append(
                     f"    {st['stage']:<10} {state:<14} "

--- a/tests/unit/test_status_overview.py
+++ b/tests/unit/test_status_overview.py
@@ -26,6 +26,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 WS = REPO_ROOT / "src" / "rosotacom" / "resources" / "ws"
 GENERATOR_PY = WS / "session" / "creation" / "generate_session_files.py"
 STATUS_CORE_PY = WS / "ros2src" / "com_py" / "com_py" / "status_overview_core.py"
+STATUS_NODE_PY = WS / "ros2src" / "com_py" / "com_py" / "status_overview.py"
 
 
 def _load_module(path: Path, name: str) -> ModuleType:
@@ -109,6 +110,14 @@ def test_use_status_overview_must_be_bool() -> None:
         generator._validate_session_template_cfg(cfg)
 
 
+def test_ota_observer_is_graph_only() -> None:
+    """Regression: status monitoring must never create an OTA DataReader."""
+    source = STATUS_NODE_PY.read_text(encoding="utf-8")
+    assert "subscribe_to_messages=False" in source
+    assert "if not self._subscribe_to_messages:" in source
+    assert 'local_topics.update(by_domain.get("ota"' not in source
+
+
 # ---------------------------------------------------------------------------
 # state classification + rollup
 # ---------------------------------------------------------------------------
@@ -160,8 +169,13 @@ def _build(observers: dict, output_dir: Path) -> core.StatusAggregator:
     )
 
 
-def _obs(pub: int = 0, last_msg_at: float | None = None) -> core.StageObservation:
-    o = core.StageObservation()
+def _obs(
+    pub: int = 0,
+    last_msg_at: float | None = None,
+    *,
+    graph_only: bool = False,
+) -> core.StageObservation:
+    o = core.StageObservation(graph_only=graph_only)
     o.pub_count = pub
     o.sub_count = 1 if pub else 0
     if last_msg_at is not None:
@@ -175,7 +189,7 @@ def test_rollup_ok_when_all_stages_flow(tmp_path: Path) -> None:
     ota = _FakeObserver()
     local.observations["/heartbeat_a"] = _obs(pub=1, last_msg_at=now)
     local.observations["/com/out/a/heartbeat_a"] = _obs(pub=1, last_msg_at=now)
-    ota.observations["/ota/a/heartbeat_a"] = _obs(pub=1, last_msg_at=now)
+    ota.observations["/ota/a/heartbeat_a"] = _obs(pub=1, graph_only=True)
 
     agg = _build({"local": local, "ota": ota}, tmp_path)
     snap = agg.build_snapshot(now_mono=now)
@@ -184,7 +198,60 @@ def test_rollup_ok_when_all_stages_flow(tmp_path: Path) -> None:
     assert topic["reached_stage"] == "ota_sent"
     assert topic["blocked_at"] is None
     assert "Phase 1" in topic["diagnosis"]
+    ota_stage = {s["stage"]: s for s in topic["stages"]}["ota_sent"]
+    assert ota_stage["state"] == core.FLOWING
+    assert ota_stage["observation"] == "graph"
+    assert ota_stage["inferred_from"] == "/com/out/a/heartbeat_a"
+    assert ota_stage["messages_total"] == 1
     assert snap["summary"]["OK"] == 1
+
+
+def test_inbound_ota_receipt_is_inferred_from_com_in(tmp_path: Path) -> None:
+    now = 100.0
+    spec = {
+        "peer": "a",
+        "remote": "b",
+        "topics": [
+            {
+                "base": "/heartbeat_b",
+                "direction": "inbound",
+                "stages": [
+                    {
+                        "stage": "ota_recv",
+                        "topic": "/ota/b/heartbeat_b",
+                        "domain": "ota",
+                    },
+                    {
+                        "stage": "com_in",
+                        "topic": "/com/in/b/heartbeat_b",
+                        "domain": "local",
+                    },
+                    {
+                        "stage": "app_in",
+                        "topic": "/heartbeat_b",
+                        "domain": "local",
+                    },
+                ],
+            }
+        ],
+    }
+    local = _FakeObserver()
+    ota = _FakeObserver()
+    ota.observations["/ota/b/heartbeat_b"] = _obs(pub=1, graph_only=True)
+    local.observations["/com/in/b/heartbeat_b"] = _obs(pub=1, last_msg_at=now)
+    local.observations["/heartbeat_b"] = _obs(pub=1, last_msg_at=now)
+
+    agg = core.StatusAggregator(
+        logger=None,
+        spec=spec,
+        output_dir=str(tmp_path),
+        observers_by_domain={"local": local, "ota": ota},
+    )
+    topic = agg.build_snapshot(now_mono=now)["topics"][0]
+    ota_stage = {s["stage"]: s for s in topic["stages"]}["ota_recv"]
+    assert topic["overall"] == core.OK
+    assert ota_stage["state"] == core.FLOWING
+    assert ota_stage["inferred_from"] == "/com/in/b/heartbeat_b"
 
 
 def test_rollup_partial_identifies_first_broken_stage(tmp_path: Path) -> None:
@@ -247,7 +314,7 @@ def test_write_produces_artifacts_and_transition_events(tmp_path: Path) -> None:
     ota = _FakeObserver()
     local.observations["/heartbeat_a"] = _obs(pub=1, last_msg_at=now)
     local.observations["/com/out/a/heartbeat_a"] = _obs(pub=1, last_msg_at=now)
-    ota.observations["/ota/a/heartbeat_a"] = _obs(pub=0)
+    ota.observations["/ota/a/heartbeat_a"] = _obs(pub=0, graph_only=True)
 
     agg = _build({"local": local, "ota": ota}, tmp_path)
     # First write establishes baseline (no transition events emitted).
@@ -257,7 +324,7 @@ def test_write_produces_artifacts_and_transition_events(tmp_path: Path) -> None:
     assert not (tmp_path / "events.jsonl").exists()
 
     # Now the ota stage starts flowing -> overall changes -> one event row.
-    ota.observations["/ota/a/heartbeat_a"] = _obs(pub=1, last_msg_at=now)
+    ota.observations["/ota/a/heartbeat_a"] = _obs(pub=1, graph_only=True)
     assert agg.write(now_mono=now) == 1
     events_text = (tmp_path / "events.jsonl").read_text(encoding="utf-8").strip().splitlines()
     assert len(events_text) == 1


### PR DESCRIPTION
## Summary

- make OTA status observers graph-only so they never create DDS DataReaders for OTA payload topics
- infer outbound and inbound OTA activity from adjacent locally observed pipeline stages
- label inferred/graph-only stages in JSON and text status output
- preserve the no-payload-subscription guarantee when local and OTA domain IDs are equal
- document the bandwidth-safe behavior and add regression coverage

## Why

The status overview previously subscribed to every configured OTA stage. On unicast DDS transports this could create an additional full payload stream across the OTA link and compromise the bandwidth isolation provided by the dedicated OTA domain.

## Validation

- `pytest -q tests/unit` — 38 passed
- pre-commit hooks passed
- focused Ruff and Python compilation checks passed