### PR TITLE
feat: add scenario orchestration for communication and local apps

### DIFF
--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -33,10 +33,10 @@ jobs:
           python-version: "3.12"
           cache: pip
 
-      - name: Install just
+      - name: Install just and tmux
         run: |
           sudo apt-get update
-          sudo apt-get install -y just
+          sudo apt-get install -y just tmux
 
       - name: Set up local environment
         run: just setup

--- a/.github/workflows/pr-merge-gate.yml
+++ b/.github/workflows/pr-merge-gate.yml
@@ -114,10 +114,10 @@ jobs:
           python-version: "3.12"
           cache: pip
 
-      - name: Install just
+      - name: Install just and tmux
         run: |
           sudo apt-get update
-          sudo apt-get install -y just
+          sudo apt-get install -y just tmux
 
       - name: Set up local environment
         run: just setup

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,10 +107,10 @@ jobs:
           python-version: "3.12"
           cache: pip
 
-      - name: Install just
+      - name: Install just and tmux
         run: |
           sudo apt-get update
-          sudo apt-get install -y just
+          sudo apt-get install -y just tmux
 
       - name: Set up local environment
         run: just setup

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The ROS Communication DevContainer is a Docker-based solution designed to stream
   for versioned Python packages this may be named like `python3.14-venv`)
 - `ros2docker` v0.1.2 or newer. The local installer below installs the pinned
   supported range into this checkout's virtual environment.
+- `tmux` for the optional `rosotacom scenario` orchestration commands
 - Machines connected to the same network (VPN or local WLAN)
 
 ### Convenience CLI: `rosotacom`
@@ -106,10 +107,11 @@ version manager.
 
 ### Basic Setup
 
-`rosotacom` uses three layers of configuration/runtime state:
+`rosotacom` uses four layers of configuration/runtime state:
 
 - A **project setup** file (`rosotacom.yaml`) points to host-local resources such as `ros2docker.json`, static `sessions/`, ignored `session-instances/`, and `data_dict.json`.
 - A **session config** defines the communication behavior for one run: peers, addresses, topics, QoS, processing, and transport choices.
+- An optional **scenario config** composes one communication session with identity-specific local application containers.
 - A **session instance** stores one concrete run: generated config, catmux pane logs, smoke debug output, and future rosbags.
 
 `rosotacom` resolves the active `rosotacom.yaml` by scope (first wins), using the
@@ -153,6 +155,7 @@ rosotacom.yaml
 ros2docker.json
 data_dict.json
 sessions/
+scenarios/
 session-instances/
 scripts/
 ```
@@ -178,6 +181,38 @@ rosotacom start 1_heartbeat --identity b
 ```
 
 `rosotacom` reads the static session input and creates generated files under `session-instances/<date>/<session>_<timestamp>_<id>/config/`, including per-peer plugin/session specs, topic lists, optional QoS, and optional `domain_bridge.yaml`. Catmux pane output is logged under the same instance in `logs/<peer>/catmux/`.
+
+### Complete use cases with scenarios
+
+A session intentionally describes only the communication contract. When a use
+case also needs a local ROS application, rosbag, or ROS command, define a
+scenario above it:
+
+```yaml
+schema_version: 1
+session: 2_native_chatter
+
+applications:
+  a:
+    - name: native_application
+      ros2docker_config: ../../scripts/2_native_chatter/machine_a/external.ros2docker.json
+  b:
+    - name: native_application
+      ros2docker_config: ../../scripts/2_native_chatter/machine_b/external.ros2docker.json
+```
+
+Start one identity's communication and local application together:
+
+```bash
+rosotacom scenario start 2_native_chatter --identity a
+rosotacom scenario attach 2_native_chatter --identity a
+rosotacom scenario stop 2_native_chatter --identity a
+```
+
+The outer view uses an isolated host tmux server. Its prefix remains `Ctrl-b`;
+send the inner container-side catmux prefix with `Ctrl-b Ctrl-b`. Detaching from
+the outer tmux does not stop the use case. `scenario stop` owns cleanup of the
+application containers, communication container, and outer tmux session.
 
 ## Usage Examples
 
@@ -253,13 +288,15 @@ Run the heartbeat example manually:
 ./scripts/1_heartbeat/run_machine_b.sh
 ```
 
-For examples with external application containers, use the matching machine script directory. Example:
+Example 2 is the pilot for one-command scenario orchestration:
 
 ```bash
