### PR TITLE
feat: enable completion with venv activation

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,10 @@ python -m rosotacom --version
 rosotacom doctor
 ```
 
-Enable command, option, and configured session-name completion once per shell:
+For a source checkout, that single `source .venv/bin/activate` command also
+enables completion. Nothing needs to be added to your shell configuration.
+
+For a pipx/global installation, add one line once to your shell startup file:
 
 ```bash
 # zsh: add this line to ~/.zshrc
@@ -68,13 +71,22 @@ eval "$(rosotacom completion zsh)"
 eval "$(rosotacom completion bash)"
 ```
 
-After reloading the shell, `rosotacom <TAB><TAB>` lists commands,
+Every new terminal then loads completion automatically; you do not run the
+command manually in each terminal. After reloading the shell,
+`rosotacom <TAB><TAB>` lists commands,
 `rosotacom smoke <TAB><TAB>` lists sessions from the active project, and a
 prefix such as `rosotacom smoke 1<TAB>` expands to `1_heartbeat`. The same
 session completion is available for `start`, `stop`, `status`, `test`, and the
 probe commands; absolute and relative session-directory paths still complete
 normally. Running `rosotacom completion` without a shell argument infers bash
 or zsh from `$SHELL`.
+
+Completion is not pinned to the version that registered it: each Tab press runs
+the `rosotacom` currently selected by `PATH`. Activating another checkout's
+virtual environment therefore switches both the command and its completion,
+and `deactivate` switches back without a reset step. A pipx-suffixed executable
+can be registered independently with, for example,
+`eval "$(rosotacom@2.2.0 completion zsh)"`.
 
 **Multiple versions / try-without-disturbing.** Because each checkout owns its
 own `.venv` and `./install.sh` never touches your PATH on its own, you can keep a

--- a/install.sh
+++ b/install.sh
@@ -45,9 +45,26 @@ python3 -m venv "$VENV_DIR"
 "$VENV_DIR/bin/python" -m pip install "$ROS2DOCKER_SPEC"
 "$VENV_DIR/bin/python" -m pip install -e "$ROOT_DIR"
 
+cat >> "$VENV_DIR/bin/activate" <<'EOF'
+
+# >>> rosotacom shell completion >>>
+# Completion follows the rosotacom executable currently selected by PATH, so
+# activating another checkout automatically switches completion to that version.
+case $- in
+  *i*)
+    if [ -n "${ZSH_VERSION:-}" ]; then
+      eval "$("$VIRTUAL_ENV/bin/rosotacom" completion zsh)"
+    elif [ -n "${BASH_VERSION:-}" ]; then
+      eval "$("$VIRTUAL_ENV/bin/rosotacom" completion bash)"
+    fi
+    ;;
+esac
+# <<< rosotacom shell completion <<<
+EOF
+
 echo "Installed rosotacom into: $VENV_DIR"
 echo
-echo "Activate it with:"
+echo "Activate it (including shell completion) with:"
 echo "  source \"$VENV_DIR/bin/activate\""
 echo
 echo "Try:"

--- a/src/rosotacom/cli.py
+++ b/src/rosotacom/cli.py
@@ -2492,11 +2492,35 @@ def list_sessions_command(args: argparse.Namespace) -> int:
     return 0
 
 
+def _safe_completion_shellcode(executable: str) -> str:
+    """Register completion only when the executable currently on PATH supports argcomplete."""
+    loader_path = importlib_resources.files("argcomplete").joinpath("bash_completion.d").joinpath("_python-argcomplete")
+    loader = loader_path.read_text(encoding="utf-8")
+    registration_marker = '\nif [[ -z "${ZSH_VERSION-}" ]]; then\n    complete -o default'
+    registration_start = loader.rfind(registration_marker)
+    if registration_start < 0:
+        raise RuntimeError("Installed argcomplete does not contain the expected shell loader.")
+    loader = loader[:registration_start].rstrip()
+    command = shlex.quote(executable)
+    return (
+        f"{loader}\n"
+        'if [[ -z "${ZSH_VERSION-}" ]]; then\n'
+        f"    complete -o default -o bashdefault -F _python_argcomplete_global {command}\n"
+        "else\n"
+        "    autoload -Uz is-at-least\n"
+        f"    compdef _python_argcomplete_global {command}\n"
+        "fi\n"
+    )
+
+
 def completion_command(args: argparse.Namespace) -> int:
     shell = args.shell or Path(os.environ.get("SHELL", "bash")).name
     if shell not in {"bash", "zsh"}:
         raise RuntimeError(f"Could not infer a supported shell from {shell!r}; pass `bash` or `zsh` explicitly.")
-    print(argcomplete.shellcode(["rosotacom"], shell=shell))
+    executable = Path(sys.argv[0]).name
+    if executable in {"__main__.py", "cli.py"}:
+        executable = "rosotacom"
+    print(_safe_completion_shellcode(executable), end="")
     return 0
 
 

--- a/tests/contract/test_package_metadata.py
+++ b/tests/contract/test_package_metadata.py
@@ -23,6 +23,15 @@ def test_console_scripts_target_package_cli() -> None:
     assert 'stop_rosotacom = "rosotacom.cli:stop_compat_main"' in pyproject
 
 
+def test_checkout_installer_enables_completion_during_venv_activation() -> None:
+    installer = (PACKAGE_ROOT / "install.sh").read_text(encoding="utf-8")
+
+    assert "# >>> rosotacom shell completion >>>" in installer
+    assert '"$VIRTUAL_ENV/bin/rosotacom" completion zsh' in installer
+    assert '"$VIRTUAL_ENV/bin/rosotacom" completion bash' in installer
+    assert "case $- in" in installer  # Do not register completion in non-interactive scripts.
+
+
 def test_python_support_contract_is_consistent() -> None:
     pyproject = (PACKAGE_ROOT / "pyproject.toml").read_text(encoding="utf-8")
     contributing = (PACKAGE_ROOT / "CONTRIBUTING.md").read_text(encoding="utf-8")

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -236,12 +236,24 @@ def test_completion_command_emits_shell_registration(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     monkeypatch.setenv("SHELL", "/usr/bin/zsh")
+    monkeypatch.setattr(sys, "argv", ["/tmp/bin/rosotacom@2.2.0"])
 
     assert rosotacom.completion_command(argparse.Namespace(shell=None)) == 0
 
     output = capsys.readouterr().out
-    assert "_python_argcomplete" in output
-    assert "rosotacom" in output
+    assert "_python_argcomplete_global" in output
+    assert "compdef _python_argcomplete_global rosotacom@2.2.0" in output
+
+
+def test_module_completion_registers_the_public_command(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(sys, "argv", ["/tmp/site-packages/rosotacom/__main__.py"])
+
+    assert rosotacom.completion_command(argparse.Namespace(shell="bash")) == 0
+
+    assert "_python_argcomplete_global rosotacom" in capsys.readouterr().out
 
 
 def test_argcomplete_protocol_returns_session_prefix_matches() -> None:


### PR DESCRIPTION
## Summary

- make `source .venv/bin/activate` enable rosotacom completion automatically after checkout installation
- use argcomplete’s guarded PATH-aware loader so switching or deactivating virtual environments needs no completion reset
- safely ignore older rosotacom installations that do not support completion
- register pipx-suffixed executables under their actual command name
- document the one-time shell-rc setup for pipx/global installs

## Linked Issue

- Follow-up to #33

## Release Notes

- [ ] Release PR: includes `docs/release-notes/vX.Y.Z.md`
- [ ] Release PR: summarizes user-facing changes since the previous release
- [ ] Release PR: documents compatibility, migration, and validation notes
- [ ] Release PR: records the intended `main` commit and previous release tag
- [x] Not a release PR

## Public Behavior

- [x] Changes public CLI/config/API/Docker behavior
- [ ] Does not change public behavior

## Checks

- [x] `just lint`
- [x] `just typecheck`
- [x] `just test-unit`
- [x] `just test-contract`
- [x] `just docs`
- [x] `just package`
- [x] `just check`
- [ ] `just test-e2e-smoke`, not needed because ROS/Docker runtime behavior is unchanged

## Test Integrity

- [x] Tests/CI were not skipped, weakened, or removed to make this pass

## Maintainer Evidence

- Required CI links: PR checks
- Manual/runtime evidence: fresh temporary checkout venv activation registered completion in bash and zsh; guarded loader did not execute a simulated older non-argcomplete rosotacom
- External OTA evidence, if this PR is part of a `main` promotion: N/A