### PR TITLE
fix: isolate scenario peers for unicast DDS

### DIFF
--- a/src/rosotacom/cli.py
+++ b/src/rosotacom/cli.py
@@ -2841,6 +2841,12 @@ def _scenario_communication_command(
         command.extend(["--peer", assignment])
     for override in getattr(args, "peer_address", []) or []:
         command.extend(["--peer-address", override])
+    network_name = getattr(args, "network_name", None)
+    if network_name:
+        command.extend(["--network-name", network_name])
+    network_ip = getattr(args, "network_ip", None)
+    if network_ip:
+        command.extend(["--network-ip", network_ip])
     return command
 
 
@@ -2892,6 +2898,7 @@ def _create_scenario_tmux(
     instance: SessionInstance,
     identity: str,
     applications: tuple[ScenarioApplication, ...],
+    communication_container: str,
     args: argparse.Namespace,
 ) -> str:
     session_name = _scenario_tmux_session(resolved.name, identity)
@@ -2968,6 +2975,20 @@ def _create_scenario_tmux(
     )
 
     for application in applications:
+        application_network = f"container:{communication_container}" if getattr(args, "network_name", None) else None
+        application_command = shlex.join(
+            _scenario_application_command(
+                runtime,
+                resolved,
+                identity,
+                application,
+                network_name=application_network,
+            )
+        )
+        if application_network:
+            application_command = (
+                f"{_wait_for_container_running_script(communication_container)}; {application_command}"
+            )
         created_window = subprocess.run(
             _tmux_command(
                 runtime,
@@ -2980,7 +3001,7 @@ def _create_scenario_tmux(
                 session_name,
                 "-n",
                 _safe_path_token(application.name),
-                shlex.join(_scenario_application_command(runtime, resolved, identity, application)),
+                application_command,
             ),
             text=True,
             capture_output=True,
@@ -3256,6 +3277,8 @@ def stop_session(args: argparse.Namespace) -> None:
 
 def _resolve_scenario_context(
     args: argparse.Namespace,
+    *,
+    require_bindings: bool = True,
 ) -> tuple[
     RuntimeConfig,
     ResolvedScenario,
@@ -3270,12 +3293,6 @@ def _resolve_scenario_context(
     definition = _load_scenario_definition(resolved)
     session = _resolve_session(definition.session, runtime)
     cfg = _effective_session_config(session.host_dir, runtime)
-    bindings = _resolve_bindings(
-        cfg,
-        runtime,
-        peer=getattr(args, "peer", None),
-        peer_address=getattr(args, "peer_address", None),
-    )
     peers = cfg.get("peers")
     if not isinstance(peers, dict):
         raise RuntimeError("Scenario session must define a peers mapping.")
@@ -3287,8 +3304,21 @@ def _resolve_scenario_context(
         )
     identity = getattr(args, "identity", None)
     if not identity and getattr(args, "auto_identity", True):
+        bindings = _resolve_bindings(
+            cfg,
+            runtime,
+            peer=getattr(args, "peer", None),
+            peer_address=getattr(args, "peer_address", None),
+        )
         identity = _auto_identity(bindings)
         print(f"Auto-selected identity: {identity}")
+    elif require_bindings:
+        _resolve_bindings(
+            cfg,
+            runtime,
+            peer=getattr(args, "peer", None),
+            peer_address=getattr(args, "peer_address", None),
+        )
     if not identity:
         raise RuntimeError("Missing --identity. Provide --identity <peer> or allow auto identity.")
     if identity not in peers:
@@ -3442,6 +3472,7 @@ def start_scenario(args: argparse.Namespace) -> int:
         instance,
         identity,
         applications,
+        communication_container,
         args,
     )
     print(f"rosotacom scenario instance: {instance.host_dir}")
@@ -3467,7 +3498,10 @@ def start_scenario(args: argparse.Namespace) -> int:
 def attach_scenario(args: argparse.Namespace) -> int:
     _require_tmux()
     _infer_active_scenario_selector(args, require_active=True)
-    runtime, resolved, _definition, _session, _cfg, identity, _applications = _resolve_scenario_context(args)
+    runtime, resolved, _definition, _session, _cfg, identity, _applications = _resolve_scenario_context(
+        args,
+        require_bindings=False,
+    )
     tmux_session = _scenario_tmux_session(resolved.name, identity)
     if not _tmux_session_exists(runtime, tmux_session):
         raise RuntimeError(f"Scenario tmux session is not running: {tmux_session}")
@@ -3479,7 +3513,10 @@ def stop_scenario(args: argparse.Namespace) -> int:
     _require_ros2docker()
     if not getattr(args, "scenario", None) or not getattr(args, "identity", None):
         _infer_active_scenario_selector(args, require_active=False)
-    runtime, resolved, _definition, _session, cfg, identity, applications = _resolve_scenario_context(args)
+    runtime, resolved, _definition, _session, cfg, identity, applications = _resolve_scenario_context(
+        args,
+        require_bindings=False,
+    )
     _stop_scenario_components(
         runtime,
         resolved,
@@ -5971,6 +6008,8 @@ def main(argv: list[str] | None = None) -> int:
     scenario_start_parser.add_argument("--force", dest="force", action="store_true")
     scenario_start_parser.add_argument("--rewrite-formatting", action="store_true")
     scenario_start_parser.add_argument("--instance-id", help="Join or create a named runtime session instance.")
+    scenario_start_parser.add_argument("--network-name", help=argparse.SUPPRESS)
+    scenario_start_parser.add_argument("--network-ip", help=argparse.SUPPRESS)
     scenario_start_parser.set_defaults(func=start_scenario, force=True)
 
     scenario_attach_parser = scenario_subparsers.add_parser(

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -5,6 +5,7 @@ import re
 import subprocess
 import sys
 import time
+from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
@@ -173,6 +174,32 @@ def rmw_matrix_project(tmp_path_factory: pytest.TempPathFactory) -> Path:
 # CI's "Upload smoke session artifacts" step (path: session-instances/) actually
 # captures catmux/domain-bridge logs when a smoke check fails.
 SESSION_INSTANCES_DIR = PACKAGE_ROOT / "session-instances"
+SCENARIO_NETWORK_SUBNET = "10.139.0.0/24"
+SCENARIO_PEER_IPS = {"a": "10.139.0.2", "b": "10.139.0.3"}
+
+
+@pytest.fixture
+def scenario_network() -> Iterator[str]:
+    network_name = "rosotacom-scenario-e2e"
+    subprocess.run(
+        ["docker", "network", "rm", network_name],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    _run(
+        ["docker", "network", "create", "--subnet", SCENARIO_NETWORK_SUBNET, network_name],
+        timeout=30,
+    )
+    try:
+        yield network_name
+    finally:
+        subprocess.run(
+            ["docker", "network", "rm", network_name],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
 
 
 def _smoke_command(project: Path, session_name: str) -> list[str]:
@@ -191,7 +218,13 @@ def _smoke_command(project: Path, session_name: str) -> list[str]:
     ]
 
 
-def _scenario_command(project: Path, action: str, identity: str, instance_id: str) -> list[str]:
+def _scenario_command(
+    project: Path,
+    action: str,
+    identity: str,
+    instance_id: str,
+    network_name: str | None = None,
+) -> list[str]:
     return [
         sys.executable,
         "-m",
@@ -208,10 +241,21 @@ def _scenario_command(project: Path, action: str, identity: str, instance_id: st
         "--instance-id",
         instance_id,
         "--peer-address",
-        "a=127.0.0.1",
+        f"a={SCENARIO_PEER_IPS['a']}",
         "--peer-address",
-        "b=127.0.0.1",
-        *(["--mode", "detached"] if action == "start" else []),
+        f"b={SCENARIO_PEER_IPS['b']}",
+        *(
+            [
+                "--mode",
+                "detached",
+                "--network-name",
+                network_name,
+                "--network-ip",
+                SCENARIO_PEER_IPS[identity],
+            ]
+            if action == "start" and network_name
+            else []
+        ),
     ]
 
 
@@ -405,11 +449,21 @@ def test_local_native_chatter_smoke_from_copied_example_project(
 
 def test_native_chatter_scenario_starts_apps_and_communication_together(
     copied_example_project: Path,
+    scenario_network: str,
 ) -> None:
     instance_id = f"scenario-pilot-{time.time_ns()}"
     try:
         for identity in ("a", "b"):
-            result = _run(_scenario_command(copied_example_project, "start", identity, instance_id), timeout=900)
+            result = _run(
+                _scenario_command(
+                    copied_example_project,
+                    "start",
+                    identity,
+                    instance_id,
+                    scenario_network,
+                ),
+                timeout=900,
+            )
             assert "rosotacom scenario started: 2_native_chatter" in result.stdout
             assert "inner catmux prefix with Ctrl-b Ctrl-b" in result.stdout
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -501,11 +501,14 @@ def test_scenario_tmux_commands_keep_ctrl_b_and_use_full_windows(
         instance,
         "a",
         definition.applications["a"],
+        "rosotacom_test_com_to_b",
         argparse.Namespace(
             force=True,
             rewrite_formatting=False,
             overwrite_peers_via_remote_peer=None,
             peer_address=[],
+            network_name="scenario-net",
+            network_ip="10.139.0.2",
         ),
     )
 
@@ -516,8 +519,12 @@ def test_scenario_tmux_commands_keep_ctrl_b_and_use_full_windows(
     assert any(command[-2:] == ["@rosotacom_scenario", "demo"] for command in calls)
     assert any(command[-2:] == ["@rosotacom_identity", "a"] for command in calls)
     assert any("inner catmux: C-b C-b" in part for command in calls for part in command)
-    assert any("rosotacom start demo --identity a --mode attach" in " ".join(command) for command in calls)
-    assert any("scenario _run-application demo" in " ".join(command) for command in calls)
+    joined = "\n".join(" ".join(command) for command in calls)
+    assert "rosotacom start demo --identity a --mode attach" in joined
+    assert "--network-name scenario-net --network-ip 10.139.0.2" in joined
+    assert "scenario _run-application demo" in joined
+    assert "--network-name container:rosotacom_test_com_to_b" in joined
+    assert "waiting for container: rosotacom_test_com_to_b" in joined
     assert sum("new-window" in command for command in calls) == 1
     assert not any("split-window" in command for command in calls)
     assert any(
@@ -1003,7 +1010,7 @@ def test_start_and_stop_scenario_manage_manifest_and_component_order(
     context = (runtime, resolved, definition, session, cfg, "a", definition.applications["a"])
     monkeypatch.setattr(rosotacom, "_require_ros2docker", lambda: None)
     monkeypatch.setattr(rosotacom, "_require_tmux", lambda: None)
-    monkeypatch.setattr(rosotacom, "_resolve_scenario_context", lambda args: context)
+    monkeypatch.setattr(rosotacom, "_resolve_scenario_context", lambda args, **kwargs: context)
     monkeypatch.setattr(rosotacom, "_tmux_session_exists", lambda runtime, name: False)
     monkeypatch.setattr(rosotacom, "_resolve_session_instance", lambda *args, **kwargs: instance)
     monkeypatch.setattr(rosotacom, "_remote_peer_name", lambda cfg, identity: "b")


### PR DESCRIPTION
## Summary
- run scenario communication peers on distinct addresses in a dedicated Docker network during E2E coverage
- attach each scenario application to its communication container network namespace
- allow scenario attach/stop to operate without re-resolving deployment bindings

## Root cause
The DDS OTA shortcut now uses interface-pinned unicast. The scenario E2E test still launched both peers with host networking and `127.0.0.1`, causing participant/port collisions in OTA domain 48 and hiding `/ota/b/chatter` from both status observers.

## Verification
- `ROSOTACOM_RUN_E2E=1 .venv/bin/python -m pytest -q tests/e2e/test_smoke.py::test_native_chatter_scenario_starts_apps_and_communication_together -s`
- `just check`

Fixes the failures observed in Actions runs 27929336089 and 27929422962.