### PR TITLE
fix: improve scenario lifecycle UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,10 @@ command manually in each terminal. After reloading the shell,
 prefix such as `rosotacom smoke 1<TAB>` expands to `1_heartbeat`. The same
 session completion is available for `start`, `stop`, `status`, `test`, and the
 probe commands; absolute and relative session-directory paths still complete
-normally. Running `rosotacom completion` without a shell argument infers bash
-or zsh from `$SHELL`.
+normally. `--identity <TAB><TAB>` lists the peer identities from the selected
+session or scenario. Scenario `attach` and `stop` complete only active
+scenarios and identities. Running `rosotacom completion` without a shell
+argument infers bash or zsh from `$SHELL`.
 
 Completion is not pinned to the version that registered it: each Tab press runs
 the `rosotacom` currently selected by `PATH`. Activating another checkout's
@@ -206,14 +208,22 @@ Start one identity's communication and local application together:
 
 ```bash
 rosotacom scenario start 2_native_chatter --identity a
-rosotacom scenario attach 2_native_chatter --identity a
-rosotacom scenario stop 2_native_chatter --identity a
+rosotacom scenario list
+rosotacom scenario attach
+rosotacom scenario stop
 ```
 
-The outer view uses an isolated host tmux server. Its prefix remains `Ctrl-b`;
-send the inner container-side catmux prefix with `Ctrl-b Ctrl-b`. Detaching from
-the outer tmux does not stop the use case. `scenario stop` owns cleanup of the
-application containers, communication container, and outer tmux session.
+`scenario list` shows both configured scenarios and currently active
+scenario/identity pairs. `attach` and `stop` infer omitted values when exactly
+one active choice exists; otherwise their completions and error messages show
+the eligible active choices.
+
+The outer view uses an isolated host tmux server with one full window for
+communication and one full window per local application. Its prefix remains
+`Ctrl-b`; switch windows with `Ctrl-b n`/`Ctrl-b p`, and send the inner
+container-side catmux prefix with `Ctrl-b Ctrl-b`. Detaching from the outer
+tmux does not stop the use case. `scenario stop` owns cleanup of the application
+containers, communication container, and outer tmux session.
 
 ## Usage Examples
 

--- a/src/rosotacom/cli.py
+++ b/src/rosotacom/cli.py
@@ -129,6 +129,13 @@ class ScenarioDefinition:
 
 
 @dataclass(frozen=True)
+class ActiveScenarioRun:
+    scenario: str
+    identity: str
+    tmux_session: str
+
+
+@dataclass(frozen=True)
 class SessionInstance:
     instance_id: str
     host_dir: Path