-cd scripts/2_native_chatter/machine_a
-./run_external.py
-./run_communication.sh
+rosotacom scenario start 2_native_chatter --identity a
 ```
+
+The existing `run_external.py` and `run_communication.sh` helpers remain
+available as a compatibility fallback. Examples 3–6 continue to use those
+helpers for now.
 
 The `sessions/` directory contains curated built-in session definitions:
 

--- a/justfile
+++ b/justfile
@@ -67,6 +67,7 @@ _package-smoke:
 	"$tmpdir/venv/bin/python" -m rosotacom --version
 	"$tmpdir/venv/bin/rosotacom" examples create "$tmpdir/examples"
 	"$tmpdir/venv/bin/rosotacom" list-sessions --rosotacom-config "$tmpdir/examples/rosotacom.yaml"
+	"$tmpdir/venv/bin/rosotacom" scenario list --rosotacom-config "$tmpdir/examples/rosotacom.yaml"
 	"$tmpdir/venv/bin/python" - <<'PY'
 	from importlib import resources
 
@@ -75,6 +76,7 @@ _package-smoke:
 	    "resources/ros2docker.json.example",
 	    "resources/examples/rosotacom.yaml",
 	    "resources/examples/sessions/1_heartbeat/session-definition.yaml",
+	    "resources/examples/scenarios/2_native_chatter/scenario-definition.yaml",
 	    "resources/ws/session/creation/run_session.py",
 	    "resources/ws/ros2src/com_msgs/msg/Heartbeat.msg",
 	)

--- a/rosotacom.yaml
+++ b/rosotacom.yaml
@@ -5,5 +5,6 @@
 #   eval "$(rosotacom setup-env ./rosotacom.yaml)"
 ros2docker_config: src/rosotacom/resources/examples/ros2docker.json
 session_configs_dir: src/rosotacom/resources/examples/sessions
+scenario_configs_dir: src/rosotacom/resources/examples/scenarios
 session_instances_dir: session-instances
 data_dict: src/rosotacom/resources/examples/data_dict.json

--- a/src/rosotacom/cli.py
+++ b/src/rosotacom/cli.py
@@ -98,6 +98,7 @@ class RuntimeConfig:
     install_id: str
     session_instances_dir: Path | None = None
     project_source: str | None = None
+    scenario_configs_dir: Path | None = None
 
 
 @dataclass(frozen=True)
@@ -105,6 +106,26 @@ class ResolvedSession:
     host_dir: Path
     container_dir: str
     source: str
+
+
+@dataclass(frozen=True)
+class ResolvedScenario:
+    name: str
+    host_dir: Path
+    definition_path: Path
+    source: str
+
+
+@dataclass(frozen=True)
+class ScenarioApplication:
+    name: str
+    ros2docker_config: Path
+
+
+@dataclass(frozen=True)
+class ScenarioDefinition:
+    session: str
+    applications: dict[str, tuple[ScenarioApplication, ...]]
 
 
 @dataclass(frozen=True)
@@ -283,6 +304,11 @@ def _load_runtime_config(args: argparse.Namespace | None = None) -> RuntimeConfi
         os.environ.get("ROSOTACOM_SESSION_CONFIGS_DIR"),
         cfg.get("session_configs_dir"),
     )
+    scenario_configs_dir_raw = _first_value(
+        getattr(args, "scenario_configs_dir", None),
+        os.environ.get("ROSOTACOM_SCENARIO_CONFIGS_DIR"),
+        cfg.get("scenario_configs_dir"),
+    )
     session_instances_dir_raw = _first_value(
         getattr(args, "session_instances_dir", None),
         os.environ.get("ROSOTACOM_SESSION_INSTANCES_DIR"),
@@ -313,6 +339,7 @@ def _load_runtime_config(args: argparse.Namespace | None = None) -> RuntimeConfi
         install_id=_install_id(rosotacom_config),
         session_instances_dir=session_instances_dir,
         project_source=project_source,
+        scenario_configs_dir=_resolve_path(scenario_configs_dir_raw, config_base, must_exist=True),
     )
 
 
@@ -331,8 +358,10 @@ def _sanitize_docker_name(name: str) -> str:
 def _scoped_image_name(runtime: RuntimeConfig) -> str:
     _require_ros2docker()
     config = load_config(runtime.ros2docker_config)
-    base = str(config.get("image_name") or "ros-communication")
-    suffix = runtime.install_id
+    return _scoped_image_name_from_base(str(config.get("image_name") or "ros-communication"), runtime.install_id)
+
+
+def _scoped_image_name_from_base(base: str, suffix: str) -> str:
     if base.endswith(f"-{suffix}"):
         return base
     last = base.rsplit("/", 1)[-1]
@@ -491,6 +520,80 @@ def _write_instance_manifest(
             "overwrite_peers_via_remote_peer": overwrite_peers_via_remote_peer,
         }
     )
+    manifest_path.write_text(
+        yaml.safe_dump(manifest, sort_keys=True, default_flow_style=False, allow_unicode=True),
+        encoding="utf-8",
+    )
+
+
+def _write_scenario_manifest(
+    instance: SessionInstance,
+    session: ResolvedSession,
+    runtime: RuntimeConfig,
+    cfg: dict[str, Any],
+    resolved: ResolvedScenario,
+    *,
+    identity: str,
+    communication_container: str,
+    applications: tuple[ScenarioApplication, ...],
+    tmux_session: str,
+) -> None:
+    manifest_path = instance.host_dir / "manifest.yaml"
+    manifest = _load_yaml_file(manifest_path)
+    now = datetime.now().isoformat(timespec="seconds")
+    if not manifest:
+        manifest = {
+            "schema_version": 1,
+            "created_at": now,
+            "instance_id": instance.instance_id,
+            "rosotacom_version": __version__,
+            "source_session_host_dir": str(session.host_dir),
+            "source_session_container_dir": session.container_dir,
+            "source": session.source,
+            "config_dir": str(instance.config_host_dir),
+            "logs_dir": str(instance.logs_host_dir),
+            "rosbags_dir": str(instance.rosbags_host_dir),
+            "rollout": None,
+            "starts": [],
+        }
+    run_key = f"{resolved.name}:{identity}"
+    manifest["updated_at"] = now
+    manifest["effective_config_sha256"] = _effective_config_sha256(cfg)
+    scenario_runs = manifest.setdefault("scenario_runs", {})
+    scenario_runs[run_key] = {
+        "started_at": now,
+        "stopped_at": None,
+        "scenario": resolved.name,
+        "identity": identity,
+        "source_definition": str(resolved.definition_path),
+        "tmux_socket": _scenario_tmux_socket(runtime),
+        "tmux_session": tmux_session,
+        "communication_container": communication_container,
+        "applications": [
+            {
+                "name": application.name,
+                "ros2docker_config": str(application.ros2docker_config),
+                "container_name": _scenario_container_name(runtime, resolved.name, identity, application.name),
+                "image_name": _scenario_application_image_name(runtime, application),
+            }
+            for application in applications
+        ],
+    }
+    manifest_path.write_text(
+        yaml.safe_dump(manifest, sort_keys=True, default_flow_style=False, allow_unicode=True),
+        encoding="utf-8",
+    )
+
+
+def _mark_scenario_stopped(instance_dir: Path, scenario_name: str, identity: str) -> None:
+    manifest_path = instance_dir / "manifest.yaml"
+    manifest = _load_yaml_file(manifest_path)
+    run = (manifest.get("scenario_runs") or {}).get(f"{scenario_name}:{identity}")
+    if not isinstance(run, dict):
+        return
+    now = datetime.now().isoformat(timespec="seconds")
+    run["stopped_at"] = now
+    manifest["updated_at"] = now
     manifest_path.write_text(
         yaml.safe_dump(manifest, sort_keys=True, default_flow_style=False, allow_unicode=True),
         encoding="utf-8",
@@ -852,6 +955,370 @@ def _session_name_completer(
     return completions
 
 
+def _is_scenario_dir(path: Path) -> bool:
+    return (path / "scenario-definition.yaml").is_file()
+
+
+def _resolve_scenario(scenario_name: str, runtime: RuntimeConfig) -> ResolvedScenario:
+    raw = Path(os.path.expandvars(os.path.expanduser(scenario_name)))
+    candidates: list[tuple[Path, str]] = []
+    if raw.is_absolute():
+        candidates.append((raw, "absolute"))
+    else:
+        candidates.append((Path.cwd() / raw, "cwd"))
+        if runtime.scenario_configs_dir:
+            candidates.append((runtime.scenario_configs_dir / raw, "scenario_configs"))
+
+    for candidate, source in candidates:
+        if candidate.is_file() and candidate.name == "scenario-definition.yaml":
+            host_dir = candidate.parent.resolve()
+            return ResolvedScenario(host_dir.name, host_dir, candidate.resolve(), source)
+        if _is_scenario_dir(candidate):
+            host_dir = candidate.resolve()
+            return ResolvedScenario(host_dir.name, host_dir, host_dir / "scenario-definition.yaml", source)
+
+    available = _format_available_scenarios(runtime)
+    raise RuntimeError(
+        f"scenario must be a directory containing scenario-definition.yaml, got: {scenario_name}\n{available}"
+    )
+
+
+def _scenario_names(runtime: RuntimeConfig) -> list[str]:
+    if not runtime.scenario_configs_dir or not runtime.scenario_configs_dir.is_dir():
+        return []
+    return [
+        path.name for path in sorted(runtime.scenario_configs_dir.iterdir()) if path.is_dir() and _is_scenario_dir(path)
+    ]
+
+
+def _format_available_scenarios(runtime: RuntimeConfig) -> str:
+    names = _scenario_names(runtime)
+    if names:
+        return "Configured scenarios:\n  - " + "\n  - ".join(names)
+    return "No configured scenarios found. Set scenario_configs_dir in rosotacom.yaml."
+
+
+def _scenario_name_completer(
+    prefix: str,
+    parsed_args: argparse.Namespace,
+    **_: Any,
+) -> dict[str, str]:
+    completions: dict[str, str] = {}
+    if prefix.startswith((".", "~", os.sep)) or os.sep in prefix:
+        completions.update({path: "scenario directory" for path in DirectoriesCompleter()(prefix)})
+    try:
+        runtime = _load_runtime_config(parsed_args)
+    except (FileNotFoundError, RuntimeError, OSError, yaml.YAMLError):
+        return completions
+    completions.update({name: "configured scenario" for name in _scenario_names(runtime) if name.startswith(prefix)})
+    return completions
+
+
+def _load_scenario_definition(resolved: ResolvedScenario) -> ScenarioDefinition:
+    raw = _load_yaml_file(resolved.definition_path)
+    allowed_root = {"schema_version", "session", "applications"}
+    extra_root = sorted(set(raw) - allowed_root)
+    if extra_root:
+        raise RuntimeError(
+            f"Unsupported keys in scenario-definition root: {extra_root}. Allowed keys: {sorted(allowed_root)}"
+        )
+    if raw.get("schema_version") != 1:
+        raise RuntimeError("scenario-definition.yaml requires schema_version: 1.")
+
+    session = raw.get("session")
+    if not isinstance(session, str) or not session.strip():
+        raise RuntimeError("scenario-definition.yaml requires a non-empty string 'session'.")
+
+    raw_applications = raw.get("applications")
+    if not isinstance(raw_applications, dict) or not raw_applications:
+        raise RuntimeError("scenario-definition.yaml requires a non-empty 'applications' mapping.")
+
+    applications: dict[str, tuple[ScenarioApplication, ...]] = {}
+    for identity, entries in raw_applications.items():
+        if not isinstance(identity, str) or not identity.strip():
+            raise RuntimeError("scenario application identity keys must be non-empty strings.")
+        if not isinstance(entries, list):
+            raise RuntimeError(f"scenario applications.{identity} must be a list.")
+        seen_names: set[str] = set()
+        parsed_entries: list[ScenarioApplication] = []
+        for index, entry in enumerate(entries):
+            context = f"scenario applications.{identity}[{index}]"
+            if not isinstance(entry, dict):
+                raise RuntimeError(f"{context} must be a mapping.")
+            allowed_entry = {"name", "ros2docker_config"}
+            extra_entry = sorted(set(entry) - allowed_entry)
+            if extra_entry:
+                raise RuntimeError(
+                    f"Unsupported keys in {context}: {extra_entry}. Allowed keys: {sorted(allowed_entry)}"
+                )
+            name = entry.get("name")
+            if not isinstance(name, str) or not name.strip():
+                raise RuntimeError(f"{context}.name must be a non-empty string.")
+            name = name.strip()
+            if name in seen_names:
+                raise RuntimeError(f"Duplicate application name '{name}' for identity '{identity}'.")
+            config_raw = entry.get("ros2docker_config")
+            if not isinstance(config_raw, str) or not config_raw.strip():
+                raise RuntimeError(f"{context}.ros2docker_config must be a non-empty string.")
+            config_path = _resolve_path(config_raw, resolved.host_dir, must_exist=True)
+            assert config_path is not None
+            if not config_path.is_file():
+                raise RuntimeError(f"{context}.ros2docker_config must resolve to a file: {config_path}")
+            load_config(config_path)
+            seen_names.add(name)
+            parsed_entries.append(ScenarioApplication(name=name, ros2docker_config=config_path))
+        applications[identity] = tuple(parsed_entries)
+
+    return ScenarioDefinition(session=session.strip(), applications=applications)
+
+
+def _scenario_application(
+    definition: ScenarioDefinition,
+    identity: str,
+    application_name: str,
+) -> ScenarioApplication:
+    for application in definition.applications.get(identity, ()):
+        if application.name == application_name:
+            return application
+    raise RuntimeError(f"Unknown scenario application '{application_name}' for identity '{identity}'.")
+
+
+def _scenario_container_name(
+    runtime: RuntimeConfig,
+    scenario_name: str,
+    identity: str,
+    application_name: str,
+) -> str:
+    base = _sanitize_docker_name(
+        f"rosotacom_{runtime.install_id}_scenario_{scenario_name}_{identity}_{application_name}"
+    )
+    if len(base) <= 120:
+        return base
+    digest = hashlib.sha1(base.encode("utf-8")).hexdigest()[:10]
+    return f"{base[:109]}_{digest}"
+
+
+def _scenario_application_image_name(runtime: RuntimeConfig, application: ScenarioApplication) -> str:
+    config = load_config(application.ros2docker_config, resolve_run_args=False)
+    base = str(config.get("image_name") or "ros2docker")
+    return _scoped_image_name_from_base(base, runtime.install_id)
+
+
+def _scenario_tmux_socket(runtime: RuntimeConfig) -> str:
+    return f"rosotacom-{runtime.install_id}"
+
+
+def _scenario_tmux_session(scenario_name: str, identity: str) -> str:
+    return _safe_path_token(f"{scenario_name}-{identity}")
+
+
+def _tmux_command(runtime: RuntimeConfig, *args: str) -> list[str]:
+    return ["tmux", "-L", _scenario_tmux_socket(runtime), *args]
+
+
+def _require_tmux() -> None:
+    if not shutil.which("tmux"):
+        raise RuntimeError("Scenario orchestration requires host tmux. Install tmux and retry.")
+
+
+def _tmux_session_exists(runtime: RuntimeConfig, session_name: str) -> bool:
+    if not shutil.which("tmux"):
+        return False
+    result = subprocess.run(
+        _tmux_command(runtime, "has-session", "-t", session_name),
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    )
+    return result.returncode == 0
+
+
+def _runtime_cli_args(runtime: RuntimeConfig) -> list[str]:
+    args: list[str] = []
+    if runtime.rosotacom_config:
+        args.extend(["--rosotacom-config", str(runtime.rosotacom_config)])
+    args.extend(["--ros2docker-config", str(runtime.ros2docker_config)])
+    if runtime.session_configs_dir:
+        args.extend(["--session-configs-dir", str(runtime.session_configs_dir)])
+    if runtime.scenario_configs_dir:
+        args.extend(["--scenario-configs-dir", str(runtime.scenario_configs_dir)])
+    if runtime.session_instances_dir:
+        args.extend(["--session-instances-dir", str(runtime.session_instances_dir)])
+    if runtime.data_dict:
+        args.extend(["--data-dict", str(runtime.data_dict)])
+    return args
+
+
+def _scenario_communication_command(
+    runtime: RuntimeConfig,
+    definition: ScenarioDefinition,
+    identity: str,
+    instance_id: str,
+    args: argparse.Namespace,
+) -> list[str]:
+    command = [
+        sys.executable,
+        "-m",
+        "rosotacom",
+        "start",
+        definition.session,
+        "--identity",
+        identity,
+        "--mode",
+        "attach",
+        "--instance-id",
+        instance_id,
+        "--scenario-managed",
+        *_runtime_cli_args(runtime),
+    ]
+    command.append("--force" if getattr(args, "force", True) else "--no-force")
+    if getattr(args, "rewrite_formatting", False):
+        command.append("--rewrite-formatting")
+    remote_override = getattr(args, "overwrite_peers_via_remote_peer", None)
+    if remote_override:
+        command.extend(["--overwrite-peers-via-remote-peer", remote_override])
+    for override in getattr(args, "peer_address", []) or []:
+        command.extend(["--peer-address", override])
+    return command
+
+
+def _scenario_application_command(
+    runtime: RuntimeConfig,
+    resolved: ResolvedScenario,
+    identity: str,
+    application: ScenarioApplication,
+) -> list[str]:
+    return [
+        sys.executable,
+        "-m",
+        "rosotacom",
+        "scenario",
+        "_run-application",
+        resolved.name,
+        "--identity",
+        identity,
+        "--application",
+        application.name,
+        *_runtime_cli_args(runtime),
+    ]
+
+
+def _scenario_log_path(instance: SessionInstance, identity: str, component: str) -> Path:
+    return instance.logs_host_dir / _safe_path_token(identity) / "scenario" / f"{_safe_path_token(component)}.log"
+
+
+def _attach_tmux_pipe(runtime: RuntimeConfig, pane_id: str, log_path: Path) -> None:
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        _tmux_command(runtime, "pipe-pane", "-o", "-t", pane_id, f"cat >> {shlex.quote(str(log_path))}"),
+        check=True,
+    )
+
+
+def _create_scenario_tmux(
+    runtime: RuntimeConfig,
+    resolved: ResolvedScenario,
+    definition: ScenarioDefinition,
+    instance: SessionInstance,
+    identity: str,
+    applications: tuple[ScenarioApplication, ...],
+    args: argparse.Namespace,
+) -> str:
+    session_name = _scenario_tmux_session(resolved.name, identity)
+    communication_command = shlex.join(
+        _scenario_communication_command(runtime, definition, identity, instance.instance_id, args)
+    )
+    created = subprocess.run(
+        _tmux_command(
+            runtime,
+            "new-session",
+            "-d",
+            "-P",
+            "-F",
+            "#{pane_id}",
+            "-s",
+            session_name,
+            "-n",
+            "scenario",
+            communication_command,
+        ),
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    communication_pane = created.stdout.strip()
+    subprocess.run(_tmux_command(runtime, "set-option", "-t", session_name, "remain-on-exit", "on"), check=True)
+    subprocess.run(_tmux_command(runtime, "set-option", "-t", session_name, "prefix", "C-b"), check=True)
+    subprocess.run(_tmux_command(runtime, "bind-key", "-T", "prefix", "C-b", "send-prefix"), check=True)
+    subprocess.run(
+        _tmux_command(runtime, "set-option", "-t", session_name, "pane-border-status", "top"),
+        check=True,
+    )
+    subprocess.run(
+        _tmux_command(
+            runtime,
+            "set-option",
+            "-t",
+            session_name,
+            "pane-border-format",
+            " #{pane_title} ",
+        ),
+        check=True,
+    )
+    subprocess.run(
+        _tmux_command(
+            runtime,
+            "set-option",
+            "-t",
+            session_name,
+            "status-right",
+            " outer: C-b | inner catmux: C-b C-b ",
+        ),
+        check=True,
+    )
+    subprocess.run(
+        _tmux_command(runtime, "select-pane", "-t", communication_pane, "-T", "communication"),
+        check=True,
+    )
+    _attach_tmux_pipe(
+        runtime,
+        communication_pane,
+        _scenario_log_path(instance, identity, "communication"),
+    )
+
+    for application in applications:
+        split = subprocess.run(
+            _tmux_command(
+                runtime,
+                "split-window",
+                "-d",
+                "-P",
+                "-F",
+                "#{pane_id}",
+                "-t",
+                f"{session_name}:0",
+                shlex.join(_scenario_application_command(runtime, resolved, identity, application)),
+            ),
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+        pane_id = split.stdout.strip()
+        subprocess.run(
+            _tmux_command(runtime, "select-pane", "-t", pane_id, "-T", f"application:{application.name}"),
+            check=True,
+        )
+        _attach_tmux_pipe(
+            runtime,
+            pane_id,
+            _scenario_log_path(instance, identity, f"application-{application.name}"),
+        )
+
+    subprocess.run(_tmux_command(runtime, "select-layout", "-t", f"{session_name}:0", "tiled"), check=True)
+    subprocess.run(_tmux_command(runtime, "select-pane", "-t", communication_pane), check=True)
+    return session_name
+
+
 def _base_extra_run_args(
     runtime: RuntimeConfig,
     session: ResolvedSession,
@@ -1046,17 +1513,18 @@ def start_session(args: argparse.Namespace) -> str:
             ]
         ),
     )
-    _write_instance_manifest(
-        instance,
-        session,
-        runtime,
-        cfg,
-        identity=identity,
-        container_name=container_name,
-        mode=mode,
-        peer_address=list(args.peer_address or []),
-        overwrite_peers_via_remote_peer=args.overwrite_peers_via_remote_peer,
-    )
+    if not getattr(args, "scenario_managed", False):
+        _write_instance_manifest(
+            instance,
+            session,
+            runtime,
+            cfg,
+            identity=identity,
+            container_name=container_name,
+            mode=mode,
+            peer_address=list(args.peer_address or []),
+            overwrite_peers_via_remote_peer=args.overwrite_peers_via_remote_peer,
+        )
     if args.force:
         _stop_container_name(container_name, runtime, quiet_missing=True)
 
@@ -1112,6 +1580,225 @@ def stop_session(args: argparse.Namespace) -> None:
         print(f"Auto-selected identity: {identity}")
     for container_name in _identity_container_names(cfg, runtime, identity):
         _stop_container_name(container_name, runtime)
+
+
+def _resolve_scenario_context(
+    args: argparse.Namespace,
+) -> tuple[
+    RuntimeConfig,
+    ResolvedScenario,
+    ScenarioDefinition,
+    ResolvedSession,
+    dict[str, Any],
+    str,
+    tuple[ScenarioApplication, ...],
+]:
+    runtime = _load_runtime_config(args)
+    resolved = _resolve_scenario(args.scenario, runtime)
+    definition = _load_scenario_definition(resolved)
+    session = _resolve_session(definition.session, runtime)
+    peer_overrides = _parse_peer_address_overrides(getattr(args, "peer_address", None))
+    cfg = _effective_session_config(
+        session.host_dir,
+        runtime,
+        overwrite_peers_via_remote_peer=getattr(args, "overwrite_peers_via_remote_peer", None),
+        peer_address_overrides=peer_overrides,
+    )
+    peers = cfg.get("peers")
+    if not isinstance(peers, dict):
+        raise RuntimeError("Scenario session must define a peers mapping.")
+    unknown_identities = sorted(set(definition.applications) - set(peers))
+    if unknown_identities:
+        raise RuntimeError(
+            f"Scenario defines applications for unknown session identities {unknown_identities}. "
+            f"Known identities: {sorted(peers)}"
+        )
+    identity = getattr(args, "identity", None)
+    if not identity and getattr(args, "auto_identity", True):
+        identity = _auto_identity(session.host_dir, runtime, cfg)
+        print(f"Auto-selected identity: {identity}")
+    if not identity:
+        raise RuntimeError("Missing --identity. Provide --identity <peer> or allow auto identity.")
+    if identity not in peers:
+        raise RuntimeError(f"--identity must be one of peers={list(peers.keys())}")
+    applications = definition.applications.get(identity)
+    if applications is None:
+        raise RuntimeError(f"Scenario '{resolved.name}' has no applications entry for identity '{identity}'.")
+    return runtime, resolved, definition, session, cfg, identity, applications
+
+
+def _stop_scenario_application(
+    runtime: RuntimeConfig,
+    resolved: ResolvedScenario,
+    identity: str,
+    application: ScenarioApplication,
+) -> bool:
+    container_name = _scenario_container_name(runtime, resolved.name, identity, application.name)
+    if not _container_exists(container_name):
+        return False
+    ros2docker_stop(
+        config_file=application.ros2docker_config,
+        override={"container_name": container_name},
+    )
+    return True
+
+
+def _kill_scenario_tmux(runtime: RuntimeConfig, session_name: str) -> bool:
+    if not _tmux_session_exists(runtime, session_name):
+        return False
+    subprocess.run(_tmux_command(runtime, "kill-session", "-t", session_name), check=True)
+    return True
+
+
+def _find_latest_scenario_instance(
+    runtime: RuntimeConfig,
+    scenario_name: str,
+    identity: str,
+    instance_id: str | None = None,
+) -> Path | None:
+    root = _session_instances_root(runtime)
+    candidates = sorted(root.glob("*/*/manifest.yaml"), reverse=True)
+    for manifest_path in candidates:
+        manifest = _load_yaml_file(manifest_path)
+        if instance_id and manifest.get("instance_id") != _safe_path_token(instance_id):
+            continue
+        scenario_runs = manifest.get("scenario_runs") or {}
+        if f"{scenario_name}:{identity}" in scenario_runs:
+            return manifest_path.parent.resolve()
+    return None
+
+
+def _stop_scenario_components(
+    runtime: RuntimeConfig,
+    resolved: ResolvedScenario,
+    cfg: dict[str, Any],
+    identity: str,
+    applications: tuple[ScenarioApplication, ...],
+    *,
+    quiet_missing: bool,
+) -> None:
+    for application in applications:
+        stopped = _stop_scenario_application(runtime, resolved, identity, application)
+        if stopped:
+            print(f"Stopped scenario application: {application.name}")
+        elif not quiet_missing:
+            print(
+                "Application container not found: "
+                + _scenario_container_name(runtime, resolved.name, identity, application.name)
+            )
+    communication_container = _container_name(_remote_peer_name(cfg, identity), runtime)
+    _stop_container_name(communication_container, runtime, quiet_missing=quiet_missing)
+    if _kill_scenario_tmux(runtime, _scenario_tmux_session(resolved.name, identity)):
+        print(f"Stopped scenario tmux session: {_scenario_tmux_session(resolved.name, identity)}")
+
+
+def start_scenario(args: argparse.Namespace) -> int:
+    _require_ros2docker()
+    _require_tmux()
+    runtime, resolved, definition, session, cfg, identity, applications = _resolve_scenario_context(args)
+    tmux_session = _scenario_tmux_session(resolved.name, identity)
+    if _tmux_session_exists(runtime, tmux_session):
+        if not getattr(args, "force", True):
+            raise RuntimeError(f"Scenario tmux session already exists: {tmux_session}. Use --force or attach to it.")
+        _stop_scenario_components(
+            runtime,
+            resolved,
+            cfg,
+            identity,
+            applications,
+            quiet_missing=True,
+        )
+
+    instance = _resolve_session_instance(runtime, session, getattr(args, "instance_id", None))
+    communication_container = _container_name(_remote_peer_name(cfg, identity), runtime)
+    _write_scenario_manifest(
+        instance,
+        session,
+        runtime,
+        cfg,
+        resolved,
+        identity=identity,
+        communication_container=communication_container,
+        applications=applications,
+        tmux_session=tmux_session,
+    )
+    created_session = _create_scenario_tmux(
+        runtime,
+        resolved,
+        definition,
+        instance,
+        identity,
+        applications,
+        args,
+    )
+    print(f"rosotacom scenario instance: {instance.host_dir}")
+    print(f"rosotacom scenario started: {resolved.name} ({identity})")
+    print("Outer tmux prefix: Ctrl-b; send the inner catmux prefix with Ctrl-b Ctrl-b.")
+    mode = _resolve_mode(getattr(args, "mode", "auto"))
+    if mode == "attach":
+        subprocess.run(_tmux_command(runtime, "attach-session", "-t", created_session), check=True)
+    else:
+        print(f"Attach with: rosotacom scenario attach {shlex.quote(resolved.name)} --identity {identity}")
+    return 0
+
+
+def attach_scenario(args: argparse.Namespace) -> int:
+    _require_tmux()
+    runtime, resolved, _definition, _session, _cfg, identity, _applications = _resolve_scenario_context(args)
+    tmux_session = _scenario_tmux_session(resolved.name, identity)
+    if not _tmux_session_exists(runtime, tmux_session):
+        raise RuntimeError(f"Scenario tmux session is not running: {tmux_session}")
+    subprocess.run(_tmux_command(runtime, "attach-session", "-t", tmux_session), check=True)
+    return 0
+
+
+def stop_scenario(args: argparse.Namespace) -> int:
+    _require_ros2docker()
+    runtime, resolved, _definition, _session, cfg, identity, applications = _resolve_scenario_context(args)
+    _stop_scenario_components(
+        runtime,
+        resolved,
+        cfg,
+        identity,
+        applications,
+        quiet_missing=False,
+    )
+    instance_dir = _find_latest_scenario_instance(
+        runtime,
+        resolved.name,
+        identity,
+        getattr(args, "instance_id", None),
+    )
+    if instance_dir:
+        _mark_scenario_stopped(instance_dir, resolved.name, identity)
+    return 0
+
+
+def run_scenario_application(args: argparse.Namespace) -> int:
+    _require_ros2docker()
+    runtime = _load_runtime_config(args)
+    resolved = _resolve_scenario(args.scenario, runtime)
+    definition = _load_scenario_definition(resolved)
+    application = _scenario_application(definition, args.identity, args.application)
+    container_name = _scenario_container_name(runtime, resolved.name, args.identity, application.name)
+    if _container_exists(container_name):
+        ros2docker_stop(
+            config_file=application.ros2docker_config,
+            override={"container_name": container_name},
+        )
+    override = {
+        "container_name": container_name,
+        "image_name": _scenario_application_image_name(runtime, application),
+    }
+    ros2docker_build(config_file=application.ros2docker_config, override=override)
+    ros2docker_run(config_file=application.ros2docker_config, override=override)
+    return 0
+
+
+def list_scenarios(args: argparse.Namespace) -> int:
+    runtime = _load_runtime_config(args)
+    print(_format_available_scenarios(runtime))
+    return 0
 
 
 def list_sessions(args: argparse.Namespace) -> None:
@@ -1292,6 +1979,10 @@ def doctor(args: argparse.Namespace) -> int:
             line("OK", "session definitions", f"{runtime.session_configs_dir} -> {SESSION_DEFINITION_CONTAINER_DIR}")
         else:
             line("INFO", "session definitions", "not configured")
+        if runtime.scenario_configs_dir:
+            line("OK", "scenario definitions", str(runtime.scenario_configs_dir))
+        else:
+            line("INFO", "scenario definitions", "not configured")
         line("OK", "session instances", f"{_session_instances_root(runtime)} -> {SESSION_INSTANCE_CONTAINER_DIR}")
         if runtime.data_dict:
             line("OK", "data dict", str(runtime.data_dict))
@@ -1312,6 +2003,12 @@ def doctor(args: argparse.Namespace) -> int:
             line("OK", "legacy start_rosotacom", f"{stale} points to this checkout")
     else:
         line("INFO", "legacy start_rosotacom", "no global legacy symlink found")
+
+    tmux = shutil.which("tmux")
+    if tmux:
+        line("OK", "tmux", tmux)
+    else:
+        line("WARN", "tmux", "not installed; required only for `rosotacom scenario`")
 
     if runtime and _ROS2DOCKER_IMPORT_ERROR is None:
         try:
@@ -2439,6 +3136,7 @@ def _add_common_config_args(parser: argparse.ArgumentParser) -> None:
     )
     parser.add_argument("-f", "--ros2docker-config", help="Path to ros2docker JSON config.")
     parser.add_argument("--session-configs-dir", help="Host directory containing named session configs.")
+    parser.add_argument("--scenario-configs-dir", help="Host directory containing named scenario configs.")
     parser.add_argument("--session-instances-dir", help="Host directory for generated session instances and logs.")
     parser.add_argument("--data-dict", help="Host data_dict.json path for data:<key> address expressions.")
 
@@ -2447,6 +3145,20 @@ def _add_session_arg(parser: argparse.ArgumentParser, *args: str, **kwargs: Any)
     action = parser.add_argument(*args, **kwargs)
     cast(Any, action).completer = _session_name_completer
     return action
+
+
+def _add_scenario_arg(parser: argparse.ArgumentParser, *args: str, **kwargs: Any) -> argparse.Action:
+    action = parser.add_argument(*args, **kwargs)
+    cast(Any, action).completer = _scenario_name_completer
+    return action
+
+
+def _add_scenario_identity_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--identity")
+    parser.add_argument("--no-auto-identity", dest="auto_identity", action="store_false")
+    parser.add_argument("--overwrite-peers-via-remote-peer")
+    parser.add_argument("--peer-address", action="append", default=[], metavar="PEER=ADDRESS_EXPR")
+    parser.set_defaults(auto_identity=True)
 
 
 def _add_start_args(parser: argparse.ArgumentParser) -> None:
@@ -2462,6 +3174,7 @@ def _add_start_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--overwrite-peers-via-remote-peer")
     parser.add_argument("--peer-address", action="append", default=[], metavar="PEER=ADDRESS_EXPR")
     parser.add_argument("--instance-id", help="Join or create a named runtime session instance.")
+    parser.add_argument("--scenario-managed", action="store_true", help=argparse.SUPPRESS)
     parser.set_defaults(force=True, auto_identity=True)
 
 
@@ -2538,6 +3251,7 @@ def main(argv: list[str] | None = None) -> int:
         "probe-check",
         "publish-test-topics",
         "list-sessions",
+        "scenario",
         "examples",
         "setup-env",
         "config",
@@ -2649,6 +3363,59 @@ def main(argv: list[str] | None = None) -> int:
     list_parser = subparsers.add_parser("list-sessions", help="List configured sessions.")
     _add_common_config_args(list_parser)
     list_parser.set_defaults(func=list_sessions_command)
+
+    scenario_parser = subparsers.add_parser(
+        "scenario",
+        help="Run a communication session together with identity-specific local applications.",
+    )
+    scenario_subparsers = scenario_parser.add_subparsers(dest="scenario_command", required=True)
+
+    scenario_start_parser = scenario_subparsers.add_parser(
+        "start",
+        help="Start a scenario in an isolated outer tmux session.",
+    )
+    _add_common_config_args(scenario_start_parser)
+    _add_scenario_arg(scenario_start_parser, "scenario")
+    _add_scenario_identity_args(scenario_start_parser)
+    scenario_start_parser.add_argument("--mode", choices=["auto", "attach", "detached"], default="auto")
+    scenario_start_parser.add_argument("--no-force", dest="force", action="store_false")
+    scenario_start_parser.add_argument("--force", dest="force", action="store_true")
+    scenario_start_parser.add_argument("--rewrite-formatting", action="store_true")
+    scenario_start_parser.add_argument("--instance-id", help="Join or create a named runtime session instance.")
+    scenario_start_parser.set_defaults(func=start_scenario, force=True)
+
+    scenario_attach_parser = scenario_subparsers.add_parser(
+        "attach",
+        help="Attach to a running scenario's outer tmux session.",
+    )
+    _add_common_config_args(scenario_attach_parser)
+    _add_scenario_arg(scenario_attach_parser, "scenario")
+    _add_scenario_identity_args(scenario_attach_parser)
+    scenario_attach_parser.set_defaults(func=attach_scenario)
+
+    scenario_stop_parser = scenario_subparsers.add_parser(
+        "stop",
+        help="Stop scenario applications, communication container, and outer tmux.",
+    )
+    _add_common_config_args(scenario_stop_parser)
+    _add_scenario_arg(scenario_stop_parser, "scenario")
+    _add_scenario_identity_args(scenario_stop_parser)
+    scenario_stop_parser.add_argument("--instance-id", help="Mark a specific scenario instance as stopped.")
+    scenario_stop_parser.set_defaults(func=stop_scenario)
+
+    scenario_list_parser = scenario_subparsers.add_parser("list", help="List configured scenarios.")
+    _add_common_config_args(scenario_list_parser)
+    scenario_list_parser.set_defaults(func=list_scenarios)
+
+    scenario_run_application_parser = scenario_subparsers.add_parser(
+        "_run-application",
+        help="Internal application runner used by scenario tmux panes.",
+    )
+    _add_common_config_args(scenario_run_application_parser)
+    _add_scenario_arg(scenario_run_application_parser, "scenario")
+    scenario_run_application_parser.add_argument("--identity", required=True)
+    scenario_run_application_parser.add_argument("--application", required=True)
+    scenario_run_application_parser.set_defaults(func=run_scenario_application)
 
     examples_parser = subparsers.add_parser("examples", help="Manage packaged rosotacom examples.")
     examples_subparsers = examples_parser.add_subparsers(dest="examples_command", required=True)

--- a/src/rosotacom/resources/examples/README.md
+++ b/src/rosotacom/resources/examples/README.md
@@ -1,7 +1,7 @@
 # Rosotacom Examples
 
 This directory is a copyable rosotacom example project. It contains local
-project setup, reusable session configs, and helper scripts.
+project setup, reusable session/scenario configs, and helper scripts.
 
 ## Use From An Installed CLI
 
@@ -27,6 +27,26 @@ rosotacom stop 1_heartbeat --identity a
 rosotacom stop 1_heartbeat --identity b
 docker ps --filter name=rosotacom   # optional: confirm cleanup
 ```
