### PR TITLE
feat: improve interactive smoke tmux feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,8 @@ target is a scenario, it also opens one window per local application container;
 each application shares its peer communication container's isolated network
 namespace so local ROS discovery behaves like colocated processes. A
 `verification` window runs the local checks/status view while you inspect the
-system. The outer prefix is `Ctrl-b`; use `Ctrl-b n`/`Ctrl-b p` for windows and
+system. Its upper pane keeps the verification log; its lower pane watches live
+status. The outer prefix is `Ctrl-b`; use `Ctrl-b n`/`Ctrl-b p` for windows and
 `Ctrl-b Ctrl-b` for the inner catmux session.
 
 `rosotacom smoke TARGET --interactive` accepts either a session or a scenario.
@@ -324,9 +325,12 @@ rosotacom ota-smoke 2_native_chatter \
 `ota-smoke` accepts sessions and scenarios. It automatically stages and
 installs the currently selected rosotacom version, stages the active project,
 runs delivery and isolation checks, collects artifacts, stops the run, and
-removes the remote workdir. Add `--interactive` for the control tmux,
-`--keep-running` to leave components up, `--keep-workdir` to retain staged
-files, or `--reuse` to reuse an existing installation.
+removes the remote workdir. Add `--interactive` for a local control tmux with
+one attachable communication/catmux window per peer and a status pane below each
+one. Stop an interactive run with `rosotacom ota-smoke TARGET --interactive
+--stop`; pass the same peer/deployment arguments if the local tmux metadata is
+not available. Use `--keep-running` to leave components up, `--keep-workdir` to
+retain staged files, or `--reuse` to reuse an existing installation.
 
 ### Live status / debugging overview
 

--- a/docs/rfcs/0002-expectation-concepts.md
+++ b/docs/rfcs/0002-expectation-concepts.md
@@ -331,7 +331,7 @@ once `optional` are all fixed:
         (verified 22 ms on 10_restamp and remote_assist `/can/twist`).
       - *headerless* topics: the OTA wrapper (`use_ota_wrapper`) already sets the
         OtaStamped header to the relay's SEND time -- an out-of-band send-time sidecar.
-        RFC 0003 adds `source_stamp` and echo-derived clock-offset correction.
+        RFC 0003 adds echo-derived clock-offset correction.
         New `expect.latency_ms.stage` redirects the latency assertion to the stage
         carrying that stamp (`com_in`), so offset-aware OTA transit latency is assertable even
         for a headerless payload. Example `13_link_latency` (a plain String): verified

--- a/docs/rfcs/0003-metric-backbone.md
+++ b/docs/rfcs/0003-metric-backbone.md
@@ -47,19 +47,22 @@ Every metric on the wishlist is a projection of one recorded object per message:
 
 ```
 (topic, seq):
-  t_source    (sender clock)     — original header.stamp, or the wrap-input time
-  t_wrap      (sender clock)     — OtaStamped.header.stamp           [exists today]
+  t_wrap      (sender clock)     — OtaStamped.header.stamp
   t_com_in    (receiver clock)   — arrival immediately after bridge_in
   status      — delivered | lost | reordered                        [from seq gap]
   sections:
-    preprocess = t_wrap   − t_source            (sender-local, exact, no sync)
-    ota_hop    = (t_com_in + θ) − t_wrap         (θ = sender/peer − receiver/local)
+    ota_hop   = (t_com_in + θ) − t_wrap          (θ = sender/peer − receiver/local)
   inter_arrival / jitter         — receiver-local regularity
 ```
 
+The envelope carries only what the cross-host **OTA hop** needs (`t_wrap` +
+`seq`). Local / per-stage latency — including the message's pre-OTA pipeline cost —
+is read uniformly from the `stage_latency` join (mechanism 3), **not** from an
+in-band stamp.
+
 | Wishlist item | Projection of the record |
 |---|---|
-| "latency split per processing section incl. OTA" | `sections` |
+| "latency split per processing section incl. OTA" | OTA hop from `sections`; per-step local split from `stage_latency` |
 | "the time-sync error was X" | `θ` (echo-heartbeat) |
 | "N messages lost, per topic" | `status` over the seq range |
 | "say exactly, after a test drive, that …" | per-message, recorded, joined offline |
@@ -75,8 +78,9 @@ append-only timeline contains both message evidence and pipeline state changes.
 1. **OTA characteristics** — loss, size, bandwidth, latency *across the OTA hop*.
    The most important tier. Measured at `com_in` from `seq` + the echo RTT.
    **Always-on.**
-2. **End-to-end latency** — `t_source` → final delivery (one cross-host hop, the
-   rest local). **Always-on.**
+2. **End-to-end latency** — composed, not a single in-band field: a headered final
+   stage already reports `now − header.stamp`, and the full per-stage split comes
+   from `stage_latency`; the transit record contributes the OTA hop.
 3. **Pre-/post-processing overhead** — the cost of each local step (restamp,
    drop, compress, framebridge, transport). **Opt-in.**
 
@@ -85,7 +89,7 @@ cross the OTA link?" — **no**:
 
 | | Always-on, light | Opt-in, deep |
 |---|---|---|
-| What | transit-record digest: OTA loss/size/bw/latency + e2e | local stage-rosbag: every step separately |
+| What | transit-record digest: OTA loss/size/bw/latency | local stage-rosbag: every step separately |
 | Key | `(topic, seq)`, cross-host | message index, intra-host |
 | Where | small enough for `status.json` (optionally a live OTA digest) | stays local; pulled only for an analysis run |
 
@@ -151,27 +155,37 @@ inferring it from two independent internet-NTP syncs. Where an endpoint is
 GPS-time-disciplined, its stamps are UTC-true and provide a free ground-truth
 cross-check — a bonus, never a dependency.
 
-### 3. Latency decomposition — two sections free, the rest local
+### 3. Latency decomposition — the OTA hop in-band, all local timing via `stage_latency`
 
-Add **one** field to `OtaStamped`: `source_stamp` (the original nonzero
-`header.stamp` before wrapping, or the wrapper input time for headerless/zero-
-stamped messages). At
-`com_in` this yields two sections per message with no sidecar:
+The transit record carries exactly **one** per-message section: the cross-host
+`ota_hop = (t_com_in + θ) − t_wrap`. That is all the envelope needs — `t_wrap`
+(`OtaStamped.header.stamp`) plus `seq`.
 
