### PR TITLE
fix: restore nightly, image scan, and e2e CI

### DIFF
--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -1,6 +1,8 @@
-name: Manual Full E2E
+name: Nightly E2E
 
 on:
+  schedule:
+    - cron: "37 2 * * *"
   workflow_dispatch:
     inputs:
       full-rmw-matrix:
@@ -17,7 +19,7 @@ concurrency:
 
 jobs:
   full-e2e:
-    name: manual-full-e2e
+    name: full-e2e
     runs-on: ubuntu-latest
     timeout-minutes: 180
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![PyPI](https://img.shields.io/pypi/v/rosotacom.svg)](https://pypi.org/project/rosotacom/)
 [![Python](https://img.shields.io/pypi/pyversions/rosotacom.svg)](https://pypi.org/project/rosotacom/)
 [![License](https://img.shields.io/badge/license-BSD--3--Clause-blue.svg)](https://github.com/develNor/ros_communication_devcontainer/blob/HEAD/LICENSE.txt)
+[![Nightly E2E](https://github.com/develNor/ros_communication_devcontainer/actions/workflows/nightly-e2e.yml/badge.svg?branch=develop)](https://github.com/develNor/ros_communication_devcontainer/actions/workflows/nightly-e2e.yml)
 
 The ROS Communication DevContainer is a Docker-based solution designed to streamline the bidirectional synchronization of ROS2 topics between two Linux machines. It provides built-in compression and routing capabilities for over-the-air (OTA) data transfer: selected topics are remapped into an OTA namespace and transmitted either via direct DDS (CycloneDDS) or through a Zenoh router. When desired, the session can also place local application nodes and OTA-facing bridge nodes into separate ROS 2 domain IDs and automatically generate a standard ROS 2 `domain_bridge` configuration for the `/com/...` boundary. This project aligns with the publication *“Scalable Remote Operation for Autonomous Vehicles: Integration of Cooperative Perception and Open Source Communication.”*
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -66,11 +66,11 @@ config, catmux pane logs, Docker logs when available, and the smoke verification
 log under `session-instances/`; collect that directory as the first debugging
 artifact when an E2E job fails.
 
-## Manual And Maintenance Checks
+## Nightly And Maintenance Checks
 
-`.github/workflows/nightly-e2e.yml` is now manual-only despite the historical
-file name. It can run the local smoke slice plus the generated RMW matrix on
-GitHub-hosted infrastructure, but it is not the private OTA promotion gate.
+`.github/workflows/nightly-e2e.yml` runs the local smoke slice plus the generated
+RMW matrix nightly on GitHub-hosted infrastructure and also supports manual
+dispatch. It is not the private OTA promotion gate.
 `.github/workflows/image-scan.yml` builds the default communication image and
 uploads an advisory Trivy report.
 

--- a/docs/rfcs/0001-expectation-driven-test-suite.md
+++ b/docs/rfcs/0001-expectation-driven-test-suite.md
@@ -51,7 +51,7 @@ test. Everything else is a lens:
 2. **`rosotacom test` reads the session's self-report (`status.json`)** rather than
    probing externally.
 3. **Generate the RMW matrix** instead of hand-maintaining one dir per combo.
-4. **Cadence: a manual full-suite gate before each promotion** (not nightly-auto).
+4. **Cadence: nightly full local suite plus a manual external OTA gate before promotion.**
 
 ## Design
 
@@ -160,7 +160,8 @@ per-session marker.
   into the generated `tests/sessions/rmw_matrix` test-config set.
 - `verify` is retired. Delivery uses `rosotacom test`; local-only isolation stays
   a framework probe via `probe-publish` / `probe-check`.
-- The full suite is a manual promotion gate rather than a scheduled job.
+- The full local suite runs nightly; the external OTA suite remains a manual
+  promotion gate.
 
 **Not feasible as written**
 - `loss_pct` for *non-heartbeat* topics: ROS 2 messages carry no sequence number

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -16,11 +16,12 @@ This project separates copyable examples from verification configs:
 | host / unit | `tests/unit` | no | none | draft + ready PR |
 | contract | `tests/contract` | no | none | ready PR |
 | local smoke | `tests/e2e` | yes | one host, isolated bridge | merge gate |
-| full suite | examples + `tests/sessions` | yes | local smoke + external OTA | manual promotion gate |
+| full local suite | examples + `tests/sessions` | yes | one host, isolated bridge | nightly + manual |
+| external OTA | operator deployment | yes | multiple machines | manual promotion gate |
 
 Ready PRs run the non-Docker checks, package validation, and the local smoke
-slice. The full suite is deliberately operator-started before a promotion to
-`main`; it is not scheduled automatically.
+slice. The full local suite also runs nightly. The external OTA gate remains
+operator-started before a promotion to `main`.
 
 ## Expectations
 

--- a/src/rosotacom/cli.py
+++ b/src/rosotacom/cli.py
@@ -2373,6 +2373,7 @@ def _smoke_ros_setup(config_container_dir: str, cfg: dict[str, Any], receiver_pe
 SMOKE_HZ_MIN = 5.0
 SMOKE_HZ_MAX = 20.0
 SMOKE_MAX_DELAY_S = 1.0
+SMOKE_PUBLISHER_DURATION_S = 900.0
 ISOLATION_PROBE_TOPIC = "/local_only"
 
 
@@ -2977,7 +2978,13 @@ def smoke(args: argparse.Namespace) -> int:
         ros_setup_b = _smoke_ros_setup(smoke_instance.config_container_dir, cfg, "b")
         containers = {"a": a_container, "b": b_container}
         ros_setups = {"a": ros_setup_a, "b": ros_setup_b}
-        smoke_publishers = _start_smoke_topic_publishers(containers, ros_setups, cfg, log_line=log_line)
+        smoke_publishers = _start_smoke_topic_publishers(
+            containers,
+            ros_setups,
+            cfg,
+            log_line=log_line,
+            duration=SMOKE_PUBLISHER_DURATION_S,
+        )
         errors: list[str] = []
         # Delivery: each peer must receive the other's crossed topics within bounds.
         errors += _verify_received_topics(b_container, ros_setup_b, cfg, "b", log_line=log_line, detail_log=detail)

--- a/src/rosotacom/resources/ros2docker.json.example
+++ b/src/rosotacom/resources/ros2docker.json.example
@@ -20,6 +20,8 @@
 
   // Build-time arguments — defaults shown; override if necessary
   "build_args": {
+    "BASE_IMAGE":                    "osrf/ros:kilted-desktop-full-noble",
+    "DIGEST":                        "@sha256:29eb6f48bb06549aba004a7a4b12c00ece23b156731df12cf1f3c1ae1b0fd178",
     "APT_PACKAGES":                  "iputils-ping psmisc net-tools snmp iw nload iftop iproute2 tshark ros-kilted-domain-bridge",
     "PIP_PACKAGES":                  "numpy>=1.26,<2 lz4 pysnmp speedtest-cli psutil zstandard opencv-python"
   }

--- a/src/rosotacom/resources/ws/ros2src/com_py/com_py/status_overview_core.py
+++ b/src/rosotacom/resources/ws/ros2src/com_py/com_py/status_overview_core.py
@@ -537,5 +537,5 @@ def collect_stage_topics(spec: Dict[str, Any]) -> Dict[str, Dict[str, Optional[s
             domain = stage.get("domain", "local")
             by_domain.setdefault(domain, {})
             existing = by_domain[domain].get(stage["topic"])
-            by_domain[domain][stage["topic"]] = existing or type_hint
+            by_domain[domain][stage["topic"]] = existing or stage.get("type") or type_hint
     return by_domain

--- a/src/rosotacom/resources/ws/session/creation/generate_session_files.py
+++ b/src/rosotacom/resources/ws/session/creation/generate_session_files.py
@@ -1293,6 +1293,13 @@ def _build_status_pipeline_spec(
             return float(pipe["trickle_hz"])
         return None
 
+    def _postprocessed_topic(pipe: Dict[str, Any], final: str) -> str:
+        if pipe.get("compress"):
+            return str(pipe["comp_in"])
+        if pipe.get("ota_wrap"):
+            return str(pipe["ota_in"])
+        return final
+
     def _relay_in_local_topic(topic: str) -> str:
         if inbound_keep_source_prefix:
             return f"/{remote_name}{topic}"
@@ -1323,18 +1330,33 @@ def _build_status_pipeline_spec(
             forward_ns = forward_final.lstrip("/")
             app_native = f"/{local_name}{base}" if native_have_source_prefix else base
             app_processed = f"/{local_name}{final}" if native_have_source_prefix else final
+            base_type = _safe_type(e, p, fallback_base_type=True)
+            final_type = _safe_type(e, p)
 
             stages: List[Dict[str, Any]] = [
-                {"stage": "native", "topic": app_native, "domain": "local", "produced_by": "application"},
+                {
+                    "stage": "native",
+                    "topic": app_native,
+                    "type": base_type,
+                    "domain": "local",
+                    "produced_by": "application",
+                },
             ]
             if final != base:
                 stages.append(
-                    {"stage": "processed", "topic": app_processed, "domain": "local", "produced_by": "preprocessing"}
+                    {
+                        "stage": "processed",
+                        "topic": app_processed,
+                        "type": final_type,
+                        "domain": "local",
+                        "produced_by": "preprocessing",
+                    }
                 )
             stages.append(
                 {
                     "stage": "com_out",
                     "topic": f"/com/out/{local_name}/{forward_ns}",
+                    "type": final_type,
                     "domain": "local",
                     "produced_by": "relay_out",
                 }
@@ -1343,6 +1365,7 @@ def _build_status_pipeline_spec(
                 {
                     "stage": "ota_sent",
                     "topic": f"/ota/{local_name}/{forward_ns}",
+                    "type": final_type,
                     "domain": "ota",
                     "produced_by": "bridge_out",
                 }
@@ -1354,7 +1377,7 @@ def _build_status_pipeline_spec(
                     "direction": "outbound",
                     "source": local_name,
                     "target": remote_name,
-                    "type": _safe_type(e, p),
+                    "type": final_type,
                     "expected_hz": _expected_hz(p),
                     "expect": e.expect,
                     "stages": stages,
@@ -1383,27 +1406,39 @@ def _build_status_pipeline_spec(
             forward_final = f"/to_{local_name}{final}" if remote_uses_target_prefix else final
             forward_ns = forward_final.lstrip("/")
             app_in = _relay_in_local_topic(final)
+            postprocessed = _postprocessed_topic(p, final)
+            base_type = _safe_type(e, p, fallback_base_type=True)
+            final_type = _safe_type(e, p)
 
             stages = [
                 {
                     "stage": "ota_recv",
                     "topic": f"/ota/{remote_name}/{forward_ns}",
+                    "type": final_type,
                     "domain": "ota",
                     "produced_by": "transport",
                 },
                 {
                     "stage": "com_in",
                     "topic": f"/com/in/{remote_name}/{forward_ns}",
+                    "type": final_type,
                     "domain": "local",
                     "produced_by": "bridge_in",
                 },
-                {"stage": "app_in", "topic": app_in, "domain": "local", "produced_by": "relay_in"},
+                {
+                    "stage": "app_in",
+                    "topic": app_in,
+                    "type": final_type,
+                    "domain": "local",
+                    "produced_by": "relay_in",
+                },
             ]
-            if final != base:
+            if postprocessed != final:
                 stages.append(
                     {
                         "stage": "native_in",
-                        "topic": _relay_in_local_topic(base),
+                        "topic": _relay_in_local_topic(postprocessed),
+                        "type": base_type,
                         "domain": "local",
                         "produced_by": "postprocessing",
                     }
@@ -1415,7 +1450,7 @@ def _build_status_pipeline_spec(
                     "direction": "inbound",
                     "source": remote_name,
                     "target": local_name,
-                    "type": _safe_type(e, p),
+                    "type": final_type,
                     "expected_hz": _expected_hz(p),
                     "expect": e.expect,
                     "stages": stages,

--- a/tests/contract/test_packaged_resources.py
+++ b/tests/contract/test_packaged_resources.py
@@ -42,6 +42,16 @@ def test_cli_resource_constants_point_inside_package_resources() -> None:
     assert cli.EXAMPLE_PROJECT_DIR == cli.RESOURCE_DIR / "examples"
 
 
+def test_default_ros2docker_config_pins_supported_kilted_noble_image() -> None:
+    default_build_args = cli.load_config(cli.DEFAULT_ROS2DOCKER_CONFIG)["build_args"]
+    example_build_args = cli.load_config(cli.EXAMPLE_PROJECT_DIR / "ros2docker.json")["build_args"]
+
+    assert default_build_args["BASE_IMAGE"] == "osrf/ros:kilted-desktop-full-noble"
+    assert default_build_args["DIGEST"].startswith("@sha256:")
+    assert default_build_args["BASE_IMAGE"] == example_build_args["BASE_IMAGE"]
+    assert default_build_args["DIGEST"] == example_build_args["DIGEST"]
+
+
 def test_shell_entrypoints_pass_syntax_check() -> None:
     scripts = sorted(cli.EXAMPLE_PROJECT_DIR.glob("scripts/**/*.sh"))
     assert scripts

--- a/tests/contract/test_security_maintenance_config.py
+++ b/tests/contract/test_security_maintenance_config.py
@@ -47,12 +47,13 @@ def test_merge_gate_requires_non_docker_package_and_docker_smoke() -> None:
     assert "just test-e2e-smoke" in merge_gate
 
 
-def test_full_e2e_workflow_is_manual_promotion_support_not_scheduled() -> None:
+def test_full_e2e_workflow_runs_nightly_and_supports_manual_dispatch() -> None:
     full_e2e = FULL_E2E_PATH.read_text(encoding="utf-8")
 
-    assert "name: Manual Full E2E" in full_e2e
+    assert "name: Nightly E2E" in full_e2e
+    assert '- cron: "37 2 * * *"' in full_e2e
     assert "workflow_dispatch:" in full_e2e
-    assert "schedule:" not in full_e2e
+    assert "name: full-e2e" in full_e2e
     assert "ROSOTACOM_RUN_FULL_E2E=1" in full_e2e
 
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -957,6 +957,13 @@ def test_stop_list_doctor_and_smoke_host_flows(
     monkeypatch.setattr(rosotacom, "_verify_received_topics", lambda *args, **kwargs: [])
     monkeypatch.setattr(rosotacom, "_verify_isolation", lambda *args, **kwargs: [])
     monkeypatch.setattr(rosotacom, "test_command", lambda args: 0)
+    publisher_durations: list[float] = []
+
+    def fake_start_publishers(*args: object, **kwargs: object) -> list[rosotacom.SmokeTopicSpec]:
+        publisher_durations.append(float(kwargs["duration"]))
+        return []
+
+    monkeypatch.setattr(rosotacom, "_start_smoke_topic_publishers", fake_start_publishers)
     assert (
         rosotacom.smoke(
             argparse.Namespace(
@@ -974,6 +981,8 @@ def test_stop_list_doctor_and_smoke_host_flows(
         )
         == 0
     )
+    assert publisher_durations == [rosotacom.SMOKE_PUBLISHER_DURATION_S]
+    assert rosotacom.SMOKE_PUBLISHER_DURATION_S == 900.0
     assert stopped[-2:] == ["container_a", "container_b"]
 
 

--- a/tests/unit/test_status_overview.py
+++ b/tests/unit/test_status_overview.py
@@ -501,6 +501,44 @@ def test_pipeline_spec_carries_per_topic_expect(tmp_path: Path) -> None:
     assert by_dir[("/costmap", "inbound")]["expect"] == {"hz": {"min": 1, "max": 5}, "latency_ms": {"max": 500}}
 
 
+def test_pipeline_spec_uses_postprocessed_topics_and_stage_specific_types(tmp_path: Path) -> None:
+    import yaml
+
+    examples = Path(__file__).resolve().parents[2] / "src" / "rosotacom" / "resources" / "examples" / "sessions"
+
+    occupancy_cfg = yaml.safe_load(
+        (examples / "3_comp_occ_grid" / "session-definition.yaml").read_text(encoding="utf-8")
+    )
+    generator.func(session_config_obj=occupancy_cfg, output_dir=str(tmp_path / "occupancy"), force=True)
+    occupancy_spec = yaml.safe_load((tmp_path / "occupancy" / "a" / "pipeline_spec.yaml").read_text(encoding="utf-8"))
+    occupancy_in = next(
+        topic
+        for topic in occupancy_spec["topics"]
+        if topic["base"] == "/costmap/costmap" and topic["direction"] == "inbound"
+    )
+    occupancy_stages = {stage["stage"]: stage for stage in occupancy_in["stages"]}
+    assert occupancy_stages["app_in"]["topic"] == "/costmap/costmap/restamped/bz2"
+    assert occupancy_stages["app_in"]["type"] == "com_msgs/msg/CompressedData"
+    assert occupancy_stages["native_in"]["topic"] == "/costmap/costmap/restamped"
+    assert occupancy_stages["native_in"]["type"] == "nav_msgs/msg/OccupancyGrid"
+
+    payload_cfg = yaml.safe_load((examples / "5_sized_payload" / "session-definition.yaml").read_text(encoding="utf-8"))
+    generator.func(session_config_obj=payload_cfg, output_dir=str(tmp_path / "payload"), force=True)
+    payload_spec = yaml.safe_load((tmp_path / "payload" / "b" / "pipeline_spec.yaml").read_text(encoding="utf-8"))
+    payload_out = next(
+        topic
+        for topic in payload_spec["topics"]
+        if topic["base"] == "/size_test_b" and topic["direction"] == "outbound"
+    )
+    payload_out_stages = {stage["stage"]: stage for stage in payload_out["stages"]}
+    assert payload_out_stages["native"]["type"] == "com_msgs/msg/SizedPayload"
+    assert payload_out_stages["processed"]["type"] == "com_msgs/msg/OtaStamped"
+
+    collected = core.collect_stage_topics(payload_spec)
+    assert collected["local"]["/size_test_b"] == "com_msgs/msg/SizedPayload"
+    assert collected["local"]["/size_test_b/ota_stamped"] == "com_msgs/msg/OtaStamped"
+
+
 def test_pipeline_spec_carries_heartbeat_expect(tmp_path: Path) -> None:
     import yaml
 


### PR DESCRIPTION
## Summary

- restore the scheduled Nightly E2E workflow and add its README badge
- pin the built-in ros2docker config to the supported Kilted/Noble image so image-scan does not float to Lyrical/Resolute while installing Kilted packages
- keep synthetic smoke publishers alive for the full smoke timeout budget
- generate stage-specific status topic types and correct postprocessed inbound topic names, preventing status observers from poisoning FastDDS type discovery and rejecting valid decompression flows

## Root causes fixed

- image-scan run https://github.com/develNor/ros_communication_devcontainer/actions/runs/27746507820 used ros2docker's floating default base and failed on `ros-kilted-domain-bridge` under Ubuntu Resolute
- the heartbeat parameter crash introduced around #27 was already corrected on current `develop` by float parameter declarations; this PR preserves and validates that behavior
- latest E2E run https://github.com/develNor/ros_communication_devcontainer/actions/runs/27786961086/job/82225986706 exposed expired 180-second test publishers plus incorrect status pipeline topic/type metadata

## Validation

- `just lint`
- `just typecheck`
- `just test-nondocker-cov` — 96 passed, coverage gate passed
- `just docs` — 8 passed
- `just package`
- pinned default ros2docker image build succeeded, including `ros-kilted-domain-bridge`
- targeted former failures — 3 passed:
  - `3_comp_occ_grid`
  - `4_comp_occ_grid_zen`
  - `5_sized_payload`
- `just test-e2e-smoke` — 8 passed, 6 skipped
- generated RMW matrix consistency check passed