+
+## Complete native-chatter scenario
+
+Example 2 composes its communication session with the matching local
+application container:
+
+```bash
+rosotacom scenario start 2_native_chatter --identity a
+```
+
+Run identity `b` on the other machine in the same way. The outer tmux prefix is
+`Ctrl-b`; use `Ctrl-b Ctrl-b` to address the inner catmux session. Detaching
+keeps the use case running:
+
+```bash
+rosotacom scenario attach 2_native_chatter --identity a
+rosotacom scenario stop 2_native_chatter --identity a
+```
+
+The existing scripts under `scripts/2_native_chatter/` remain as a fallback.
 
 ## Local smoke test
 
@@ -64,6 +84,7 @@ one host and identity `b` on the other with the same session.
 - `ros2docker.json`: Docker runtime defaults used by the communication containers
 - `data_dict.json`: example machine address data used by `data:<key>` session entries
 - `sessions/`: tracked static session definitions/templates
+- `scenarios/`: complete use cases that combine a session with local applications
 - `session-instances/`: ignored generated runtime configs, catmux logs, smoke logs, and rosbags
 - `scripts/`: convenience wrappers and external-node launchers
 

--- a/src/rosotacom/resources/examples/rosotacom.yaml
+++ b/src/rosotacom/resources/examples/rosotacom.yaml
@@ -5,5 +5,6 @@
 # `--rosotacom-config`.
 ros2docker_config: ros2docker.json
 session_configs_dir: sessions
