### PR TITLE
test: include examples 2-6 in OTA suite

### DIFF
--- a/src/rosotacom/cli.py
+++ b/src/rosotacom/cli.py
@@ -1831,13 +1831,15 @@ def _received_sized_payload_size(container_name: str, ros_setup: str, topic: str
     return int(match.group(1)) if match else None
 
 
-def _smoke_publish_specs(cfg: dict[str, Any]) -> list[SmokeTopicSpec]:
+def _smoke_publish_specs(cfg: dict[str, Any], source_peer_key: str | None = None) -> list[SmokeTopicSpec]:
     peers = cfg.get("peers") or {}
     specs: list[SmokeTopicSpec] = []
     seen: set[tuple[str, str, str]] = set()
     for receiver in peers:
         for spec in _received_crossed_topics(cfg, str(receiver)):
             if not spec.publish_topic:
+                continue
+            if source_peer_key is not None and spec.source_peer_key != source_peer_key:
                 continue
             if not spec.publish_type:
                 raise RuntimeError(f"Smoke topic {spec.publish_topic!r} requires a message type.")
@@ -1856,9 +1858,10 @@ def _start_smoke_topic_publishers(
     *,
     log_line: Callable[[str], None] = print,
     duration: float = 180.0,
+    source_peer_key: str | None = None,
 ) -> list[SmokeTopicSpec]:
     started: list[SmokeTopicSpec] = []
-    for spec in _smoke_publish_specs(cfg):
+    for spec in _smoke_publish_specs(cfg, source_peer_key=source_peer_key):
         assert spec.publish_topic is not None and spec.publish_type is not None
         container = containers[spec.source_peer_key]
         ros_setup = ros_setups[spec.source_peer_key]
@@ -2064,6 +2067,40 @@ def probe_check_command(args: argparse.Namespace) -> int:
     state = "present" if present else "absent"
     print(f"{args.topic} is {state} in {container} (identity {args.identity}); expected {args.expect}")
     return 0 if present == (args.expect == "present") else 1
+
+
+def publish_test_topics_command(args: argparse.Namespace) -> int:
+    """Start or stop synthetic local app publishers for the peer's crossed topics.
+
+    The external OTA harness uses this to exercise non-heartbeat example sessions
+    with the same topic payloads that local smoke uses. Heartbeat-only sessions
+    are a clean no-op because their plugins already self-publish heartbeats.
+    """
+    container, ros_setup, cfg = _resolve_running_peer(args, args.identity)
+    specs = _smoke_publish_specs(cfg, source_peer_key=args.identity)
+    if args.stop:
+        _stop_smoke_topic_publishers({args.identity: container}, specs)
+        print(f"Stopped {len(specs)} test topic publisher(s) in {container} (identity {args.identity})")
+        return 0
+
+    if not specs:
+        print(f"No synthetic test topic publishers needed for identity {args.identity}")
+        return 0
+
+    try:
+        started = _start_smoke_topic_publishers(
+            {args.identity: container},
+            {args.identity: ros_setup},
+            cfg,
+            duration=args.duration,
+            source_peer_key=args.identity,
+        )
+    except RuntimeError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"Started {len(started)} test topic publisher(s) in {container} (identity {args.identity})")
+    return 0
 
 
 def test_command(args: argparse.Namespace) -> int:
@@ -2370,6 +2407,7 @@ def main(argv: list[str] | None = None) -> int:
         "verify",
         "probe-publish",
         "probe-check",
+        "publish-test-topics",
         "list-sessions",
         "examples",
         "setup-env",
@@ -2476,6 +2514,21 @@ def main(argv: list[str] | None = None) -> int:
     probe_check_parser.add_argument("--topic", default=ISOLATION_PROBE_TOPIC)
     probe_check_parser.add_argument("--expect", choices=["present", "absent"], default="absent")
     probe_check_parser.set_defaults(func=probe_check_command)
