### PR TITLE
docs: clarify CI Python version roles

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -40,6 +40,9 @@ ci-success
 The merge gate runs Python 3.10 through 3.14 non-Docker checks, package
 validation, and the Docker heartbeat smoke matrix:
 
+Python 3.10–3.14 are supported for the host CLI; Python 3.12 is the reference
+interpreter for packaging and Docker E2E jobs.
+
 ```bash
 just lint
 just typecheck


### PR DESCRIPTION
## Summary

- document that the host CLI supports Python 3.10 through 3.14
- clarify that Python 3.12 is the reference interpreter for packaging and Docker E2E jobs

## Validation

- pre-commit hooks passed
- documentation-only change