+scenario_configs_dir: scenarios
 session_instances_dir: session-instances
 data_dict: data_dict.json

--- a/src/rosotacom/resources/examples/scenarios/2_native_chatter/scenario-definition.yaml
+++ b/src/rosotacom/resources/examples/scenarios/2_native_chatter/scenario-definition.yaml
@@ -1,0 +1,10 @@
+schema_version: 1
+session: 2_native_chatter
+
+applications:
+  a:
+    - name: native_application
+      ros2docker_config: ../../scripts/2_native_chatter/machine_a/external.ros2docker.json
+  b:
+    - name: native_application
+      ros2docker_config: ../../scripts/2_native_chatter/machine_b/external.ros2docker.json

--- a/src/rosotacom/resources/examples/scripts/2_native_chatter/machine_a/external.ros2docker.json
+++ b/src/rosotacom/resources/examples/scripts/2_native_chatter/machine_a/external.ros2docker.json
@@ -1,5 +1,6 @@
 {
   "container_name": "machine_a_logic",
+  "image_name": "rosotacom-native-chatter",
 
   "run_type": "command",
   "command": "/wait_for_echo_topic.sh",
@@ -8,6 +9,12 @@
   "run_args": [
     "--network", "host",
     "-v", "./wait_for_echo_topic.sh:/wait_for_echo_topic.sh",
+    "-e", "RMW_IMPLEMENTATION=rmw_cyclonedds_cpp",
     "-e", "ROS_DOMAIN_ID=46"
-  ]
+  ],
+
+  "build_args": {
+    "BASE_IMAGE": "osrf/ros:kilted-desktop-full-noble",
+    "DIGEST": "@sha256:29eb6f48bb06549aba004a7a4b12c00ece23b156731df12cf1f3c1ae1b0fd178"
+  }
 }