-- `preprocess = t_wrap − source_stamp` — sender-local, exact, no sync.
-- `ota_hop = (t_com_in + θ) − t_wrap` — the single offset-corrected cross-host
-  section.
-
-Deeper decomposition of the *local* pipeline (per-step cost of restamp / drop /
-compress / framebridge / transport) does **not** need a new in-band field. Set
-`shared.metric_backbone.record_stages: true` to record every generated local
-stage topic into an MCAP rosbag under the run's `logs/<peer>/metrics/` directory.
-`ros2 run com_py stage_latency BAG TOPIC...` joins bag receive timestamps by
-message index and reports consecutive-stage costs. The index join is valid
-because this path is single-clock, lossless, and in-order.
+**All local / per-stage latency is read uniformly from the `stage_latency`
+join**, not from an in-band stamp. Set `shared.metric_backbone.record_stages:
+true` to record every generated local stage topic into an MCAP rosbag under the
+run's `logs/<peer>/metrics/` directory; `ros2 run com_py stage_latency BAG
+TOPIC...` joins bag receive timestamps **by message index** and reports
+consecutive-stage costs. This works because the local path is single-clock and
+in-order.
 
 > This is the systematic form of what is already done by hand: reading
 > `ros2 topic delay` on successive suffixed stage topics and subtracting.
+
+> **Earlier design, reverted.** A first cut added an `OtaStamped.source_stamp`
+> field to surface a `preprocess = t_wrap − source_stamp` section in-band. It was
+> removed: the number was misleading (≈ the wrap step only for headerless topics;
+> source-staleness incl. pre-rosotacom age for headered), redundant with the
+> payload stamp where one exists, and already covered by `stage_latency`. Local
+> timing now has a single, uniform home.
+>
+> **Index-join caveat.** The `stage_latency` index join is valid only across
+> **non-decimating (1:1) stages**. A `drop` / `throttle` stage gives the next
+> topic fewer messages, so positional index *i* stops referring to the same
+> message, and headerless messages carry no key to repair it. Per-step *timing* is
+> therefore meaningful across the latency-adding 1:1 steps (compress / framebridge
+> / transport); decimating steps are characterized by **rate**, not per-message
+> index.
 
 ## Honest limits (design notes)
 
@@ -234,10 +248,12 @@ profile work), not hardcoded here.
 - [x] Track `OtaStamped.seq` at inbound `com_in`; expose window and run-total
   loss, reorder count, and maximum missing burst in `status.json`.
 - [x] Implement generic `expect.loss_pct: { max, stage? }` evaluation.
-- [x] Add `OtaStamped.source_stamp` and populate it from the payload stamp or
-  wrapper-input time.
-- [x] Emit corrected/uncorrected OTA hop, preprocessing, offset, RTT, size,
-  inter-arrival, and jitter data.
+- [x] Read all local / per-stage latency from the `stage_latency` message-index
+  join; the transit record's only in-band section is the OTA hop. (An earlier
+  `OtaStamped.source_stamp` / `preprocess` section was added then **reverted** —
+  see mechanism 3.)
+- [x] Emit corrected/uncorrected OTA hop, offset, RTT, size, inter-arrival, and
+  jitter data.
 - [x] Replace the one-way heartbeat implementation with `EchoHeartbeat` and a
   symmetric piggyback echo node.
 - [x] Continuously estimate peer offset from the minimum-RTT sample and state the

--- a/docs/rfcs/0004-network-profiles.md
+++ b/docs/rfcs/0004-network-profiles.md
@@ -185,20 +185,31 @@ RFC 0002's `calibrate` / `--suggest` machinery, **per profile**:
   reading per-direction *latency* back out still depends on the clock-offset
   handling in RFC 0003.
 
-## Build order
+## Implementation checklist
 
-1. **Profile schema + arm/teardown on the OTA egress**, fail-safe, `--profile` on
-   `ota-smoke`/`test`. The smallest end-to-end slice: a named static profile that
-   reliably applies and always tears down. *(highest risk is the teardown
-   guarantee — do it first)*
-2. **Per-direction (uplink/downlink) application** on each peer's egress.
-3. **`expect.per_profile` + the invariant/conditional split** in `status_eval`.
-4. **Timeline profiles** (segments + `outage`) — unlocks the recovery genre in
-   RFC 0005.
-5. **`calibrate --profile`** — per-profile conditional bands.
+Roughly in dependency order; the fail-safe teardown (second item) is the highest
+risk — a stuck `qdisc` silently corrupts every later result on the machine.
 
-Steps 1–3 make the gate profile-aware; 4–5 unlock benchmarking and live-contract
-derivation.
+- [ ] Define the profile schema (static + per-direction `{rate, delay, jitter,
+  distribution, loss, loss_correlation, reorder, duplicate}`) at project scope, and
+  resolve selection via `--profile <name>` / `shared.profile` / `none`.
+- [ ] Arm a named static profile on the OTA-interface egress with fail-safe
+  teardown (revert on stop, on error, and via a safety max-duration); target the
+  data interface only, never the SSH/control interface.
+- [ ] Apply profiles per direction — `uplink` on the sending peer's egress,
+  `downlink` on the receiver's — and reject profile selection on a real-deployment
+  run.
+- [ ] Add `expect.per_profile` overrides and the invariant/conditional split to
+  `status_eval`, so `rosotacom test --profile P` asserts the invariant block plus
+  `P`'s conditional band (default conditional where `P` has no override).
+- [ ] Add timeline profiles (ordered segments + `outage`) — the substrate for the
+  recovery genre in RFC 0005.
+- [ ] Add `rosotacom calibrate --profile P` to emit per-profile conditional bands
+  from a reference replay.
+- [ ] Confirm the `/proc/net/dev` link sampler (RFC 0003 / `link_bytes.py`) reports
+  post-shaping wire bytes so link-overhead stays meaningful under a profile.
+- [ ] Cover schema parsing, arm/teardown (including crash teardown), per-direction
+  application, and `per_profile` evaluation with tests.
 
 ## Open questions
 

--- a/docs/rfcs/0005-benchmark-genres-and-ci.md
+++ b/docs/rfcs/0005-benchmark-genres-and-ci.md
@@ -61,6 +61,14 @@ still passes, per profile.
   pattern** (e.g. `4×0 B + 1×70 KB`) so it reproduces the irregular-size
   head-of-line behaviour the baseline identifies as the real failure mode (this
   extension is already on the operator's wishlist).
+- **Bounded, not unbounded.** Every sweep stops at an operationally-relevant
+  ceiling (a configured max size / rate / bandwidth), not "until it breaks at any
+  cost." These are **OTA tests**: the goal is behaviour under realistic —
+  especially **simulated-degraded** — networks, not the theoretical maximum of a
+  pristine link. On the unshaped / LAN rung in particular the sweep must stay
+  within a bounded budget and **never saturate the shared LAN**; push the limits on
+  the emulated bad-network profiles instead, where the profile's own rate cap
+  bounds the offered load.
 
 ### Genre 2 — Perturbation / recovery (transient response)
 
@@ -136,17 +144,29 @@ harness, not in this public repo.
   are only visible per-message (RFC 0003) and under irregular load (the a/b
   pattern) — a benchmark on averages would miss exactly what matters.
 
-## Build order
+## Implementation checklist
 
-1. **Capacity binary-search driver** — `sized_publisher` + a/b pattern + the
-   backbone oracle → "largest reliable message" per profile. Smallest slice;
-   reuses RFC 0003 + 0004. *(start here)*
-2. **Budget store + regression compare** — the nightly monitor verdict.
-3. **Recovery driver** on timeline profiles (RFC 0004 step 4) + the recovery metric
-   set.
-4. **Linear-ramp curves** — the latency-vs-load surface, for trend.
-5. **Wire the nightly monitor into CI** — gate-vs-monitor; the harness wires the
-   actual runner.
+Roughly in dependency order; the capacity driver is the smallest self-contained
+slice and reuses RFC 0003 + 0004.
+
+- [ ] Extend `sized_publisher` with an a/b size pattern (e.g. `4×0 B + 1×70 KB`) to
+  drive irregular-size load.
+- [ ] Build the capacity binary-search driver: sweep size/rate against the backbone
+  oracle (`loss < p` **and** `latency < L` over a window) → the breakpoint per
+  profile, with the slice (size/rate) stated.
+- [ ] Bound every sweep with a configured max (size / rate / bandwidth) and a
+  shared-link guard, so an unshaped / LAN run never saturates the shared network;
+  the sweep's focus is the emulated degraded profiles, not a pristine link's
+  ceiling.
+- [ ] Add the budget store (per `(SHA, profile, genre)`) and the regression compare
+  against a recorded baseline ± tolerance.
+- [ ] Build the recovery driver on timeline profiles (RFC 0004) + the recovery
+  metric set (`t_recover`, `t_steady`, backlog/burst, lost-during-outage, latched
+  re-arrival).
+- [ ] Add coarse linear-ramp curves (latency-vs-load) for trend.
+- [ ] Wire the nightly benchmark run as a **monitor** (alerts on budget regression,
+  never blocks); the harness wires the actual runner.
+- [ ] Cover the driver oracle, budget compare, and recovery metrics with tests.
 
 ## Open questions
 

--- a/docs/rfcs/0006-dynamic-qos.md
+++ b/docs/rfcs/0006-dynamic-qos.md
@@ -1,0 +1,124 @@
+# RFC 0006 — Dynamic QoS (mirror correctness, shape bandwidth)
+
+**Status:** Draft — design agreed, not yet implemented · **Scope:** QoS resolution
+across the OTA hop · extends [RFC 0002](0002-expectation-concepts.md) (the
+`remote_assist` workload it simplifies); shares the correctness/performance split
+with [RFC 0004](0004-network-profiles.md)
+
+## Summary
+
+Today every topic's QoS across the OTA hop is hand-written. The FZI-private
+`remote_assist` session repeats, for **each** latched topic, the same block —
+`durability: transient_local` + `for_role.ota_pub/ota_sub` + a long `lifespan` —
+because a held value must survive the hop. This is boilerplate, and getting it
+wrong is a whole bug class (RFC 0002: `domain_bridge` auto-detecting a topic's QoS
+and racing it to `volatile`, silently dropping every latched value).
+
+This RFC adds **`qos: dynamic`** (the default): rosotacom introspects the *native*
+publisher's QoS — from the bag's `offered_qos` on replay, from the live endpoint
+otherwise — and derives the OTA QoS automatically, on one principle:
+
+- **mirror the correctness-bearing QoS** (durability / latched-ness) across every
+  stage, including the hop;
+- **keep the bandwidth-bearing QoS a policy** (reliability / depth / lifespan on
+  streams), because re-shaping it to fit the link is the OTA hop's whole job.
+
+Explicit per-topic / per-role `qos:` still wins (the existing `qos.py` merge).
+
+## Motivation
+
+- **Boilerplate + a bug class.** The repetitive `transient_local` blocks are
+  mechanical, and the one time they are wrong the held value vanishes with no error
+  (RFC 0002's `domain_bridge` durability race). Deriving them removes both.
+- **The information already exists.** `bag_ground_truth.py` already parses each bag
+  topic's `offered_qos` (durability, reliability); the live graph exposes the same
+  via `get_publishers_info_by_topic`. Nothing new is measured — only consumed.
+
+## The principle: QoS has the same correctness/performance split
+
+The split that runs through the whole system (motivation.md; RFC 0004's
+invariant/conditional expectations) applies to QoS too:
+
+| QoS field | Kind | Dynamic behaviour |
+|---|---|---|
+| `durability` (latched-ness) | **correctness** | **mirror** native across all stages + hold it across the hop (transient_local + long `lifespan` on the OTA pub) + set `expect.mode: latched` |
+| `reliability` | **load-dependent** (see below) | mirror when the topic fits the budget; force `best_effort` when it must be decimated |
+| `depth` / `history` | **performance** | policy: `keep_last` / `depth 1` for streams unless overridden |
+| `lifespan` (on streams) | **performance** | policy: short, to bound the reconnect backlog (RFC 0003/0005) |
+
+`dynamic` is therefore **not transparent pass-through** — the OTA hop deliberately
+*changes* the performance QoS (a 100 Hz reliable stream becomes best_effort /
+depth-1 to fit the pipe) while *preserving* the correctness QoS (a latched value
+stays latched end-to-end).
+
+## Resolution
+
+1. **Read native QoS.** Replay: `offered_qos` from the bag metadata
+   (`bag_ground_truth.py`). Live: the publisher endpoint(s) via
+   `get_publishers_info_by_topic`.
+2. **Classify latched-ness.** `durability == transient_local` (corroborated on
+   replay by a low message count ⇒ publish-on-change) ⇒ latched.
+3. **Derive:**
+   - latched ⇒ `transient_local` on the local relay pubs, the OTA pub/sub, and the
+     receiver; long `lifespan` on the OTA pub so a late subscriber still gets the
+     held value; `expect.mode: latched`.
+   - non-latched ⇒ the default streaming policy (best_effort / keep_last / depth 1
+     / short lifespan).
+4. **Reliability by load (the subtle part).** A low-rate reliable topic (e.g. a
+   command) is a *correctness* concern — a dropped command is bad — and fits the
+   budget, so mirror `reliable`. A high-rate reliable stream is a *bandwidth*
+   concern, so force `best_effort` regardless of native (the decimation is
+   intended). The discriminator is the offered load (rate × size) vs the per-topic
+   budget.
+5. **Explicit overrides win**, per field and per role, via the existing merge.
+
+## Implementation checklist
+
+- [ ] Read native QoS from the bag `offered_qos` (replay) and from live publisher
+  endpoints (`get_publishers_info_by_topic`).
+- [ ] Add `qos: dynamic` and make it the default when a topic gives no explicit
+  `qos:`.
+- [ ] Mirror correctness QoS: propagate `durability` across all stages incl. the
+  OTA hop, hold latched values (transient_local + long OTA-pub `lifespan`), and set
+  `expect.mode: latched` automatically.
+- [ ] Apply the default streaming policy (best_effort / keep_last / depth 1 / short
+  lifespan) to non-latched topics; never inherit native depth / large history for
+  streams.
+- [ ] Decide `reliability` by offered load: mirror `reliable` for low-rate topics
+  within budget, force `best_effort` above it.
+- [ ] Keep explicit per-topic / per-role `qos:` overriding dynamic resolution, per
+  field (the existing `qos.py` merge order).
+- [ ] Handle the live discovery race (resolve lazily when the publisher appears)
+  and multi-publisher QoS conflict (defined precedence — most restrictive).
+- [ ] Migrate `remote_assist`: drop the repetitive per-latched-topic
+  `transient_local` / `for_role` / `lifespan` blocks now derived by `dynamic`, and
+  confirm delivery is unchanged.
+- [ ] Tests: latched mirroring + hold-across-hop, stream policy, load-based
+  reliability, override precedence, replay-vs-live source, conflict resolution.
+
+## Honest limits
+
+- **Live discovery race.** Live resolution needs the native publisher to exist when
+  rosotacom resolves QoS → resolve lazily (the wrapper already subscribes
+  dynamically), not eagerly at generate-time. Replay is clean (the bag metadata is
+  known upfront).
+- **Latched detection is a heuristic.** `durability` alone can mis-read a high-rate
+  `transient_local` topic as latched; replay corroborates with the count, live must
+  infer from the observed rate.
+- **Multi-publisher conflict.** Several publishers offering different QoS need a
+  rule (most-restrictive); `bag_ground_truth` currently takes the first profile.
+- **The non-obvious core.** "Dynamic" mirrors correctness QoS and *re-shapes*
+  performance QoS — it is **not** transparent inheritance. Mirroring native
+  reliability / depth onto a high-rate stream would blow the OTA budget, the
+  opposite of the intent.
+
+## Open questions
+
+- **Latched discriminator:** `durability` alone, or `durability` + low-rate /
+  low-count? (Replay has the count; live must infer.)
+- **Reliability-by-load threshold:** a simple rate/size threshold first, or the
+  full per-topic-budget comparison (ties into RFC 0004/0005 budgets)?
+- **Resolution time:** lazy run-time for live vs generate-time for replay — one path
+  or two?
+- **Override granularity:** per-field merge (as `qos.py` already does) vs
+  all-or-nothing when an explicit `qos:` is present.

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -9,6 +9,8 @@ self-contained; later ones extend earlier ones.
 | [0002](0002-expectation-concepts.md) | Richer expectation concepts (presence / mode / completeness / overhead) | Implemented |
 | [0003](0003-metric-backbone.md) | Metric backbone (per-message transit records, offset-aware latency, real loss) | Implemented |
 | [0004](0004-network-profiles.md) | Network profiles & the fidelity ladder (per-direction netem, profile-bound expectations) | Draft |
+| [0005](0005-benchmark-genres-and-ci.md) | Benchmark genres & CI distribution (sweep/capacity + recovery, budgets, gate vs monitor) | Draft |
+| [0006](0006-dynamic-qos.md) | Dynamic QoS (mirror correctness durability, shape bandwidth reliability/depth) | Draft |
 
 Add a new RFC as `NNNN-title.md` and list it here, so it stays reachable from the
 README (see the documentation-traceability rule in `AGENTS.md`).

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -101,7 +101,9 @@ A generic OTA run:
 Use `rosotacom ota-smoke TARGET --peer-address ... --peer-ssh ...` for a
 configuration-free operator run, or map peers to named hosts with `--peer`
 through the active project's deployment file. Add `--interactive` to open a
-local control tmux for the same run.
+local control tmux for the same run; each peer gets an attachable
+communication/catmux pane with a live status pane below it. Stop it with
+`rosotacom ota-smoke TARGET --interactive --stop`.
 
 External runners should use `ota_suite_sessions()` to discover the scenario set
 from examples and generated test-configs instead of hardcoding transport names.

--- a/src/rosotacom/cli.py
+++ b/src/rosotacom/cli.py
@@ -1366,6 +1366,13 @@ def _ota_print_failure_output(label: str, result: subprocess.CompletedProcess[st
         print(f"--- end {label} output ---", file=sys.stderr)
 
 
+def _print_completed_output(result: subprocess.CompletedProcess[str]) -> None:
+    if result.stdout:
+        print(result.stdout, end="" if result.stdout.endswith("\n") else "\n")
+    if result.stderr:
+        print(result.stderr, end="" if result.stderr.endswith("\n") else "\n", file=sys.stderr)
+
+
 def _ota_project_cli_args(plan: OtaSmokePlan) -> list[str]:
     return ["--rosotacom-config", plan.project]
 
@@ -1689,12 +1696,49 @@ def _format_active_ota_smoke_runs(runs: list[ActiveOtaSmokeRun]) -> str:
     return "\n".join(lines)
 
 
+def _manifest_ota_smoke_runs(runtime: RuntimeConfig) -> list[ActiveOtaSmokeRun]:
+    root = _session_instances_root(runtime)
+    runs: list[ActiveOtaSmokeRun] = []
+    for manifest_path in sorted(root.glob("*/*/manifest.yaml"), reverse=True):
+        manifest = _load_yaml_file(manifest_path)
+        instance_id = str(manifest.get("instance_id") or manifest_path.parent.name.rsplit("_", 1)[-1])
+        for run in (manifest.get("ota_smoke_runs") or {}).values():
+            if not isinstance(run, dict):
+                continue
+            if run.get("stopped_at") or run.get("phase") == "stopped":
+                continue
+            target = str(run.get("target") or "")
+            target_type = str(run.get("target_type") or "")
+            state_path = str(run.get("deployment_state") or "")
+            if not target or not target_type or not state_path:
+                continue
+            tmux_session = str(run.get("tmux_session") or _ota_smoke_tmux_session(target_type, target))
+            runs.append(
+                ActiveOtaSmokeRun(
+                    target=target,
+                    target_type=target_type,
+                    tmux_session=tmux_session,
+                    instance_id=instance_id,
+                    state_path=state_path,
+                )
+            )
+    return sorted(runs, key=lambda run: (run.target_type, run.target, run.instance_id))
+
+
 def _infer_active_ota_smoke_run(
     runtime: RuntimeConfig,
     target_arg: str | None,
     target_type: str,
+    instance_id: str | None = None,
 ) -> ActiveOtaSmokeRun:
     runs = _active_ota_smoke_runs(runtime)
+    seen = {(run.target, run.target_type, run.instance_id) for run in runs}
+    runs.extend(
+        run for run in _manifest_ota_smoke_runs(runtime) if (run.target, run.target_type, run.instance_id) not in seen
+    )
+    if instance_id:
+        instance_token = _safe_path_token(instance_id)
+        runs = [run for run in runs if run.instance_id == instance_token]
     if target_arg:
         target = _resolve_interactive_smoke_target(target_arg, runtime, target_type)
         matches = [run for run in runs if run.target == target.name and run.target_type == target.target_type]
@@ -1963,12 +2007,16 @@ def _ota_start_session_publishers(
     dry_run: bool,
 ) -> None:
     if target.target_type != "session":
+        print("OTA smoke: target is a scenario; using its application publishers.")
         return
     peer_args = _ota_peer_address_args(plan)
     for peer_name in sorted(plan.peers):
         peer = plan.peers[peer_name]
         command = _ota_rosotacom_command(plan, _ota_publish_parts(target, peer_name, peer_args))
-        _ota_run(peer, command, label=f"{peer_name}: start synthetic publishers", dry_run=dry_run, check=False)
+        result = _ota_run(peer, command, label=f"{peer_name}: start synthetic publishers", dry_run=dry_run, check=False)
+        _print_completed_output(result)
+        if result.returncode != 0:
+            _ota_print_failure_output(f"{peer_name}: start synthetic publishers", result)
 
 
 def _ota_stop_session_publishers(
@@ -1994,6 +2042,7 @@ def _ota_verify_delivery(
     dry_run: bool,
 ) -> list[str]:
     errors: list[str] = []
+    print("OTA smoke: running status/expectation checks on every peer.")
     for peer_name in sorted(plan.peers):
         peer = plan.peers[peer_name]
         command = _ota_rosotacom_command(plan, _ota_test_parts(target, instance_id))
@@ -2001,6 +2050,8 @@ def _ota_verify_delivery(
         if result.returncode != 0:
             _ota_print_failure_output(f"{peer_name}: rosotacom test", result)
             errors.append(f"{peer_name}: rosotacom test failed")
+        else:
+            _print_completed_output(result)
     return errors
 
 
@@ -2016,12 +2067,14 @@ def _ota_verify_isolation(
     receiver = plan.peers[receiver_name]
     peer_args = _ota_peer_address_args(plan)
     errors: list[str] = []
+    print(f"OTA smoke: checking isolation from {source_name} to {receiver_name}.")
     publish = _ota_rosotacom_command(plan, _ota_probe_publish_parts(target, source_name, peer_args, stop=False))
     published = _ota_run(source, publish, label=f"{source_name}: publish isolation probe", dry_run=dry_run, check=False)
     if published.returncode != 0:
         _ota_print_failure_output(f"{source_name}: publish isolation probe", published)
         errors.append(f"{source_name}: isolation probe publisher failed")
         return errors
+    _print_completed_output(published)
     check = _ota_rosotacom_command(plan, _ota_probe_check_parts(target, receiver_name, peer_args))
     checked = _ota_run(
         receiver,
@@ -2033,8 +2086,11 @@ def _ota_verify_isolation(
     if checked.returncode != 0:
         _ota_print_failure_output(f"{receiver_name}: check isolation probe absent", checked)
         errors.append(f"{receiver_name}: isolation probe crossed OTA boundary")
+    else:
+        _print_completed_output(checked)
     stop = _ota_rosotacom_command(plan, _ota_probe_publish_parts(target, source_name, peer_args, stop=True))
-    _ota_run(source, stop, label=f"{source_name}: stop isolation probe", dry_run=dry_run, check=False)
+    stopped = _ota_run(source, stop, label=f"{source_name}: stop isolation probe", dry_run=dry_run, check=False)
+    _print_completed_output(stopped)
     return errors
 
 
@@ -2054,12 +2110,15 @@ def _ota_verify_content_integrity(
         for topic, msg_type, field, expected in _content_integrity_specs(cfg, receiver_name):
             parts = _ota_content_check_parts(target, receiver_name, peer_args, topic, msg_type, field, expected)
             cmd = _ota_rosotacom_command(plan, parts)
+            print(f"OTA smoke: checking content integrity for {receiver_name} {topic}.")
             result = _ota_run(
                 receiver, cmd, label=f"{receiver_name}: content integrity {topic}", dry_run=dry_run, check=False
             )
             if result.returncode != 0:
                 _ota_print_failure_output(f"{receiver_name}: content integrity {topic}", result)
                 errors.append(f"{receiver_name}: content integrity mismatch on {topic}")
+            else:
+                _print_completed_output(result)
     return errors
 
 
@@ -2113,6 +2172,8 @@ def _ota_verify_only(args: argparse.Namespace) -> int:
     if not instance_id:
         raise RuntimeError("ota-smoke --verify-only requires --instance-id.")
     dry_run = bool(getattr(args, "dry_run", False))
+    print(f"OTA smoke verification starting: {target.name} ({target.target_type}), instance={instance_id}")
+    print("OTA smoke: starting synthetic publishers where needed.")
     _ota_start_session_publishers(target, plan, dry_run=dry_run)
     errors = _ota_verify_delivery(target, plan, instance_id, dry_run=dry_run)
     errors += _ota_verify_isolation(target, plan, dry_run=dry_run)
@@ -2134,7 +2195,11 @@ def _ota_status_watch_script(
 
 
 def _ota_debug_shell_script(plan: OtaSmokePlan) -> str:
-    return f'cd {shlex.quote(plan.workdir)} && exec "${{SHELL:-bash}}"'
+    return (
+        f"cd {shlex.quote(plan.workdir)} && "
+        f"echo '[INFO] debug shell for OTA smoke workdir: {shlex.quote(plan.workdir)}' && "
+        'exec "${SHELL:-bash}"'
+    )
 
 
 def _ota_create_tmux(
@@ -2150,10 +2215,18 @@ def _ota_create_tmux(
     first_peer = peers[0]
     first_start = _ota_rosotacom_command(
         plan,
-        _ota_start_parts(target, first_peer.name, instance.instance_id, peer_args, mode="detached"),
+        _ota_start_parts(target, first_peer.name, instance.instance_id, peer_args, mode="attach"),
     )
     first_status = _ota_status_watch_script(plan, target, instance.instance_id, first_peer.name)
-    first_script = f"set -e; {first_start}; echo; echo '[INFO] live remote status follows'; {first_status}"
+    first_script = (
+        "set -e; "
+        f"echo '[INFO] starting interactive communication for remote peer {first_peer.name}'; "
+        "echo '[INFO] this pane attaches to the peer communication/catmux session'; "
+        f"{first_start}; "
+        "echo; "
+        f"echo '[INFO] remote peer {first_peer.name} communication exited; live status is in the lower pane'; "
+        "exec bash"
+    )
     created = subprocess.run(
         _tmux_command(
             runtime,
@@ -2165,7 +2238,7 @@ def _ota_create_tmux(
             "-s",
             session_name,
             "-n",
-            _safe_path_token(f"{first_peer.name}_remote"),
+            _safe_path_token(f"{first_peer.name}_communication"),
             _ota_quote_cmd(_ota_remote_argv(first_peer, first_script, tty=bool(first_peer.ssh))),
         ),
         text=True,
@@ -2198,23 +2271,57 @@ def _ota_create_tmux(
             "-t",
             session_name,
             "status-right",
-            " ota smoke | windows: C-b n/p | remote tmux attach is opt-in ",
+            " ota smoke | windows: C-b n/p | peer tmux/catmux: C-b C-b ",
         ),
         check=True,
     )
     subprocess.run(
-        _tmux_command(runtime, "select-pane", "-t", first_pane, "-T", f"{first_peer.name}:remote"),
+        _tmux_command(runtime, "select-pane", "-t", first_pane, "-T", f"{first_peer.name}:communication"),
         check=True,
     )
-    _attach_tmux_pipe(runtime, first_pane, instance.logs_host_dir / "ota-smoke" / f"{first_peer.name}-remote.log")
+    _attach_tmux_pipe(
+        runtime,
+        first_pane,
+        instance.logs_host_dir / "ota-smoke" / f"{first_peer.name}-communication.log",
+    )
+    first_status_script = (
+        f"echo '[INFO] starting live remote status watch for {first_peer.name}'; "
+        f"echo '[INFO] waiting for status artifacts from instance {instance.instance_id}'; "
+        f"exec {first_status}"
+    )
+    _create_tmux_split_below(
+        runtime,
+        first_pane,
+        f"{first_peer.name}:status",
+        _ota_quote_cmd(_ota_remote_argv(first_peer, first_status_script, tty=bool(first_peer.ssh))),
+        log_path=instance.logs_host_dir / "ota-smoke" / f"{first_peer.name}-status.log",
+    )
+    subprocess.run(
+        _tmux_command(
+            runtime,
+            "select-layout",
+            "-t",
+            f"{session_name}:{_safe_path_token(f'{first_peer.name}_communication')}",
+            "even-vertical",
+        ),
+        check=True,
+    )
 
     for peer in peers[1:]:
         start = _ota_rosotacom_command(
             plan,
-            _ota_start_parts(target, peer.name, instance.instance_id, peer_args, mode="detached"),
+            _ota_start_parts(target, peer.name, instance.instance_id, peer_args, mode="attach"),
         )
         status = _ota_status_watch_script(plan, target, instance.instance_id, peer.name)
-        script = f"set -e; {start}; echo; echo '[INFO] live remote status follows'; {status}"
+        script = (
+            "set -e; "
+            f"echo '[INFO] starting interactive communication for remote peer {peer.name}'; "
+            "echo '[INFO] this pane attaches to the peer communication/catmux session'; "
+            f"{start}; "
+            "echo; "
+            f"echo '[INFO] remote peer {peer.name} communication exited; live status is in the lower pane'; "
+            "exec bash"
+        )
         created_window = subprocess.run(
             _tmux_command(
                 runtime,
@@ -2226,7 +2333,7 @@ def _ota_create_tmux(
                 "-t",
                 session_name,
                 "-n",
-                _safe_path_token(f"{peer.name}_remote"),
+                _safe_path_token(f"{peer.name}_communication"),
                 _ota_quote_cmd(_ota_remote_argv(peer, script, tty=bool(peer.ssh))),
             ),
             text=True,
@@ -2234,8 +2341,33 @@ def _ota_create_tmux(
             check=True,
         )
         pane_id = created_window.stdout.strip()
-        subprocess.run(_tmux_command(runtime, "select-pane", "-t", pane_id, "-T", f"{peer.name}:remote"), check=True)
-        _attach_tmux_pipe(runtime, pane_id, instance.logs_host_dir / "ota-smoke" / f"{peer.name}-remote.log")
+        subprocess.run(
+            _tmux_command(runtime, "select-pane", "-t", pane_id, "-T", f"{peer.name}:communication"),
+            check=True,
+        )
+        _attach_tmux_pipe(runtime, pane_id, instance.logs_host_dir / "ota-smoke" / f"{peer.name}-communication.log")
+        status_script = (
+            f"echo '[INFO] starting live remote status watch for {peer.name}'; "
+            f"echo '[INFO] waiting for status artifacts from instance {instance.instance_id}'; "
+            f"exec {status}"
+        )
+        _create_tmux_split_below(
+            runtime,
+            pane_id,
+            f"{peer.name}:status",
+            _ota_quote_cmd(_ota_remote_argv(peer, status_script, tty=bool(peer.ssh))),
+            log_path=instance.logs_host_dir / "ota-smoke" / f"{peer.name}-status.log",
+        )
+        subprocess.run(
+            _tmux_command(
+                runtime,
+                "select-layout",
+                "-t",
+                f"{session_name}:{_safe_path_token(f'{peer.name}_communication')}",
+                "even-vertical",
+            ),
+            check=True,
+        )
 
     for peer in peers:
         shell_script = _ota_debug_shell_script(plan)
@@ -2276,7 +2408,13 @@ def _ota_create_tmux(
         *_runtime_cli_args(runtime),
     ]
     verify_cmd = _ota_quote_cmd(verify_parts)
-    verify_script = f"{verify_cmd}; rc=$?; echo; echo '[INFO] verification exited with status' \"$rc\"; exec bash"
+    verify_script = (
+        f"echo '[INFO] starting OTA smoke verification for {target.name}'; "
+        f"{verify_cmd}; rc=$?; "
+        "echo; echo '[INFO] verification exited with status' \"$rc\"; "
+        "echo '[INFO] verification log remains in this pane'; "
+        "exec bash"
+    )
     verification = subprocess.run(
         _tmux_command(
             runtime,
@@ -2366,17 +2504,17 @@ def _start_interactive_ota_smoke(args: argparse.Namespace) -> int:
     created = _ota_create_tmux(runtime, target, plan, instance)
     print(f"rosotacom OTA smoke instance: {instance.host_dir}")
     print(f"rosotacom OTA smoke started: {target.name} ({target.target_type})")
-    print("Local control tmux prefix: Ctrl-b. Remote scenario/catmux attach is opt-in from debug shells.")
+    print("Local control tmux prefix: Ctrl-b. Send the peer tmux/catmux prefix with Ctrl-b Ctrl-b.")
     if target.target_type == "scenario":
         for peer_name, peer in plan.peers.items():
             attach = _ota_rosotacom_command(plan, ["scenario", "attach", target.name, "--identity", peer_name])
             attach_cmd = _ota_quote_cmd(_ota_remote_argv(peer, attach, tty=bool(peer.ssh)))
-            print(f"Remote scenario attach for {peer_name}: {attach_cmd}")
+            print(f"Manual remote scenario reattach for {peer_name}: {attach_cmd}")
     if mode == "attach":
         subprocess.run(_tmux_command(runtime, "attach-session", "-t", created), check=True)
     else:
         print(f"Attach with: rosotacom ota-smoke {shlex.quote(target.name)} --interactive")
-        print(f"Stop with: rosotacom ota-smoke {shlex.quote(target.name)} --stop")
+        print(f"Stop with: rosotacom ota-smoke {shlex.quote(target.name)} --interactive --stop")
     return 0
 
 
@@ -2447,11 +2585,22 @@ def _stop_ota_smoke(args: argparse.Namespace) -> int:
     target_type = getattr(args, "target_type", "auto")
     active: ActiveOtaSmokeRun | None = None
     if not getattr(args, "state_file", None):
-        active = _infer_active_ota_smoke_run(runtime, target_arg, target_type)
-        args.state_file = active.state_path
-        args.instance_id = getattr(args, "instance_id", None) or active.instance_id
-        args.target = target_arg or active.target
-        args.target_type = active.target_type
+        try:
+            active = _infer_active_ota_smoke_run(
+                runtime,
+                target_arg,
+                target_type,
+                getattr(args, "instance_id", None),
+            )
+        except RuntimeError:
+            if not target_arg:
+                raise
+            active = None
+        else:
+            args.state_file = active.state_path
+            args.instance_id = getattr(args, "instance_id", None) or active.instance_id
+            args.target = target_arg or active.target
+            args.target_type = active.target_type
     runtime, plan, target = _resolve_ota_smoke_context(args)
     instance_id = getattr(args, "instance_id", None)
     _ota_stop_peers(target, plan, instance_id, dry_run=dry_run)
@@ -2889,6 +3038,38 @@ def _attach_tmux_pipe(runtime: RuntimeConfig, pane_id: str, log_path: Path) -> N
         _tmux_command(runtime, "pipe-pane", "-o", "-t", pane_id, f"cat >> {shlex.quote(str(log_path))}"),
         check=True,
     )
+
+
+def _create_tmux_split_below(
+    runtime: RuntimeConfig,
+    target_pane: str,
+    title: str,
+    command: str,
+    *,
+    log_path: Path | None = None,
+) -> str:
+    created = subprocess.run(
+        _tmux_command(
+            runtime,
+            "split-window",
+            "-d",
+            "-v",
+            "-P",
+            "-F",
+            "#{pane_id}",
+            "-t",
+            target_pane,
+            command,
+        ),
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    pane_id = created.stdout.strip()
+    subprocess.run(_tmux_command(runtime, "select-pane", "-t", pane_id, "-T", title), check=True)
+    if log_path is not None:
+        _attach_tmux_pipe(runtime, pane_id, log_path)
+    return pane_id
 
 
 def _create_scenario_tmux(
@@ -4290,6 +4471,7 @@ def _verify_received_topics(
     for spec in _received_crossed_topics(cfg, receiver_peer_key):
         topic = spec.topic
         label = spec.label
+        log_line(f"Waiting for {label} ({topic}) in {container_name}")
         output = _wait_for_topic_hz(container_name, ros_setup, topic)
         if detail_log:
             detail_log(f"\n--- {label} ({topic}) in {container_name} ---\n{output}")
@@ -4432,6 +4614,10 @@ def _start_smoke_topic_publishers(
         container = containers[spec.source_peer_key]
         ros_setup = ros_setups[spec.source_peer_key]
         cmd = _smoke_publisher_command(spec, ros_setup, duration)
+        log_line(
+            f"Starting smoke publisher {spec.source_peer_key}->{spec.receiver_peer_key} "
+            f"{spec.publish_topic} ({spec.publish_type}) in {container}"
+        )
         subprocess.run(
             ["docker", "exec", "-d", container, "bash", "-lc", cmd],
             capture_output=True,
@@ -4516,16 +4702,19 @@ def _verify_isolation(
 ) -> list[str]:
     """Publish a local-only topic in pub_container's local domain and assert it
     never appears in check_container's local domain."""
+    log_line(f"Starting isolation probe {topic} in {pub_container}")
     _publish_isolation_probe(pub_container, pub_setup, topic)
     try:
         live = False
         for _ in range(8):
+            log_line(f"Waiting for isolation probe {topic} to advertise in {pub_container}")
             if _topic_present(pub_container, pub_setup, topic):
                 live = True
                 break
             time.sleep(1)
         if not live:
             return [f"isolation check inconclusive: {topic} never advertised in {pub_container}"]
+        log_line(f"Checking that isolation probe {topic} is absent in {check_container}")
         if _topic_present(check_container, check_setup, topic):
             return [f"isolation breach: {topic} from {pub_container} leaked to {check_container}"]
         log_line(f"OK: isolation holds ({topic} from {pub_container} not visible in {check_container})")
@@ -4833,9 +5022,15 @@ def test_command(args: argparse.Namespace) -> int:
         print(yaml.safe_dump(suggestions, sort_keys=True, default_flow_style=False).rstrip())
         return 0
 
+    wait_timeout = max(0.0, float(getattr(args, "timeout", 30.0)))
+    print(f"rosotacom test: waiting up to {wait_timeout:g}s for status reports under {logs_dir}")
+    saw_reports = False
     while True:
         reports = _load_status_reports(logs_dir) if logs_dir.is_dir() else {}
         if reports:
+            if not saw_reports:
+                print(f"rosotacom test: evaluating {len(reports)} peer status report(s)")
+                saw_reports = True
             failures = status_eval.evaluate_reports(reports, expect_by_topic, link_expect, ground_truth)
             if not failures:
                 topic_count = sum(len(r.get("topics", [])) for r in reports.values())
@@ -5164,8 +5359,9 @@ def _create_interactive_smoke_tmux(
     verify = shlex.join(_interactive_smoke_verify_command(runtime, target, instance, peer_ips))
     status_watch = shlex.join(_interactive_smoke_status_command(runtime, target, instance))
     verify_script = (
+        f"echo '[INFO] starting interactive smoke verification for {target.name}'; "
         f"{verify}; rc=$?; echo; echo '[INFO] one-shot verification exited with status' \"$rc\"; "
-        f"echo '[INFO] live status follows (Ctrl-C in this pane only stops the watch)'; exec {status_watch}"
+        "echo '[INFO] verification log remains in this pane'; exec bash"
     )
     verification = subprocess.run(
         _tmux_command(
@@ -5188,6 +5384,22 @@ def _create_interactive_smoke_tmux(
     verification_pane = verification.stdout.strip()
     subprocess.run(_tmux_command(runtime, "select-pane", "-t", verification_pane, "-T", "verification"), check=True)
     _attach_tmux_pipe(runtime, verification_pane, _interactive_smoke_log_path(instance, None, "verification"))
+    status_script = (
+        f"echo '[INFO] starting live status watch for {target.name}'; "
+        f"echo '[INFO] waiting for status artifacts from instance {instance.instance_id}'; "
+        f"exec {status_watch}"
+    )
+    _create_tmux_split_below(
+        runtime,
+        verification_pane,
+        "status",
+        _host_shell(status_script),
+        log_path=_interactive_smoke_log_path(instance, None, "status-watch"),
+    )
+    subprocess.run(
+        _tmux_command(runtime, "select-layout", "-t", f"{session_name}:verification", "even-vertical"),
+        check=True,
+    )
     subprocess.run(_tmux_command(runtime, "select-window", "-t", f"{session_name}:verification"), check=True)
     return session_name
 
@@ -5227,11 +5439,15 @@ def _interactive_smoke_verify(args: argparse.Namespace) -> int:
 
     peers = _require_two_peer_smoke_cfg(target.cfg, target.name)
     containers = {peer: _container_name(_remote_peer_name(target.cfg, peer), runtime) for peer in peers}
-    for container in containers.values():
+    log_line(f"Interactive smoke verification starting: {target.name} ({target.target_type})")
+    log_line(f"Verification artifacts: {instance.host_dir}")
+    for peer, container in containers.items():
+        log_line(f"Waiting for communication container {peer}: {container}")
         _wait_for_container_ready(container, timeout_s=360)
     ros_setups = {peer: _smoke_ros_setup(instance.config_container_dir, target.cfg, peer) for peer in peers}
 
     if target.target_type == "session":
+        log_line("Starting synthetic publishers for session target")
         _start_smoke_topic_publishers(
             containers,
             ros_setups,
@@ -5242,6 +5458,7 @@ def _interactive_smoke_verify(args: argparse.Namespace) -> int:
 
     errors: list[str] = []
     for peer in peers:
+        log_line(f"Checking crossed topic delivery for receiver {peer}")
         errors += _verify_received_topics(
             containers[peer],
             ros_setups[peer],
@@ -5258,6 +5475,7 @@ def _interactive_smoke_verify(args: argparse.Namespace) -> int:
         ISOLATION_PROBE_TOPIC,
         log_line=log_line,
     )
+    log_line("Running rosotacom test against status reports")
     test_rc = test_command(
         argparse.Namespace(
             rosotacom_config=args.rosotacom_config,
@@ -5474,6 +5692,7 @@ def smoke(args: argparse.Namespace) -> int:
         errors += _verify_isolation(
             a_container, ros_setup_a, b_container, ros_setup_b, ISOLATION_PROBE_TOPIC, log_line=log_line
         )
+        log_line("Running rosotacom test against status reports")
         test_rc = test_command(
             argparse.Namespace(
                 rosotacom_config=args.rosotacom_config,

--- a/src/rosotacom/resources/examples/README.md
+++ b/src/rosotacom/resources/examples/README.md
@@ -83,10 +83,11 @@ rosotacom smoke 2_native_chatter --interactive --stop
 ```
 
 This opens an outer tmux session with full windows for each peer's communication
