### PR TITLE
feat: expand smoke coverage and harden release workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-process.md
+++ b/.github/ISSUE_TEMPLATE/release-process.md
@@ -13,17 +13,26 @@ Ship a validated, well-described `rosotacom` release.
 ## Target
 
 - Target tag: `vX.Y.Z`
+- `main` commit SHA:
+- Previous release tag:
+- Promotion/validation evidence:
 
 ## Tasks
 
 - [ ] Choose the target tag in the form `vX.Y.Z`.
 - [ ] Identify the previous release tag.
+- [ ] Confirm the release commit is on `main` and record its exact SHA.
+- [ ] Review all commits and the full diff since the previous release.
 - [ ] Summarize user-facing CLI, config, Docker, dependency, and packaging changes.
 - [ ] Copy `docs/release-notes/TEMPLATE.md` to `docs/release-notes/vX.Y.Z.md`.
 - [ ] State breaking changes and migration steps, or explicitly say there are none.
 - [ ] Include local command results in the PR description.
 - [ ] After merge, tag the release commit and push the tag.
-- [ ] Confirm PyPI and GitHub Release publication.
+- [ ] Confirm the tag workflow succeeded for the exact recorded SHA.
+- [ ] Confirm the configured package deployment succeeded.
+- [ ] Inspect the wheel, source distribution, checksums, and GitHub Release.
+- [ ] Record release, workflow, and deployment links.
+- [ ] Do not create a downstream sync PR until all release evidence is reviewed.
 
 ## Checks
 
@@ -34,3 +43,11 @@ Ship a validated, well-described `rosotacom` release.
 - [ ] `just docs`
 - [ ] `just package`
 - [ ] `just test-e2e-smoke`
+
+## Evidence
+
+- Release PR:
+- GitHub Release:
+- Release workflow:
+- Deployment:
+- Artifacts inspected:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,6 +11,7 @@
 - [ ] Release PR: includes `docs/release-notes/vX.Y.Z.md`
 - [ ] Release PR: summarizes user-facing changes since the previous release
 - [ ] Release PR: documents compatibility, migration, and validation notes
+- [ ] Release PR: records the intended `main` commit and previous release tag
 - [ ] Not a release PR
 
 ## Public Behavior
@@ -32,3 +33,9 @@
 ## Test Integrity
 
 - [ ] Tests/CI were not skipped, weakened, or removed to make this pass
+
+## Maintainer Evidence
+
+- Required CI links:
+- Manual/runtime evidence:
+- External OTA evidence, if this PR is part of a `main` promotion:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,14 +121,14 @@ jobs:
       - name: Run heartbeat smoke matrix
         run: just test-e2e-smoke
 
-  publish-pypi:
-    name: publish-pypi
+  publish:
+    name: publish
     runs-on: ubuntu-latest
     needs: [non-docker, package, fast-e2e]
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-    environment:
-      name: pypi
-      url: https://pypi.org/p/rosotacom
+    # No GitHub environment: authorization is the per-repo Trusted Publisher
+    # (registered with a blank environment), so this needs no environment-admin
+    # rights in any repo that shares this file.
     permissions:
       id-token: write
 
@@ -142,41 +142,35 @@ jobs:
       - name: Remove checksum sidecar
         run: rm -f dist/SHA256SUMS
 
-      - name: Publish distributions to PyPI
+      - name: Verify configured publishing target
+        env:
+          PYPI_PUBLISH_URL: ${{ vars.PYPI_PUBLISH_URL }}
+        run: |
+          if [ -z "$PYPI_PUBLISH_URL" ]; then
+            echo "::error::PYPI_PUBLISH_URL is not configured for this repository."
+            exit 1
+          fi
+          case "$PYPI_PUBLISH_URL" in
+            https://*) ;;
+            *)
+              echo "::error::PYPI_PUBLISH_URL must be an HTTPS endpoint."
+              exit 1
+              ;;
+          esac
+
+      # The destination is repository configuration, not shared git content:
+      # rehearsal index in the development fork, production index upstream.
+      # Trusted Publisher registration remains the authorization boundary.
+      - name: Publish distributions
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
+          repository-url: ${{ vars.PYPI_PUBLISH_URL }}
           skip-existing: true
-
-  publish-testpypi:
-    name: publish-testpypi
-    runs-on: ubuntu-latest
-    needs: [non-docker, package, fast-e2e]
-    if: github.event_name == 'workflow_dispatch'
-    environment:
-      name: testpypi
-      url: https://test.pypi.org/p/rosotacom
-    permissions:
-      id-token: write
-
-    steps:
-      - name: Download distributions
-        uses: actions/download-artifact@v8
-        with:
-          name: python-package-distributions
-          path: dist/
-
-      - name: Remove checksum sidecar
-        run: rm -f dist/SHA256SUMS
-
-      - name: Publish distributions to TestPyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          repository-url: https://test.pypi.org/legacy/
 
   github-release:
     name: github-release
     runs-on: ubuntu-latest
-    needs: publish-pypi
+    needs: publish
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     permissions:
       contents: write

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,31 +47,37 @@ heartbeat smoke matrix separately so failures are easier to inspect.
 
 ## Branch And Merge Policy
 
-`main` is protected. Do not push directly to `main`.
+Do not push directly to a protected branch.
 
-All changes must go through a pull request. Start each change from an up-to-date
-`origin/main` topic branch:
+All changes must go through a pull request. Repositories using this shared
+codebase may use a development branch before the `main` release line. Start each
+change from the repository's current default branch:
 
 ```bash
 git fetch --prune
-git switch -c <type>/<short-topic> origin/main
+git remote set-head origin --auto
+git switch -c <type>/<short-topic> origin/HEAD
 ```
 
 Keep the change small and coherent. Update tests, README, docs, examples, and
 packaging metadata when CLI, config, package, Docker, or public runtime behavior
 changes.
 
+Moving validated development work to `main` is a deliberate maintainer action.
+It may require an external OTA gate supplied by the repository operator; it is
+not triggered by an arbitrary commit in this repository.
+
 ## CI Policy
 
-The required merge gate for `main` is:
+The required merge gate for protected development and release branches is:
 
 ```text
 ci-success
 ```
 
-Draft PRs run lightweight checks. Ready PRs, pushes to `main`, and merge queue
-entries run the full gate: Python 3.10 through 3.14 non-Docker checks, coverage,
-package validation, and Docker smoke.
+Draft PRs run lightweight checks. Ready PRs, pushes to `main` or `develop`, and
+merge queue entries run the full gate: Python 3.10 through 3.14 non-Docker
+checks, coverage, package validation, and Docker smoke.
 
 Codecov uses the uploaded `nondocker` report. Docker E2E remains behavioral
 validation and is not collected for coverage.
@@ -86,7 +92,7 @@ Releases are built from tags in the form `vX.Y.Z`. Release PRs must include
 `docs/release-notes/vX.Y.Z.md`, copied from
 [docs/release-notes/TEMPLATE.md](docs/release-notes/TEMPLATE.md).
 
-After the release PR has merged:
+After the release PR has merged to `main`, verify the exact commit and then:
 
 ```bash
 git switch main
@@ -96,5 +102,9 @@ git tag vX.Y.Z
 git push origin vX.Y.Z
 ```
 
-Tag pushes publish to PyPI through Trusted Publishing and create a GitHub
-Release. Manual release workflow dispatch publishes to TestPyPI.
+Tag pushes validate, publish through the repository's configured Trusted
+Publisher, and create a GitHub Release. Before any downstream repository sync,
+maintainers must review the resulting release workflow, deployment, artifacts,
+and release notes. Downstream synchronization is never implied by creating the
+tag. Manual release-workflow dispatch validates and builds only; it does not
+publish.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ The ROS Communication DevContainer is a Docker-based solution designed to stream
 
 - Docker installed on all machines
 - Git for configuration management
+- Python 3 with virtual environment support (`python3-venv` on Debian/Ubuntu;
+  for versioned Python packages this may be named like `python3.14-venv`)
 - `ros2docker` v0.1.2 or newer. The local installer below installs the pinned
   supported range into this checkout's virtual environment.
 - Machines connected to the same network (VPN or local WLAN)
@@ -161,6 +163,12 @@ Run the local heartbeat smoke test:
 
 ```bash
 rosotacom smoke
+```
+
+To smoke-test one specific configured session locally, pass its name:
+
+```bash
+rosotacom smoke 1_heartbeat_cyclone-ota
 ```
 
 The smoke test verifies both directions through the communication path: it waits

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -6,18 +6,20 @@ together, see [testing.md](testing.md).
 
 ## Branch model
 
-Work flows through one linear history in three tiers:
+This shared codebase is used by repositories with different default branches,
+but one stable release line:
 
-- topic PRs are gated into **`develop`** by the merge gate below
-  (single-machine-proven);
-- **`develop`** is promoted to **`main`** by an external multi-machine suite
-  (multi-machine-proven); `main` is the default branch and the release line, and
-  is only ever advanced by that promotion, so it stays a fast-forward of
-  `develop`;
+- topic PRs are gated into the repository's active development branch by the
+  GitHub checks below;
+- **`main`** is the stable release line;
+- moving development work to `main` is a deliberate maintainer operation and
+  may require an external OTA gate;
 - releases are tags `vX.Y.Z` cut from `main` (see [release.md](release.md)).
 
-The multi-machine tier is not part of this repository's public CI; it runs on an
-external runner described generically in [testing.md](testing.md).
+The OTA tier is not part of this repository's public CI. An operator-supplied
+external runner may provide it as a manual promotion gate, as described
+generically in [testing.md](testing.md). A commit, mirror update, or green public
+CI run does not by itself authorize an external runner or a `main` promotion.
 
 ## Pull Requests
 
@@ -64,11 +66,12 @@ config, catmux pane logs, Docker logs when available, and the smoke verification
 log under `session-instances/`; collect that directory as the first debugging
 artifact when an E2E job fails.
 
-## Nightly And Maintenance
+## Scheduled And Maintenance Checks
 
 `.github/workflows/nightly-e2e.yml` runs Docker E2E on a schedule and by manual