--- a/src/rosotacom/resources/examples/scripts/2_native_chatter/machine_b/external.ros2docker.json
+++ b/src/rosotacom/resources/examples/scripts/2_native_chatter/machine_b/external.ros2docker.json
@@ -1,11 +1,18 @@
 {
   "container_name": "machine_b_logic",
+  "image_name": "rosotacom-native-chatter",
 
   "run_type": "command",
   "command": ["ros2", "topic", "pub", "-r", "1", "/chatter", "std_msgs/String", "data: 'hello from talker'"],
 
   "run_args": [
     "--network", "host",
+    "-e", "RMW_IMPLEMENTATION=rmw_cyclonedds_cpp",
     "-e", "ROS_DOMAIN_ID=47"
-  ]
+  ],
+
+  "build_args": {
+    "BASE_IMAGE": "osrf/ros:kilted-desktop-full-noble",
+    "DIGEST": "@sha256:29eb6f48bb06549aba004a7a4b12c00ece23b156731df12cf1f3c1ae1b0fd178"
+  }
 }

--- a/src/rosotacom/resources/examples/sessions/2_native_chatter/session-definition.yaml
+++ b/src/rosotacom/resources/examples/sessions/2_native_chatter/session-definition.yaml
@@ -12,8 +12,8 @@ peer_settings:
 
 shared:
   use_status_overview: true