@@ -955,6 +962,18 @@ def _session_name_completer(
     return completions
 
 
+def _session_identities(runtime: RuntimeConfig, session_name: str) -> list[str]:
+    try:
+        session = _resolve_session(session_name, runtime)
+        cfg = _effective_session_config(session.host_dir, runtime)
+    except (FileNotFoundError, RuntimeError, OSError, yaml.YAMLError):
+        return []
+    peers = cfg.get("peers")
+    if not isinstance(peers, dict):
+        return []
+    return [str(identity) for identity in peers]
+
+
 def _is_scenario_dir(path: Path) -> bool:
     return (path / "scenario-definition.yaml").is_file()
 
@@ -998,6 +1017,75 @@ def _format_available_scenarios(runtime: RuntimeConfig) -> str:
     return "No configured scenarios found. Set scenario_configs_dir in rosotacom.yaml."
 
 
+def _scenario_identities(runtime: RuntimeConfig, scenario_name: str) -> list[str]:
+    try:
+        resolved = _resolve_scenario(scenario_name, runtime)
+        definition = _load_scenario_definition(resolved)
+    except (FileNotFoundError, RuntimeError, OSError, yaml.YAMLError):
+        return []
+    return list(definition.applications)
+
+
+def _active_scenario_runs(runtime: RuntimeConfig) -> list[ActiveScenarioRun]:
+    if not shutil.which("tmux"):
+        return []
+    result = subprocess.run(
+        _tmux_command(
+            runtime,
+            "list-sessions",
+            "-F",
+            "#{session_name}\t#{@rosotacom_scenario}\t#{@rosotacom_identity}",
+        ),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return []
+
+    configured_by_tmux_name: dict[str, tuple[str, str]] = {}
+    for scenario_name in _scenario_names(runtime):
+        for identity in _scenario_identities(runtime, scenario_name):
+            configured_by_tmux_name[_scenario_tmux_session(scenario_name, identity)] = (scenario_name, identity)
+
+    runs: list[ActiveScenarioRun] = []
+    for line in result.stdout.splitlines():
+        tmux_session, _, metadata = line.partition("\t")
+        scenario, _, identity = metadata.partition("\t")
+        if not scenario or not identity:
+            fallback = configured_by_tmux_name.get(tmux_session)
+            if fallback:
+                scenario, identity = fallback
+        if scenario and identity:
+            runs.append(ActiveScenarioRun(scenario=scenario, identity=identity, tmux_session=tmux_session))
+    return sorted(runs, key=lambda run: (run.scenario, run.identity))
+
+
+def _format_active_scenario_runs(runs: list[ActiveScenarioRun]) -> str:
+    if not runs:
+        return "  (none)"
+    return "\n".join(f"  - {run.scenario} --identity {run.identity}" for run in runs)
+
+
+def _format_scenario_listing(runtime: RuntimeConfig) -> str:
+    configured = _scenario_names(runtime)
+    active = _active_scenario_runs(runtime)
+    active_by_scenario: dict[str, list[str]] = {}
+    for run in active:
+        active_by_scenario.setdefault(run.scenario, []).append(run.identity)
+
+    if configured:
+        configured_lines = []
+        for name in configured:
+            identities = active_by_scenario.get(name, [])
+            state = f"active: {', '.join(identities)}" if identities else "inactive"
+            configured_lines.append(f"  - {name} ({state})")
+        configured_text = "\n".join(configured_lines)
+    else:
+        configured_text = "  (none)"
+    return f"Configured scenarios:\n{configured_text}\nActive scenarios:\n{_format_active_scenario_runs(active)}"
+
+
 def _scenario_name_completer(
     prefix: str,
     parsed_args: argparse.Namespace,
@@ -1012,6 +1100,49 @@ def _scenario_name_completer(
         return completions
     completions.update({name: "configured scenario" for name in _scenario_names(runtime) if name.startswith(prefix)})
     return completions
+
+
+def _active_scenario_name_completer(
+    prefix: str,
+    parsed_args: argparse.Namespace,
+    **_: Any,
+) -> dict[str, str]:
+    try:
+        runtime = _load_runtime_config(parsed_args)
+    except (FileNotFoundError, RuntimeError, OSError, yaml.YAMLError):
+        return {}
+    names = sorted({run.scenario for run in _active_scenario_runs(runtime)})
+    return {name: "active scenario" for name in names if name.startswith(prefix)}
+
+
+def _identity_completer(
+    prefix: str,
+    parsed_args: argparse.Namespace,
+    **_: Any,
+) -> dict[str, str]:
+    try:
+        runtime = _load_runtime_config(parsed_args)
+    except (FileNotFoundError, RuntimeError, OSError, yaml.YAMLError):
+        return {}
+
+    if getattr(parsed_args, "command", None) == "scenario":
+        scenario_name = getattr(parsed_args, "scenario", None)
+        if getattr(parsed_args, "scenario_command", None) in {"attach", "stop"}:
+            identities = sorted(
+                {
+                    run.identity
+                    for run in _active_scenario_runs(runtime)
+                    if not scenario_name or run.scenario == scenario_name
+                }
+            )
+        elif scenario_name:
+            identities = _scenario_identities(runtime, scenario_name)
+        else:
+            identities = []
+    else:
+        session_name = getattr(parsed_args, "session_dir", None) or getattr(parsed_args, "session_dir_positional", None)
+        identities = _session_identities(runtime, session_name) if session_name else []
+    return {identity: "peer identity" for identity in identities if identity.startswith(prefix)}
 
 
 def _load_scenario_definition(resolved: ResolvedScenario) -> ScenarioDefinition:
@@ -1239,7 +1370,7 @@ def _create_scenario_tmux(
             "-s",
             session_name,
             "-n",
-            "scenario",
+            "communication",
             communication_command,
         ),
         text=True,
@@ -1247,8 +1378,19 @@ def _create_scenario_tmux(
         check=True,
     )
     communication_pane = created.stdout.strip()
-    subprocess.run(_tmux_command(runtime, "set-option", "-t", session_name, "remain-on-exit", "on"), check=True)
+    subprocess.run(
+        _tmux_command(runtime, "set-window-option", "-g", "-t", session_name, "remain-on-exit", "on"),
+        check=True,
+    )
     subprocess.run(_tmux_command(runtime, "set-option", "-t", session_name, "prefix", "C-b"), check=True)
+    subprocess.run(
+        _tmux_command(runtime, "set-option", "-t", session_name, "@rosotacom_scenario", resolved.name),
+        check=True,
+    )
+    subprocess.run(
+        _tmux_command(runtime, "set-option", "-t", session_name, "@rosotacom_identity", identity),
+        check=True,
+    )
     subprocess.run(_tmux_command(runtime, "bind-key", "-T", "prefix", "C-b", "send-prefix"), check=True)
     subprocess.run(
         _tmux_command(runtime, "set-option", "-t", session_name, "pane-border-status", "top"),
@@ -1272,7 +1414,7 @@ def _create_scenario_tmux(
             "-t",
             session_name,
             "status-right",
-            " outer: C-b | inner catmux: C-b C-b ",
+            " windows: C-b n/p | inner catmux: C-b C-b ",
         ),
         check=True,
     )
@@ -1287,23 +1429,25 @@ def _create_scenario_tmux(
     )
 
     for application in applications:
-        split = subprocess.run(
+        created_window = subprocess.run(
             _tmux_command(
                 runtime,
-                "split-window",
+                "new-window",
                 "-d",
                 "-P",
                 "-F",
                 "#{pane_id}",
                 "-t",
-                f"{session_name}:0",
+                session_name,
+                "-n",
+                _safe_path_token(application.name),
                 shlex.join(_scenario_application_command(runtime, resolved, identity, application)),
             ),
             text=True,
             capture_output=True,
             check=True,
         )
-        pane_id = split.stdout.strip()
+        pane_id = created_window.stdout.strip()
         subprocess.run(
             _tmux_command(runtime, "select-pane", "-t", pane_id, "-T", f"application:{application.name}"),
             check=True,
@@ -1314,8 +1458,7 @@ def _create_scenario_tmux(
             _scenario_log_path(instance, identity, f"application-{application.name}"),
         )
 
-    subprocess.run(_tmux_command(runtime, "select-layout", "-t", f"{session_name}:0", "tiled"), check=True)
-    subprocess.run(_tmux_command(runtime, "select-pane", "-t", communication_pane), check=True)
+    subprocess.run(_tmux_command(runtime, "select-window", "-t", f"{session_name}:communication"), check=True)
     return session_name
 
 
@@ -1627,6 +1770,45 @@ def _resolve_scenario_context(
     return runtime, resolved, definition, session, cfg, identity, applications
 
 
+def _infer_active_scenario_selector(args: argparse.Namespace, *, require_active: bool) -> None:
+    runtime = _load_runtime_config(args)
+    runs = _active_scenario_runs(runtime)
+    scenario_name = getattr(args, "scenario", None)
+    identity = getattr(args, "identity", None)
+
+    if not scenario_name:
+        eligible_runs = [run for run in runs if not identity or run.identity == identity]
+        scenario_names = sorted({run.scenario for run in eligible_runs})
+        if len(scenario_names) == 1:
+            scenario_name = scenario_names[0]
+            args.scenario = scenario_name
+            print(f"Auto-selected active scenario: {scenario_name}")
+        elif not scenario_names:
+            raise RuntimeError("No active scenarios found. Start one with `rosotacom scenario start <name>`.")
+        else:
+            raise RuntimeError(
+                "Multiple active scenarios found; specify one:\n" + _format_active_scenario_runs(eligible_runs)
+            )
+
+    matching = [run for run in runs if run.scenario == scenario_name]
+    if not identity:
+        identities = sorted({run.identity for run in matching})
+        if len(identities) == 1:
+            identity = identities[0]
+            args.identity = identity
+            print(f"Auto-selected active identity: {identity}")
+        elif not identities:
+            raise RuntimeError(f"No active run found for scenario '{scenario_name}'.")
+        else:
+            raise RuntimeError(
+                f"Scenario '{scenario_name}' has multiple active identities; specify --identity:\n"
+                + _format_active_scenario_runs(matching)
+            )
+
+    if require_active and not any(run.scenario == scenario_name and run.identity == identity for run in matching):
+        raise RuntimeError(f"Scenario '{scenario_name}' is not active for identity '{identity}'.")
+
+
 def _stop_scenario_application(
     runtime: RuntimeConfig,
     resolved: ResolvedScenario,
@@ -1738,12 +1920,13 @@ def start_scenario(args: argparse.Namespace) -> int:
     if mode == "attach":
         subprocess.run(_tmux_command(runtime, "attach-session", "-t", created_session), check=True)
     else:
-        print(f"Attach with: rosotacom scenario attach {shlex.quote(resolved.name)} --identity {identity}")
+        print("Attach with: rosotacom scenario attach")
     return 0
 
 
 def attach_scenario(args: argparse.Namespace) -> int:
     _require_tmux()
+    _infer_active_scenario_selector(args, require_active=True)
     runtime, resolved, _definition, _session, _cfg, identity, _applications = _resolve_scenario_context(args)
     tmux_session = _scenario_tmux_session(resolved.name, identity)
     if not _tmux_session_exists(runtime, tmux_session):
@@ -1754,6 +1937,8 @@ def attach_scenario(args: argparse.Namespace) -> int:
 
 def stop_scenario(args: argparse.Namespace) -> int:
     _require_ros2docker()
+    if not getattr(args, "scenario", None) or not getattr(args, "identity", None):
+        _infer_active_scenario_selector(args, require_active=False)
     runtime, resolved, _definition, _session, cfg, identity, applications = _resolve_scenario_context(args)
     _stop_scenario_components(
         runtime,
@@ -1797,7 +1982,7 @@ def run_scenario_application(args: argparse.Namespace) -> int:
 
 def list_scenarios(args: argparse.Namespace) -> int:
     runtime = _load_runtime_config(args)
-    print(_format_available_scenarios(runtime))
+    print(_format_scenario_listing(runtime))
     return 0
 
 
@@ -3154,14 +3339,24 @@ def _add_session_arg(parser: argparse.ArgumentParser, *args: str, **kwargs: Any)
     return action
 
 
-def _add_scenario_arg(parser: argparse.ArgumentParser, *args: str, **kwargs: Any) -> argparse.Action:
+def _add_scenario_arg(
+    parser: argparse.ArgumentParser,
+    *args: str,
+    active_only: bool = False,
+    **kwargs: Any,
+) -> argparse.Action:
     action = parser.add_argument(*args, **kwargs)
-    cast(Any, action).completer = _scenario_name_completer
+    cast(Any, action).completer = _active_scenario_name_completer if active_only else _scenario_name_completer
     return action
 
 
+def _add_identity_arg(parser: argparse.ArgumentParser, *, required: bool = False, help: str | None = None) -> None:
+    action = parser.add_argument("--identity", required=required, help=help)
+    cast(Any, action).completer = _identity_completer
+
+
 def _add_scenario_identity_args(parser: argparse.ArgumentParser) -> None:
-    parser.add_argument("--identity")
+    _add_identity_arg(parser)
     parser.add_argument("--no-auto-identity", dest="auto_identity", action="store_false")
     parser.add_argument("--overwrite-peers-via-remote-peer")
     parser.add_argument("--peer-address", action="append", default=[], metavar="PEER=ADDRESS_EXPR")
@@ -3172,7 +3367,7 @@ def _add_start_args(parser: argparse.ArgumentParser) -> None:
     _add_common_config_args(parser)
     _add_session_arg(parser, "session_dir_positional", nargs="?")
     _add_session_arg(parser, "-s", "--session-dir", dest="session_dir")
-    parser.add_argument("--identity")
+    _add_identity_arg(parser)
     parser.add_argument("--mode", choices=["auto", "attach", "detached"], default="auto")
     parser.add_argument("--no-auto-identity", dest="auto_identity", action="store_false")
     parser.add_argument("--no-force", dest="force", action="store_false")
@@ -3281,7 +3476,7 @@ def main(argv: list[str] | None = None) -> int:
     _add_common_config_args(stop_parser)
     _add_session_arg(stop_parser, "session_dir_positional", nargs="?")
     _add_session_arg(stop_parser, "-s", "--session-dir", dest="session_dir")
-    stop_parser.add_argument("--identity")
+    _add_identity_arg(stop_parser)
     stop_parser.add_argument("--auto-identity", action="store_true")
     stop_parser.add_argument("--peer-address", action="append", default=[], metavar="PEER=ADDRESS_EXPR")
     stop_parser.add_argument("--overwrite-peers-via-remote-peer")
@@ -3305,7 +3500,7 @@ def main(argv: list[str] | None = None) -> int:
     )
     _add_common_config_args(status_parser)
     _add_session_arg(status_parser, "session_dir", nargs="?", default=DEFAULT_SMOKE_SESSION)
-    status_parser.add_argument("--identity", help="Show only this peer identity (default: all available).")
+    _add_identity_arg(status_parser, help="Show only this peer identity (default: all available).")
     status_parser.add_argument(
         "--instance-id", help="Inspect a specific instance id (default: most recent for the session)."
     )
@@ -3329,7 +3524,7 @@ def main(argv: list[str] | None = None) -> int:
     )
     _add_common_config_args(probe_publish_parser)
     _add_session_arg(probe_publish_parser, "session_dir", nargs="?", default=DEFAULT_SMOKE_SESSION)
-    probe_publish_parser.add_argument("--identity", required=True)
+    _add_identity_arg(probe_publish_parser, required=True)
     probe_publish_parser.add_argument("--peer-address", action="append", default=[], metavar="PEER=ADDRESS_EXPR")
     probe_publish_parser.add_argument("--instance-id")
     probe_publish_parser.add_argument("--topic", default=ISOLATION_PROBE_TOPIC)
@@ -3345,7 +3540,7 @@ def main(argv: list[str] | None = None) -> int:
     )
     _add_common_config_args(probe_check_parser)
     _add_session_arg(probe_check_parser, "session_dir", nargs="?", default=DEFAULT_SMOKE_SESSION)
-    probe_check_parser.add_argument("--identity", required=True)
+    _add_identity_arg(probe_check_parser, required=True)
     probe_check_parser.add_argument("--peer-address", action="append", default=[], metavar="PEER=ADDRESS_EXPR")
     probe_check_parser.add_argument("--instance-id")
     probe_check_parser.add_argument("--topic", default=ISOLATION_PROBE_TOPIC)
@@ -3358,7 +3553,7 @@ def main(argv: list[str] | None = None) -> int:
     )
     _add_common_config_args(publish_test_topics_parser)
     _add_session_arg(publish_test_topics_parser, "session_dir", nargs="?", default=DEFAULT_SMOKE_SESSION)
-    publish_test_topics_parser.add_argument("--identity", required=True)
+    _add_identity_arg(publish_test_topics_parser, required=True)
     publish_test_topics_parser.add_argument("--peer-address", action="append", default=[], metavar="PEER=ADDRESS_EXPR")
     publish_test_topics_parser.add_argument("--instance-id")
     publish_test_topics_parser.add_argument("--duration", type=float, default=180.0)
@@ -3396,7 +3591,7 @@ def main(argv: list[str] | None = None) -> int:
         help="Attach to a running scenario's outer tmux session.",
     )
     _add_common_config_args(scenario_attach_parser)
-    _add_scenario_arg(scenario_attach_parser, "scenario")
+    _add_scenario_arg(scenario_attach_parser, "scenario", nargs="?", active_only=True)
     _add_scenario_identity_args(scenario_attach_parser)
     scenario_attach_parser.set_defaults(func=attach_scenario)
 
@@ -3405,7 +3600,7 @@ def main(argv: list[str] | None = None) -> int:
         help="Stop scenario applications, communication container, and outer tmux.",
     )
     _add_common_config_args(scenario_stop_parser)
-    _add_scenario_arg(scenario_stop_parser, "scenario")
+    _add_scenario_arg(scenario_stop_parser, "scenario", nargs="?", active_only=True)
     _add_scenario_identity_args(scenario_stop_parser)
     scenario_stop_parser.add_argument("--instance-id", help="Mark a specific scenario instance as stopped.")
     scenario_stop_parser.set_defaults(func=stop_scenario)
@@ -3420,7 +3615,7 @@ def main(argv: list[str] | None = None) -> int:
     )
     _add_common_config_args(scenario_run_application_parser)
     _add_scenario_arg(scenario_run_application_parser, "scenario")
-    scenario_run_application_parser.add_argument("--identity", required=True)
+    _add_identity_arg(scenario_run_application_parser, required=True)
     scenario_run_application_parser.add_argument("--application", required=True)
     scenario_run_application_parser.set_defaults(func=run_scenario_application)
 

--- a/src/rosotacom/resources/examples/README.md
+++ b/src/rosotacom/resources/examples/README.md
@@ -38,13 +38,18 @@ rosotacom scenario start 2_native_chatter --identity a
 ```
 
 Run identity `b` on the other machine in the same way. The outer tmux prefix is
-`Ctrl-b`; use `Ctrl-b Ctrl-b` to address the inner catmux session. Detaching
-keeps the use case running:
+`Ctrl-b`; communication and the local application use separate full windows.
+Switch with `Ctrl-b n`/`Ctrl-b p`, and use `Ctrl-b Ctrl-b` to address the inner
+catmux session. Detaching keeps the use case running:
 
 ```bash
-rosotacom scenario attach 2_native_chatter --identity a
-rosotacom scenario stop 2_native_chatter --identity a
+rosotacom scenario list
+rosotacom scenario attach
+rosotacom scenario stop
 ```
+
+The short `attach`/`stop` forms work when exactly one scenario/identity pair is
+active. Otherwise tab completion lists only the active choices.
 
 The existing scripts under `scripts/2_native_chatter/` remain as a fallback.
 

--- a/src/rosotacom/resources/examples/scripts/2_native_chatter/machine_a/wait_for_echo_topic.sh
+++ b/src/rosotacom/resources/examples/scripts/2_native_chatter/machine_a/wait_for_echo_topic.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Wait until the topic is available and has a known type
-until ros2 topic info /chatter | grep -q "Type:"; do
+until topic_info="$(ros2 topic info /chatter 2>/dev/null)" && grep -q "Type:" <<<"$topic_info"; do
     echo "[INFO] Waiting for /chatter to become available..."
     sleep 1
 done

--- a/tests/contract/test_packaged_resources.py
+++ b/tests/contract/test_packaged_resources.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import subprocess
 from importlib import resources
 from pathlib import Path
@@ -63,3 +64,41 @@ def test_shell_entrypoints_pass_syntax_check() -> None:
         ["python3", "-m", "py_compile", str(cli.WS_DIR / "session" / "creation" / "strip_ansi.py")],
         check=True,
     )
+
+
+def test_native_chatter_waiter_reads_topic_info_without_broken_pipe(tmp_path: Path) -> None:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_ros2 = fake_bin / "ros2"
+    fake_ros2.write_text(
+        "\n".join(
+            [
+                "#!/usr/bin/env bash",
+                'if [[ "$1 $2" == "topic info" ]]; then',
+                '  for i in {1..100}; do echo "detail $i"; done',
+                '  echo "Type: std_msgs/msg/String"',
+                "  exit 0",
+                "fi",
+                'if [[ "$1 $2" == "topic echo" ]]; then',
+                '  echo "echo started"',
+                "  exit 0",
+                "fi",
+                "exit 2",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    fake_ros2.chmod(0o755)
+    script = cli.EXAMPLE_PROJECT_DIR / "scripts" / "2_native_chatter" / "machine_a" / "wait_for_echo_topic.sh"
+
+    result = subprocess.run(
+        [str(script)],
+        text=True,
+        capture_output=True,
+        check=True,
+        env={**os.environ, "PATH": f"{fake_bin}:{os.environ['PATH']}"},
+    )
+
+    assert result.stdout.strip() == "echo started"
+    assert "BrokenPipeError" not in result.stderr

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -397,6 +397,24 @@ def test_native_chatter_scenario_starts_apps_and_communication_together(
             assert "rosotacom scenario started: 2_native_chatter" in result.stdout
             assert "inner catmux prefix with Ctrl-b Ctrl-b" in result.stdout
 
+        listing = _run(
+            [
+                sys.executable,
+                "-m",
+                "rosotacom",
+                "scenario",
+                "list",
+                "--rosotacom-config",
+                str(copied_example_project / "rosotacom.yaml"),
+                "--session-instances-dir",
+                str(SESSION_INSTANCES_DIR),
+            ],
+            timeout=30,
+        )
+        assert "2_native_chatter (active: a, b)" in listing.stdout
+        assert "2_native_chatter --identity a" in listing.stdout
+        assert "2_native_chatter --identity b" in listing.stdout
+
         _run(
             [
                 sys.executable,
@@ -424,6 +442,32 @@ def test_native_chatter_scenario_starts_apps_and_communication_together(
         assert "rosotacom_" in manifest
         scenario_logs = list(manifests[-1].parent.glob("logs/*/scenario/*.log"))
         assert scenario_logs
+
+        tmux_socket = re.search(r"tmux_socket: (.+)", manifest)
+        assert tmux_socket
+        windows = _run(
+            ["tmux", "-L", tmux_socket.group(1), "list-windows", "-t", "2_native_chatter-a", "-F", "#{window_name}"],
+            timeout=30,
+        )
+        assert windows.stdout.splitlines() == ["communication", "native_application"]
+
+        _run(_scenario_command(copied_example_project, "stop", "b", instance_id), timeout=60)
+        inferred_stop = _run(
+            [
+                sys.executable,
+                "-m",
+                "rosotacom",
+                "scenario",
+                "stop",
+                "--rosotacom-config",
+                str(copied_example_project / "rosotacom.yaml"),
+                "--session-instances-dir",
+                str(SESSION_INSTANCES_DIR),
+            ],
+            timeout=60,
+        )
+        assert "Auto-selected active scenario: 2_native_chatter" in inferred_stop.stdout
+        assert "Auto-selected active identity: a" in inferred_stop.stdout
     finally:
         for identity in ("a", "b"):
             _run(_scenario_command(copied_example_project, "stop", identity, instance_id), timeout=60)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -342,7 +342,115 @@ def test_scenario_name_completion_uses_active_project(
     assert rosotacom._scenario_name_completer("de", argparse.Namespace()) == {"demo": "configured scenario"}
 
 
-def test_scenario_tmux_commands_keep_ctrl_b_and_log_each_pane(
+def test_active_scenarios_are_discovered_from_tmux_metadata(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime, _resolved = _write_test_scenario_project(tmp_path)
+
+    def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        assert command[:3] == ["tmux", "-L", "rosotacom-test"]
+        return subprocess.CompletedProcess(command, 0, "demo-a\tdemo\ta\ndemo-b\tdemo\tb\n", "")
+
+    monkeypatch.setattr(rosotacom.shutil, "which", lambda name: "/usr/bin/tmux")
+    monkeypatch.setattr(rosotacom.subprocess, "run", fake_run)
+
+    assert rosotacom._active_scenario_runs(runtime) == [
+        rosotacom.ActiveScenarioRun("demo", "a", "demo-a"),
+        rosotacom.ActiveScenarioRun("demo", "b", "demo-b"),
+    ]
+    assert rosotacom._format_scenario_listing(runtime) == "\n".join(
+        [
+            "Configured scenarios:",
+            "  - demo (active: a, b)",
+            "Active scenarios:",
+            "  - demo --identity a",
+            "  - demo --identity b",
+        ]
+    )
+
+
+def test_scenario_attach_selector_infers_the_only_active_run(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    runtime, _resolved = _write_test_scenario_project(tmp_path)
+    monkeypatch.setattr(rosotacom, "_load_runtime_config", lambda args: runtime)
+    monkeypatch.setattr(
+        rosotacom,
+        "_active_scenario_runs",
+        lambda runtime: [rosotacom.ActiveScenarioRun("demo", "a", "demo-a")],
+    )
+    args = argparse.Namespace(scenario=None, identity=None)
+
+    rosotacom._infer_active_scenario_selector(args, require_active=True)
+
+    assert (args.scenario, args.identity) == ("demo", "a")
+    assert "Auto-selected active scenario: demo" in capsys.readouterr().out
+
+
+def test_scenario_selector_requires_choice_for_multiple_active_identities(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime, _resolved = _write_test_scenario_project(tmp_path)
+    monkeypatch.setattr(rosotacom, "_load_runtime_config", lambda args: runtime)
+    monkeypatch.setattr(
+        rosotacom,
+        "_active_scenario_runs",
+        lambda runtime: [
+            rosotacom.ActiveScenarioRun("demo", "a", "demo-a"),
+            rosotacom.ActiveScenarioRun("demo", "b", "demo-b"),
+        ],
+    )
+
+    with pytest.raises(RuntimeError, match="multiple active identities"):
+        rosotacom._infer_active_scenario_selector(
+            argparse.Namespace(scenario="demo", identity=None),
+            require_active=True,
+        )
+
+
+def test_scenario_and_identity_completion_follow_active_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime, _resolved = _write_test_scenario_project(tmp_path)
+    monkeypatch.setattr(rosotacom, "_load_runtime_config", lambda args: runtime)
+    monkeypatch.setattr(
+        rosotacom,
+        "_active_scenario_runs",
+        lambda runtime: [rosotacom.ActiveScenarioRun("demo", "a", "demo-a")],
+    )
+
+    attach_args = argparse.Namespace(command="scenario", scenario_command="attach", scenario=None)
+    assert rosotacom._active_scenario_name_completer("d", attach_args) == {"demo": "active scenario"}
+    assert rosotacom._identity_completer("", attach_args) == {"a": "peer identity"}
+
+    start_args = argparse.Namespace(command="scenario", scenario_command="start", scenario="demo")
+    assert rosotacom._identity_completer("", start_args) == {
+        "a": "peer identity",
+        "b": "peer identity",
+    }
+
+    session_args = argparse.Namespace(command="start", session_dir_positional="demo", session_dir=None)
+    assert rosotacom._identity_completer("", session_args) == {
+        "a": "peer identity",
+        "b": "peer identity",
+    }
+
+
+def test_scenario_attach_cli_accepts_no_selector(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[argparse.Namespace] = []
+    monkeypatch.setattr(rosotacom, "attach_scenario", lambda args: calls.append(args) or 0)
+
+    assert rosotacom.main(["scenario", "attach"]) == 0
+    assert calls[0].scenario is None
+    assert calls[0].identity is None
+
+
+def test_scenario_tmux_commands_keep_ctrl_b_and_use_full_windows(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -356,7 +464,7 @@ def test_scenario_tmux_commands_keep_ctrl_b_and_log_each_pane(
     def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
         nonlocal pane_number
         calls.append(command)
-        if "new-session" in command or "split-window" in command:
+        if "new-session" in command or "new-window" in command:
             pane_number += 1
             return subprocess.CompletedProcess(command, 0, f"%{pane_number}\n", "")
         return subprocess.CompletedProcess(command, 0, "", "")
@@ -382,9 +490,19 @@ def test_scenario_tmux_commands_keep_ctrl_b_and_log_each_pane(
     assert all(command[:3] == ["tmux", "-L", "rosotacom-test"] for command in calls)
     assert any(command[-2:] == ["prefix", "C-b"] for command in calls if "set-option" in command)
     assert any(command[-3:] == ["prefix", "C-b", "send-prefix"] for command in calls if "bind-key" in command)
+    assert any(command[-2:] == ["@rosotacom_scenario", "demo"] for command in calls)
+    assert any(command[-2:] == ["@rosotacom_identity", "a"] for command in calls)
     assert any("inner catmux: C-b C-b" in part for command in calls for part in command)
     assert any("rosotacom start demo --identity a --mode attach" in " ".join(command) for command in calls)
     assert any("scenario _run-application demo" in " ".join(command) for command in calls)
+    assert sum("new-window" in command for command in calls) == 1
+    assert not any("split-window" in command for command in calls)
+    assert any(
+        command[command.index("-n") : command.index("-n") + 2] == ["-n", "local_app"]
+        for command in calls
+        if "new-window" in command
+    )
+    assert any(command[-1] == "demo-a:communication" for command in calls if "select-window" in command)
     assert (instance.logs_host_dir / "a" / "scenario").is_dir()
 
 
@@ -495,6 +613,28 @@ def test_argcomplete_protocol_returns_session_prefix_matches() -> None:
     )
 
     assert result.stdout.split("\v") == ["1_heartbeat", "1_heartbeat_status"]
+
+
+def test_argcomplete_protocol_returns_identity_matches() -> None:
+    line = "rosotacom start 1_heartbeat --identity "
+    env = {
+        **os.environ,
+        "_ARGCOMPLETE": "1",
+        "_ARGCOMPLETE_IFS": "\v",
+        "_ARGCOMPLETE_SUPPRESS_SPACE": "1",
+        "COMP_LINE": line,
+        "COMP_POINT": str(len(line)),
+    }
+
+    result = subprocess.run(
+        ["bash", "-c", f"{rosotacom.shlex.quote(sys.executable)} -m rosotacom 8>&1"],
+        check=True,
+        capture_output=True,
+        env=env,
+        text=True,
+    )
+
+    assert result.stdout.split("\v") == ["a", "b"]
 
 
 def test_local_check_derives_from_domains_and_allows_opt_out(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- distinguish configured scenarios from active scenario/identity runs and infer the sole active run for `scenario attach` and `scenario stop`
- add context-aware scenario/session identity completion, with active-only completion for attach and stop
- give communication and each local application their own full outer-tmux window while preserving `Ctrl-b` and `Ctrl-b Ctrl-b` for inner catmux
- avoid the native-chatter wait script's `BrokenPipeError` when probing topic metadata
- document the shorter lifecycle and cover it with unit, contract, completion, and Docker E2E tests

## Validation

- `just lint`
- `just typecheck`
- `just test-nondocker-cov` (100 passed)
- `just docs` (8 passed)
- `just package`
- targeted Example 2 scenario Docker pilot (1 passed)
- existing native chatter Docker smoke test (1 passed)