-dispatch. `.github/workflows/image-scan.yml` builds the default communication
-image and uploads an advisory Trivy report.
+dispatch on GitHub-hosted infrastructure. It is not the private OTA promotion
+gate. `.github/workflows/image-scan.yml` builds the default communication image
+and uploads an advisory Trivy report.
 
 Dependabot is configured for weekly grouped GitHub Actions and Python dependency
 updates.

--- a/docs/github-repository-settings.md
+++ b/docs/github-repository-settings.md
@@ -1,25 +1,32 @@
 # GitHub Repository Settings
 
-These settings live outside git and must be verified in GitHub. This document
-records the expected contract for repository `develNor/rosotacom`; the GitHub
-UI, CLI, and API remain the live source of truth.
+These settings live outside git and must be verified separately in every
+repository using this shared codebase. The GitHub UI, CLI, and API remain the
+live source of truth.
 
 ## Branch Protection
 
-Expected state:
+Expected shared state:
 
-- `main` is protected.
+- `main` is the protected release line.
+- The repository's active development/default branch is protected.
 - Pull requests are required.
 - The required status check is `ci-success`.
 - Squash merges are allowed.
 - CodeQL default setup is enabled for Actions and Python.
+- The `release` environment and `PYPI_PUBLISH_URL` variable point at this
+  repository's intended package index.
 
 Verify:
 
 ```bash
-gh ruleset list --repo develNor/rosotacom --parents
-gh ruleset check main --repo develNor/rosotacom
-gh api repos/develNor/rosotacom/code-scanning/default-setup
+REPO="$(gh repo view --json nameWithOwner --jq .nameWithOwner)"
+DEFAULT_BRANCH="$(gh repo view --repo "$REPO" --json defaultBranchRef --jq .defaultBranchRef.name)"
+gh ruleset list --repo "$REPO" --parents
+gh ruleset check "$DEFAULT_BRANCH" --repo "$REPO"
+gh ruleset check main --repo "$REPO"
+gh api "repos/$REPO/code-scanning/default-setup"
+gh variable get PYPI_PUBLISH_URL --repo "$REPO"
 ```
 
 ## Repository Metadata
@@ -30,7 +37,7 @@ Expected topics include `ros2`, `docker`, `robotics`, `teleoperation`, and
 Verify:
 
 ```bash
-gh repo view develNor/rosotacom --json description,homepageUrl,repositoryTopics
+gh repo view --json description,homepageUrl,repositoryTopics
 ```
 
 ## Drift Handling

--- a/docs/release-notes/v2.2.md
+++ b/docs/release-notes/v2.2.md
@@ -16,9 +16,9 @@
 
 ## Compatibility And Migration
 