-  # Active variant: fastdds shortcut (sets both local and OTA RMW implementations).
-  rmw: fastdds
+  # Active variant: cyclone shortcut (sets both local and OTA RMW implementations).
+  rmw: cyclone
   ota_domain_id: 48
 
   # --- Alternative rmw syntaxes (uncomment one, comment out the others) ---

--- a/tests/contract/test_packaged_resources.py
+++ b/tests/contract/test_packaged_resources.py
@@ -21,6 +21,7 @@ def test_packaged_resources_include_curated_examples_and_runtime_workspace() -> 
         "resources/examples/data_dict.json",
         "resources/examples/sessions/1_heartbeat/session-definition.yaml",
         "resources/examples/sessions/1_heartbeat_status/session-definition.yaml",
+        "resources/examples/scenarios/2_native_chatter/scenario-definition.yaml",
         "resources/ws/session/creation/run_session.py",
         "resources/ws/session/creation/catmux_log_setup.sh",
         "resources/ws/session/creation/strip_ansi.py",

--- a/tests/contract/test_readme_examples.py
+++ b/tests/contract/test_readme_examples.py
@@ -24,6 +24,7 @@ def test_source_checkout_rosotacom_yaml_loads() -> None:
 
     assert runtime.ros2docker_config == cli.EXAMPLE_PROJECT_DIR / "ros2docker.json"
     assert runtime.session_configs_dir == cli.EXAMPLE_PROJECT_DIR / "sessions"
+    assert runtime.scenario_configs_dir == cli.EXAMPLE_PROJECT_DIR / "scenarios"
     assert runtime.session_instances_dir == PACKAGE_ROOT / "session-instances"
     assert runtime.data_dict == cli.EXAMPLE_PROJECT_DIR / "data_dict.json"
 
@@ -34,6 +35,7 @@ def test_packaged_example_setup_paths_are_relative_to_example_root() -> None:
     assert setup == {
         "ros2docker_config": "ros2docker.json",
         "session_configs_dir": "sessions",
+        "scenario_configs_dir": "scenarios",
         "session_instances_dir": "session-instances",
         "data_dict": "data_dict.json",
     }
@@ -43,5 +45,19 @@ def test_packaged_example_project_contains_documented_heartbeat_session() -> Non
     readme = (PACKAGE_ROOT / "README.md").read_text(encoding="utf-8")
 
     assert "`1_heartbeat`" in readme
+    assert "rosotacom scenario start 2_native_chatter" in readme
     assert (cli.EXAMPLE_PROJECT_DIR / "sessions" / "1_heartbeat" / "session-definition.yaml").is_file()
+    assert (cli.EXAMPLE_PROJECT_DIR / "scenarios" / "2_native_chatter" / "scenario-definition.yaml").is_file()
     assert (cli.EXAMPLE_PROJECT_DIR / "scripts" / "1_heartbeat" / "run_machine_a.sh").is_file()