+
+    publish_test_topics_parser = subparsers.add_parser(
+        "publish-test-topics",
+        help="Start/stop synthetic local app publishers for OTA example verification.",
+    )
+    _add_common_config_args(publish_test_topics_parser)
+    publish_test_topics_parser.add_argument("session_dir", nargs="?", default=DEFAULT_SMOKE_SESSION)
+    publish_test_topics_parser.add_argument("--identity", required=True)
+    publish_test_topics_parser.add_argument("--peer-address", action="append", default=[], metavar="PEER=ADDRESS_EXPR")
+    publish_test_topics_parser.add_argument("--instance-id")
+    publish_test_topics_parser.add_argument("--duration", type=float, default=180.0)
+    publish_test_topics_parser.add_argument(
+        "--stop", action="store_true", help="Stop running synthetic test topic publishers."
+    )
+    publish_test_topics_parser.set_defaults(func=publish_test_topics_command)
 
     list_parser = subparsers.add_parser("list-sessions", help="List configured sessions.")
     _add_common_config_args(list_parser)

--- a/src/rosotacom/resources/examples/sessions/2_native_chatter/session-definition.yaml
+++ b/src/rosotacom/resources/examples/sessions/2_native_chatter/session-definition.yaml
@@ -1,7 +1,7 @@
 # Test-tier capability markers (see docs/testing.md).
 test_tiers:
   single_machine: ok
-  multi_machine: na
+  multi_machine: ok
 
 peers:
   a:

--- a/src/rosotacom/resources/examples/sessions/3_comp_occ_grid/session-definition.yaml
+++ b/src/rosotacom/resources/examples/sessions/3_comp_occ_grid/session-definition.yaml
@@ -1,7 +1,7 @@
 # Test-tier capability markers (see docs/testing.md).
 test_tiers:
   single_machine: ok
-  multi_machine: na
+  multi_machine: ok
 
 peers:
   a:
@@ -19,6 +19,7 @@ shared:
   use_topic_monitor: true
   use_heartbeat: true
   ota_domain_id: 48
+  rmw: fastdds
 
   qos:
     defaults:

--- a/src/rosotacom/resources/examples/sessions/4_comp_occ_grid_zen/session-definition.yaml
+++ b/src/rosotacom/resources/examples/sessions/4_comp_occ_grid_zen/session-definition.yaml
@@ -1,7 +1,7 @@
 # Test-tier capability markers (see docs/testing.md).
 test_tiers:
   single_machine: ok
-  multi_machine: na
+  multi_machine: ok
 
 peers:
   a:

--- a/src/rosotacom/resources/examples/sessions/5_sized_payload/session-definition.yaml
+++ b/src/rosotacom/resources/examples/sessions/5_sized_payload/session-definition.yaml
@@ -1,7 +1,7 @@
 # Test-tier capability markers (see docs/testing.md).
 test_tiers:
   single_machine: ok
-  multi_machine: na
+  multi_machine: ok
 
 peers:
   a:

--- a/src/rosotacom/resources/examples/sessions/6_sized_payload_zen/session-definition.yaml
+++ b/src/rosotacom/resources/examples/sessions/6_sized_payload_zen/session-definition.yaml
@@ -1,7 +1,7 @@
 # Test-tier capability markers (see docs/testing.md).
 test_tiers:
   single_machine: ok
-  multi_machine: na
+  multi_machine: ok
 
 peers:
   a:

--- a/src/rosotacom/resources/ws/ros2src/com_py/com_py/heartbeat_in_monitor.py
+++ b/src/rosotacom/resources/ws/ros2src/com_py/com_py/heartbeat_in_monitor.py
@@ -100,8 +100,8 @@ class HeartbeatInMonitor(Node):
         self.declare_parameter("expected_hz", 10.0)
 
         # Thresholds for status classification
-        self.declare_parameter("delay_good_ms", 100)
-        self.declare_parameter("delay_bad_ms", 200)
+        self.declare_parameter("delay_good_ms", 100.0)
+        self.declare_parameter("delay_bad_ms", 200.0)
         self.declare_parameter("loss3_degraded_pct", 5.0)
         self.declare_parameter("loss3_bad_pct", 10.0)
         # Hz tolerance in messages (due to window timing, ±1 is acceptable)

