### PR TITLE
docs: rename "heartbeat smoke matrix" to "single-machine smoke matrix"

### DIFF
--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -41,5 +41,5 @@ jobs:
       - name: Show Docker environment
         run: docker info
 
-      - name: Run heartbeat smoke matrix
+      - name: Run single-machine smoke matrix
         run: just test-e2e-smoke

--- a/.github/workflows/pr-merge-gate.yml
+++ b/.github/workflows/pr-merge-gate.yml
@@ -125,7 +125,7 @@ jobs:
       - name: Show Docker environment
         run: docker info
 
-      - name: Run heartbeat smoke matrix
+      - name: Run single-machine smoke matrix
         run: just test-e2e-smoke
 
       - name: Upload smoke session artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,7 +118,7 @@ jobs:
       - name: Show Docker environment
         run: docker info
 
-      - name: Run heartbeat smoke matrix
+      - name: Run single-machine smoke matrix
         run: just test-e2e-smoke
 
   publish:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ just test-e2e-smoke
 
 `just check` runs linting, type checking, host tests under coverage, docs checks,
 and package validation. `just test-e2e-smoke` runs the required Docker-backed
-heartbeat smoke matrix separately so failures are easier to inspect.
+single-machine smoke matrix separately so failures are easier to inspect.
 
 ## Branch And Merge Policy
 

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ never creates an additional OTA payload subscription. Combine both peers' files
 for the full end-to-end picture; cross-peer confirmation is reserved for a later
 phase.
 
-Run the CI heartbeat smoke matrix locally:
+Run the CI single-machine smoke matrix locally:
 
 ```bash
 just test-e2e-smoke

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -40,7 +40,7 @@ ci-success
 ```
 
 The merge gate runs Python 3.10 through 3.14 non-Docker checks, package
-validation, and the Docker heartbeat smoke matrix:
+validation, and the Docker single-machine smoke matrix:
 
 Python 3.10–3.14 are supported for the host CLI; Python 3.12 is the reference
 interpreter for packaging and Docker E2E jobs.
@@ -59,7 +59,7 @@ Docker E2E is not collected for coverage.
 
 ## Docker E2E
 
-`just test-e2e-smoke` runs the local heartbeat smoke matrix through Docker. It
+`just test-e2e-smoke` runs the local single-machine smoke matrix through Docker. It
 is a required merge-gate job because `rosotacom` exists to orchestrate
 Docker-backed ROS communication sessions. Each smoke run writes generated
 config, catmux pane logs, Docker logs when available, and the smoke verification


### PR DESCRIPTION
Align CI workflow step names and docs with the single-machine smoke matrix terminology.

## Changes
- `.github/workflows/nightly-e2e.yml`, `pr-merge-gate.yml`, `release.yml`: rename the "Run heartbeat smoke matrix" step to "Run single-machine smoke matrix"
- `README.md`, `CONTRIBUTING.md`, `docs/ci.md`: update prose references to the single-machine smoke matrix

Pure rename — no behavioral changes (`just test-e2e-smoke` is unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)