+
+
+def test_packaged_native_chatter_scenario_and_application_configs_load() -> None:
+    runtime = cli._load_runtime_config(
+        argparse.Namespace(rosotacom_config=str(cli.EXAMPLE_PROJECT_DIR / "rosotacom.yaml"))
+    )
+    resolved = cli._resolve_scenario("2_native_chatter", runtime)
+
+    definition = cli._load_scenario_definition(resolved)
+
+    assert definition.session == "2_native_chatter"
+    assert set(definition.applications) == {"a", "b"}

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -4,6 +4,7 @@ import os
 import re
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 import pytest
@@ -190,6 +191,30 @@ def _smoke_command(project: Path, session_name: str) -> list[str]:
     ]
 
 
+def _scenario_command(project: Path, action: str, identity: str, instance_id: str) -> list[str]:
+    return [
+        sys.executable,
+        "-m",
+        "rosotacom",
+        "scenario",
+        action,
+        "2_native_chatter",
+        "--identity",
+        identity,
+        "--rosotacom-config",
+        str(project / "rosotacom.yaml"),
+        "--session-instances-dir",
+        str(SESSION_INSTANCES_DIR),
+        "--instance-id",
+        instance_id,
+        "--peer-address",
+        "a=127.0.0.1",
+        "--peer-address",
+        "b=127.0.0.1",
+        *(["--mode", "detached"] if action == "start" else []),
+    ]
+
+
 def _artifact_dir(stdout: str) -> Path:
     matches = re.findall(r"Smoke artifacts: (.+)", stdout)
     assert matches, f"no 'Smoke artifacts:' line in smoke output:\n{stdout}"
@@ -360,6 +385,48 @@ def test_local_native_chatter_smoke_from_copied_example_project(
 
     _assert_no_ros_or_catmux_errors(session_name, artifact_dir)
     _assert_metric_present(session_name, result.stdout, topic="/chatter", label="b->a final topic")
+
+
+def test_native_chatter_scenario_starts_apps_and_communication_together(
+    copied_example_project: Path,
+) -> None:
+    instance_id = f"scenario-pilot-{time.time_ns()}"
+    try:
+        for identity in ("a", "b"):
+            result = _run(_scenario_command(copied_example_project, "start", identity, instance_id), timeout=900)
+            assert "rosotacom scenario started: 2_native_chatter" in result.stdout
+            assert "inner catmux prefix with Ctrl-b Ctrl-b" in result.stdout
+
+        _run(
+            [
+                sys.executable,
+                "-m",
+                "rosotacom",
+                "test",
+                "2_native_chatter",
+                "--rosotacom-config",
+                str(copied_example_project / "rosotacom.yaml"),
+                "--session-instances-dir",
+                str(SESSION_INSTANCES_DIR),
+                "--instance-id",
+                instance_id,
+                "--timeout",
+                "120",
+            ],
+            timeout=180,
+        )
+
+        manifests = sorted(SESSION_INSTANCES_DIR.glob(f"*/*_{instance_id}/manifest.yaml"))
+        assert manifests
+        manifest = manifests[-1].read_text(encoding="utf-8")
+        assert "2_native_chatter:a" in manifest
+        assert "2_native_chatter:b" in manifest
+        assert "rosotacom_" in manifest
+        scenario_logs = list(manifests[-1].parent.glob("logs/*/scenario/*.log"))
+        assert scenario_logs
+    finally:
+        for identity in ("a", "b"):
+            _run(_scenario_command(copied_example_project, "stop", identity, instance_id), timeout=60)
 
 
 @pytest.mark.parametrize("session_name", COMP_OCC_GRID_SMOKE_SESSIONS)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -19,6 +19,7 @@ def clear_config_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         "ROSOTACOM_CONFIG",
         "ROSOTACOM_ROS2DOCKER_CONFIG",
         "ROSOTACOM_SESSION_CONFIGS_DIR",
+        "ROSOTACOM_SCENARIO_CONFIGS_DIR",
         "ROSOTACOM_SESSION_INSTANCES_DIR",
         "ROSOTACOM_DATA_DICT",
     ):
@@ -105,12 +106,14 @@ def test_rosotacom_yaml_relative_paths_resolve_from_config_dir(tmp_path: Path) -
     (tmp_path / "ros2docker.json").write_text('{"image_name": "test"}\n', encoding="utf-8")
     (tmp_path / "data_dict.json").write_text('{"machine_a_ip": "127.0.0.1"}\n', encoding="utf-8")
     (tmp_path / "sessions").mkdir()