-container, each scenario application, and a verification/status view. Scenario
-applications share their peer communication container's isolated network
-namespace. The outer prefix is `Ctrl-b`; use `Ctrl-b Ctrl-b` for the inner
-catmux sessions.
+container, each scenario application, and a verification/status view. The
+verification window keeps the check log in one pane and live status in another.
+Scenario applications share their peer communication container's isolated
+network namespace. The outer prefix is `Ctrl-b`; use `Ctrl-b Ctrl-b` for the
+inner catmux sessions.
 
 ## Two-machine runs
 

--- a/src/rosotacom/resources/ws/ros2src/com_msgs/msg/OtaStamped.msg
+++ b/src/rosotacom/resources/ws/ros2src/com_msgs/msg/OtaStamped.msg
@@ -1,5 +1,4 @@
 std_msgs/Header header
-builtin_interfaces/Time source_stamp
 uint64 seq
 string msg_type
 uint8[] serialized_msg

--- a/src/rosotacom/resources/ws/ros2src/com_py/com_py/status_overview.py
+++ b/src/rosotacom/resources/ws/ros2src/com_py/com_py/status_overview.py
@@ -163,7 +163,6 @@ class StageObserver(Node):
             now_ros_s = now_ros.nanoseconds / 1e9
             delay_s: Optional[float] = None
             raw_delay_s: Optional[float] = None
