### PR TITLE
feat: drive heartbeat_in_monitor from shared.heartbeat.expect (RFC 0001: heartbeat contract + loss_pct)

### DIFF
--- a/docs/rfcs/0001-expectation-driven-test-suite.md
+++ b/docs/rfcs/0001-expectation-driven-test-suite.md
@@ -150,14 +150,21 @@ per-session marker.
   contract is surfaced in `status.json` (`quality` / `expect`).
 - `rosotacom test` leans on that verdict: a delivered topic whose final stage is
   `quality: BAD` fails (in addition to the raw-metric check).
+- Heartbeat `expect` (`shared.heartbeat.expect`) drives both the status overview
+  and the dedicated `heartbeat_in_monitor`: its `delay_bad_ms` / `loss3_bad_pct`
+  come from `latency_ms.max` / `loss_pct.max`, and `expected_hz` tracks the
+  publish rate. This is also where `loss_pct` is enforced.
 
 **Follow-ups**
-- Heartbeat `expect` (it has no `topics:` entry — likely `shared.heartbeat.expect`)
-  and feeding the same contract to `heartbeat_in_monitor`.
 - Marker migration (drop `multi_machine`; derive/`local_check`).
 - Examples curation + generated RMW matrix; `tests/sessions/` split.
 - Wire the manual full-suite promotion gate; fold `verify` into `rosotacom test`.
-- `loss_pct` in `expect` and the evaluator.
+
+**Not feasible as written**
+- `loss_pct` for *non-heartbeat* topics: ROS 2 messages carry no sequence number
+  (only `header.stamp`), so the generic status node cannot detect gaps. Loss is
+  only computable where the payload carries an explicit sequence (the heartbeat,
+  handled above).
 
 ## Notes / open
 

--- a/src/rosotacom/resources/examples/sessions/1_heartbeat_status/session-definition.yaml
+++ b/src/rosotacom/resources/examples/sessions/1_heartbeat_status/session-definition.yaml
@@ -29,6 +29,7 @@ shared:
     expect:
       hz: { min: 8, max: 12 }
       latency_ms: { max: 200 }
+      loss_pct: { max: 5 }
   # Maintain a continuously-updated per-topic pipeline status overview
   # (status.json / status.txt / events.jsonl under logs/<peer>/status/).
   # OTA stages are graph-only; this does not add OTA payload subscriptions.

--- a/src/rosotacom/resources/ws/session/content/base/session_plugin_base.yaml
+++ b/src/rosotacom/resources/ws/session/content/base/session_plugin_base.yaml
@@ -68,6 +68,9 @@ parameters:
   heartbeat_out_hz: 10.0
   heartbeat_in_topic:
   heartbeat_in_hz_window_s: 1.0
+  # heartbeat_in_monitor status thresholds; overridden from shared.heartbeat.expect.
+  heartbeat_delay_bad_ms: 200.0
+  heartbeat_loss3_bad_pct: 10.0
 
   rs: false
   rs_restamp_topics: "" # e.g. "/costmap/costmap,/visualization/planning/pso/submitted_visualization,/visualization/maneuver/announcements_barriers,/visualization/planning/free/curvature_planning,/visualization/planning/free/result"
@@ -357,7 +360,7 @@ windows:
       - commands:
         - ros2 run com_py heartbeat_out_publisher --ros-args -p topic_names:=[${heartbeat_out_topics}] -p qos_config_file:='${qos_config_file}' -p hz:=${heartbeat_out_hz}
       - commands:
-        - ros2 run com_py heartbeat_in_monitor --ros-args -p heartbeat_topic:=${heartbeat_in_topic} -p hz_window_s:=${heartbeat_in_hz_window_s} -p qos_config_file:='${qos_config_file}'
+        - ros2 run com_py heartbeat_in_monitor --ros-args -p heartbeat_topic:=${heartbeat_in_topic} -p hz_window_s:=${heartbeat_in_hz_window_s} -p qos_config_file:='${qos_config_file}' -p expected_hz:=${heartbeat_out_hz} -p delay_bad_ms:=${heartbeat_delay_bad_ms} -p loss3_bad_pct:=${heartbeat_loss3_bad_pct}
       - commands:
         - ros2 topic delay ${heartbeat_in_topic}
       - commands:

--- a/src/rosotacom/resources/ws/session/creation/generate_session_files.py
+++ b/src/rosotacom/resources/ws/session/creation/generate_session_files.py
@@ -1216,6 +1216,22 @@ def _final_topic_type(entry: TopicEntry, pipe: Dict[str, Any]) -> str:
     return msg_type
 
 