+    (tmp_path / "scenarios").mkdir()
     config = tmp_path / "rosotacom.yaml"
     config.write_text(
         "\n".join(
             [
                 "ros2docker_config: ros2docker.json",
                 "session_configs_dir: sessions",
+                "scenario_configs_dir: scenarios",
                 "session_instances_dir: session-instances",
                 "data_dict: data_dict.json",
                 "",
@@ -124,6 +127,7 @@ def test_rosotacom_yaml_relative_paths_resolve_from_config_dir(tmp_path: Path) -
     assert runtime.rosotacom_config == config
     assert runtime.ros2docker_config == tmp_path / "ros2docker.json"
     assert runtime.session_configs_dir == tmp_path / "sessions"
+    assert runtime.scenario_configs_dir == tmp_path / "scenarios"
     assert runtime.session_instances_dir == tmp_path / "session-instances"
     assert runtime.data_dict == tmp_path / "data_dict.json"
 
@@ -160,6 +164,7 @@ def test_examples_create_copies_project_and_refuses_overwrite(
     assert (target / "data_dict.json").is_file()
     assert "session-instances/" in (target / ".gitignore").read_text(encoding="utf-8")
     assert (target / "sessions" / "1_heartbeat" / "session-definition.yaml").is_file()
+    assert (target / "scenarios" / "2_native_chatter" / "scenario-definition.yaml").is_file()
     assert not (target / "__init__.py").exists()
     assert "Copied rosotacom examples" in capsys.readouterr().out
 
@@ -229,6 +234,220 @@ def test_session_name_completion_uses_active_project_and_prefix(
     path_completions = rosotacom._session_name_completer("./ext", argparse.Namespace())
 
     assert path_completions["./external_session/"] == "session directory"
+
+
+def _write_test_scenario_project(tmp_path: Path) -> tuple[rosotacom.RuntimeConfig, rosotacom.ResolvedScenario]:
+    sessions = tmp_path / "sessions"
+    session = sessions / "demo"
+    session.mkdir(parents=True)
+    session.joinpath("session-definition.yaml").write_text(
+        "\n".join(
+            [
+                "peers:",
+                "  a: { address: 127.0.0.1 }",
+                "  b: { address: 127.0.0.1 }",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    app_dir = tmp_path / "apps"
+    app_dir.mkdir()
+    for identity in ("a", "b"):
+        app_dir.joinpath(f"{identity}.json").write_text(
+            "\n".join(
+                [
+                    "{",
+                    f'  "container_name": "{identity}_app",',
+                    '  "run_type": "command",',
+                    '  "command": ["true"]',
+                    "}",
+                    "",
+                ]
+            ),
+            encoding="utf-8",
+        )
+    scenario_dir = tmp_path / "scenarios" / "demo"
+    scenario_dir.mkdir(parents=True)
+    scenario_dir.joinpath("scenario-definition.yaml").write_text(
+        "\n".join(
+            [
+                "schema_version: 1",
+                "session: demo",
+                "applications:",
+                "  a:",
+                "    - name: local_app",
+                "      ros2docker_config: ../../apps/a.json",
+                "  b:",
+                "    - name: local_app",
+                "      ros2docker_config: ../../apps/b.json",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    runtime = rosotacom.RuntimeConfig(
+        rosotacom_config=tmp_path / "rosotacom.yaml",
+        ros2docker_config=rosotacom.DEFAULT_ROS2DOCKER_CONFIG,
+        session_configs_dir=sessions,
+        data_dict=None,
+        install_id="test",
+        session_instances_dir=tmp_path / "session-instances",
+        scenario_configs_dir=tmp_path / "scenarios",
+    )
+    return runtime, rosotacom._resolve_scenario("demo", runtime)
+
+
+def test_scenario_definition_resolves_and_validates_strictly(tmp_path: Path) -> None:
+    runtime, resolved = _write_test_scenario_project(tmp_path)
+
+    definition = rosotacom._load_scenario_definition(resolved)
+
+    assert definition.session == "demo"
+    assert definition.applications["a"][0].name == "local_app"
+    assert definition.applications["a"][0].ros2docker_config == tmp_path / "apps" / "a.json"
+    assert rosotacom._scenario_names(runtime) == ["demo"]
+    assert rosotacom._scenario_container_name(runtime, "demo", "a", "local_app") == (
+        "rosotacom_test_scenario_demo_a_local_app"
+    )
+    assert rosotacom._scenario_application_image_name(runtime, definition.applications["a"][0]) == "ros2docker-test"
+
+    resolved.definition_path.write_text(
+        "schema_version: 1\nsession: demo\napplications: {}\nunknown: true\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(RuntimeError, match="Unsupported keys"):
+        rosotacom._load_scenario_definition(resolved)
+
+
+def test_scenario_name_completion_uses_active_project(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime, _resolved = _write_test_scenario_project(tmp_path)
+    (tmp_path / "ros2docker.json").write_text('{"image_name": "completion"}\n', encoding="utf-8")
+    runtime.rosotacom_config.write_text(
+        "\n".join(
+            [
+                "ros2docker_config: ros2docker.json",
+                "session_configs_dir: sessions",
+                "scenario_configs_dir: scenarios",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+
+    assert rosotacom._scenario_name_completer("de", argparse.Namespace()) == {"demo": "configured scenario"}
+
+
+def test_scenario_tmux_commands_keep_ctrl_b_and_log_each_pane(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime, resolved = _write_test_scenario_project(tmp_path)
+    definition = rosotacom._load_scenario_definition(resolved)
+    session = rosotacom._resolve_session("demo", runtime)
+    instance = rosotacom._resolve_session_instance(runtime, session, "tmux")
+    calls: list[list[str]] = []
+    pane_number = 0
+
+    def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        nonlocal pane_number
+        calls.append(command)
+        if "new-session" in command or "split-window" in command:
+            pane_number += 1
+            return subprocess.CompletedProcess(command, 0, f"%{pane_number}\n", "")
+        return subprocess.CompletedProcess(command, 0, "", "")
+
+    monkeypatch.setattr(rosotacom.subprocess, "run", fake_run)
+
+    tmux_session = rosotacom._create_scenario_tmux(
+        runtime,
+        resolved,
+        definition,
+        instance,
+        "a",
+        definition.applications["a"],
+        argparse.Namespace(
+            force=True,
+            rewrite_formatting=False,
+            overwrite_peers_via_remote_peer=None,
+            peer_address=[],
+        ),
+    )
+
+    assert tmux_session == "demo-a"
+    assert all(command[:3] == ["tmux", "-L", "rosotacom-test"] for command in calls)
+    assert any(command[-2:] == ["prefix", "C-b"] for command in calls if "set-option" in command)
+    assert any(command[-3:] == ["prefix", "C-b", "send-prefix"] for command in calls if "bind-key" in command)
+    assert any("inner catmux: C-b C-b" in part for command in calls for part in command)
+    assert any("rosotacom start demo --identity a --mode attach" in " ".join(command) for command in calls)
+    assert any("scenario _run-application demo" in " ".join(command) for command in calls)
+    assert (instance.logs_host_dir / "a" / "scenario").is_dir()
+
+
+def test_start_and_stop_scenario_manage_manifest_and_component_order(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime, resolved = _write_test_scenario_project(tmp_path)
+    definition = rosotacom._load_scenario_definition(resolved)
+    session = rosotacom._resolve_session("demo", runtime)
+    cfg = {"peers": {"a": {}, "b": {}}}
+    instance = rosotacom._resolve_session_instance(runtime, session, "managed")
+    calls: list[str] = []
+
+    context = (runtime, resolved, definition, session, cfg, "a", definition.applications["a"])
+    monkeypatch.setattr(rosotacom, "_require_ros2docker", lambda: None)
+    monkeypatch.setattr(rosotacom, "_require_tmux", lambda: None)
+    monkeypatch.setattr(rosotacom, "_resolve_scenario_context", lambda args: context)
+    monkeypatch.setattr(rosotacom, "_tmux_session_exists", lambda runtime, name: False)
+    monkeypatch.setattr(rosotacom, "_resolve_session_instance", lambda *args, **kwargs: instance)
+    monkeypatch.setattr(rosotacom, "_remote_peer_name", lambda cfg, identity: "b")
+    monkeypatch.setattr(
+        rosotacom, "_create_scenario_tmux", lambda *args, **kwargs: calls.append("tmux-start") or "demo-a"
+    )
+    monkeypatch.setattr(rosotacom, "_resolve_mode", lambda mode: "detached")
+
+    args = argparse.Namespace(
+        scenario="demo",
+        identity="a",
+        force=True,
+        mode="detached",
+        instance_id="managed",
+    )
+    assert rosotacom.start_scenario(args) == 0
+    manifest = yaml.safe_load((instance.host_dir / "manifest.yaml").read_text(encoding="utf-8"))
+    run = manifest["scenario_runs"]["demo:a"]
+    assert run["tmux_session"] == "demo-a"
+    assert run["communication_container"] == "rosotacom_test_com_to_b"
+    assert run["applications"][0]["container_name"] == "rosotacom_test_scenario_demo_a_local_app"
+    assert run["applications"][0]["image_name"] == "ros2docker-test"
+    assert calls == ["tmux-start"]
+
+    monkeypatch.setattr(
+        rosotacom,
+        "_stop_scenario_application",
+        lambda *args, **kwargs: calls.append("application-stop") or True,
+    )
+    monkeypatch.setattr(
+        rosotacom,
+        "_stop_container_name",
+        lambda *args, **kwargs: calls.append("communication-stop") or True,
+    )
+    monkeypatch.setattr(
+        rosotacom,
+        "_kill_scenario_tmux",
+        lambda *args, **kwargs: calls.append("tmux-stop") or True,
+    )
+    monkeypatch.setattr(rosotacom, "_find_latest_scenario_instance", lambda *args, **kwargs: instance.host_dir)
+
+    assert rosotacom.stop_scenario(args) == 0
+    assert calls[-3:] == ["application-stop", "communication-stop", "tmux-stop"]
+    stopped_manifest = yaml.safe_load((instance.host_dir / "manifest.yaml").read_text(encoding="utf-8"))
+    assert stopped_manifest["scenario_runs"]["demo:a"]["stopped_at"]
 
 
 def test_completion_command_emits_shell_registration(


### PR DESCRIPTION
## Summary

- add a strict scenario-definition layer above communication sessions, with identity-specific local applications backed exclusively by ros2docker configs
- add `rosotacom scenario start|attach|stop|list`, isolated outer tmux lifecycle, scoped application containers/images, per-instance logs, and manifest ownership
- pilot the workflow with `2_native_chatter` while retaining the existing helper scripts

## Linked Issue

- No linked issue

## Release Notes

- [ ] Release PR: includes `docs/release-notes/vX.Y.Z.md`
- [ ] Release PR: summarizes user-facing changes since the previous release
- [ ] Release PR: documents compatibility, migration, and validation notes
- [ ] Release PR: records the intended `main` commit and previous release tag
- [x] Not a release PR

## Public Behavior

- [x] Changes public CLI/config/API/Docker behavior
- [ ] Does not change public behavior

## Checks

- [x] `just lint`
- [x] `just typecheck`
- [x] `just test-unit`
- [x] `just test-contract`
- [x] `just docs`
- [x] `just package`
- [ ] `just check`
- [ ] full `just test-e2e-smoke`

Additional targeted Docker checks:

- [x] existing native-chatter smoke
- [x] new scenario pilot: both identities, local apps + communication, status contract, manifest, and cleanup

## Test Integrity

- [x] Tests/CI were not skipped, weakened, or removed to make this pass

## Maintainer Evidence

- Required CI links: GitHub checks on this PR
- Manual/runtime evidence: scenario pilot passed locally; both peer reports reached `OK`, and no rosotacom containers/tmux sessions remained after cleanup
- External OTA evidence, if this PR is part of a `main` promotion: not applicable

## UX Notes

- the outer tmux prefix remains `Ctrl-b`
- send the inner catmux prefix with `Ctrl-b Ctrl-b`
- detaching does not stop the use case; `scenario stop` owns cleanup