-            preprocess_s: Optional[float] = None
             rtt_s: Optional[float] = None
             clock_offset_s: Optional[float] = None
             seq: Optional[int] = None
@@ -210,10 +209,8 @@ class StageObserver(Node):
                 )
                 if com_in is not None:
                     seq = int(msg.seq)
-                    t_source_s = _stamp_seconds(msg.source_stamp)
                     t_wrap_s = _stamp_seconds(msg.header.stamp)
                     raw_delay_s = now_ros_s - t_wrap_s
-                    preprocess_s = t_wrap_s - t_source_s
                     estimate = self.clock_estimator.estimate()
                     if estimate is not None:
                         clock_offset_s = estimate["offset_s"]
@@ -226,7 +223,6 @@ class StageObserver(Node):
                         "topic": com_in.get("base"),
                         "direction": com_in.get("direction"),
                         "stage": com_in.get("stage"),
-                        "t_source": t_source_s,
                         "t_wrap": t_wrap_s,
                         "t_com_in": now_ros_s,
                     }
@@ -247,7 +243,6 @@ class StageObserver(Node):
                 delay_s,
                 seq=seq,
                 raw_delay_s=raw_delay_s,
-                preprocess_s=preprocess_s,
                 rtt_s=rtt_s,
                 clock_offset_s=clock_offset_s,
                 transit=transit,

