### PR TITLE
feat: add dynamic shell completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,24 @@ python -m rosotacom --version
 rosotacom doctor
 ```
 
+Enable command, option, and configured session-name completion once per shell:
+
+```bash
+# zsh: add this line to ~/.zshrc
+eval "$(rosotacom completion zsh)"
+
+# bash: add this line to ~/.bashrc
+eval "$(rosotacom completion bash)"
+```
+
+After reloading the shell, `rosotacom <TAB><TAB>` lists commands,
+`rosotacom smoke <TAB><TAB>` lists sessions from the active project, and a
+prefix such as `rosotacom smoke 1<TAB>` expands to `1_heartbeat`. The same
+session completion is available for `start`, `stop`, `status`, `test`, and the
+probe commands; absolute and relative session-directory paths still complete
+normally. Running `rosotacom completion` without a shell argument infers bash
+or zsh from `$SHELL`.
+
 **Multiple versions / try-without-disturbing.** Because each checkout owns its
 own `.venv` and `./install.sh` never touches your PATH on its own, you can keep a
 pinned/production version in use while smoke-testing another in one terminal:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ authors = [
 ]
 keywords = ["ros2", "docker", "teleoperation", "communication", "cli"]
 dependencies = [
+  "argcomplete>=3.6,<4",
   "PyYAML>=6",
   "ros2docker>=0.1.2,<0.2",
 ]

--- a/src/rosotacom/cli.py
+++ b/src/rosotacom/cli.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# PYTHON_ARGCOMPLETE_OK
 """rosotacom host CLI.
 
 This module owns rosotacom-specific concepts such as session config
@@ -29,7 +30,9 @@ from pathlib import Path
 from types import ModuleType
 from typing import Any, cast
 
+import argcomplete
 import yaml
+from argcomplete.completers import DirectoriesCompleter
 
 from . import __version__
 
@@ -822,6 +825,31 @@ def _format_available_sessions(runtime: RuntimeConfig) -> str:
         "`rosotacom examples create ./rosotacom_examples` and wire them with "
         '`eval "$(rosotacom setup-env ./rosotacom_examples/rosotacom.yaml)"`.'
     )
+
+
+def _session_names(runtime: RuntimeConfig) -> list[str]:
+    if not runtime.session_configs_dir or not runtime.session_configs_dir.is_dir():
+        return []
+    return [
+        path.name for path in sorted(runtime.session_configs_dir.iterdir()) if path.is_dir() and _is_session_dir(path)
+    ]
+
+
+def _session_name_completer(
+    prefix: str,
+    parsed_args: argparse.Namespace,
+    **_: Any,
+) -> dict[str, str]:
+    """Complete session names from the project selected by the arguments parsed so far."""
+    completions: dict[str, str] = {}
+    if prefix.startswith((".", "~", os.sep)) or os.sep in prefix:
+        completions.update({path: "session directory" for path in DirectoriesCompleter()(prefix)})
+    try:
+        runtime = _load_runtime_config(parsed_args)
+    except (FileNotFoundError, RuntimeError, OSError, yaml.YAMLError):
+        return completions
+    completions.update({name: "configured session" for name in _session_names(runtime) if name.startswith(prefix)})
+    return completions
 
 
 def _base_extra_run_args(
@@ -2415,10 +2443,16 @@ def _add_common_config_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--data-dict", help="Host data_dict.json path for data:<key> address expressions.")
 
 
+def _add_session_arg(parser: argparse.ArgumentParser, *args: str, **kwargs: Any) -> argparse.Action:
+    action = parser.add_argument(*args, **kwargs)
+    cast(Any, action).completer = _session_name_completer
+    return action
+
+
 def _add_start_args(parser: argparse.ArgumentParser) -> None:
     _add_common_config_args(parser)
-    parser.add_argument("session_dir_positional", nargs="?")
-    parser.add_argument("-s", "--session-dir", dest="session_dir")
+    _add_session_arg(parser, "session_dir_positional", nargs="?")
+    _add_session_arg(parser, "-s", "--session-dir", dest="session_dir")
     parser.add_argument("--identity")
     parser.add_argument("--mode", choices=["auto", "attach", "detached"], default="auto")
     parser.add_argument("--no-auto-identity", dest="auto_identity", action="store_false")
@@ -2458,6 +2492,14 @@ def list_sessions_command(args: argparse.Namespace) -> int:
     return 0
 
 
+def completion_command(args: argparse.Namespace) -> int:
+    shell = args.shell or Path(os.environ.get("SHELL", "bash")).name
+    if shell not in {"bash", "zsh"}:
+        raise RuntimeError(f"Could not infer a supported shell from {shell!r}; pass `bash` or `zsh` explicitly.")
+    print(argcomplete.shellcode(["rosotacom"], shell=shell))
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     argv = list(sys.argv[1:] if argv is None else argv)
     commands = {
@@ -2475,6 +2517,7 @@ def main(argv: list[str] | None = None) -> int:
         "examples",
         "setup-env",
         "config",
+        "completion",
     }
     if not argv:
         argv = ["start"]
@@ -2491,8 +2534,8 @@ def main(argv: list[str] | None = None) -> int:
 
     stop_parser = subparsers.add_parser("stop", help="Stop rosotacom containers for a session.")
     _add_common_config_args(stop_parser)
-    stop_parser.add_argument("session_dir_positional", nargs="?")
-    stop_parser.add_argument("-s", "--session-dir", dest="session_dir")
+    _add_session_arg(stop_parser, "session_dir_positional", nargs="?")
+    _add_session_arg(stop_parser, "-s", "--session-dir", dest="session_dir")
     stop_parser.add_argument("--identity")
     stop_parser.add_argument("--auto-identity", action="store_true")
     stop_parser.add_argument("--peer-address", action="append", default=[], metavar="PEER=ADDRESS_EXPR")
@@ -2505,7 +2548,7 @@ def main(argv: list[str] | None = None) -> int:
 
     smoke_parser = subparsers.add_parser("smoke", help="Run a local smoke test.")
     _add_common_config_args(smoke_parser)
-    smoke_parser.add_argument("session_dir", nargs="?", default=DEFAULT_SMOKE_SESSION)
+    _add_session_arg(smoke_parser, "session_dir", nargs="?", default=DEFAULT_SMOKE_SESSION)
     smoke_parser.add_argument("--local", action="store_true", default=True)
     smoke_parser.add_argument("--local-ip")
     smoke_parser.add_argument("--keep-running", action="store_true", help="Leave smoke-test containers running.")
@@ -2516,7 +2559,7 @@ def main(argv: list[str] | None = None) -> int:
         "status", help="Show the live per-topic pipeline status for a session instance."
     )
     _add_common_config_args(status_parser)
-    status_parser.add_argument("session_dir", nargs="?", default=DEFAULT_SMOKE_SESSION)
+    _add_session_arg(status_parser, "session_dir", nargs="?", default=DEFAULT_SMOKE_SESSION)
     status_parser.add_argument("--identity", help="Show only this peer identity (default: all available).")
     status_parser.add_argument(
         "--instance-id", help="Inspect a specific instance id (default: most recent for the session)."
@@ -2530,7 +2573,7 @@ def main(argv: list[str] | None = None) -> int:
         "test", help="Assert a running/recent session meets its status + per-topic expect contract."
     )
     _add_common_config_args(test_parser)
-    test_parser.add_argument("session_dir", nargs="?", default=DEFAULT_SMOKE_SESSION)
+    _add_session_arg(test_parser, "session_dir", nargs="?", default=DEFAULT_SMOKE_SESSION)
     test_parser.add_argument("--instance-id", help="Evaluate a specific instance id (default: most recent).")
     test_parser.add_argument("--timeout", type=float, default=30.0, help="Seconds to wait for status to settle.")
     test_parser.add_argument("--interval", type=float, default=2.0, help="Polling interval while waiting (s).")
@@ -2540,7 +2583,7 @@ def main(argv: list[str] | None = None) -> int:
         "probe-publish", help="Publish a local-only probe topic in a running peer's local domain (isolation)."
     )
     _add_common_config_args(probe_publish_parser)
-    probe_publish_parser.add_argument("session_dir", nargs="?", default=DEFAULT_SMOKE_SESSION)
+    _add_session_arg(probe_publish_parser, "session_dir", nargs="?", default=DEFAULT_SMOKE_SESSION)
     probe_publish_parser.add_argument("--identity", required=True)
     probe_publish_parser.add_argument("--peer-address", action="append", default=[], metavar="PEER=ADDRESS_EXPR")
     probe_publish_parser.add_argument("--instance-id")
@@ -2556,7 +2599,7 @@ def main(argv: list[str] | None = None) -> int:
         "probe-check", help="Assert a topic is present/absent in a running peer's local domain (isolation)."
     )
     _add_common_config_args(probe_check_parser)
-    probe_check_parser.add_argument("session_dir", nargs="?", default=DEFAULT_SMOKE_SESSION)
+    _add_session_arg(probe_check_parser, "session_dir", nargs="?", default=DEFAULT_SMOKE_SESSION)
     probe_check_parser.add_argument("--identity", required=True)
     probe_check_parser.add_argument("--peer-address", action="append", default=[], metavar="PEER=ADDRESS_EXPR")
     probe_check_parser.add_argument("--instance-id")
@@ -2569,7 +2612,7 @@ def main(argv: list[str] | None = None) -> int:
         help="Start/stop synthetic local app publishers for OTA example verification.",
     )
     _add_common_config_args(publish_test_topics_parser)
-    publish_test_topics_parser.add_argument("session_dir", nargs="?", default=DEFAULT_SMOKE_SESSION)
+    _add_session_arg(publish_test_topics_parser, "session_dir", nargs="?", default=DEFAULT_SMOKE_SESSION)
     publish_test_topics_parser.add_argument("--identity", required=True)
     publish_test_topics_parser.add_argument("--peer-address", action="append", default=[], metavar="PEER=ADDRESS_EXPR")
     publish_test_topics_parser.add_argument("--instance-id")
@@ -2642,6 +2685,19 @@ def main(argv: list[str] | None = None) -> int:
     )
     config_unset_parser.set_defaults(func=config_command)
 
+    completion_parser = subparsers.add_parser(
+        "completion",
+        help="Print shell code that enables command and session-name tab completion.",
+    )
+    completion_parser.add_argument(
+        "shell",
+        choices=["bash", "zsh"],
+        nargs="?",
+        help="Shell syntax to emit (default: infer from $SHELL).",
+    )
+    completion_parser.set_defaults(func=completion_command)
+
+    argcomplete.autocomplete(parser)
     args = parser.parse_args(argv)
     try:
         return int(args.func(args) or 0)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import os
 import subprocess
 import sys
 from collections.abc import Callable
@@ -196,6 +197,73 @@ def test_session_name_resolves_through_configured_sessions_dir(tmp_path: Path) -
     assert resolved.host_dir == session.resolve()
     assert resolved.container_dir == "/session/definitions/1_heartbeat"
     assert resolved.source == "session_configs"
+
+
+def test_session_name_completion_uses_active_project_and_prefix(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sessions = tmp_path / "sessions"
+    for name in ("1_heartbeat", "1_heartbeat_status", "2_native_chatter"):
+        session = sessions / name
+        session.mkdir(parents=True)
+        (session / "session-definition.yaml").write_text("peers: {}\n", encoding="utf-8")
+    (sessions / "not_a_session").mkdir()
+    (tmp_path / "ros2docker.json").write_text('{"image_name": "completion"}\n', encoding="utf-8")
+    config = tmp_path / "rosotacom.yaml"
+    config.write_text(
+        "ros2docker_config: ros2docker.json\nsession_configs_dir: sessions\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+
+    completions = rosotacom._session_name_completer("1_", argparse.Namespace())
+
+    assert completions == {
+        "1_heartbeat": "configured session",
+        "1_heartbeat_status": "configured session",
+    }
+
+    external = tmp_path / "external_session"
+    external.mkdir()
+    path_completions = rosotacom._session_name_completer("./ext", argparse.Namespace())
+
+    assert path_completions["./external_session/"] == "session directory"
+
+
+def test_completion_command_emits_shell_registration(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("SHELL", "/usr/bin/zsh")
+
+    assert rosotacom.completion_command(argparse.Namespace(shell=None)) == 0
+
+    output = capsys.readouterr().out
+    assert "_python_argcomplete" in output
+    assert "rosotacom" in output
+
+
+def test_argcomplete_protocol_returns_session_prefix_matches() -> None:
+    line = "rosotacom smoke 1_"
+    env = {
+        **os.environ,
+        "_ARGCOMPLETE": "1",
+        "_ARGCOMPLETE_IFS": "\v",
+        "_ARGCOMPLETE_SUPPRESS_SPACE": "1",
+        "COMP_LINE": line,
+        "COMP_POINT": str(len(line)),
+    }
+
+    result = subprocess.run(
+        ["bash", "-c", f"{rosotacom.shlex.quote(sys.executable)} -m rosotacom 8>&1"],
+        check=True,
+        capture_output=True,
+        env=env,
+        text=True,
+    )
+
+    assert result.stdout.split("\v") == ["1_heartbeat", "1_heartbeat_status"]
 
 
 def test_local_check_derives_from_domains_and_allows_opt_out(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- add bash/zsh completion activation through `rosotacom completion`
- complete commands, options, and session names from the active project
- preserve completion for explicit session-directory paths
- document setup and cover project-aware completion plus the argcomplete protocol

## Linked Issue

- N/A

## Release Notes

- [ ] Release PR: includes `docs/release-notes/vX.Y.Z.md`
- [ ] Release PR: summarizes user-facing changes since the previous release
- [ ] Release PR: documents compatibility, migration, and validation notes
- [ ] Release PR: records the intended `main` commit and previous release tag
- [x] Not a release PR

## Public Behavior

- [x] Changes public CLI/config/API/Docker behavior
- [ ] Does not change public behavior

## Checks

- [x] `just lint`
- [x] `just typecheck`
- [x] `just test-unit`
- [x] `just test-contract`
- [x] `just docs`
- [x] `just package`
- [x] `just check`
- [ ] `just test-e2e-smoke`, not needed because ROS/Docker runtime behavior is unchanged

## Test Integrity

- [x] Tests/CI were not skipped, weakened, or removed to make this pass

## Maintainer Evidence

- Required CI links: draft PR checks
- Manual/runtime evidence: argcomplete protocol returned the expected built-in session prefix matches; generated zsh registration was inspected
- External OTA evidence, if this PR is part of a `main` promotion: N/A