--- a/tests/contract/test_security_maintenance_config.py
+++ b/tests/contract/test_security_maintenance_config.py
@@ -86,7 +86,20 @@ def test_session_test_tier_markers_drive_both_test_matrices() -> None:
     # cyclone-ota-tuned hides local topics on a shared domain (no per-peer domain
     # split), so it is only provable multi-machine.
     assert markers["1_heartbeat_cyclone-ota-tuned"] == {"single_machine": "na", "multi_machine": "required"}
-    assert "1_heartbeat_cyclone-ota-tuned" in sessions_in_tier("multi_machine", {"ok", "required"})
+    assert set(sessions_in_tier("multi_machine", {"ok", "required"})) == {
+        "1_heartbeat_cyclone-local_fastdds-ota",
+        "1_heartbeat_cyclone-local_zenoh-ros2dds-ota",
+        "1_heartbeat_cyclone-ota",
+        "1_heartbeat_cyclone-ota-tuned",
+        "1_heartbeat_fastdds",
+        "1_heartbeat_fastdds-local_cyclone-ota",
+        "1_heartbeat_zen-endpoints",
+        "2_native_chatter",
+        "3_comp_occ_grid",
+        "4_comp_occ_grid_zen",
+        "5_sized_payload",
+        "6_sized_payload_zen",
+    }
 
     # The smoke test must derive its matrix from the markers, not hardcode it.
     e2e_smoke = (PACKAGE_ROOT / "tests" / "e2e" / "test_smoke.py").read_text(encoding="utf-8")

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -248,14 +248,20 @@ def test_new_verification_verbs_dispatch_not_wrapped_in_start(monkeypatch: pytes
 
         return _cmd
 
-    for name in ("verify_command", "probe_publish_command", "probe_check_command"):
+    for name in ("verify_command", "probe_publish_command", "probe_check_command", "publish_test_topics_command"):
         monkeypatch.setattr(rosotacom, name, record(name))
 
     assert rosotacom.main(["verify", "1_heartbeat", "--identity", "a"]) == 0
     assert rosotacom.main(["probe-publish", "1_heartbeat", "--identity", "a"]) == 0
     assert rosotacom.main(["probe-check", "1_heartbeat", "--identity", "b", "--expect", "absent"]) == 0
+    assert rosotacom.main(["publish-test-topics", "1_heartbeat", "--identity", "b"]) == 0
 
-    assert [n for n, _ in seen] == ["verify_command", "probe_publish_command", "probe_check_command"]
+    assert [n for n, _ in seen] == [
+        "verify_command",
+        "probe_publish_command",
+        "probe_check_command",
+        "publish_test_topics_command",
+    ]
     assert all(args.session_dir == "1_heartbeat" for _, args in seen)
     assert seen[2][1].expect == "absent"
 
@@ -650,8 +656,60 @@ def test_smoke_crossed_topics_include_native_chatter_direction() -> None:
     assert [(s.source_peer_key, s.receiver_peer_key, s.publish_topic) for s in rosotacom._smoke_publish_specs(cfg)] == [
         ("b", "a", "/chatter")
     ]
+    assert [
+        (s.source_peer_key, s.receiver_peer_key, s.publish_topic)
+        for s in rosotacom._smoke_publish_specs(cfg, source_peer_key="b")
+    ] == [("b", "a", "/chatter")]
+    assert rosotacom._smoke_publish_specs(cfg, source_peer_key="a") == []
     assert "export ROS_DOMAIN_ID=46" in rosotacom._smoke_ros_setup("/config", cfg, "a")
     assert "export ROS_DOMAIN_ID=47" in rosotacom._smoke_ros_setup("/config", cfg, "b")
+
+
+def test_publish_test_topics_command_starts_and_stops_identity_publishers(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    cfg = yaml.safe_load(
+        (rosotacom.EXAMPLE_PROJECT_DIR / "sessions" / "2_native_chatter" / "session-definition.yaml").read_text(
+            encoding="utf-8"
+        )
+    )
+    started: list[tuple[str, float | None]] = []
+    stopped: list[str] = []
+
+    monkeypatch.setattr(rosotacom, "_resolve_running_peer", lambda args, identity: ("container_b", "source ros", cfg))
+
+    def fake_start(
+        containers: dict[str, str],
+        ros_setups: dict[str, str],
+        cfg: dict[str, object],
+        **kwargs: object,
+    ) -> list[rosotacom.SmokeTopicSpec]:
+        started.append((containers["b"], kwargs.get("duration") if isinstance(kwargs.get("duration"), float) else None))
+        return rosotacom._smoke_publish_specs(cfg, source_peer_key="b")
+
+    def fake_stop(containers: dict[str, str], specs: list[rosotacom.SmokeTopicSpec]) -> None:
+        stopped.extend([containers[s.source_peer_key] for s in specs])
+
+    monkeypatch.setattr(rosotacom, "_start_smoke_topic_publishers", fake_start)
+    monkeypatch.setattr(rosotacom, "_stop_smoke_topic_publishers", fake_stop)
+
+    assert (
+        rosotacom.publish_test_topics_command(
+            argparse.Namespace(identity="b", duration=42.0, stop=False, session_dir="2_native_chatter")
+        )
+        == 0
+    )
+    assert started == [("container_b", 42.0)]
+    assert "Started 1 test topic publisher" in capsys.readouterr().out
+
+    assert (
+        rosotacom.publish_test_topics_command(
+            argparse.Namespace(identity="b", duration=42.0, stop=True, session_dir="2_native_chatter")
+        )
+        == 0
+    )
+    assert stopped == ["container_b"]
 
 
 def test_smoke_crossed_topics_keep_heartbeat_labels() -> None:


### PR DESCRIPTION
## Summary

- add `publish-test-topics` so the external OTA harness can start the same synthetic source-topic publishers used by local smoke
- mark examples 2-6 as `multi_machine: ok` so they are selected by the OTA suite
- fix example 3 for real OTA by giving it an explicit Fast DDS RMW config
- make heartbeat monitor delay thresholds accept float overrides without crashing ROS parameter declaration

## OTA evidence

Run against two real VPN peers from `rosotacom_test`:

- `2_native_chatter`: passed delivery + isolation at `3966b87` predecessor `edbff43`
- `4_comp_occ_grid_zen`: passed delivery + isolation at `edbff43`
- `5_sized_payload`: passed delivery + isolation at `edbff43`
- `6_sized_payload_zen`: passed delivery + isolation at `edbff43`
- `3_comp_occ_grid`: initially failed without explicit OTA RMW; passed after the Fast DDS fix at `3966b87af4d9d9c97a38568f458a895790ab4193`

Commands used:

```bash
python3 tests/run_multi_machine.py \
  --inventory inventory/hosts.yml \
  --submodule ros_communication_devcontainer \
  --develop-sha edbff43f2899f4d91c6c9fd011b388419d0acd94 \
  --ref codex/ota-examples-2-6 \
  --session 2_native_chatter \
  --session 3_comp_occ_grid \
  --session 4_comp_occ_grid_zen \
  --session 5_sized_payload \
  --session 6_sized_payload_zen

python3 tests/run_multi_machine.py \
  --inventory inventory/hosts.yml \
  --submodule ros_communication_devcontainer \
  --develop-sha 3966b87af4d9d9c97a38568f458a895790ab4193 \
  --ref codex/ota-examples-2-6 \
  --session 3_comp_occ_grid
```

Note: the private `rosotacom_test` harness needs its companion update to call `rosotacom publish-test-topics` before `verify`; that local change was used for the OTA evidence above.

## Local verification

- `just check`
- focused before final: `pytest -q tests/unit/test_cli.py -k 'verification_verbs or publish_test_topics or smoke_crossed_topics' tests/contract/test_security_maintenance_config.py`