-- No code or CLI changes. After merging, rename the GitHub branch
-  `volatile` → `develop` and set `main` as the default branch so the new badge
-  and merge-gate triggers resolve.
+- No code or CLI changes. Rename the integration branch
+  `volatile` → `develop` and update the repository's default-branch, badge, and
+  merge-gate settings to match its development/release policy.
 
 ## Validation
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -15,9 +15,8 @@ Stable releases use tags in this form:
 vX.Y.Z
 ```
 
-Tags are cut from `main`, which only carries multi-machine-proven commits
-promoted from `develop` (see [ci.md](ci.md) for the branch model). Push the tag
-from the chosen `main` commit.
+Tags are cut from a deliberately selected and validated `main` commit (see
+[ci.md](ci.md) for the branch model). Push the tag from that exact commit.
 
 ## Release Notes
 
@@ -33,6 +32,18 @@ dependency, compatibility, and migration changes.
 
 ## Publishing
 
-Tag pushes publish to PyPI through Trusted Publishing and create a GitHub
-Release with the release notes, wheel, source distribution, and `SHA256SUMS`.
-Manual workflow dispatch publishes only to TestPyPI.
+Tag pushes validate, publish through the repository's configured Trusted
+Publisher, and create a GitHub Release with the release notes, wheel, source
+distribution, and `SHA256SUMS`. Manual workflow dispatch validates and builds
+artifacts but does not publish; publishing requires a deliberate `vX.Y.Z` tag.
+
+The target index is set per repository by the `PYPI_PUBLISH_URL` Actions
+variable, and authorization is granted by the Trusted Publisher registered for
+that repository. Both controls live in repository settings rather than shared
+git content.
+
+Publishing a release does not authorize or trigger synchronization to another
+repository. A downstream sync should use one stable tag as its boundary and
+must separately verify the exact tag SHA, release notes, successful release
+workflow, successful deployment, and generated artifacts before a PR is
+created.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -20,7 +20,7 @@ This project separates two things that are easy to conflate:
 | host / unit | `tests/unit` | no | none | draft + ready PR |
 | contract | `tests/contract` | no | none | ready PR (merge gate) |
 | single-machine e2e (smoke) | `tests/e2e` | yes | loopback | merge gate + nightly |
-| multi-machine e2e | *external* | yes | two hosts over a real link | external runner |
+| OTA e2e | *external* | yes | two hosts over a real link | operator-started external gate |
 
 `just lint typecheck test-nondocker-cov docs package` plus `just test-e2e-smoke`
 is the full pre-merge suite; `just check` runs everything except the Docker
@@ -75,10 +75,13 @@ sessions marked `single_machine: ok`; the multi-machine set is derived from
 new or changed session must carry a valid marker. **To change a session's tier
 coverage, edit its `test_tiers` marker** — the matrices follow automatically.
 
-## Multi-machine tier (external)
+## OTA tier (external)
 
 Multi-machine tests need a real two-host link, which public CI cannot provide,
-so they run on an **external runner** that supplies the hosts. That runner is
+so a repository operator may run them on an **external runner** that supplies
+the hosts. This is a deliberate promotion gate, not a per-commit trigger: an
+operator explicitly selects the candidate, starts the suite, reviews the
+evidence, and separately confirms any branch promotion. The runner is
 parameterized purely by **host addresses / SSH targets** — it does not live in
 this repository, and this repository carries no host names, addresses, or
 network details.
@@ -93,7 +96,7 @@ A multi-machine run, generically:
    local-only probe topic published on A never appears on B (isolation),
 5. collects each host's `session-instances/` logs.
 
-The set of sessions a multi-machine runner exercises is the sessions marked
+The set of sessions an OTA runner exercises is the sessions marked
 `multi_machine: ok` or `multi_machine: required`. Keeping the markers in this
 repo lets any external runner derive its scenario list without hardcoding it.
 

--- a/src/rosotacom/cli.py
+++ b/src/rosotacom/cli.py
@@ -131,6 +131,7 @@ class SmokeTopicSpec:
     hz_min: float | None = None
     hz_max: float | None = None
     max_delay_s: float | None = None
+    expected_size: int | None = None
 
 
 def _load_yaml_file(path: Path | None) -> dict[str, Any]:
@@ -1730,6 +1731,7 @@ def _received_crossed_topics(cfg: dict[str, Any], receiver_peer_key: str) -> lis
                         hz_min=expect_hz_min,
                         hz_max=expect_hz_max,
                         max_delay_s=expect_max_delay_s,
+                        expected_size=66000 if entry.msg_type == "com_msgs/msg/SizedPayload" else None,
                     ),
                 ]
             )
@@ -1769,6 +1771,14 @@ def _verify_received_topics(
             detail_log(f"\n--- delay {label} ({topic}) in {container_name} ---\n{delay_output}")
         delay_s = _parse_topic_delay_seconds(delay_output)
         log_line(_smoke_metric_line(label=label, topic=topic, container_name=container_name, hz=hz, delay_s=delay_s))
+        if spec.expected_size is not None:
+            received_size = _received_sized_payload_size(container_name, ros_setup, topic)
+            if received_size != spec.expected_size:
+                errors.append(
+                    f"{label} ({topic}) payload size {received_size} != {spec.expected_size} in {container_name}"
+                )
+            else:
+                log_line(f"OK: {label} ({topic}) preserves SizedPayload size {received_size} in {container_name}")
         if spec.enforce_bounds:
             effective_hz_min = hz_min if spec.use_default_bounds else spec.hz_min
             effective_hz_max = hz_max if spec.use_default_bounds else spec.hz_max
@@ -1793,6 +1803,32 @@ def _smoke_publish_message(msg_type: str) -> str:
             "data: [0, 0, 0, 0, 0, 25, 50, 0, 0, 50, 100, 0, -1, -1, -1, -1]}"
         )
     raise RuntimeError(f"Smoke cannot synthesize a publisher for message type {msg_type!r}.")
+
+
+def _smoke_publisher_command(spec: SmokeTopicSpec, ros_setup: str, duration: float) -> str:
+    assert spec.publish_topic is not None and spec.publish_type is not None
+    if spec.publish_type == "com_msgs/msg/SizedPayload":
+        size = spec.expected_size or 66000
+        return (
+            f"{ros_setup} && timeout {duration} ros2 run com_py sized_publisher --ros-args "
+            f"-p topic:={shlex.quote(spec.publish_topic)} -p size:={size} -p rate:={spec.publish_rate}"
+        )
+    message = _smoke_publish_message(spec.publish_type)
+    return (
+        f"{ros_setup} && timeout {duration} ros2 topic pub -r {spec.publish_rate} "
+        f"{shlex.quote(spec.publish_topic)} {shlex.quote(spec.publish_type)} "
+        f"{shlex.quote(message)}"
+    )
+
+
+def _received_sized_payload_size(container_name: str, ros_setup: str, topic: str) -> int | None:
+    command = (
+        f"{ros_setup} && timeout -k 2 15 ros2 topic echo "
+        f"{shlex.quote(topic)} com_msgs/msg/SizedPayload --once --field size"
+    )
+    result = _run_container_shell(container_name, command, timeout_s=_TOPIC_PROBE_EXEC_TIMEOUT_S)
+    match = re.search(r"(?m)^\s*(\d+)\s*$", (result.stdout or "") + (result.stderr or ""))
+    return int(match.group(1)) if match else None
 
 
 def _smoke_publish_specs(cfg: dict[str, Any]) -> list[SmokeTopicSpec]:
@@ -1826,12 +1862,7 @@ def _start_smoke_topic_publishers(
         assert spec.publish_topic is not None and spec.publish_type is not None
         container = containers[spec.source_peer_key]
         ros_setup = ros_setups[spec.source_peer_key]
-        message = _smoke_publish_message(spec.publish_type)
-        cmd = (
-            f"{ros_setup} && timeout {duration} ros2 topic pub -r {spec.publish_rate} "
-            f"{shlex.quote(spec.publish_topic)} {shlex.quote(spec.publish_type)} "
-            f"{shlex.quote(message)}"
-        )
+        cmd = _smoke_publisher_command(spec, ros_setup, duration)
         subprocess.run(
             ["docker", "exec", "-d", container, "bash", "-lc", cmd],
             capture_output=True,
@@ -1863,8 +1894,12 @@ def _stop_smoke_topic_publishers(containers: dict[str, str], specs: list[SmokeTo
         container = containers.get(spec.source_peer_key)
         if not container:
             continue
+        if spec.publish_type == "com_msgs/msg/SizedPayload":
+            pattern = f"sized_publisher.*topic:={spec.publish_topic}"
+        else:
+            pattern = f"ros2 topic pub.*{spec.publish_topic}"
         subprocess.run(
-            ["docker", "exec", container, "pkill", "-f", f"ros2 topic pub {spec.publish_topic}"],
+            ["docker", "exec", container, "pkill", "-f", pattern],
             capture_output=True,
             text=True,
             check=False,

--- a/src/rosotacom/cli.py
+++ b/src/rosotacom/cli.py
@@ -27,7 +27,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from types import ModuleType
-from typing import Any
+from typing import Any, cast
 
 import yaml
 
@@ -115,6 +115,22 @@ class SessionInstance:
     logs_container_dir: str
     rosbags_host_dir: Path
     rosbags_container_dir: str
+
+
+@dataclass(frozen=True)
+class SmokeTopicSpec:
+    source_peer_key: str
+    receiver_peer_key: str
+    topic: str
+    label: str
+    enforce_bounds: bool
+    use_default_bounds: bool = False
+    publish_topic: str | None = None
+    publish_type: str | None = None
+    publish_rate: float = 5.0
+    hz_min: float | None = None
+    hz_max: float | None = None
+    max_delay_s: float | None = None
 
 
 def _load_yaml_file(path: Path | None) -> dict[str, Any]:
@@ -1445,6 +1461,118 @@ def _smoke_inbound_bridge_topic(cfg: dict[str, Any], source_peer_key: str) -> st
     return f"/com/in/{source_name}/{heartbeat_topic}"
 
 
+def _smoke_forward_topic_for_inbound(
+    cfg: dict[str, Any], source_peer_key: str, receiver_peer_key: str, topic: str
+) -> str:
+    peer_settings = cfg.get("peer_settings", {}) or {}
+    peer_settings = peer_settings if isinstance(peer_settings, dict) else {}
+    source_settings = peer_settings.get(source_peer_key, {}) or {}
+    source_settings = source_settings if isinstance(source_settings, dict) else {}
+    outbound = source_settings.get("outbound", {}) or {}
+    outbound = outbound if isinstance(outbound, dict) else {}
+    target_prefix = outbound.get("target_prefix", {}) or {}
+    target_prefix = target_prefix if isinstance(target_prefix, dict) else {}
+    if bool(target_prefix.get("use_target_prefix", False)):
+        peers = cfg.get("peers", {}) or {}
+        if not isinstance(peers, dict):
+            raise RuntimeError("Smoke verification requires a session config with peers.")
+        return f"/to_{_peer_com_name(peers, receiver_peer_key)}{topic}"
+    return topic
+
+
+def _smoke_inbound_forward_topic(cfg: dict[str, Any], source_peer_key: str, receiver_peer_key: str, topic: str) -> str:
+    peers = cfg.get("peers", {}) or {}
+    if not isinstance(peers, dict):
+        raise RuntimeError("Smoke verification requires a session config with peers.")
+    source_name = _peer_com_name(peers, source_peer_key)
+    forward_topic = _smoke_forward_topic_for_inbound(cfg, source_peer_key, receiver_peer_key, topic).lstrip("/")
+    return f"/com/in/{source_name}/{forward_topic}"
+
+
+def _smoke_receiver_final_topic(cfg: dict[str, Any], source_peer_key: str, receiver_peer_key: str, topic: str) -> str:
+    peer_settings = cfg.get("peer_settings", {}) or {}
+    peer_settings = peer_settings if isinstance(peer_settings, dict) else {}
+    receiver_settings = peer_settings.get(receiver_peer_key, {}) or {}
+    receiver_settings = receiver_settings if isinstance(receiver_settings, dict) else {}
+    inbound = receiver_settings.get("inbound", {}) or {}
+    inbound = inbound if isinstance(inbound, dict) else {}
+    if bool(inbound.get("keep_source_prefix", False)):
+        peers = cfg.get("peers", {}) or {}
+        if not isinstance(peers, dict):
+            raise RuntimeError("Smoke verification requires a session config with peers.")
+        return f"/{_peer_com_name(peers, source_peer_key)}{topic}"
+    return topic
+
+
+def _topic_direction_peers(direction: str, cfg: dict[str, Any]) -> tuple[str, str]:
+    parts = direction.split("_to_")
+    if len(parts) != 2:
+        raise RuntimeError(f"topics key '{direction}' must match '<src>_to_<dst>'.")
+    src, dst = parts
+    peers = cfg.get("peers") or {}
+    if src not in peers or dst not in peers:
+        raise RuntimeError(f"topics key '{direction}' refers to unknown peer(s) '{src}'/'{dst}'.")
+    return src, dst
+
+
+def _smoke_topic_pipeline(cfg: dict[str, Any], entry: Any) -> dict[str, Any]:
+    shared = cfg.get("shared", {}) or {}
+    shared = shared if isinstance(shared, dict) else {}
+    suffixes = shared.get("processing_suffixes", {}) or {}
+    suffixes = suffixes if isinstance(suffixes, dict) else {}
+    restamped_suffix = str(suffixes.get("restamped", "/restamped"))
+    latched_suffix = str(suffixes.get("latched", "/latched"))
+    globalframe_suffix = str(suffixes.get("framebridge_global", "/globalframe"))
+    ota_suffix = str(suffixes.get("ota_stamped", "/ota_stamped"))
+    compression = shared.get("compression", {}) or {}
+    compression = compression if isinstance(compression, dict) else {}
+    comp_alg_suffix = "/" + str(compression.get("algorithm", "bz2") or "bz2").strip()
+    return cast(
+        dict[str, Any],
+        session_gen._compute_pipeline(
+            entry,
+            {},
+            restamped_suffix,
+            latched_suffix,
+            globalframe_suffix,
+            comp_alg_suffix,
+            ota_suffix,
+        ),
+    )
+
+
+def _smoke_postprocessed_topic(entry: Any, pipe: dict[str, Any]) -> str:
+    if pipe.get("compress"):
+        return str(pipe["comp_in"])
+    if pipe.get("ota_wrap"):
+        return str(pipe["ota_in"])
+    return str(pipe["final"])
+
+
+def _smoke_expect_bounds(expect: Any) -> tuple[float | None, float | None, float | None]:
+    if not isinstance(expect, dict):
+        return None, None, None
+    hz = expect.get("hz") or {}
+    latency = expect.get("latency_ms") or {}
+    hz_min = float(hz["min"]) if isinstance(hz, dict) and hz.get("min") is not None else None
+    hz_max = float(hz["max"]) if isinstance(hz, dict) and hz.get("max") is not None else None
+    max_delay_s = (
+        float(latency["max"]) / 1000.0 if isinstance(latency, dict) and latency.get("max") is not None else None
+    )
+    return hz_min, hz_max, max_delay_s
+
+
+def _smoke_publish_rate(expect: Any) -> float:
+    hz_min, hz_max, _ = _smoke_expect_bounds(expect)
+    if hz_min is not None and hz_max is not None:
+        return (hz_min + hz_max) / 2.0
+    if hz_min is not None:
+        return max(1.0, hz_min * 1.5)
+    if hz_max is not None:
+        return max(0.5, hz_max / 2.0)
+    return 5.0
+
+
 def _smoke_rmw_spec(cfg: dict[str, Any]) -> Any:
     peers = cfg.get("peers", {}) or {}
     if not isinstance(peers, dict):
@@ -1530,15 +1658,83 @@ def _other_peer_key(cfg: dict[str, Any], identity: str) -> str:
     return str(next(k for k in peers if k != identity))
 
 
-def _received_crossed_topics(cfg: dict[str, Any], receiver_peer_key: str) -> list[tuple[str, str, bool]]:
-    """(topic, label, enforce_bounds) the receiver must get from the other peer:
-    the inbound-bridge topic (presence only) and the final remapped heartbeat
-    (presence + rate/latency bounds)."""
+def _received_crossed_topics(cfg: dict[str, Any], receiver_peer_key: str) -> list[SmokeTopicSpec]:
+    """Topics the receiver must get from crossed session traffic.
+
+    Heartbeat sessions self-publish from their plugin; plain topic examples need
+    smoke to synthesize a local app publisher on the source peer.
+    """
     source = _other_peer_key(cfg, receiver_peer_key)
-    return [
-        (_smoke_inbound_bridge_topic(cfg, source), f"{source}->{receiver_peer_key} inbound bridge heartbeat", False),
-        (_smoke_heartbeat_topic(cfg, source), f"{source}->{receiver_peer_key} final heartbeat", True),
-    ]
+    specs: list[SmokeTopicSpec] = []
+    shared = cfg.get("shared", {}) or {}
+    shared = shared if isinstance(shared, dict) else {}
+
+    if bool(shared.get("use_heartbeat", False)):
+        specs.extend(
+            [
+                SmokeTopicSpec(
+                    source_peer_key=source,
+                    receiver_peer_key=receiver_peer_key,
+                    topic=_smoke_inbound_bridge_topic(cfg, source),
+                    label=f"{source}->{receiver_peer_key} inbound bridge heartbeat",
+                    enforce_bounds=False,
+                ),
+                SmokeTopicSpec(
+                    source_peer_key=source,
+                    receiver_peer_key=receiver_peer_key,
+                    topic=_smoke_heartbeat_topic(cfg, source),
+                    label=f"{source}->{receiver_peer_key} final heartbeat",
+                    enforce_bounds=True,
+                    use_default_bounds=True,
+                ),
+            ]
+        )
+
+    topics = cfg.get("topics", {}) or {}
+    if not isinstance(topics, dict):
+        raise RuntimeError("Smoke verification requires 'topics' to be a mapping when provided.")
+
+    for direction in topics:
+        src, dst = _topic_direction_peers(str(direction), cfg)
+        if src != source or dst != receiver_peer_key:
+            continue
+        for entry in session_gen._topic_entries(cfg, str(direction)):
+            pipe = _smoke_topic_pipeline(cfg, entry)
+            final_topic = str(pipe["final"])
+            if bool(shared.get("use_heartbeat", False)) and final_topic == _smoke_heartbeat_topic(cfg, src):
+                continue
+            postprocessed_topic = _smoke_postprocessed_topic(entry, pipe)
+            received_topic = _smoke_receiver_final_topic(cfg, src, dst, postprocessed_topic)
+            inbound_topic = _smoke_inbound_forward_topic(cfg, src, dst, final_topic)
+            expect_hz_min, expect_hz_max, expect_max_delay_s = _smoke_expect_bounds(entry.expect)
+            specs.extend(
+                [
+                    SmokeTopicSpec(
+                        source_peer_key=src,
+                        receiver_peer_key=dst,
+                        topic=inbound_topic,
+                        label=f"{src}->{dst} inbound bridge topic",
+                        enforce_bounds=False,
+                    ),
+                    SmokeTopicSpec(
+                        source_peer_key=src,
+                        receiver_peer_key=dst,
+                        topic=received_topic,
+                        label=f"{src}->{dst} final topic",
+                        enforce_bounds=any(
+                            value is not None for value in (expect_hz_min, expect_hz_max, expect_max_delay_s)
+                        ),
+                        publish_topic=entry.base,
+                        publish_type=entry.msg_type,
+                        publish_rate=_smoke_publish_rate(entry.expect),
+                        hz_min=expect_hz_min,
+                        hz_max=expect_hz_max,
+                        max_delay_s=expect_max_delay_s,
+                    ),
+                ]
+            )
+
+    return specs
 
 
 def _verify_received_topics(
@@ -1557,7 +1753,9 @@ def _verify_received_topics(
     so within rate/latency bounds). Emits the OK/SMOKE_METRIC lines smoke has
     always produced; returns a list of failures (empty == all good)."""
     errors: list[str] = []
-    for topic, label, enforce_bounds in _received_crossed_topics(cfg, receiver_peer_key):
+    for spec in _received_crossed_topics(cfg, receiver_peer_key):
+        topic = spec.topic
+        label = spec.label
         output = _wait_for_topic_hz(container_name, ros_setup, topic)
         if detail_log:
             detail_log(f"\n--- {label} ({topic}) in {container_name} ---\n{output}")
@@ -1571,12 +1769,106 @@ def _verify_received_topics(
             detail_log(f"\n--- delay {label} ({topic}) in {container_name} ---\n{delay_output}")
         delay_s = _parse_topic_delay_seconds(delay_output)
         log_line(_smoke_metric_line(label=label, topic=topic, container_name=container_name, hz=hz, delay_s=delay_s))
-        if enforce_bounds:
-            if hz is None or not (hz_min <= hz <= hz_max):
-                errors.append(f"{label} ({topic}) rate {hz} Hz outside [{hz_min}, {hz_max}] in {container_name}")
-            if delay_s is None or delay_s >= max_delay_s:
-                errors.append(f"{label} ({topic}) latency {delay_s}s >= {max_delay_s}s in {container_name}")
+        if spec.enforce_bounds:
+            effective_hz_min = hz_min if spec.use_default_bounds else spec.hz_min
+            effective_hz_max = hz_max if spec.use_default_bounds else spec.hz_max
+            effective_max_delay_s = max_delay_s if spec.use_default_bounds else spec.max_delay_s
+            if effective_hz_min is not None and (hz is None or hz < effective_hz_min):
+                errors.append(f"{label} ({topic}) rate {hz} Hz below {effective_hz_min} in {container_name}")
+            if effective_hz_max is not None and (hz is None or hz > effective_hz_max):
+                errors.append(f"{label} ({topic}) rate {hz} Hz above {effective_hz_max} in {container_name}")
+            if effective_max_delay_s is not None and (delay_s is None or delay_s >= effective_max_delay_s):
+                errors.append(f"{label} ({topic}) latency {delay_s}s >= {effective_max_delay_s}s in {container_name}")
     return errors
+
+
+def _smoke_publish_message(msg_type: str) -> str:
+    normalized = msg_type.strip()
+    if normalized in {"std_msgs/msg/String", "std_msgs/String"}:
+        return "{data: 'rosotacom smoke'}"
+    if normalized == "nav_msgs/msg/OccupancyGrid":
+        return (
+            "{header: {frame_id: map}, "
+            "info: {resolution: 0.5, width: 4, height: 4, origin: {orientation: {w: 1.0}}}, "
+            "data: [0, 0, 0, 0, 0, 25, 50, 0, 0, 50, 100, 0, -1, -1, -1, -1]}"
+        )
+    raise RuntimeError(f"Smoke cannot synthesize a publisher for message type {msg_type!r}.")
+
+
+def _smoke_publish_specs(cfg: dict[str, Any]) -> list[SmokeTopicSpec]:
+    peers = cfg.get("peers") or {}
+    specs: list[SmokeTopicSpec] = []
+    seen: set[tuple[str, str, str]] = set()
+    for receiver in peers:
+        for spec in _received_crossed_topics(cfg, str(receiver)):
+            if not spec.publish_topic:
+                continue
+            if not spec.publish_type:
+                raise RuntimeError(f"Smoke topic {spec.publish_topic!r} requires a message type.")
+            key = (spec.source_peer_key, spec.publish_topic, spec.publish_type)
+            if key in seen:
+                continue
+            seen.add(key)
+            specs.append(spec)
+    return specs
+
+
+def _start_smoke_topic_publishers(
+    containers: dict[str, str],
+    ros_setups: dict[str, str],
+    cfg: dict[str, Any],
+    *,
+    log_line: Callable[[str], None] = print,
+    duration: float = 180.0,
+) -> list[SmokeTopicSpec]:
+    started: list[SmokeTopicSpec] = []
+    for spec in _smoke_publish_specs(cfg):
+        assert spec.publish_topic is not None and spec.publish_type is not None
+        container = containers[spec.source_peer_key]
+        ros_setup = ros_setups[spec.source_peer_key]
+        message = _smoke_publish_message(spec.publish_type)
+        cmd = (
+            f"{ros_setup} && timeout {duration} ros2 topic pub -r {spec.publish_rate} "
+            f"{shlex.quote(spec.publish_topic)} {shlex.quote(spec.publish_type)} "
+            f"{shlex.quote(message)}"
+        )
+        subprocess.run(
+            ["docker", "exec", "-d", container, "bash", "-lc", cmd],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        for _ in range(10):
+            if _topic_present(container, ros_setup, spec.publish_topic):
+                log_line(
+                    f"OK: smoke publisher {spec.source_peer_key}->{spec.receiver_peer_key} "
+                    f"{spec.publish_topic} ({spec.publish_type}) is advertising in {container} "
+                    f"at {spec.publish_rate:g} Hz"
+                )
+                started.append(spec)
+                break
+            time.sleep(1)
+        else:
+            raise RuntimeError(
+                f"Smoke publisher {spec.source_peer_key}->{spec.receiver_peer_key} "
+                f"{spec.publish_topic} ({spec.publish_type}) did not advertise in {container}."
+            )
+    return started
+
+
+def _stop_smoke_topic_publishers(containers: dict[str, str], specs: list[SmokeTopicSpec]) -> None:
+    for spec in specs:
+        if not spec.publish_topic:
+            continue
+        container = containers.get(spec.source_peer_key)
+        if not container:
+            continue
+        subprocess.run(
+            ["docker", "exec", container, "pkill", "-f", f"ros2 topic pub {spec.publish_topic}"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
 
 
 def _publish_isolation_probe(
@@ -1815,6 +2107,7 @@ def smoke(args: argparse.Namespace) -> int:
     log_line(f"Smoke artifacts: {smoke_instance.host_dir}")
     a_container = None
     b_container = None
+    smoke_publishers: list[SmokeTopicSpec] = []
     try:
         _ensure_smoke_network()
         a_container = start_session(
@@ -1837,6 +2130,9 @@ def smoke(args: argparse.Namespace) -> int:
 
         ros_setup_a = _smoke_ros_setup(smoke_instance.config_container_dir, cfg, "a")
         ros_setup_b = _smoke_ros_setup(smoke_instance.config_container_dir, cfg, "b")
+        containers = {"a": a_container, "b": b_container}
+        ros_setups = {"a": ros_setup_a, "b": ros_setup_b}
+        smoke_publishers = _start_smoke_topic_publishers(containers, ros_setups, cfg, log_line=log_line)
         errors: list[str] = []
         # Delivery: each peer must receive the other's crossed topics within bounds.
         errors += _verify_received_topics(b_container, ros_setup_b, cfg, "b", log_line=log_line, detail_log=detail)
@@ -1853,6 +2149,7 @@ def smoke(args: argparse.Namespace) -> int:
         _append_log(smoke_log, f"ERROR: {exc}")
         raise
     finally:
+        _stop_smoke_topic_publishers({"a": a_container or "", "b": b_container or ""}, smoke_publishers)
         for started_container, peer in [(a_container, "a"), (b_container, "b")]:
             if started_container:
                 _write_docker_log(started_container, smoke_instance, peer)

--- a/src/rosotacom/resources/examples/scripts/2_native_chatter/machine_a/external.ros2docker.json
+++ b/src/rosotacom/resources/examples/scripts/2_native_chatter/machine_a/external.ros2docker.json
@@ -8,6 +8,6 @@
   "run_args": [
     "--network", "host",
     "-v", "./wait_for_echo_topic.sh:/wait_for_echo_topic.sh",
-    "-e", "ROS_DOMAIN_ID=47"
+    "-e", "ROS_DOMAIN_ID=46"
   ]
 }

--- a/src/rosotacom/resources/examples/scripts/3_comp_occ_grid/machine_a/external.ros2docker.json
+++ b/src/rosotacom/resources/examples/scripts/3_comp_occ_grid/machine_a/external.ros2docker.json
@@ -7,6 +7,6 @@
   "run_args": [
     "--network", "host",
     "-v", "./external_session.yaml:/external_session.yaml",
-    "-e", "ROS_DOMAIN_ID=47"
+    "-e", "ROS_DOMAIN_ID=46"
   ]
 }

--- a/src/rosotacom/resources/examples/scripts/4_comp_occ_grid_zen/machine_a/external.ros2docker.json
+++ b/src/rosotacom/resources/examples/scripts/4_comp_occ_grid_zen/machine_a/external.ros2docker.json
@@ -7,6 +7,6 @@
   "run_args": [
     "--network", "host",
     "-v", "./external_session.yaml:/external_session.yaml",
-    "-e", "ROS_DOMAIN_ID=47"
+    "-e", "ROS_DOMAIN_ID=46"
   ]
 }

--- a/src/rosotacom/resources/examples/scripts/5_sized_payload/machine_a/external.ros2docker.json
+++ b/src/rosotacom/resources/examples/scripts/5_sized_payload/machine_a/external.ros2docker.json
@@ -10,7 +10,7 @@
     "-v", "./external_session.yaml:/external_session.yaml",
     "-v", "../../../ws:/ws",
     "-e", "RMW_IMPLEMENTATION=rmw_fastrtps_cpp",
-    "-e", "ROS_DOMAIN_ID=47",
+    "-e", "ROS_DOMAIN_ID=46",
     "-e", "BUILD_ROS2WS=1"
   ],
 

--- a/src/rosotacom/resources/examples/scripts/6_sized_payload_zen/machine_a/external.ros2docker.json
+++ b/src/rosotacom/resources/examples/scripts/6_sized_payload_zen/machine_a/external.ros2docker.json
@@ -8,7 +8,7 @@
     "--network", "host",
     "-v", "./external_session.yaml:/external_session.yaml",
     "-v", "../../../ws:/ws",
-    "-e", "ROS_DOMAIN_ID=47",
+    "-e", "ROS_DOMAIN_ID=46",
     "-e", "BUILD_ROS2WS=1"
   ],
 

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_status/session-definition.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_status/session-definition.yaml
@@ -22,6 +22,13 @@ peer_settings:
 
 shared:
   use_heartbeat: true
+  heartbeat:
+    # The heartbeat's intended behavior. The status overview classifies the live
+    # heartbeat against it (status.json `quality`/`reason`) and `rosotacom test`
+    # asserts it. See docs/rfcs/0001-expectation-driven-test-suite.md.
+    expect:
+      hz: { min: 8, max: 12 }
+      latency_ms: { max: 200 }
   # Maintain a continuously-updated per-topic pipeline status overview
   # (status.json / status.txt / events.jsonl under logs/<peer>/status/).
   # OTA stages are graph-only; this does not add OTA payload subscriptions.

--- a/src/rosotacom/resources/examples/sessions/2_native_chatter/session-definition.yaml
+++ b/src/rosotacom/resources/examples/sessions/2_native_chatter/session-definition.yaml
@@ -1,7 +1,6 @@
-# Test-tier capability markers (see docs/testing.md). Teaching example, not part
-# of the automated test tiers yet.
+# Test-tier capability markers (see docs/testing.md).
 test_tiers:
-  single_machine: na
+  single_machine: ok
   multi_machine: na
 
 peers:
@@ -10,9 +9,16 @@ peers:
   b:
     address: "data:machine_b_ip"
 
+peer_settings:
+  a:
+    domain_id: 46
+  b:
+    domain_id: 47
+
 shared:
-  # Active variant: fastdds shortcut (sets both local and ota).
+  # Active variant: fastdds shortcut (sets both local and OTA RMW implementations).
   rmw: fastdds
+  ota_domain_id: 48
 
   # --- Alternative rmw syntaxes (uncomment one, comment out the others) ---
   #

--- a/src/rosotacom/resources/examples/sessions/3_comp_occ_grid/session-definition.yaml
+++ b/src/rosotacom/resources/examples/sessions/3_comp_occ_grid/session-definition.yaml
@@ -1,7 +1,6 @@
-# Test-tier capability markers (see docs/testing.md). Teaching example, not part
-# of the automated test tiers yet.
+# Test-tier capability markers (see docs/testing.md).
 test_tiers:
-  single_machine: na
+  single_machine: ok
   multi_machine: na
 
 peers:
@@ -10,9 +9,16 @@ peers:
   b:
     address: "data:machine_b_ip"
 
+peer_settings:
+  a:
+    domain_id: 46
+  b:
+    domain_id: 47
+
 shared:
   use_topic_monitor: true
   use_heartbeat: true
+  ota_domain_id: 48
 
   qos:
     defaults:

--- a/src/rosotacom/resources/examples/sessions/4_comp_occ_grid_zen/session-definition.yaml
+++ b/src/rosotacom/resources/examples/sessions/4_comp_occ_grid_zen/session-definition.yaml
@@ -1,7 +1,6 @@
-# Test-tier capability markers (see docs/testing.md). Teaching example, not part
-# of the automated test tiers yet.
+# Test-tier capability markers (see docs/testing.md).
 test_tiers:
-  single_machine: na
+  single_machine: ok
   multi_machine: na
 
 peers:

--- a/src/rosotacom/resources/examples/sessions/4_comp_occ_grid_zen/session-definition.yaml
+++ b/src/rosotacom/resources/examples/sessions/4_comp_occ_grid_zen/session-definition.yaml
@@ -10,10 +10,15 @@ peers:
   b:
     address: "data:machine_b_ip"
 
+peer_settings:
+  a:
+    domain_id: 46
+  b:
+    domain_id: 47
+
 shared:
   use_topic_monitor: true
   use_heartbeat: true
-  local_domain_id: 47
   ota_domain_id: 48
 
   rmw:

--- a/src/rosotacom/resources/examples/sessions/5_sized_payload/session-definition.yaml
+++ b/src/rosotacom/resources/examples/sessions/5_sized_payload/session-definition.yaml
@@ -10,10 +10,15 @@ peers:
   b:
     address: "data:machine_b_ip"
 
+peer_settings:
+  a:
+    domain_id: 46
+  b:
+    domain_id: 47
+
 shared:
   use_topic_monitor: true
   use_heartbeat: false
-  local_domain_id: 47
   ota_domain_id: 48
   rmw: fastdds
 

--- a/src/rosotacom/resources/examples/sessions/5_sized_payload/session-definition.yaml
+++ b/src/rosotacom/resources/examples/sessions/5_sized_payload/session-definition.yaml
@@ -1,7 +1,6 @@
-# Test-tier capability markers (see docs/testing.md). Teaching example, not part
-# of the automated test tiers yet.
+# Test-tier capability markers (see docs/testing.md).
 test_tiers:
-  single_machine: na
+  single_machine: ok
   multi_machine: na
 
 peers:

--- a/src/rosotacom/resources/examples/sessions/6_sized_payload_zen/session-definition.yaml
+++ b/src/rosotacom/resources/examples/sessions/6_sized_payload_zen/session-definition.yaml
@@ -1,7 +1,6 @@
-# Test-tier capability markers (see docs/testing.md). Teaching example, not part
-# of the automated test tiers yet.
+# Test-tier capability markers (see docs/testing.md).
 test_tiers:
-  single_machine: na
+  single_machine: ok
   multi_machine: na
 
 peers:

--- a/src/rosotacom/resources/examples/sessions/6_sized_payload_zen/session-definition.yaml
+++ b/src/rosotacom/resources/examples/sessions/6_sized_payload_zen/session-definition.yaml
@@ -10,10 +10,15 @@ peers:
   b:
     address: "data:machine_b_ip"
 
+peer_settings:
+  a:
+    domain_id: 46
+  b:
+    domain_id: 47
+
 shared:
   use_topic_monitor: true
   use_heartbeat: true
-  local_domain_id: 47
   ota_domain_id: 48
 
   rmw:

--- a/src/rosotacom/resources/ws/session/creation/generate_session_files.py
+++ b/src/rosotacom/resources/ws/session/creation/generate_session_files.py
@@ -936,6 +936,7 @@ def _validate_session_template_cfg(cfg: Dict[str, Any]) -> None:
                 "use_topic_monitor",
                 "use_status_overview",
                 "use_heartbeat",
+                "heartbeat",
                 "use_in",
                 "use_out",
                 "rmw",
@@ -979,6 +980,11 @@ def _validate_session_template_cfg(cfg: Dict[str, Any]) -> None:
         if "qos" in shared and shared["qos"] is not None:
             qos = _assert_mapping(shared.get("qos"), "shared.qos")
             _assert_allowed_keys("shared.qos", qos, {"defaults", "for_role"})
+        if "heartbeat" in shared and shared["heartbeat"] is not None:
+            hb = _assert_mapping(shared.get("heartbeat"), "shared.heartbeat")
+            _assert_allowed_keys("shared.heartbeat", hb, {"expect"})
+            if "expect" in hb and hb["expect"] is not None and not isinstance(hb["expect"], dict):
+                raise RuntimeError("shared.heartbeat.expect must be a mapping.")
 
     # peer_settings is optional
     if "peer_settings" in cfg and cfg["peer_settings"] is not None:
@@ -1228,6 +1234,7 @@ def _build_status_pipeline_spec(
     uses_domain_bridge: bool,
     hb_topic: Dict[str, str],
     use_heartbeat: bool,
+    heartbeat_expect: Optional[Dict[str, Any]],
     out_enabled: bool,
     in_enabled: bool,
     final_topic_type,
@@ -1281,7 +1288,8 @@ def _build_status_pipeline_spec(
             outbound_items.append((e, p))
         if use_heartbeat and hb_local:
             hb_entry = TopicEntry(
-                base=hb_local, msg_type=HEARTBEAT_MSG_TYPE, processing={}, qos=None, zen_qos=None, index=-1
+                base=hb_local, msg_type=HEARTBEAT_MSG_TYPE, processing={}, qos=None, zen_qos=None, index=-1,
+                expect=heartbeat_expect,
             )
             hb_pipe = {"final": hb_local}
             outbound_items.insert(0, (hb_entry, hb_pipe))
@@ -1341,7 +1349,8 @@ def _build_status_pipeline_spec(
             inbound_items.append((e, p))
         if use_heartbeat and hb_remote:
             hb_entry = TopicEntry(
-                base=hb_remote, msg_type=HEARTBEAT_MSG_TYPE, processing={}, qos=None, zen_qos=None, index=-1
+                base=hb_remote, msg_type=HEARTBEAT_MSG_TYPE, processing={}, qos=None, zen_qos=None, index=-1,
+                expect=heartbeat_expect,
             )
             hb_pipe = {"final": hb_remote}
             inbound_items.insert(0, (hb_entry, hb_pipe))
@@ -2589,6 +2598,7 @@ def func(
                 uses_domain_bridge=_use_domain_bridge(local),
                 hb_topic=hb_topic,
                 use_heartbeat=use_heartbeat,
+                heartbeat_expect=(shared.get("heartbeat") or {}).get("expect"),
                 out_enabled=out_enabled,
                 in_enabled=in_enabled,
                 final_topic_type=_final_topic_type,

--- a/tests/contract/test_security_maintenance_config.py
+++ b/tests/contract/test_security_maintenance_config.py
@@ -6,6 +6,7 @@ PACKAGE_ROOT = Path(__file__).resolve().parents[2]
 DEPENDABOT_PATH = PACKAGE_ROOT / ".github" / "dependabot.yml"
 IMAGE_SCAN_PATH = PACKAGE_ROOT / ".github" / "workflows" / "image-scan.yml"
 MERGE_GATE_PATH = PACKAGE_ROOT / ".github" / "workflows" / "pr-merge-gate.yml"
+RELEASE_PATH = PACKAGE_ROOT / ".github" / "workflows" / "release.yml"
 
 
 def test_dependabot_groups_weekly_actions_and_python_updates() -> None:
@@ -43,6 +44,20 @@ def test_merge_gate_requires_non_docker_package_and_docker_smoke() -> None:
     assert "just test-e2e-smoke" in merge_gate
 
 
+def test_release_publishes_only_for_a_version_tag_via_repository_configuration() -> None:
+    release = RELEASE_PATH.read_text(encoding="utf-8")
+
+    assert "workflow_dispatch:" in release
+    assert "github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')" in release
+    assert "repository-url: ${{ vars.PYPI_PUBLISH_URL }}" in release
+    assert "PYPI_PUBLISH_URL is not configured" in release
+    assert "PYPI_PUBLISH_URL must be an HTTPS endpoint" in release
+    assert "name: release" in release
+    assert "publish-testpypi" not in release
+    assert "https://upload.pypi.org" not in release
+    assert "https://test.pypi.org" not in release
+
+
 def test_session_test_tier_markers_drive_both_test_matrices() -> None:
     """Every session declares test_tiers; the single-machine smoke matrix and the
     multi-machine set are derived from those markers (the single source of truth),
@@ -63,6 +78,9 @@ def test_session_test_tier_markers_drive_both_test_matrices() -> None:
         "1_heartbeat_cyclone-local_zenoh-ros2dds-ota",
         "2_native_chatter",
         "3_comp_occ_grid",
+        "4_comp_occ_grid_zen",
+        "5_sized_payload",
+        "6_sized_payload_zen",
     }
 
     # cyclone-ota-tuned hides local topics on a shared domain (no per-peer domain

--- a/tests/contract/test_security_maintenance_config.py
+++ b/tests/contract/test_security_maintenance_config.py
@@ -52,7 +52,7 @@ def test_release_publishes_only_for_a_version_tag_via_repository_configuration()
     assert "repository-url: ${{ vars.PYPI_PUBLISH_URL }}" in release
     assert "PYPI_PUBLISH_URL is not configured" in release
     assert "PYPI_PUBLISH_URL must be an HTTPS endpoint" in release
-    assert "name: release" in release
+    assert "name: Release" in release
     assert "publish-testpypi" not in release
     assert "https://upload.pypi.org" not in release
     assert "https://test.pypi.org" not in release

--- a/tests/contract/test_security_maintenance_config.py
+++ b/tests/contract/test_security_maintenance_config.py
@@ -52,8 +52,8 @@ def test_session_test_tier_markers_drive_both_test_matrices() -> None:
     markers = session_test_markers()  # raises if any session lacks valid markers
     assert markers, "no example sessions found"
 
-    # Anti-drift guard: the heartbeat-RMW matrix is exactly the single-machine
-    # smoke set. Adding/removing an RMW example must update its marker accordingly.
+    # Anti-drift guard: these examples are exactly the single-machine smoke set.
+    # Adding/removing an example must update its marker accordingly.
     assert set(sessions_in_tier("single_machine", {"ok"})) == {
         "1_heartbeat_cyclone-ota",
         "1_heartbeat_fastdds",
@@ -61,6 +61,8 @@ def test_session_test_tier_markers_drive_both_test_matrices() -> None:
         "1_heartbeat_fastdds-local_cyclone-ota",
         "1_heartbeat_cyclone-local_fastdds-ota",
         "1_heartbeat_cyclone-local_zenoh-ros2dds-ota",
+        "2_native_chatter",
+        "3_comp_occ_grid",
     }
 
     # cyclone-ota-tuned hides local topics on a shared domain (no per-peer domain

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -27,8 +27,15 @@ def _smoke_id(session_name: str) -> str:
     return session_name.removeprefix("1_heartbeat_").replace("_", "-")
 
 
+SMOKE_SESSIONS = sessions_in_tier("single_machine", {"ok"})
 HEARTBEAT_SMOKE_SESSIONS = [
-    pytest.param(name, id=_smoke_id(name)) for name in sessions_in_tier("single_machine", {"ok"})
+    pytest.param(name, id=_smoke_id(name)) for name in SMOKE_SESSIONS if name.startswith("1_heartbeat_")
+]
+NATIVE_CHATTER_SMOKE_SESSIONS = [
+    pytest.param(name, id="native-chatter") for name in SMOKE_SESSIONS if name == "2_native_chatter"
+]
+COMP_OCC_GRID_SMOKE_SESSIONS = [
+    pytest.param(name, id="compressed-occupancy-grid") for name in SMOKE_SESSIONS if name == "3_comp_occ_grid"
 ]
 
 EXPECTED_HEARTBEAT_CHECKS = (
@@ -40,6 +47,19 @@ EXPECTED_HEARTBEAT_CHECKS = (
     # Isolation is now asserted in smoke too (local-only topic must not cross);
     # container names vary, so match the stable prefix.
     "OK: isolation holds (/local_only",
+)
+EXPECTED_NATIVE_CHATTER_CHECKS = (
+    "OK: generated plugin.yaml files use literal CLI addresses",
+    "OK: smoke publisher b->a /chatter (std_msgs/msg/String) is advertising",
+    "OK: b->a inbound bridge topic (/com/in/b/chatter)",
+    "OK: b->a final topic (/chatter)",
+    "OK: isolation holds (/local_only",
+)
+EXPECTED_COMP_OCC_GRID_CHECKS = (
+    *EXPECTED_HEARTBEAT_CHECKS,
+    "OK: smoke publisher b->a /costmap/costmap (nav_msgs/msg/OccupancyGrid) is advertising",
+    "OK: b->a inbound bridge topic (/com/in/b/costmap/costmap/restamped/bz2)",
+    "OK: b->a final topic (/costmap/costmap/restamped)",
 )
 
 # Heartbeat publishers emit at 10 Hz; received rate should stay close to that.
@@ -189,6 +209,35 @@ def _assert_heartbeat_rate_and_latency_within_bounds(session_name: str, stdout: 
     )
 
 
+def _assert_metric_present(session_name: str, stdout: str, *, topic: str, label: str) -> None:
+    matches = [m for m in _parse_metrics(stdout) if m["topic"] == topic and m["label"] == label]
+    assert matches, f"no metric for {label} ({topic}) in smoke output for {session_name}:\n{stdout}"
+    assert any(isinstance(m["hz"], float) for m in matches), (
+        f"no publishing rate for {label} ({topic}) in smoke output for {session_name}:\n{stdout}"
+    )
+
+
+def _assert_metric_within_bounds(
+    session_name: str,
+    stdout: str,
+    *,
+    topic: str,
+    label: str,
+    hz_min: float,
+    hz_max: float,
+    max_delay_s: float,
+) -> None:
+    matches = [m for m in _parse_metrics(stdout) if m["topic"] == topic and m["label"] == label]
+    assert matches, f"no metric for {label} ({topic}) in smoke output for {session_name}:\n{stdout}"
+    metric = matches[-1]
+    assert isinstance(metric["hz"], float) and hz_min <= metric["hz"] <= hz_max, (
+        f"{label} ({topic}) rate {metric['hz']} outside [{hz_min}, {hz_max}] for {session_name}"
+    )
+    assert isinstance(metric["delay_s"], float) and metric["delay_s"] < max_delay_s, (
+        f"{label} ({topic}) delay {metric['delay_s']} >= {max_delay_s}s for {session_name}"
+    )
+
+
 @pytest.mark.parametrize("session_name", HEARTBEAT_SMOKE_SESSIONS)
 def test_local_heartbeat_smoke_matrix_from_copied_example_project(
     copied_example_project: Path,
@@ -206,3 +255,56 @@ def test_local_heartbeat_smoke_matrix_from_copied_example_project(
 
     _assert_no_ros_or_catmux_errors(session_name, artifact_dir)
     _assert_heartbeat_rate_and_latency_within_bounds(session_name, result.stdout)
+
+
+@pytest.mark.parametrize("session_name", NATIVE_CHATTER_SMOKE_SESSIONS)
+def test_local_native_chatter_smoke_from_copied_example_project(
+    copied_example_project: Path,
+    session_name: str,
+) -> None:
+    result = _run(_smoke_command(copied_example_project, session_name), timeout=900)
+
+    for expected in EXPECTED_NATIVE_CHATTER_CHECKS:
+        assert expected in result.stdout
+
+    artifact_dir = _artifact_dir(result.stdout)
+    assert (artifact_dir / "config" / "a" / "plugin.yaml").is_file()
+    assert (artifact_dir / "config" / "b" / "plugin.yaml").is_file()
+    assert (artifact_dir / "config" / "b_to_a_topics.txt").read_text(encoding="utf-8").strip() == "/chatter"
+    assert list((artifact_dir / "logs").glob("*/catmux/*/*.log"))
+
+    _assert_no_ros_or_catmux_errors(session_name, artifact_dir)
+    _assert_metric_present(session_name, result.stdout, topic="/chatter", label="b->a final topic")
+
+
+@pytest.mark.parametrize("session_name", COMP_OCC_GRID_SMOKE_SESSIONS)
+def test_local_compressed_occupancy_grid_smoke_from_copied_example_project(
+    copied_example_project: Path,
+    session_name: str,
+) -> None:
+    result = _run(_smoke_command(copied_example_project, session_name), timeout=900)
+
+    for expected in EXPECTED_COMP_OCC_GRID_CHECKS:
+        assert expected in result.stdout
+
+    artifact_dir = _artifact_dir(result.stdout)
+    config_dir = artifact_dir / "config"
+    assert (config_dir / "b_to_a_topics.txt").read_text(encoding="utf-8").splitlines() == [
+        "/heartbeat_b",
+        "/costmap/costmap/restamped/bz2",
+    ]
+    assert "costmap/costmap/restamped" in (config_dir / "b" / "compression.yaml").read_text(encoding="utf-8")
+    assert "costmap/costmap/restamped/bz2" in (config_dir / "a" / "decompression.yaml").read_text(encoding="utf-8")
+    assert list((artifact_dir / "logs").glob("*/catmux/*/*.log"))
+
+    _assert_no_ros_or_catmux_errors(session_name, artifact_dir)
+    _assert_heartbeat_rate_and_latency_within_bounds(session_name, result.stdout)
+    _assert_metric_within_bounds(
+        session_name,
+        result.stdout,
+        topic="/costmap/costmap/restamped",
+        label="b->a final topic",
+        hz_min=1.0,
+        hz_max=5.0,
+        max_delay_s=0.5,
+    )

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -37,6 +37,15 @@ NATIVE_CHATTER_SMOKE_SESSIONS = [
 COMP_OCC_GRID_SMOKE_SESSIONS = [
     pytest.param(name, id="compressed-occupancy-grid") for name in SMOKE_SESSIONS if name == "3_comp_occ_grid"
 ]
+ZEN_COMP_OCC_GRID_SMOKE_SESSIONS = [
+    pytest.param(name, id="compressed-occupancy-grid-zenoh") for name in SMOKE_SESSIONS if name == "4_comp_occ_grid_zen"
+]
+SIZED_PAYLOAD_SMOKE_SESSIONS = [
+    pytest.param(name, id="sized-payload-fastdds") for name in SMOKE_SESSIONS if name == "5_sized_payload"
+]
+ZEN_SIZED_PAYLOAD_SMOKE_SESSIONS = [
+    pytest.param(name, id="sized-payload-zenoh") for name in SMOKE_SESSIONS if name == "6_sized_payload_zen"
+]
 
 EXPECTED_HEARTBEAT_CHECKS = (
     "OK: generated plugin.yaml files use literal CLI addresses",
@@ -60,6 +69,29 @@ EXPECTED_COMP_OCC_GRID_CHECKS = (
     "OK: smoke publisher b->a /costmap/costmap (nav_msgs/msg/OccupancyGrid) is advertising",
     "OK: b->a inbound bridge topic (/com/in/b/costmap/costmap/restamped/bz2)",
     "OK: b->a final topic (/costmap/costmap/restamped)",
+)
+EXPECTED_WRAPPED_SIZED_PAYLOAD_CHECKS = (
+    "OK: generated plugin.yaml files use literal CLI addresses",
+    "OK: smoke publisher a->b /size_test_a (com_msgs/msg/SizedPayload) is advertising",
+    "OK: smoke publisher b->a /size_test_b (com_msgs/msg/SizedPayload) is advertising",
+    "OK: a->b inbound bridge topic (/com/in/a/size_test_a/ota_stamped)",
+    "OK: a->b final topic (/size_test_a)",
+    "OK: a->b final topic (/size_test_a) preserves SizedPayload size 66000",
+    "OK: b->a inbound bridge topic (/com/in/b/size_test_b/ota_stamped)",
+    "OK: b->a final topic (/size_test_b)",
+    "OK: b->a final topic (/size_test_b) preserves SizedPayload size 66000",
+    "OK: isolation holds (/local_only",
+)
+EXPECTED_ZEN_SIZED_PAYLOAD_CHECKS = (
+    *EXPECTED_HEARTBEAT_CHECKS,
+    "OK: smoke publisher a->b /size_test_a (com_msgs/msg/SizedPayload) is advertising",
+    "OK: smoke publisher b->a /size_test_b (com_msgs/msg/SizedPayload) is advertising",
+    "OK: a->b inbound bridge topic (/com/in/a/size_test_a)",
+    "OK: a->b final topic (/size_test_a)",
+    "OK: a->b final topic (/size_test_a) preserves SizedPayload size 66000",
+    "OK: b->a inbound bridge topic (/com/in/b/size_test_b)",
+    "OK: b->a final topic (/size_test_b)",
+    "OK: b->a final topic (/size_test_b) preserves SizedPayload size 66000",
 )
 
 # Heartbeat publishers emit at 10 Hz; received rate should stay close to that.
@@ -308,3 +340,88 @@ def test_local_compressed_occupancy_grid_smoke_from_copied_example_project(
         hz_max=5.0,
         max_delay_s=0.5,
     )
+
+
+@pytest.mark.parametrize("session_name", ZEN_COMP_OCC_GRID_SMOKE_SESSIONS)
+def test_local_zenoh_compressed_occupancy_grid_smoke_from_copied_example_project(
+    copied_example_project: Path,
+    session_name: str,
+) -> None:
+    result = _run(_smoke_command(copied_example_project, session_name), timeout=900)
+
+    for expected in EXPECTED_COMP_OCC_GRID_CHECKS:
+        assert expected in result.stdout
+
+    artifact_dir = _artifact_dir(result.stdout)
+    config_dir = artifact_dir / "config"
+    assert (config_dir / "b_to_a_topics.txt").read_text(encoding="utf-8").splitlines() == [
+        "/heartbeat_b",
+        "/costmap/costmap/restamped/bz2",
+    ]
+    assert "use_zenoh_ros2dds: true" in (config_dir / "a" / "plugin.yaml").read_text(encoding="utf-8")
+    assert 'priority: "data"' in (config_dir / "b" / "plugin.yaml").read_text(encoding="utf-8")
+    assert list((artifact_dir / "logs").glob("*/catmux/*/*.log"))
+
+    _assert_no_ros_or_catmux_errors(session_name, artifact_dir)
+    _assert_heartbeat_rate_and_latency_within_bounds(session_name, result.stdout)
+    _assert_metric_present(
+        session_name,
+        result.stdout,
+        topic="/costmap/costmap/restamped",
+        label="b->a final topic",
+    )
+
+
+@pytest.mark.parametrize("session_name", SIZED_PAYLOAD_SMOKE_SESSIONS)
+def test_local_wrapped_sized_payload_smoke_from_copied_example_project(
+    copied_example_project: Path,
+    session_name: str,
+) -> None:
+    result = _run(_smoke_command(copied_example_project, session_name), timeout=900)
+
+    for expected in EXPECTED_WRAPPED_SIZED_PAYLOAD_CHECKS:
+        assert expected in result.stdout
+
+    artifact_dir = _artifact_dir(result.stdout)
+    config_dir = artifact_dir / "config"
+    assert (config_dir / "a_to_b_topics.txt").read_text(encoding="utf-8").strip() == "/size_test_a/ota_stamped"
+    assert (config_dir / "b_to_a_topics.txt").read_text(encoding="utf-8").strip() == "/size_test_b/ota_stamped"
+    assert "size_test_a" in (config_dir / "a" / "ota_wrapper.yaml").read_text(encoding="utf-8")
+    assert "size_test_b/ota_stamped" in (config_dir / "a" / "ota_unwrapper.yaml").read_text(encoding="utf-8")
+    assert "size_test_b" in (config_dir / "b" / "ota_wrapper.yaml").read_text(encoding="utf-8")
+    assert "size_test_a/ota_stamped" in (config_dir / "b" / "ota_unwrapper.yaml").read_text(encoding="utf-8")
+    assert list((artifact_dir / "logs").glob("*/catmux/*/*.log"))
+
+    _assert_no_ros_or_catmux_errors(session_name, artifact_dir)
+    _assert_metric_present(session_name, result.stdout, topic="/size_test_a", label="a->b final topic")
+    _assert_metric_present(session_name, result.stdout, topic="/size_test_b", label="b->a final topic")
+
+
+@pytest.mark.parametrize("session_name", ZEN_SIZED_PAYLOAD_SMOKE_SESSIONS)
+def test_local_zenoh_sized_payload_smoke_from_copied_example_project(
+    copied_example_project: Path,
+    session_name: str,
+) -> None:
+    result = _run(_smoke_command(copied_example_project, session_name), timeout=900)
+
+    for expected in EXPECTED_ZEN_SIZED_PAYLOAD_CHECKS:
+        assert expected in result.stdout
+
+    artifact_dir = _artifact_dir(result.stdout)
+    config_dir = artifact_dir / "config"
+    assert (config_dir / "a_to_b_topics.txt").read_text(encoding="utf-8").splitlines() == [
+        "/heartbeat_a",
+        "/size_test_a",
+    ]
+    assert (config_dir / "b_to_a_topics.txt").read_text(encoding="utf-8").splitlines() == [
+        "/heartbeat_b",
+        "/size_test_b",
+    ]
+    assert "use_zenoh_ros2dds: true" in (config_dir / "a" / "plugin.yaml").read_text(encoding="utf-8")
+    assert 'priority: "data"' in (config_dir / "a" / "plugin.yaml").read_text(encoding="utf-8")
+    assert list((artifact_dir / "logs").glob("*/catmux/*/*.log"))
+
+    _assert_no_ros_or_catmux_errors(session_name, artifact_dir)
+    _assert_heartbeat_rate_and_latency_within_bounds(session_name, result.stdout)
+    _assert_metric_present(session_name, result.stdout, topic="/size_test_a", label="a->b final topic")
+    _assert_metric_present(session_name, result.stdout, topic="/size_test_b", label="b->a final topic")

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -686,6 +686,61 @@ def test_smoke_crossed_topics_include_compressed_occupancy_grid_pipeline() -> No
     assert "width: 4" in rosotacom._smoke_publish_message(final.publish_type)
 
 
+def test_smoke_crossed_topics_include_zenoh_compressed_occupancy_grid_pipeline() -> None:
+    cfg = yaml.safe_load(
+        (rosotacom.EXAMPLE_PROJECT_DIR / "sessions" / "4_comp_occ_grid_zen" / "session-definition.yaml").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    specs = [s for s in rosotacom._received_crossed_topics(cfg, "a") if "costmap" in s.topic]
+
+    assert [(s.topic, s.label) for s in specs] == [
+        ("/com/in/b/costmap/costmap/restamped/bz2", "b->a inbound bridge topic"),
+        ("/costmap/costmap/restamped", "b->a final topic"),
+    ]
+    assert specs[-1].publish_type == "nav_msgs/msg/OccupancyGrid"
+
+
+@pytest.mark.parametrize(
+    ("session_name", "receiver", "expected_topics"),
+    [
+        (
+            "5_sized_payload",
+            "b",
+            ["/com/in/a/size_test_a/ota_stamped", "/size_test_a"],
+        ),
+        (
+            "6_sized_payload_zen",
+            "b",
+            ["/com/in/a/size_test_a", "/size_test_a"],
+        ),
+    ],
+)
+def test_smoke_crossed_topics_include_sized_payload_pipelines(
+    session_name: str,
+    receiver: str,
+    expected_topics: list[str],
+) -> None:
+    cfg = yaml.safe_load(
+        (rosotacom.EXAMPLE_PROJECT_DIR / "sessions" / session_name / "session-definition.yaml").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    specs = [s for s in rosotacom._received_crossed_topics(cfg, receiver) if "size_test" in s.topic]
+
+    assert [s.topic for s in specs] == expected_topics
+    final = specs[-1]
+    assert final.publish_topic == "/size_test_a"
+    assert final.publish_type == "com_msgs/msg/SizedPayload"
+    assert final.expected_size == 66000
+    command = rosotacom._smoke_publisher_command(final, "source ros", 180.0)
+    assert "ros2 run com_py sized_publisher" in command
+    assert "-p topic:=/size_test_a" in command
+    assert "-p size:=66000" in command
+
+
 def test_run_session_generates_into_instance_config_without_touching_static_source(tmp_path: Path) -> None:
     from session.creation import run_session
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -632,6 +632,60 @@ def test_isolated_network_run_args_swaps_host_networking() -> None:
     assert rosotacom._isolated_network_run_args(["--network=host"], "net", None) == ["--network", "net"]
 
 
+def test_smoke_crossed_topics_include_native_chatter_direction() -> None:
+    cfg = yaml.safe_load(
+        (rosotacom.EXAMPLE_PROJECT_DIR / "sessions" / "2_native_chatter" / "session-definition.yaml").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    specs_a = rosotacom._received_crossed_topics(cfg, "a")
+    specs_b = rosotacom._received_crossed_topics(cfg, "b")
+
+    assert [(s.topic, s.label, s.publish_topic, s.publish_type) for s in specs_a] == [
+        ("/com/in/b/chatter", "b->a inbound bridge topic", None, None),
+        ("/chatter", "b->a final topic", "/chatter", "std_msgs/msg/String"),
+    ]
+    assert specs_b == []
+    assert [(s.source_peer_key, s.receiver_peer_key, s.publish_topic) for s in rosotacom._smoke_publish_specs(cfg)] == [
+        ("b", "a", "/chatter")
+    ]
+    assert "export ROS_DOMAIN_ID=46" in rosotacom._smoke_ros_setup("/config", cfg, "a")
+    assert "export ROS_DOMAIN_ID=47" in rosotacom._smoke_ros_setup("/config", cfg, "b")
+
+
+def test_smoke_crossed_topics_keep_heartbeat_labels() -> None:
+    cfg = {"peers": {"a": {}, "b": {}}, "shared": {"use_heartbeat": True}}
+
+    assert [(s.topic, s.label, s.enforce_bounds) for s in rosotacom._received_crossed_topics(cfg, "b")] == [
+        ("/com/in/a/heartbeat_a", "a->b inbound bridge heartbeat", False),
+        ("/heartbeat_a", "a->b final heartbeat", True),
+    ]
+
+
+def test_smoke_crossed_topics_include_compressed_occupancy_grid_pipeline() -> None:
+    cfg = yaml.safe_load(
+        (rosotacom.EXAMPLE_PROJECT_DIR / "sessions" / "3_comp_occ_grid" / "session-definition.yaml").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    specs = rosotacom._received_crossed_topics(cfg, "a")
+    costmap_specs = [s for s in specs if "costmap" in s.topic]
+
+    assert [(s.topic, s.label) for s in costmap_specs] == [
+        ("/com/in/b/costmap/costmap/restamped/bz2", "b->a inbound bridge topic"),
+        ("/costmap/costmap/restamped", "b->a final topic"),
+    ]
+    final = costmap_specs[-1]
+    assert final.publish_topic == "/costmap/costmap"
+    assert final.publish_type == "nav_msgs/msg/OccupancyGrid"
+    assert final.publish_rate == 3.0
+    assert (final.hz_min, final.hz_max, final.max_delay_s) == (1.0, 5.0, 0.5)
+    assert final.enforce_bounds
+    assert "width: 4" in rosotacom._smoke_publish_message(final.publish_type)
+
+
 def test_run_session_generates_into_instance_config_without_touching_static_source(tmp_path: Path) -> None:
     from session.creation import run_session
 

--- a/tests/unit/test_status_overview.py
+++ b/tests/unit/test_status_overview.py
@@ -499,3 +499,17 @@ def test_pipeline_spec_carries_per_topic_expect(tmp_path: Path) -> None:
     spec = yaml.safe_load((tmp_path / "a" / "pipeline_spec.yaml").read_text(encoding="utf-8"))
     by_dir = {(t["base"], t["direction"]): t for t in spec["topics"]}
     assert by_dir[("/costmap", "inbound")]["expect"] == {"hz": {"min": 1, "max": 5}, "latency_ms": {"max": 500}}
+
+
+def test_pipeline_spec_carries_heartbeat_expect(tmp_path: Path) -> None:
+    import yaml
+
+    cfg = _heartbeat_cfg()
+    contract = {"hz": {"min": 8, "max": 12}, "latency_ms": {"max": 200}}
+    cfg["shared"]["heartbeat"] = {"expect": contract}
+    generator.func(session_config_obj=cfg, output_dir=str(tmp_path), force=True)
+    spec = yaml.safe_load((tmp_path / "a" / "pipeline_spec.yaml").read_text(encoding="utf-8"))
+    by_dir = {(t["base"], t["direction"]): t for t in spec["topics"]}
+    # The contract applies to both the locally-published and the received heartbeat.
+    assert by_dir[("/heartbeat_a", "outbound")]["expect"] == contract
+    assert by_dir[("/heartbeat_b", "inbound")]["expect"] == contract


### PR DESCRIPTION
## Summary

- expand local smoke verification beyond heartbeat sessions to native chatter, compressed occupancy grids, and sized payloads over DDS and Zenoh
- enforce configured rate, latency, and payload-size expectations while standardizing per-peer ROS domain IDs in the examples
- make release publishing tag-only and repository-configurable, with updated release documentation and maintainer evidence checklists

## Linked Issue

- Refs #2, #8, #17, #20

## Release Notes

- [ ] Release PR: includes `docs/release-notes/vX.Y.Z.md`
- [ ] Release PR: summarizes user-facing changes since the previous release
- [ ] Release PR: documents compatibility, migration, and validation notes
- [ ] Release PR: records the intended `main` commit and previous release tag
- [x] Not a release PR

## Public Behavior

- [x] Changes public CLI/config/API/Docker behavior
- [ ] Does not change public behavior

## Checks

- [x] `just lint`
- [x] `just typecheck`
- [x] `just test-unit`
- [x] `just test-contract`
- [x] `just docs`
- [x] `just package`
- [x] `just check`
- [ ] `just test-e2e-smoke`, delegated to CI

## Test Integrity

- [x] Tests/CI were not skipped, weakened, or removed to make this pass

## Maintainer Evidence

- Required CI links: pending
- Manual/runtime evidence: `just check` passed locally on June 18, 2026; Docker smoke is delegated to CI
- External OTA evidence, if this PR is part of a `main` promotion: not applicable
