### PR TITLE
feat: prototype expectation-driven testing (RFC 0001)

### DIFF
--- a/docs/rfcs/0001-expectation-driven-test-suite.md
+++ b/docs/rfcs/0001-expectation-driven-test-suite.md
@@ -1,0 +1,159 @@
+# RFC 0001 — Expectation-driven, OTA-first test suite
+
+**Status:** Draft · **Scope:** test/example architecture · supersedes the marker
+model in `docs/testing.md`
+
+## Summary
+
+Replace the current two-axis capability markers and external-probe test harness
+with a single, OTA-first model built around **per-topic `expect` contracts** that
+are consumed by *both* the live status overview and an automated `rosotacom test`.
+Separate **examples** (few, curated, teaching) from **test-configs** (exhaustive,
+generated), and run the full suite as a **manual gate before promotion** rather
+than on every commit.
+
+This PR lands the load-bearing slice (the `expect` schema + `rosotacom test`
+reading the session's self-report); the rest is specified here for follow-ups.
+
+## Motivation
+
+Today (`docs/testing.md`, `tests/e2e/test_smoke.py`, and the FZI parent harness):
+
+- **Too many markers.** `single_machine: ok|na` × `multi_machine: ok|required|na`
+  is 2×3 of mandatory boilerplate on every session.
+- **`multi_machine: ok` vs `required` is a false distinction.** "required" just
+  meant "OTA-only"; "ok" meant "also fakeable locally". That is not two OTA
+  categories — it is one OTA membership plus a *local* property.
+- **"multi-machine" is the wrong name.** This is an OTA product; OTA delivery is
+  *the* thing under test, not a special tier.
+- **Test metadata in `session-definition.yaml` felt out of place** — until you
+  notice it should not be test-only metadata at all (see `expect`, below).
+- **No categorization.** Educational examples, the RMW combination matrix, and
+  heavy real-data sessions are all mixed together; the full run is already slow.
+
+## The reframe
+
+OTA delivery within a config's declared expectations is the product, so it is the
+test. Everything else is a lens:
+
+- **OTA is the default, not a tier.** A supported config is in the suite unless it
+  is explicitly experimental.
+- **Local testing is a speed optimization** — a fast pre-check for configs that can
+  be faked on one host with distinct domain IDs. Never the target.
+- **No locally-testable-but-not-OTA-deployable configs.** The only legitimate
+  asymmetry is OTA-only (e.g. `1_heartbeat_cyclone-ota-tuned`, which hides local
+  topics on a shared domain).
+
+## Decisions (settled)
+
+1. **`expect` is per-topic.**
+2. **`rosotacom test` reads the session's self-report (`status.json`)** rather than
+   probing externally.
+3. **Generate the RMW matrix** instead of hand-maintaining one dir per combo.
+4. **Cadence: a manual full-suite gate before each promotion** (not nightly-auto).
+
+## Design
+
+### 1. Per-topic `expect` — a behavioral contract, not test metadata
+
+```yaml
+topics:
+  vehicle_to_center:
+    - topic: /costmap/costmap
+      expect:
+        hz:         { min: 1, max: 5 }    # formalizes today's "2–5hz (OK)" comments
+        latency_ms: { max: 300 }
+        loss_pct:   { max: 5 }            # (planned)
+```
+
+It belongs in the user-facing `session-definition.yaml` because it has a **runtime
+role**, consumed by three things:
+
+- **The live status overview** → the `status` node warns when a topic violates its
+  contract. Already implemented for heartbeats (`heartbeat_in_monitor` declares
+  `expected_hz`, `delay_bad_ms`, `loss3_*`); generalize `topic_monitor` to read
+  per-topic `expect`. *(follow-up)*
+- **`rosotacom test`** → assert the contract holds (this PR).
+- **User configs** → because it is runtime config, `rosotacom test my_session`
+  works for any session, not just packaged examples.
+
+Isolation (a local-only topic must not cross) is a *universal* OTA invariant, not a
+per-topic expectation, so it stays a framework probe (`probe-publish`/`probe-check`),
+not a `session-definition` field.
+
+### 2. `rosotacom test` — assert the self-report
+
+The status overview already classifies every topic per stage
+(`status_overview_core.py`: `state`, `quality`, `hz`, `latency_ms`; settled state
+rolls up to `overall: OK`). So testing delivery is *reading the self-report*, not
+re-probing from outside:
+
+```
+rosotacom test [session]
+```
+Reads each peer's `logs/<peer>/status/status.json` for the most recent instance and
+asserts every crossed topic reached `overall: OK` and that inbound topics meet their
+`expect`. Orchestration (bringing the session up) stays the caller's job — `smoke`
+locally, or the multi-machine harness over two hosts — so the same `rosotacom test`
+is the single oracle for both tiers. The pure evaluator is `status_eval.py`
+(unit-tested against `status.json` fixtures).
+
+This retires the external `ros2 topic hz` probing in the `verify` verb (PR #21):
+delivery becomes self-report; `verify` is subsumed by `rosotacom test`.
+
+### 3. Markers → at most one real axis
+
+- **Drop `multi_machine: ok|required`.** Default = in the OTA suite.
+- **Keep one honest flag,** the local fast-check eligibility, and prefer to *derive*
+  it (distinct per-peer domains ⇒ fakeable; shared-domain hiding ⇒ not), allowing an
+  explicit `local_check: false` override only on the exceptions.
+- Net: from ~13 mandatory two-field blocks to a handful of one-line opt-outs.
+
+### 4. Examples vs test-configs
+
+| | Examples | Test-configs |
+|---|---|---|
+| Purpose | teach (one idea each) | exhaustive verification |
+| Count | few, curated | many / generated |
+| Location | `examples/sessions/` | `tests/sessions/` (or generated) |
+
+- **Curate examples down.** The seven `1_heartbeat_<rmw>` dirs are a test matrix,
+  not seven teaching examples — move them out.
+- **Generate the RMW matrix** from one minimal-heartbeat template × a list of RMW
+  combos. Adding a combo becomes one list entry. *(follow-up)*
+
+### 5. Test types × cadence
+
+**Types:** (A) RMW matrix — minimal heartbeat × every transport combo (generated);
+(B) example validation — every example comes up + meets `expect`; (C) real-data /
+complex (`remote_assist`-class over rosbag; private data lives in the FZI parent
+harness first).
+
+**Cadence:** per-PR runs L0 (unit/contract) + a small representative slice; the
+**full suite is a manual gate the operator runs and confirms green before promoting
+`main`** (decision 4). Cadence membership is a framework/dir decision, not another
+per-session marker.
+
+## What this PR prototypes vs. what is planned
+
+**This PR**
+- `expect` accepted on topic entries (`generate_session_files.py` validator; ignored
+  by generation).
+- `status_eval.py`: pure evaluator of `status.json` against `expect`.
+- `rosotacom test [session]`: reads the latest instance's per-peer `status.json` and
+  asserts delivery + `expect`. Exit non-zero on any failure.
+- Unit tests for the evaluator; validated end-to-end against a live local session.
+
+**Follow-ups**
+- Generalize `topic_monitor` to consume `expect` for live warnings.
+- Marker migration (drop `multi_machine`; derive/`local_check`).
+- Examples curation + generated RMW matrix; `tests/sessions/` split.
+- Wire the manual full-suite promotion gate; fold `verify` into `rosotacom test`.
+- `loss_pct` in `expect` and the evaluator.
+
+## Notes / open
+
+- `status.json` `overall` is `OK` only once a session has settled; `rosotacom test`
+  should poll/settle before asserting (the harness already waits).
+- Heartbeat `expect` placement (no `topics:` entry) — likely `shared.heartbeat.expect`
+  — is deferred with the monitor generalization.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,5 +1,10 @@
 # Testing
 
+> **Note:** an expectation-driven, OTA-first rework of this model is proposed in
+> `docs/rfcs/0001-expectation-driven-test-suite.md` (per-topic `expect` contracts,
+> `rosotacom test` reading the session self-report, fewer markers). This document
+> describes the model in effect today.
+
 This project separates two things that are easy to conflate:
 
 - **Examples** exist to *teach a user* how to run a session. They live in

--- a/src/rosotacom/cli.py
+++ b/src/rosotacom/cli.py
@@ -1739,6 +1739,44 @@ def probe_check_command(args: argparse.Namespace) -> int:
     return 0 if present == (args.expect == "present") else 1
 
 
+def test_command(args: argparse.Namespace) -> int:
+    """Assert a running/recent session meets its status + per-topic `expect` contract.
+
+    Reads each peer's self-reported status.json (the live status overview) for the
+    most recent instance and checks every crossed topic was delivered and meets its
+    declared hz/latency expectations. Orchestration (bringing the session up) is the
+    caller's job (e.g. `smoke` or the multi-machine harness)."""
+    from . import status_eval  # local import: the package's lazy __getattr__ makes a top-level one re-entrant
+
+    runtime = _load_runtime_config(args)
+    session = _resolve_session(getattr(args, "session_dir", None) or DEFAULT_SMOKE_SESSION, runtime)
+    cfg = _effective_session_config(session.host_dir, runtime)
+    instance_dir = _find_latest_instance_dir(runtime, session, getattr(args, "instance_id", None))
+    logs_dir = instance_dir / "logs"
+
+    reports: dict[str, Any] = {}
+    for peer_dir in sorted(p for p in logs_dir.iterdir() if p.is_dir()):
+        status_json = peer_dir / "status" / "status.json"
+        if status_json.exists():
+            reports[peer_dir.name] = json.loads(status_json.read_text(encoding="utf-8"))
+    if not reports:
+        print(
+            f"rosotacom test: no status.json under {logs_dir}. Start the session with "
+            "shared.use_status_overview=true first.",
+            file=sys.stderr,
+        )
+        return 1
+
+    failures = status_eval.evaluate_reports(reports, status_eval.expectations_from_cfg(cfg))
+    for failure in failures:
+        print(f"TEST FAIL: {failure}", file=sys.stderr)
+    if failures:
+        return 1
+    topic_count = sum(len(r.get("topics", [])) for r in reports.values())
+    print(f"TEST OK: {len(reports)} peer(s), {topic_count} topic(s) meet status + expectations")
+    return 0
+
+
 def smoke(args: argparse.Namespace) -> int:
     if not args.local:
         raise RuntimeError("Only --local smoke mode is implemented.")
@@ -1996,6 +2034,7 @@ def main(argv: list[str] | None = None) -> int:
         "doctor",
         "smoke",
         "status",
+        "test",
         "verify",
         "probe-publish",
         "probe-check",
@@ -2053,6 +2092,14 @@ def main(argv: list[str] | None = None) -> int:
     status_parser.add_argument("--watch", action="store_true", help="Continuously refresh the view.")
     status_parser.add_argument("--watch-interval", type=float, default=2.0, help="Watch refresh interval (s).")
     status_parser.set_defaults(func=status)
+
+    test_parser = subparsers.add_parser(
+        "test", help="Assert a running/recent session meets its status + per-topic expect contract."
+    )
+    _add_common_config_args(test_parser)
+    test_parser.add_argument("session_dir", nargs="?", default=DEFAULT_SMOKE_SESSION)
+    test_parser.add_argument("--instance-id", help="Evaluate a specific instance id (default: most recent).")
+    test_parser.set_defaults(func=test_command)
 
     # Verification verbs operate on an already-running session per identity, so the
     # external multi-machine runner can call them over SSH (one peer per host) with

--- a/src/rosotacom/resources/examples/sessions/3_comp_occ_grid/session-definition.yaml
+++ b/src/rosotacom/resources/examples/sessions/3_comp_occ_grid/session-definition.yaml
@@ -30,3 +30,8 @@ topics:
       processing:
         restamp_if: true
         compress: true
+      # Declared behavioral contract: read by the status overview (live warnings)
+      # and asserted by `rosotacom test`. See docs/rfcs/0001-expectation-driven-test-suite.md.
+      expect:
+        hz: { min: 1, max: 5 }
+        latency_ms: { max: 500 }

--- a/src/rosotacom/resources/ws/session/creation/generate_session_files.py
+++ b/src/rosotacom/resources/ws/session/creation/generate_session_files.py
@@ -196,11 +196,9 @@ def _parse_rmw_side(value: Any, ctx: str, *, is_local: bool) -> RmwSideSpec:
         )
 
     if len(value) != 1:
-        raise RuntimeError(
-            f"{ctx} mapping must have exactly one key (the RMW name); got {sorted(value.keys())}."
-        )
+        raise RuntimeError(f"{ctx} mapping must have exactly one key (the RMW name); got {sorted(value.keys())}.")
 
-    (impl_raw, cfg_raw), = value.items()
+    ((impl_raw, cfg_raw),) = value.items()
     if not isinstance(impl_raw, str) or not impl_raw.strip():
         raise RuntimeError(f"{ctx} key must be a non-empty string (the RMW name).")
     impl = impl_raw.strip()
@@ -280,9 +278,7 @@ def _parse_rmw_side(value: Any, ctx: str, *, is_local: bool) -> RmwSideSpec:
 def _validate_rmw_impl(impl: str, ctx: str, *, is_local: bool) -> None:
     if is_local:
         if impl == "zenoh_ros2dds":
-            raise RuntimeError(
-                f"{ctx}: 'zenoh_ros2dds' is OTA-only and cannot be used as the local RMW."
-            )
+            raise RuntimeError(f"{ctx}: 'zenoh_ros2dds' is OTA-only and cannot be used as the local RMW.")
         if impl == _ZENOH_CONNECT_ENDPOINTS:
             raise RuntimeError(
                 f"{ctx}: '{_ZENOH_CONNECT_ENDPOINTS}' is OTA-only; use local: zenoh for native rmw_zenoh_cpp."
@@ -290,9 +286,7 @@ def _validate_rmw_impl(impl: str, ctx: str, *, is_local: bool) -> None:
         # Everything else (including raw rmw strings) is permitted for local.
     else:
         if impl not in _OTA_SHORTS:
-            raise RuntimeError(
-                f"{ctx} must be one of {sorted(_OTA_SHORTS)}; got {impl!r}."
-            )
+            raise RuntimeError(f"{ctx} must be one of {sorted(_OTA_SHORTS)}; got {impl!r}.")
 
 
 def _parse_rmw_block(value: Any, peer_keys: List[str]) -> RmwSpec:
@@ -315,15 +309,11 @@ def _parse_rmw_block(value: Any, peer_keys: List[str]) -> RmwSpec:
         return RmwSpec(local=RmwSideSpec(impl=short), ota=RmwSideSpec(impl=short))
 
     if not isinstance(value, dict):
-        raise RuntimeError(
-            f"shared.rmw must be a string or a mapping with {{local, ota}} keys; got {type(value)}."
-        )
+        raise RuntimeError(f"shared.rmw must be a string or a mapping with {{local, ota}} keys; got {type(value)}.")
 
     extra = set(value.keys()) - {"local", "ota"}
     if extra:
-        raise RuntimeError(
-            f"shared.rmw contains unsupported keys {sorted(extra)}. Allowed: ['local', 'ota']."
-        )
+        raise RuntimeError(f"shared.rmw contains unsupported keys {sorted(extra)}. Allowed: ['local', 'ota'].")
 
     spec = RmwSpec(
         local=_parse_rmw_side(value.get("local"), "shared.rmw.local", is_local=True),
@@ -387,6 +377,7 @@ def _parse_optional_domain_id(value: Any, field_name: str) -> Optional[int]:
 # ---------------------------
 # IO + normalization helpers
 # ---------------------------
+
 
 def _read_text(path: str) -> str:
     with open(path, "r", encoding="utf-8") as f:
@@ -620,6 +611,7 @@ def _write_generated_files(generated: List[Tuple[str, str]], force: bool, rewrit
 # Session config logic
 # ---------------------------
 
+
 def _resolve_session_template_path(param_dir: str, template_path: str) -> str:
     """
     Resolve a session template path:
@@ -691,9 +683,7 @@ def _parse_session_config_template_spec(param: Dict[str, Any], param_dir: str) -
         )
 
     if not isinstance(spec, dict):
-        raise RuntimeError(
-            "load_template must be a mapping with keys {filepath, parameters}. "
-        )
+        raise RuntimeError("load_template must be a mapping with keys {filepath, parameters}. ")
 
     filepath = spec.get("filepath")
     session_template_fs = _resolve_session_template_path(param_dir, filepath)
@@ -721,8 +711,7 @@ def _build_vars_map_from_template(cfg_raw: Dict[str, Any], provided_params: Dict
     extra = sorted([k for k in (provided_params or {}).keys() if k not in input_params])
     if extra:
         raise RuntimeError(
-            "session-config provides unknown parameters not declared in the session template "
-            f"input_parameters: {extra}"
+            f"session-config provides unknown parameters not declared in the session template input_parameters: {extra}"
         )
 
     missing_required: List[str] = []
@@ -916,7 +905,11 @@ def _validate_session_template_cfg(cfg: Dict[str, Any]) -> None:
             raise RuntimeError(f"peers.{peer_key}.address is required")
         if not isinstance(peer_obj["address"], str) or not peer_obj["address"].strip():
             raise RuntimeError(f"peers.{peer_key}.address must be a non-empty string")
-        if "com-name" in peer_obj and peer_obj["com-name"] is not None and not isinstance(peer_obj["com-name"], (str, int, float, bool)):
+        if (
+            "com-name" in peer_obj
+            and peer_obj["com-name"] is not None
+            and not isinstance(peer_obj["com-name"], (str, int, float, bool))
+        ):
             raise RuntimeError(f"peers.{peer_key}.com-name must be a scalar if provided")
 
     # shared is optional
@@ -931,9 +924,7 @@ def _validate_session_template_cfg(cfg: Dict[str, Any]) -> None:
         }
         for legacy, replacement in _LEGACY_SHARED_KEYS.items():
             if legacy in shared:
-                raise RuntimeError(
-                    f"shared.{legacy} is no longer supported. Use {replacement} instead."
-                )
+                raise RuntimeError(f"shared.{legacy} is no longer supported. Use {replacement} instead.")
 
         _assert_allowed_keys(
             "shared",
@@ -992,9 +983,7 @@ def _validate_session_template_cfg(cfg: Dict[str, Any]) -> None:
         peer_keys = list(peers.keys())
         extra_peers = sorted([k for k in peer_settings.keys() if k not in peer_keys])
         if extra_peers:
-            raise RuntimeError(
-                f"peer_settings contains unsupported peer keys {extra_peers}. Known peers: {peer_keys}"
-            )
+            raise RuntimeError(f"peer_settings contains unsupported peer keys {extra_peers}. Known peers: {peer_keys}")
         for p, ps in peer_settings.items():
             ps = _assert_mapping(ps, f"peer_settings.{p}")
             _assert_allowed_keys(
@@ -1024,18 +1013,29 @@ def _validate_session_template_cfg(cfg: Dict[str, Any]) -> None:
                 if isinstance(item, str):
                     continue
                 if isinstance(item, dict):
-                    _assert_allowed_keys(f"topics.{dir_key}[{i}]", item, {"topic", "type", "processing", "qos", "zen_qos"})
+                    # `expect` declares the topic's intended delivered behavior
+                    # (hz/latency/loss). It is consumed by the status overview and
+                    # by `rosotacom test`; generation otherwise ignores it.
+                    _assert_allowed_keys(
+                        f"topics.{dir_key}[{i}]", item, {"topic", "type", "processing", "qos", "zen_qos", "expect"}
+                    )
                     if "topic" not in item or not isinstance(item["topic"], str) or not item["topic"].strip():
                         raise RuntimeError(f"topics.{dir_key}[{i}].topic must be a non-empty string.")
                     if "type" in item and item["type"] is not None:
                         if not isinstance(item["type"], str) or not item["type"].strip():
                             raise RuntimeError(f"topics.{dir_key}[{i}].type must be a non-empty string if provided.")
-                    if "processing" in item and item["processing"] is not None and not isinstance(item["processing"], dict):
+                    if (
+                        "processing" in item
+                        and item["processing"] is not None
+                        and not isinstance(item["processing"], dict)
+                    ):
                         raise RuntimeError(f"topics.{dir_key}[{i}].processing must be a mapping.")
                     if "qos" in item and item["qos"] is not None and not isinstance(item["qos"], dict):
                         raise RuntimeError(f"topics.{dir_key}[{i}].qos must be a mapping.")
                     if "zen_qos" in item and item["zen_qos"] is not None and not isinstance(item["zen_qos"], dict):
                         raise RuntimeError(f"topics.{dir_key}[{i}].zen_qos must be a mapping.")
+                    if "expect" in item and item["expect"] is not None and not isinstance(item["expect"], dict):
+                        raise RuntimeError(f"topics.{dir_key}[{i}].expect must be a mapping.")
                     continue
                 raise RuntimeError(f"Unsupported topic entry at topics.{dir_key}[{i}]: {type(item)}")
 
@@ -1116,17 +1116,13 @@ def _render_plugin_yaml(blocks: List[PluginBlock]) -> str:
 
 
 def _render_session_spec(base_plugin_path: str) -> str:
-    return _ensure_trailing_newline(
-        "session_plugins:\n"
-        "  - ./plugin.yaml\n"
-        f"  - {base_plugin_path}\n"
-    )
+    return _ensure_trailing_newline(f"session_plugins:\n  - ./plugin.yaml\n  - {base_plugin_path}\n")
 
 
 def _render_regex_list(key: str, topics: List[str]) -> str:
     lines = [f"{key}:\n"]
     for t in topics:
-        lines.append(f"  - topic_regex: \"^{t}$\"\n")
+        lines.append(f'  - topic_regex: "^{t}$"\n')
     return _ensure_trailing_newline("".join(lines))
 
 
@@ -1280,7 +1276,9 @@ def _build_status_pipeline_spec(
                 continue
             outbound_items.append((e, p))
         if use_heartbeat and hb_local:
-            hb_entry = TopicEntry(base=hb_local, msg_type=HEARTBEAT_MSG_TYPE, processing={}, qos=None, zen_qos=None, index=-1)
+            hb_entry = TopicEntry(
+                base=hb_local, msg_type=HEARTBEAT_MSG_TYPE, processing={}, qos=None, zen_qos=None, index=-1
+            )
             hb_pipe = {"final": hb_local}
             outbound_items.insert(0, (hb_entry, hb_pipe))
 
@@ -1300,10 +1298,20 @@ def _build_status_pipeline_spec(
                     {"stage": "processed", "topic": app_processed, "domain": "local", "produced_by": "preprocessing"}
                 )
             stages.append(
-                {"stage": "com_out", "topic": f"/com/out/{local_name}/{forward_ns}", "domain": "local", "produced_by": "relay_out"}
+                {
+                    "stage": "com_out",
+                    "topic": f"/com/out/{local_name}/{forward_ns}",
+                    "domain": "local",
+                    "produced_by": "relay_out",
+                }
             )
             stages.append(
-                {"stage": "ota_sent", "topic": f"/ota/{local_name}/{forward_ns}", "domain": "ota", "produced_by": "bridge_out"}
+                {
+                    "stage": "ota_sent",
+                    "topic": f"/ota/{local_name}/{forward_ns}",
+                    "domain": "ota",
+                    "produced_by": "bridge_out",
+                }
             )
 
             topics.append(
@@ -1327,7 +1335,9 @@ def _build_status_pipeline_spec(
                 continue
             inbound_items.append((e, p))
         if use_heartbeat and hb_remote:
-            hb_entry = TopicEntry(base=hb_remote, msg_type=HEARTBEAT_MSG_TYPE, processing={}, qos=None, zen_qos=None, index=-1)
+            hb_entry = TopicEntry(
+                base=hb_remote, msg_type=HEARTBEAT_MSG_TYPE, processing={}, qos=None, zen_qos=None, index=-1
+            )
             hb_pipe = {"final": hb_remote}
             inbound_items.insert(0, (hb_entry, hb_pipe))
 
@@ -1339,13 +1349,28 @@ def _build_status_pipeline_spec(
             app_in = _relay_in_local_topic(final)
 
             stages = [
-                {"stage": "ota_recv", "topic": f"/ota/{remote_name}/{forward_ns}", "domain": "ota", "produced_by": "transport"},
-                {"stage": "com_in", "topic": f"/com/in/{remote_name}/{forward_ns}", "domain": "local", "produced_by": "bridge_in"},
+                {
+                    "stage": "ota_recv",
+                    "topic": f"/ota/{remote_name}/{forward_ns}",
+                    "domain": "ota",
+                    "produced_by": "transport",
+                },
+                {
+                    "stage": "com_in",
+                    "topic": f"/com/in/{remote_name}/{forward_ns}",
+                    "domain": "local",
+                    "produced_by": "bridge_in",
+                },
                 {"stage": "app_in", "topic": app_in, "domain": "local", "produced_by": "relay_in"},
             ]
             if final != base:
                 stages.append(
-                    {"stage": "native_in", "topic": _relay_in_local_topic(base), "domain": "local", "produced_by": "postprocessing"}
+                    {
+                        "stage": "native_in",
+                        "topic": _relay_in_local_topic(base),
+                        "domain": "local",
+                        "produced_by": "postprocessing",
+                    }
                 )
 
             topics.append(
@@ -1568,6 +1593,7 @@ def _compute_pipeline(
 # Main
 # ---------------------------
 
+
 def func(
     session_config_yaml: str = "",
     force: bool = False,
@@ -1588,9 +1614,7 @@ def func(
 
     if session_config_obj is not None:
         if not isinstance(session_config_obj, dict):
-            raise RuntimeError(
-                f"session_config_obj must be a mapping, got {type(session_config_obj)}"
-            )
+            raise RuntimeError(f"session_config_obj must be a mapping, got {type(session_config_obj)}")
         vars_map = {}
         cfg = dict(session_config_obj)
         template_mode = False
@@ -1697,9 +1721,7 @@ def func(
     # If both are set for the same peer and disagree, that's an error — either the
     # user meant the shortcut (drop the per-peer value) or they meant to override it
     # (drop the shared one), but silently letting them diverge would hide mistakes.
-    shared_local_domain_id = _parse_optional_domain_id(
-        shared.get("local_domain_id"), "shared.local_domain_id"
-    )
+    shared_local_domain_id = _parse_optional_domain_id(shared.get("local_domain_id"), "shared.local_domain_id")
     peer_local_domain_id: Dict[str, Optional[int]] = {}
     for p in peer_keys:
         per_peer = _parse_optional_domain_id(
@@ -1784,10 +1806,12 @@ def func(
             items.append(("local_config_template", side.dds_config))
             items.append(("local_config_file", "${peer_dir}/local_dds.xml"))
             if side.impl == "fastdds" and side.dds_config == "fastdds_easy_mode.xml":
-                items.append((
-                    "local_easy_mode_ip_key",
-                    side.dds_easy_mode_ip_key or peer_ip[peer_keys[0]],
-                ))
+                items.append(
+                    (
+                        "local_easy_mode_ip_key",
+                        side.dds_easy_mode_ip_key or peer_ip[peer_keys[0]],
+                    )
+                )
         return items
 
     def _build_ota_rmw_items() -> List[Tuple[str, Any]]:
@@ -1806,10 +1830,12 @@ def func(
             items.append(("ota_config_template", ota.dds_config))
             items.append(("ota_config_file", "${peer_dir}/ota_dds.xml"))
             if ota.impl == "fastdds" and ota.dds_config == "fastdds_easy_mode.xml":
-                items.append((
-                    "ota_easy_mode_ip_key",
-                    ota.dds_easy_mode_ip_key or peer_ip[peer_keys[0]],
-                ))
+                items.append(
+                    (
+                        "ota_easy_mode_ip_key",
+                        ota.dds_easy_mode_ip_key or peer_ip[peer_keys[0]],
+                    )
+                )
         return items
 
     def _build_zenoh_block(
@@ -1883,9 +1909,7 @@ def func(
             )
         src, dst = parts[0], parts[1]
         if src not in peer_ip or dst not in peer_ip:
-            raise RuntimeError(
-                f"topics key '{k}' refers to unknown peer(s) '{src}'/'{dst}'. Known peers: {peer_keys}"
-            )
+            raise RuntimeError(f"topics key '{k}' refers to unknown peer(s) '{src}'/'{dst}'. Known peers: {peer_keys}")
         if (src, dst) in direction_key_for:
             raise RuntimeError(f"Duplicate topics direction for {src}_to_{dst}.")
         direction_key_for[(src, dst)] = k
@@ -1895,7 +1919,9 @@ def func(
     # - force in/out unless user explicitly disabled them (then error)
     if use_heartbeat:
         if shared_use_in is False or shared_use_out is False:
-            raise RuntimeError("shared.use_heartbeat=true requires in/out. Remove shared.use_in/use_out overrides or set both to true.")
+            raise RuntimeError(
+                "shared.use_heartbeat=true requires in/out. Remove shared.use_in/use_out overrides or set both to true."
+            )
         if shared_use_in is None:
             shared_use_in = True
         if shared_use_out is None:
@@ -1959,9 +1985,7 @@ def func(
             elif peer_local_domain_id[local] is not None:
                 # Still export ROS_DOMAIN_ID for the peer's local graph even
                 # if no domain bridging is active.
-                blocks.append(
-                    PluginBlock("domain", [("local_domain_id", peer_local_domain_id[local])])
-                )
+                blocks.append(PluginBlock("domain", [("local_domain_id", peer_local_domain_id[local])]))
             blocks.append(PluginBlock("rmw", _build_ota_rmw_items()))
             if use_topic_monitor:
                 blocks.append(PluginBlock("topic_monitor", [("topic_monitor", True)]))
@@ -2094,7 +2118,9 @@ def func(
         key_expr_path = "/".join(parts)
         return f"ota/{peer_name[publisher_peer]}/{key_expr_path}"
 
-    def _zenoh_qos_pub_block(entries_and_pipes: List[Tuple[TopicEntry, Dict[str, Any]]], publisher_peer: str) -> Optional[YamlBlockScalar]:
+    def _zenoh_qos_pub_block(
+        entries_and_pipes: List[Tuple[TopicEntry, Dict[str, Any]]], publisher_peer: str
+    ) -> Optional[YamlBlockScalar]:
         items: List[Tuple[str, Dict[str, Any]]] = []
         for e, p in entries_and_pipes:
             if not e.zen_qos:
@@ -2105,7 +2131,9 @@ def func(
             allowed = {"priority", "express"}
             extra = sorted([k for k in zq.keys() if k not in allowed])
             if extra:
-                raise RuntimeError(f"zen_qos for topic '{e.base}' has unsupported keys {extra}. Allowed: {sorted(allowed)}")
+                raise RuntimeError(
+                    f"zen_qos for topic '{e.base}' has unsupported keys {extra}. Allowed: {sorted(allowed)}"
+                )
             priority_raw = zq.get("priority")
             if priority_raw is None:
                 raise RuntimeError("zen_qos.priority is required when zen_qos is provided.")
@@ -2134,12 +2162,7 @@ def func(
             if cfg.get("express"):
                 parts_cfg.append("express: true")
             cfg_inline = "{ " + ", ".join(parts_cfg) + " }"
-            rendered_entries.append(
-                "{\n"
-                f'  key_exprs: [ "{key_expr}" ],\n'
-                f"  config: {cfg_inline}\n"
-                "}"
-            )
+            rendered_entries.append(f'{{\n  key_exprs: [ "{key_expr}" ],\n  config: {cfg_inline}\n}}')
 
         # Join as a comma-separated list of objects (as expected by zenoh.json5.template)
         content = ",\n".join(rendered_entries)
@@ -2224,7 +2247,9 @@ def func(
 
     def _prefix_with_source_name_if_needed(target_peer: str, source_peer: str, topic: str) -> str:
         ps = peer_settings_all.get(target_peer, {}) or {}
-        keep_source = bool((ps.get("inbound", {}) or {}).get("keep_source_prefix", False)) if isinstance(ps, dict) else False
+        keep_source = (
+            bool((ps.get("inbound", {}) or {}).get("keep_source_prefix", False)) if isinstance(ps, dict) else False
+        )
         prefix = f"/{peer_name[source_peer]}" if keep_source else ""
         return f"{prefix}{topic}"
 
@@ -2250,7 +2275,8 @@ def func(
         # and republishes at a fixed rate for visualization software.
         trickle_in_items = [
             (_prefix_with_source_name_if_needed(local, remote, p["final"]), p["trickle_hz"])
-            for p in in_pipes if p["trickle_hz"] is not None
+            for p in in_pipes
+            if p["trickle_hz"] is not None
         ]
         trickle_all_topics = _dedup_keep_order([t for t, _ in trickle_in_items])
         # Use the first configured rate (all trickle topics share a single timer).
@@ -2367,7 +2393,9 @@ def func(
         ps_remote = peer_settings_all.get(remote, {}) or {}
         ps_remote = ps_remote if isinstance(ps_remote, dict) else {}
         remote_outbound = (ps_remote.get("outbound", {}) or {}) if isinstance(ps_remote, dict) else {}
-        remote_outbound_target = (remote_outbound.get("target_prefix", {}) or {}) if isinstance(remote_outbound, dict) else {}
+        remote_outbound_target = (
+            (remote_outbound.get("target_prefix", {}) or {}) if isinstance(remote_outbound, dict) else {}
+        )
         remote_uses_target_prefix = bool(remote_outbound_target.get("use_target_prefix", False))
 
         # ---------------------------
@@ -2384,7 +2412,9 @@ def func(
             )
         native_have_source_prefix = outbound_source_cfg.get("native_have_source_prefix", False)
         if not isinstance(native_have_source_prefix, bool):
-            raise RuntimeError(f"peer_settings.{local}.outbound.source_prefix.native_have_source_prefix must be boolean.")
+            raise RuntimeError(
+                f"peer_settings.{local}.outbound.source_prefix.native_have_source_prefix must be boolean."
+            )
 
         # Target prefix:
         # - native_have_outgoing_target_prefix defaults to use_target_prefix
@@ -2392,7 +2422,9 @@ def func(
         use_target_prefix = outbound_target_cfg.get("use_target_prefix", False)
         if not isinstance(use_target_prefix, bool):
             raise RuntimeError(f"peer_settings.{local}.outbound.target_prefix.use_target_prefix must be boolean.")
-        native_have_outgoing_target_prefix = outbound_target_cfg.get("native_have_outgoing_target_prefix", use_target_prefix)
+        native_have_outgoing_target_prefix = outbound_target_cfg.get(
+            "native_have_outgoing_target_prefix", use_target_prefix
+        )
         if not isinstance(native_have_outgoing_target_prefix, bool):
             raise RuntimeError(
                 f"peer_settings.{local}.outbound.target_prefix.native_have_outgoing_target_prefix must be boolean."
@@ -2423,7 +2455,9 @@ def func(
 
         # IN: only if inbound direction exists (or explicitly requested, in which case error if missing)
         in_list = dir_topic_list.get((remote, local), []) if in_dir_key else []
-        in_list_with_types = dir_topic_list_with_types.get((remote, local), []) if use_domain_bridge and in_dir_key else []
+        in_list_with_types = (
+            dir_topic_list_with_types.get((remote, local), []) if use_domain_bridge and in_dir_key else []
+        )
         in_enabled = bool(shared_use_in) if shared_use_in is not None else (len(in_list) > 0)
         if in_enabled and not in_dir_key:
             raise RuntimeError(f"shared.use_in=true but no inbound topics direction '{remote}_to_{local}' is defined.")
@@ -2445,10 +2479,14 @@ def func(
 
         # OUT: only if outbound direction exists (or explicitly requested, in which case error if missing)
         out_list = dir_topic_list.get((local, remote), []) if out_dir_key else []
-        out_list_with_types = dir_topic_list_with_types.get((local, remote), []) if use_domain_bridge and out_dir_key else []
+        out_list_with_types = (
+            dir_topic_list_with_types.get((local, remote), []) if use_domain_bridge and out_dir_key else []
+        )
         out_enabled = bool(shared_use_out) if shared_use_out is not None else (len(out_list) > 0)
         if out_enabled and not out_dir_key:
-            raise RuntimeError(f"shared.use_out=true but no outbound topics direction '{local}_to_{remote}' is defined.")
+            raise RuntimeError(
+                f"shared.use_out=true but no outbound topics direction '{local}_to_{remote}' is defined."
+            )
         if out_dir_key:
             out_items: List[Tuple[str, Any]] = [
                 ("out", out_enabled),
@@ -2500,9 +2538,7 @@ def func(
                 )
         elif peer_local_domain_id[local] is not None:
             # No domain bridging but the peer still has a pinned ROS_DOMAIN_ID.
-            blocks.append(
-                PluginBlock("domain", [("local_domain_id", peer_local_domain_id[local])])
-            )
+            blocks.append(PluginBlock("domain", [("local_domain_id", peer_local_domain_id[local])]))
 
         zen_block = _build_zenoh_block(
             local,
@@ -2521,9 +2557,11 @@ def func(
             blocks.append(
                 PluginBlock(
                     "topic_monitor",
-                    ([("topic_monitor", True)]
-                     + ([("tm_in_to_adressant", tm_in_to)] if tm_in_to is not None else [])
-                     + ([("tm_out_to_adressant", tm_out_to)] if tm_out_to is not None else [])),
+                    (
+                        [("topic_monitor", True)]
+                        + ([("tm_in_to_adressant", tm_in_to)] if tm_in_to is not None else [])
+                        + ([("tm_out_to_adressant", tm_out_to)] if tm_out_to is not None else [])
+                    ),
                 )
             )
 
@@ -2765,7 +2803,9 @@ def func(
 
         per_peer_plugin[local] = _render_plugin_yaml(blocks)
 
-    qos_yaml = _render_qos_yaml(shared.get("qos", {}) if isinstance(shared, dict) else {}, qos_overrides) if write_qos else ""
+    qos_yaml = (
+        _render_qos_yaml(shared.get("qos", {}) if isinstance(shared, dict) else {}, qos_overrides) if write_qos else ""
+    )
 
     # session_specification.yaml
     session_spec_yaml = _render_session_spec(base_plugin_path)

--- a/src/rosotacom/status_eval.py
+++ b/src/rosotacom/status_eval.py
@@ -1,0 +1,84 @@
+"""Evaluate a session's self-reported status (status.json) against the per-topic
+`expect` contract declared in its session-definition.
+
+This is the test-side half of the expectation-driven model (see
+docs/rfcs/0001-expectation-driven-test-suite.md): the live status overview already
+classifies every topic (state/quality/hz/latency per stage); `rosotacom test`
+reads that self-report and asserts each crossed topic was delivered (overall OK)
+and that the inbound side meets its declared hz/latency expectations. Pure
+functions (no ROS/Docker), so they are unit-testable against status.json fixtures.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+STATUS_OK = "OK"
+
+
+def expectations_from_cfg(cfg: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    """Map a topic's base name -> its `expect` block, from a session config."""
+    out: dict[str, dict[str, Any]] = {}
+    topics = cfg.get("topics")
+    if not isinstance(topics, dict):
+        return out
+    for entries in topics.values():
+        for item in entries or []:
+            if isinstance(item, dict) and isinstance(item.get("expect"), dict) and item.get("topic"):
+                out[str(item["topic"])] = item["expect"]
+    return out
+
+
+def _final_stage(topic: dict[str, Any]) -> dict[str, Any] | None:
+    """The deepest *flowing* stage of a topic pipeline (its delivered end)."""
+    stages: list[dict[str, Any]] = topic.get("stages") or []
+    flowing = [s for s in stages if s.get("state") == "FLOWING"]
+    if flowing:
+        return flowing[-1]
+    return stages[-1] if stages else None
+
+
+def _check_expect(peer: str, base: str, stage: dict[str, Any], expect: dict[str, Any]) -> list[str]:
+    failures: list[str] = []
+    hz, hz_exp = stage.get("hz"), expect.get("hz") or {}
+    if "min" in hz_exp and (hz is None or hz < hz_exp["min"]):
+        failures.append(f"[{peer}] {base}: hz {hz} < expected min {hz_exp['min']}")
+    if "max" in hz_exp and (hz is None or hz > hz_exp["max"]):
+        failures.append(f"[{peer}] {base}: hz {hz} > expected max {hz_exp['max']}")
+    lat, lat_exp = stage.get("latency_ms"), expect.get("latency_ms") or {}
+    if "max" in lat_exp and (lat is None or lat > lat_exp["max"]):
+        failures.append(f"[{peer}] {base}: latency {lat}ms > expected max {lat_exp['max']}ms")
+    return failures
+
+
+def evaluate_report(report: dict[str, Any], expect_by_topic: dict[str, dict[str, Any]]) -> list[str]:
+    """Failures for one peer's status.json (empty == all good)."""
+    peer = report.get("peer", "?")
+    topics = report.get("topics", [])
+    if not topics:
+        return [f"[{peer}] status report has no topics"]
+    failures: list[str] = []
+    for topic in topics:
+        base = topic.get("base", "?")
+        overall = topic.get("overall")
+        if overall != STATUS_OK:
+            diag = topic.get("diagnosis")
+            failures.append(f"[{peer}] {base}: status {overall}" + (f" ({diag})" if diag else ""))
+            continue
+        # Expectations are about delivered behavior, observed on the inbound side.
+        expect = expect_by_topic.get(base)
+        if expect and topic.get("direction") == "inbound":
+            stage = _final_stage(topic)
+            if stage is None:
+                failures.append(f"[{peer}] {base}: no observable stage to check expectations")
+            else:
+                failures += _check_expect(peer, base, stage, expect)
+    return failures
+
+
+def evaluate_reports(reports: dict[str, dict[str, Any]], expect_by_topic: dict[str, dict[str, Any]]) -> list[str]:
+    """Failures across every peer's status.json (empty == all good)."""
+    failures: list[str] = []
+    for report in reports.values():
+        failures += evaluate_report(report, expect_by_topic)
+    return failures

--- a/tests/unit/test_status_eval.py
+++ b/tests/unit/test_status_eval.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from rosotacom.status_eval import evaluate_report, evaluate_reports, expectations_from_cfg
+
+
+def _stage(stage: str, hz: float, latency_ms: float | None, state: str = "FLOWING") -> dict:
+    return {"stage": stage, "hz": hz, "latency_ms": latency_ms, "state": state}
+
+
+def _topic(base: str, direction: str, overall: str, stages: list[dict]) -> dict:
+    return {"base": base, "direction": direction, "overall": overall, "stages": stages}
+
+
+# Mirrors a settled 1_heartbeat status.json: inbound delivered through app_in,
+# outbound observed locally at the native publish stage.
+OK_REPORT = {
+    "peer": "b",
+    "topics": [
+        _topic("/heartbeat_a", "inbound", "OK", [_stage("com_in", 10.0, 5.3), _stage("app_in", 10.0, 6.9)]),
+        _topic("/heartbeat_b", "outbound", "OK", [_stage("native", 10.0, None)]),
+    ],
+}
+
+
+def test_all_ok_without_expectations_passes() -> None:
+    assert evaluate_report(OK_REPORT, {}) == []
+
+
+def test_non_ok_overall_fails_with_diagnosis() -> None:
+    report = {"peer": "a", "topics": [_topic("/x", "inbound", "STALLED", [_stage("com_in", 0.0, None, "STALE")])]}
+    report["topics"][0]["diagnosis"] = "stopped 4s ago"
+    failures = evaluate_report(report, {})
+    assert len(failures) == 1 and "STALLED" in failures[0] and "stopped 4s ago" in failures[0]
+
+
+def test_empty_report_fails() -> None:
+    assert evaluate_report({"peer": "a", "topics": []}, {})
+
+
+def test_expect_within_bounds_passes() -> None:
+    expect = {"/heartbeat_a": {"hz": {"min": 8, "max": 12}, "latency_ms": {"max": 200}}}
+    assert evaluate_report(OK_REPORT, expect) == []
+
+
+def test_expect_hz_too_low_fails() -> None:
+    failures = evaluate_report(OK_REPORT, {"/heartbeat_a": {"hz": {"min": 50}}})
+    assert len(failures) == 1 and "hz" in failures[0]
+
+
+def test_expect_latency_exceeded_fails() -> None:
+    failures = evaluate_report(OK_REPORT, {"/heartbeat_a": {"latency_ms": {"max": 1}}})
+    assert len(failures) == 1 and "latency" in failures[0]
+
+
+def test_expect_only_checked_on_inbound_side() -> None:
+    # Delivery (and thus the contract) is observed inbound; an outbound topic's
+    # expect is not asserted against its local publish stage.
+    assert evaluate_report(OK_REPORT, {"/heartbeat_b": {"hz": {"min": 50}}}) == []
+
+
+def test_expectations_from_cfg_collects_only_expect_blocks() -> None:
+    cfg = {"topics": {"b_to_a": [{"topic": "/c", "expect": {"hz": {"min": 1}}}, {"topic": "/d"}, "/e"]}}
+    assert expectations_from_cfg(cfg) == {"/c": {"hz": {"min": 1}}}
+
+
+def test_evaluate_reports_aggregates_across_peers() -> None:
+    bad = {"peer": "a", "topics": [_topic("/x", "inbound", "ABSENT", [])]}
+    failures = evaluate_reports({"a": bad, "b": OK_REPORT}, {})
+    assert len(failures) == 1 and "ABSENT" in failures[0]


### PR DESCRIPTION
## What

First slice of an OTA-first test rework (full proposal: `docs/rfcs/0001-expectation-driven-test-suite.md`).

Introduces **per-topic `expect` contracts** consumed by a new `rosotacom test`, which asserts a session's own **status.json self-report** instead of probing topics externally. The session already self-monitors (status overview), so testing delivery becomes *reading the self-report*.

## Changes

- `expect: { hz: {min,max}, latency_ms: {max} }` accepted on topic entries (validator); generation ignores it.
- `status_eval.py` — pure evaluator (`status.json` × `expect` → failures), unit-tested.
- `rosotacom test [session]` — reads each peer's latest-instance `status.json`; asserts delivery (`overall: OK`) + `expect`; exits non-zero on failure. Orchestration stays the caller's job (smoke / multi-machine harness).
- Demo `expect` on `3_comp_occ_grid`; pointer from `docs/testing.md` to the RFC.

## Validation

- lint + typecheck + **64** contract/unit tests green (8 new evaluator tests).
- `rosotacom test` validated end-to-end against a live local `1_heartbeat_status` session: `TEST OK: 2 peer(s), 4 topic(s) meet status + expectations`.

## Scope / follow-ups (detailed in the RFC)

Generalize `topic_monitor` to consume `expect` for live warnings; marker simplification; generated RMW matrix; examples/test-config split; manual full-suite promotion gate; fold `verify` into `rosotacom test`; `loss_pct`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