--- a/src/rosotacom/resources/ws/ros2src/com_py/com_py/status_overview_core.py
+++ b/src/rosotacom/resources/ws/ros2src/com_py/com_py/status_overview_core.py
@@ -223,7 +223,6 @@ class StageObservation:
     last_recv_wall: Optional[float] = None
     last_delay_s: Optional[float] = None
     last_raw_delay_s: Optional[float] = None
-    last_preprocess_s: Optional[float] = None
     last_rtt_s: Optional[float] = None
     last_clock_offset_s: Optional[float] = None
     # (t_mono, size_bytes, delay_s_or_None)
@@ -251,7 +250,6 @@ class StageObservation:
         *,
         seq: Optional[int] = None,
         raw_delay_s: Optional[float] = None,
-        preprocess_s: Optional[float] = None,
         rtt_s: Optional[float] = None,
         clock_offset_s: Optional[float] = None,
         transit: Optional[Dict[str, Any]] = None,
@@ -264,7 +262,6 @@ class StageObservation:
             self.last_recv_wall = wall
             self.last_delay_s = delay_s
             self.last_raw_delay_s = raw_delay_s
-            self.last_preprocess_s = preprocess_s
             self.last_rtt_s = rtt_s
             self.last_clock_offset_s = clock_offset_s
             self.events.append((now, size, delay_s))