+def _heartbeat_monitor_overrides(heartbeat_expect: Optional[Dict[str, Any]]) -> List[Tuple[str, Any]]:
+    """Override the heartbeat_in_monitor status thresholds from a declared
+    `shared.heartbeat.expect`. Only latency and loss map cleanly to the monitor's
+    threshold model; the expected rate is the publish rate (heartbeat_out_hz) and
+    `expect.hz` (min/max) is enforced separately by the status overview."""
+    expect = heartbeat_expect if isinstance(heartbeat_expect, dict) else {}
+    overrides: List[Tuple[str, Any]] = []
+    latency = expect.get("latency_ms")
+    if isinstance(latency, dict) and "max" in latency:
+        overrides.append(("heartbeat_delay_bad_ms", float(latency["max"])))
+    loss = expect.get("loss_pct")
+    if isinstance(loss, dict) and "max" in loss:
+        overrides.append(("heartbeat_loss3_bad_pct", float(loss["max"])))
+    return overrides
+
+
 def _build_status_pipeline_spec(
     *,
     local: str,
@@ -2012,6 +2028,7 @@ def func(
                             ("heartbeat", True),
                             ("heartbeat_out_topics", hb_topic[local]),
                             ("heartbeat_in_topic", hb_topic[remote]),
+                            *_heartbeat_monitor_overrides((shared.get("heartbeat") or {}).get("expect")),
                         ],
                     )
                 )
@@ -2628,6 +2645,7 @@ def func(
                         ("heartbeat", True),
                         ("heartbeat_out_topics", hb_out),
                         ("heartbeat_in_topic", hb_in),
+                        *_heartbeat_monitor_overrides((shared.get("heartbeat") or {}).get("expect")),
                     ],
                 )
             )

--- a/tests/unit/test_status_overview.py
+++ b/tests/unit/test_status_overview.py
@@ -513,3 +513,22 @@ def test_pipeline_spec_carries_heartbeat_expect(tmp_path: Path) -> None:
     # The contract applies to both the locally-published and the received heartbeat.
     assert by_dir[("/heartbeat_a", "outbound")]["expect"] == contract
     assert by_dir[("/heartbeat_b", "inbound")]["expect"] == contract
+
+
+def test_heartbeat_monitor_thresholds_overridden_from_expect(tmp_path: Path) -> None:
+    # latency/loss from shared.heartbeat.expect override the heartbeat_in_monitor
+    # status thresholds (delay_bad_ms / loss3_bad_pct).
+    cfg = _heartbeat_cfg()
+    cfg["shared"]["heartbeat"] = {"expect": {"latency_ms": {"max": 150}, "loss_pct": {"max": 3}}}
+    generator.func(session_config_obj=cfg, output_dir=str(tmp_path), force=True)
+    plugin = (tmp_path / "a" / "plugin.yaml").read_text(encoding="utf-8")
+    assert "heartbeat_delay_bad_ms: 150.0" in plugin
+    assert "heartbeat_loss3_bad_pct: 3.0" in plugin
+
+
+def test_heartbeat_monitor_thresholds_default_without_expect(tmp_path: Path) -> None:
+    generator.func(session_config_obj=_heartbeat_cfg(), output_dir=str(tmp_path), force=True)
+    plugin = (tmp_path / "a" / "plugin.yaml").read_text(encoding="utf-8")
+    # No override emitted -> the plugin base template defaults apply.
+    assert "heartbeat_delay_bad_ms" not in plugin
+    assert "heartbeat_loss3_bad_pct" not in plugin


### PR DESCRIPTION
## What

The dedicated `heartbeat_in_monitor` health node now honors `shared.heartbeat.expect` — completing the heartbeat side of the expectation model (RFC 0001) and delivering **`loss_pct` enforcement** (the heartbeat is the only topic whose payload carries a sequence number, so it's the only place loss is computable).

## Changes

- **generator**: `_heartbeat_monitor_overrides` emits `heartbeat_delay_bad_ms` / `heartbeat_loss3_bad_pct` (from `expect.latency_ms.max` / `expect.loss_pct.max`) into both heartbeat plugin blocks.
- **plugin template**: `heartbeat_in_monitor` now receives `-p expected_hz:=${heartbeat_out_hz} -p delay_bad_ms:= -p loss3_bad_pct:=` — defaults preserved when no `expect`; `expected_hz` now tracks the actual publish rate instead of a hardcoded 10.
- **demo**: `1_heartbeat_status` gains `loss_pct: {max: 5}`.
- Unit tests: override emitted from `expect`; template defaults when absent.

`expect.hz` (min/max) is intentionally *not* fed here — the monitor's expected±tolerance model doesn't match min/max, and the status overview already enforces it; `expected_hz` is correctly the publish rate.

## Validation

lint + typecheck + **81** contract/unit tests (2 new); generation verified (plugin.yaml carries the override values, defaults otherwise). Built on an isolated worktree/venv from develop.

## Not feasible (documented in RFC)

Generic per-topic `loss_pct` — ROS 2 messages carry no sequence number, so the generic status node can't detect gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