@@ -316,11 +313,10 @@ class StageObservation:
                                 **common,
                                 "seq": missing_seq,
                                 "status": "lost",
-                                "t_source": None,
                                 "t_wrap": None,
                                 "t_com_in": None,
                                 "clock_offset_ms": None,
-                                "sections": {"preprocess_ms": None, "ota_hop_ms": None},
+                                "sections": {"ota_hop_ms": None},
                                 "size_bytes": None,
                                 "inter_arrival_ms": None,
                                 "jitter_ms": None,
@@ -344,7 +340,6 @@ class StageObservation:
                         **common,
                         "seq": int(seq),
                         "status": sequence_status,
-                        "t_source": transit.get("t_source"),
                         "t_wrap": transit.get("t_wrap"),
                         "t_com_in": transit.get("t_com_in"),
                         "clock_offset_ms": (
@@ -353,11 +348,6 @@ class StageObservation:
                             else None
                         ),
                         "sections": {
-                            "preprocess_ms": (
-                                round(preprocess_s * 1000.0, 3)
-                                if preprocess_s is not None
-                                else None
-                            ),
                             "ota_hop_ms": (
                                 round(delay_s * 1000.0, 3) if delay_s is not None else None
                             ),
@@ -397,7 +387,6 @@ class StageObservation:
             last_recv_wall = self.last_recv_wall
             last_delay = self.last_delay_s
             last_raw_delay = self.last_raw_delay_s
-            last_preprocess = self.last_preprocess_s
             last_rtt = self.last_rtt_s
             last_clock_offset = self.last_clock_offset_s
             msg_total = self.msg_total
@@ -414,7 +403,6 @@ class StageObservation:
             "mean_size_bytes": mean_size,
             "last_delay_s": last_delay,
             "last_raw_delay_s": last_raw_delay,
-            "last_preprocess_s": last_preprocess,
             "last_rtt_s": last_rtt,
             "last_clock_offset_s": last_clock_offset,
             "delays_in_window": delays,
@@ -492,7 +480,6 @@ class StatusAggregator:
             "mean_size_bytes": 0.0,
             "latency_ms": None,
             "latency_uncorrected_ms": None,
-            "preprocess_ms": None,
             "rtt_ms": None,
             "clock_offset_ms": None,
             "loss_pct": None,
@@ -524,8 +511,6 @@ class StatusAggregator:
             result["latency_ms"] = round(m["last_delay_s"] * 1000.0, 1)
         if m["last_raw_delay_s"] is not None:
             result["latency_uncorrected_ms"] = round(m["last_raw_delay_s"] * 1000.0, 1)
-        if m["last_preprocess_s"] is not None:
-            result["preprocess_ms"] = round(m["last_preprocess_s"] * 1000.0, 1)
         if m["last_rtt_s"] is not None:
             result["rtt_ms"] = round(m["last_rtt_s"] * 1000.0, 1)
         if m["last_clock_offset_s"] is not None:
@@ -567,7 +552,6 @@ class StatusAggregator:
             "mean_size_bytes",
             "latency_ms",
             "latency_uncorrected_ms",
-            "preprocess_ms",
             "rtt_ms",
             "clock_offset_ms",
             "loss_pct",

--- a/src/rosotacom/resources/ws/ros2src/com_py/com_py/universal_ota_wrapper.py
+++ b/src/rosotacom/resources/ws/ros2src/com_py/com_py/universal_ota_wrapper.py
@@ -129,18 +129,12 @@ class UniversalOtaWrapperNode(Node):
 
     def wrapper_callback(self, msg, publisher, source_topic: str, msg_type_str: str):
         try:
-            input_stamp = self.get_clock().now().to_msg()
-            source_stamp = input_stamp
             header = getattr(msg, 'header', None)
-            stamp = getattr(header, 'stamp', None) if header is not None else None
-            if stamp is not None and (int(stamp.sec) != 0 or int(stamp.nanosec) != 0):
-                source_stamp = stamp
 
             serialized = serialize_message(msg)
 
             out_msg = OtaStamped()
             out_msg.header.stamp = self.get_clock().now().to_msg()
-            out_msg.source_stamp = source_stamp
             if header is not None:
                 out_msg.header.frame_id = header.frame_id
             out_msg.seq = self._next_sequence(source_topic)

--- a/src/rosotacom/resources/ws/session/content/base/session_plugin_base.yaml
+++ b/src/rosotacom/resources/ws/session/content/base/session_plugin_base.yaml
@@ -331,10 +331,12 @@ windows:
         - ros2 run com_py topic_monitor --ros-args -p sourcename:=${local_name} -p direction:=out -p to_adressant:='${tm_out_to_adressant}' -p ip_local:=${ip_local} -p ip_remote:=${ip_remote} -p interface:=${interface} -p link_duration_buffer_s:=${tm_link_duration_buffer_s}
   - name: STAT
     if: status_overview
+    layout: even-vertical
     splits:
       - commands:
         - status_out_dir="$(dirname "${ROSOTACOM_CATMUX_LOG_DIR:-/tmp/rosotacom_logs/catmux}")/status"
         - mkdir -p "$status_out_dir"
+        - echo "[INFO] starting status_overview node; writing $status_out_dir/status.{json,txt}"
         # Pass the local OTA address; the node resolves the link interface from it
         # for link-overhead measurement (empty address -> `link` block stays null).
         - ros2 run com_py status_overview --ros-args
@@ -344,6 +346,10 @@ windows:
             -p liveness_window_s:=${status_liveness_window_s}
             -p stale_after_s:=${status_stale_after_s}
             -p ota_local_ip:=${ip_local}
+      - commands:
+        - status_out_dir="$(dirname "${ROSOTACOM_CATMUX_LOG_DIR:-/tmp/rosotacom_logs/catmux}")/status"
+        - status_txt="$status_out_dir/status.txt"
+        - while true; do clear; echo "[INFO] watching status overview file: $status_txt"; if [ -f "$status_txt" ]; then cat "$status_txt"; else echo "[INFO] waiting for status_overview to write status.txt"; fi; sleep "${status_write_interval_s:-2.0}"; done
   - name: NET
     if: network_monitor
     splits:

--- a/src/rosotacom/transit.py
+++ b/src/rosotacom/transit.py
@@ -77,11 +77,6 @@ def summarize_transit_records(records: Iterable[dict[str, Any]]) -> dict[str, An
             for record in topic_records
             if isinstance(record.get("sections"), dict) and record["sections"].get("ota_hop_ms") is not None
         ]
-        preprocess = [
-            float(record["sections"]["preprocess_ms"])
-            for record in topic_records
-            if isinstance(record.get("sections"), dict) and record["sections"].get("preprocess_ms") is not None
-        ]
         jitter = [float(record["jitter_ms"]) for record in topic_records if record.get("jitter_ms") is not None]
         topics[topic] = {
             "expected": len(topic_records),
@@ -90,10 +85,6 @@ def summarize_transit_records(records: Iterable[dict[str, Any]]) -> dict[str, An
             "loss_pct": round(100.0 * lost / len(topic_records), 3) if topic_records else 0.0,
             "reordered": reordered,
             "ota_hop_ms": {"p50": _percentile(ota, 0.50), "p95": _percentile(ota, 0.95)},
-            "preprocess_ms": {
-                "p50": _percentile(preprocess, 0.50),
-                "p95": _percentile(preprocess, 0.95),
-            },
             "jitter_ms": {"p50": _percentile(jitter, 0.50), "p95": _percentile(jitter, 0.95)},
         }
     return {"schema_version": 1, "topics": topics}

--- a/tests/contract/test_packaged_resources.py
+++ b/tests/contract/test_packaged_resources.py
@@ -36,7 +36,8 @@ def test_packaged_resources_include_curated_examples_and_runtime_workspace() -> 
 
     ota_stamped = package.joinpath("resources/ws/ros2src/com_msgs/msg/OtaStamped.msg").read_text(encoding="utf-8")
     echo = package.joinpath("resources/ws/ros2src/com_msgs/msg/EchoHeartbeat.msg").read_text(encoding="utf-8")
-    assert "builtin_interfaces/Time source_stamp" in ota_stamped
+    assert "source_stamp" not in ota_stamped
+    assert "uint64 seq" in ota_stamped
     assert "builtin_interfaces/Time echo_t1" in echo
     assert "builtin_interfaces/Time echo_t2" in echo
     assert "builtin_interfaces/Time echo_t3" in echo

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -487,7 +487,7 @@ def test_scenario_tmux_commands_keep_ctrl_b_and_use_full_windows(
     def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
         nonlocal pane_number
         calls.append(command)
-        if "new-session" in command or "new-window" in command:
+        if "new-session" in command or "new-window" in command or "split-window" in command:
             pane_number += 1
             return subprocess.CompletedProcess(command, 0, f"%{pane_number}\n", "")
         return subprocess.CompletedProcess(command, 0, "", "")
@@ -564,7 +564,7 @@ def test_interactive_smoke_tmux_uses_full_windows_and_metadata(
     def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
         nonlocal pane_number
         calls.append(command)
-        if "new-session" in command or "new-window" in command:
+        if "new-session" in command or "new-window" in command or "split-window" in command:
             pane_number += 1
             return subprocess.CompletedProcess(command, 0, f"%{pane_number}\n", "")
         return subprocess.CompletedProcess(command, 0, "", "")
@@ -792,19 +792,19 @@ def test_interactive_ota_smoke_tmux_uses_control_windows_and_metadata(
         for command in calls
         if ("new-session" in command or "new-window" in command) and "-n" in command
     ]
-    assert window_names == ["a_remote", "b_remote", "a_shell", "b_shell", "verification"]
+    assert window_names == ["a_communication", "b_communication", "a_shell", "b_shell", "verification"]
     assert any(command[-2:] == ["@rosotacom_ota_smoke_target", "demo"] for command in calls)
     assert any(command[-2:] == ["@rosotacom_ota_smoke_target_type", "scenario"] for command in calls)
     assert any(command[-2:] == ["@rosotacom_ota_smoke_instance", "ota-interactive"] for command in calls)
     assert any(command[-2:] == ["@rosotacom_ota_smoke_state", str(plan.state_path)] for command in calls)
     joined = "\n".join(" ".join(command) for command in calls)
-    assert "scenario start demo --identity a --mode detached --instance-id ota-interactive" in joined
-    assert "scenario start demo --identity b --mode detached --instance-id ota-interactive" in joined
+    assert "scenario start demo --identity a --mode attach --instance-id ota-interactive" in joined
+    assert "scenario start demo --identity b --mode attach --instance-id ota-interactive" in joined
     assert "status demo --identity a --instance-id ota-interactive --watch" in joined
     assert "status demo --identity b --instance-id ota-interactive --watch" in joined
+    assert any("split-window" in command for command in calls)
     assert "ota-smoke demo --state-file" in joined
     assert "--verify-only" in joined
-    assert "scenario attach" not in joined
 
 
 def test_ota_smoke_parser_accepts_stop_without_peer_arguments(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -848,6 +848,42 @@ def test_ota_smoke_stop_dry_run_does_not_kill_local_tmux(
 
     assert calls == ["remote-dry-run"]
     assert "Would stop OTA smoke tmux session: ota-smoke-scenario-demo" in capsys.readouterr().out
+
+
+def test_ota_smoke_stop_with_target_falls_back_to_peer_arguments(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    runtime, _resolved = _write_test_scenario_project(tmp_path)
+    plan = _ota_plan(tmp_path)
+    target = rosotacom._resolve_interactive_smoke_target("demo", runtime, "scenario")
+    calls: list[str] = []
+
+    monkeypatch.setattr(rosotacom, "_load_runtime_config", lambda args: runtime)
+    monkeypatch.setattr(rosotacom, "_active_ota_smoke_runs", lambda runtime: [])
+    monkeypatch.setattr(rosotacom, "_manifest_ota_smoke_runs", lambda runtime: [])
+    monkeypatch.setattr(rosotacom, "_resolve_ota_smoke_context", lambda args: (runtime, plan, target))
+    monkeypatch.setattr(rosotacom, "_ota_stop_peers", lambda *args, **kwargs: calls.append("remote-stop"))
+    monkeypatch.setattr(rosotacom, "_kill_scenario_tmux", lambda *args, **kwargs: calls.append("tmux") or False)
+    monkeypatch.setattr(rosotacom, "_ota_cleanup_hosts", lambda *args, **kwargs: calls.append("cleanup"))
+
+    assert (
+        rosotacom._stop_ota_smoke(
+            argparse.Namespace(
+                target="demo",
+                target_type="scenario",
+                state_file=None,
+                instance_id=None,
+                dry_run=False,
+                keep_workdir=False,
+            )
+        )
+        == 0
+    )
+
+    assert calls == ["remote-stop", "tmux", "cleanup"]
+    assert "No active OTA smoke run found" not in capsys.readouterr().err
 
 
 def test_noninteractive_ota_smoke_lifecycle_uses_generic_runner(

--- a/tests/unit/test_status_overview.py
+++ b/tests/unit/test_status_overview.py
@@ -686,7 +686,6 @@ def test_sequence_loss_reorder_and_transit_records() -> None:
         "topic": "/wrapped",
         "direction": "inbound",
         "stage": "com_in",
-        "t_source": 1.0,
         "t_wrap": 1.01,
         "t_com_in": 1.05,
     }
@@ -697,7 +696,6 @@ def test_sequence_loss_reorder_and_transit_records() -> None:
         now_wall=1.05,
         seq=10,
         raw_delay_s=0.04,
-        preprocess_s=0.01,
         clock_offset_s=0.0,
         transit=transit,
     )
@@ -708,7 +706,6 @@ def test_sequence_loss_reorder_and_transit_records() -> None:
         now_wall=1.10,
         seq=13,
         raw_delay_s=0.05,
-        preprocess_s=0.01,
         clock_offset_s=0.0,
         transit={**transit, "t_com_in": 1.10},
     )

--- a/tests/unit/test_transit.py
+++ b/tests/unit/test_transit.py
@@ -16,7 +16,7 @@ def _record(seq: int, status: str, ota_ms: float | None = None) -> dict:
         "topic": "/x",
         "seq": seq,
         "status": status,
-        "sections": {"preprocess_ms": 1.0, "ota_hop_ms": ota_ms},
+        "sections": {"ota_hop_ms": ota_ms},
         "jitter_ms": 2.0 if ota_ms is not None else None,
     }
 


### PR DESCRIPTION
## Summary
- keep interactive smoke verification logs visible while live status watches run in split panes
- make OTA interactive peer windows attach to communication/catmux sessions and show per-peer status panes
- make OTA interactive stop fall back to manifests or explicit peer/deployment arguments when tmux metadata is unavailable
- includes the existing RFC 0003 source_stamp cleanup commit already present locally

## Checks
- ruff check src/rosotacom/cli.py tests/unit/test_cli.py
- pytest tests/unit/test_cli.py tests/unit/test_status_overview.py tests/contract/test_markdown_links.py tests/contract/test_readme_examples.py
- git diff --check
- python -m py_compile src/rosotacom/cli.py src/rosotacom/resources/ws/session/creation/generate_session_files.py