### PR TITLE
fix: stabilize interactive smoke panes

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,11 +326,12 @@ rosotacom ota-smoke 2_native_chatter \
 installs the currently selected rosotacom version, stages the active project,
 runs delivery and isolation checks, collects artifacts, stops the run, and
 removes the remote workdir. Add `--interactive` for a local control tmux with
-one attachable communication/catmux window per peer and a status pane below each
-one. Stop an interactive run with `rosotacom ota-smoke TARGET --interactive
---stop`; pass the same peer/deployment arguments if the local tmux metadata is
-not available. Use `--keep-running` to leave components up, `--keep-workdir` to
-retain staged files, or `--reuse` to reuse an existing installation.
+one attachable communication/catmux window per peer. Scenario targets also get
+one native application-container window per scenario app. Stop an interactive run
+with `rosotacom ota-smoke TARGET --interactive --stop`; pass the same
+peer/deployment arguments if the local tmux metadata is not available. Use
+`--keep-running` to leave components up, `--keep-workdir` to retain staged
+files, or `--reuse` to reuse an existing installation.
 
 ### Live status / debugging overview
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -102,7 +102,8 @@ Use `rosotacom ota-smoke TARGET --peer-address ... --peer-ssh ...` for a
 configuration-free operator run, or map peers to named hosts with `--peer`
 through the active project's deployment file. Add `--interactive` to open a
 local control tmux for the same run; each peer gets an attachable
-communication/catmux pane with a live status pane below it. Stop it with
+communication/catmux window, and scenario targets also get native
+application-container windows. Stop it with
 `rosotacom ota-smoke TARGET --interactive --stop`.
 
 External runners should use `ota_suite_sessions()` to discover the scenario set

--- a/src/rosotacom/cli.py
+++ b/src/rosotacom/cli.py
@@ -1463,6 +1463,48 @@ def _ota_start_parts(
     return parts
 
 
+def _ota_communication_start_parts(
+    target: InteractiveSmokeTarget,
+    identity: str,
+    instance_id: str,
+    peer_args: list[str],
+    *,
+    mode: str,
+    force: bool = True,
+) -> list[str]:
+    parts = [
+        "start",
+        _ota_target_session_arg(target),
+        "--identity",
+        identity,
+        "--mode",
+        mode,
+        "--instance-id",
+        instance_id,
+        "--smoke-managed",
+    ]
+    parts.append("--force" if force else "--no-force")
+    for override in peer_args:
+        parts.extend(["--peer-address", override])
+    return parts
+
+
+def _ota_application_parts(
+    target: InteractiveSmokeTarget,
+    identity: str,
+    application: ScenarioApplication,
+) -> list[str]:
+    return [
+        "scenario",
+        "_run-application",
+        target.name,
+        "--identity",
+        identity,
+        "--application",
+        application.name,
+    ]
+
+
 def _ota_stop_parts(
     target: InteractiveSmokeTarget,
     identity: str,
@@ -2178,26 +2220,36 @@ def _ota_verify_only(args: argparse.Namespace) -> int:
     return 0
 
 
-def _ota_application_attach_script(
+def _ota_wait_for_running_container_suffix_script(suffix: str, label: str) -> str:
+    pattern = shlex.quote(f"{re.escape(suffix)}$")
+    quoted_label = shlex.quote(label)
+    return (
+        "container=''; "
+        f"until container=$(docker ps --filter status=running --format '{{{{.Names}}}}' "
+        f"| grep -E {pattern} | head -n 1) "
+        '&& [ -n "$container" ]; do '
+        f"echo '[INFO] waiting for running container:' {quoted_label}; "
+        "sleep 2; "
+        "done; "
+        'echo "[INFO] found running container: $container"'
+    )
+
+
+def _ota_application_run_script(
+    plan: OtaSmokePlan,
     target: InteractiveSmokeTarget,
     peer_name: str,
     application: ScenarioApplication,
 ) -> str:
-    suffix = _sanitize_docker_name(f"_scenario_{target.name}_{peer_name}_{application.name}")
-    pattern = shlex.quote(f"{re.escape(suffix)}$")
-    label = shlex.quote(f"{peer_name}:{application.name}")
+    communication_suffix = _sanitize_docker_name(f"_com_to_{_remote_peer_name(target.cfg, peer_name)}")
+    label = f"{peer_name}:{application.name}"
+    command = _ota_rosotacom_command(plan, _ota_application_parts(target, peer_name, application))
     return (
-        f"echo '[INFO] waiting for native application container:' {label}; "
-        "container=''; "
-        f"until container=$(docker ps --format '{{{{.Names}}}}' | grep -E {pattern} | head -n 1) "
-        '&& [ -n "$container" ]; do '
-        f"echo '[INFO] still waiting for native application container:' {label}; "
-        "sleep 2; "
-        "done; "
-        'echo "[INFO] attaching native application container: $container"; '
-        'docker attach "$container"; '
+        f"{_ota_wait_for_running_container_suffix_script(communication_suffix, f'{peer_name}:communication')}; "
+        f"echo '[INFO] starting native application container:' {shlex.quote(label)}; "
+        f"{command}; "
         "rc=$?; "
-        "echo; echo '[INFO] native application attach exited with status' \"$rc\"; "
+        "echo; echo '[INFO] native application exited with status' \"$rc\"; "
         "exec bash"
     )
 
@@ -2215,7 +2267,7 @@ def _ota_create_tmux(
     first_peer = peers[0]
     first_start = _ota_rosotacom_command(
         plan,
-        _ota_start_parts(target, first_peer.name, instance.instance_id, peer_args, mode="attach"),
+        _ota_communication_start_parts(target, first_peer.name, instance.instance_id, peer_args, mode="attach"),
     )
     first_script = (
         "set -e; "
@@ -2287,7 +2339,7 @@ def _ota_create_tmux(
     for peer in peers[1:]:
         start = _ota_rosotacom_command(
             plan,
-            _ota_start_parts(target, peer.name, instance.instance_id, peer_args, mode="attach"),
+            _ota_communication_start_parts(target, peer.name, instance.instance_id, peer_args, mode="attach"),
         )
         script = (
             "set -e; "
@@ -2326,7 +2378,7 @@ def _ota_create_tmux(
     if target.scenario_definition:
         for peer in peers:
             for application in target.scenario_definition.applications.get(peer.name, ()):
-                application_script = _ota_application_attach_script(target, peer.name, application)
+                application_script = _ota_application_run_script(plan, target, peer.name, application)
                 created_application = subprocess.run(
                     _tmux_command(
                         runtime,

--- a/src/rosotacom/cli.py
+++ b/src/rosotacom/cli.py
@@ -1515,13 +1515,6 @@ def _ota_test_parts(target: InteractiveSmokeTarget, instance_id: str) -> list[st
     ]
 
 
-def _ota_status_parts(target: InteractiveSmokeTarget, instance_id: str, identity: str, *, watch: bool) -> list[str]:
-    parts = ["status", _ota_target_session_arg(target), "--identity", identity, "--instance-id", instance_id]
-    if watch:
-        parts.append("--watch")
-    return parts
-
-
 def _ota_probe_publish_parts(
     target: InteractiveSmokeTarget,
     identity: str,
@@ -2185,20 +2178,27 @@ def _ota_verify_only(args: argparse.Namespace) -> int:
     return 0
 
 
-def _ota_status_watch_script(
-    plan: OtaSmokePlan,
+def _ota_application_attach_script(
     target: InteractiveSmokeTarget,
-    instance_id: str,
     peer_name: str,
+    application: ScenarioApplication,
 ) -> str:
-    return _ota_rosotacom_command(plan, _ota_status_parts(target, instance_id, peer_name, watch=True))
-
-
-def _ota_debug_shell_script(plan: OtaSmokePlan) -> str:
+    suffix = _sanitize_docker_name(f"_scenario_{target.name}_{peer_name}_{application.name}")
+    pattern = shlex.quote(f"{re.escape(suffix)}$")
+    label = shlex.quote(f"{peer_name}:{application.name}")
     return (
-        f"cd {shlex.quote(plan.workdir)} && "
-        f"echo '[INFO] debug shell for OTA smoke workdir: {shlex.quote(plan.workdir)}' && "
-        'exec "${SHELL:-bash}"'
+        f"echo '[INFO] waiting for native application container:' {label}; "
+        "container=''; "
+        f"until container=$(docker ps --format '{{{{.Names}}}}' | grep -E {pattern} | head -n 1) "
+        '&& [ -n "$container" ]; do '
+        f"echo '[INFO] still waiting for native application container:' {label}; "
+        "sleep 2; "
+        "done; "
+        'echo "[INFO] attaching native application container: $container"; '
+        'docker attach "$container"; '
+        "rc=$?; "
+        "echo; echo '[INFO] native application attach exited with status' \"$rc\"; "
+        "exec bash"
     )
 
 
@@ -2217,14 +2217,13 @@ def _ota_create_tmux(
         plan,
         _ota_start_parts(target, first_peer.name, instance.instance_id, peer_args, mode="attach"),
     )
-    first_status = _ota_status_watch_script(plan, target, instance.instance_id, first_peer.name)
     first_script = (
         "set -e; "
         f"echo '[INFO] starting interactive communication for remote peer {first_peer.name}'; "
         "echo '[INFO] this pane attaches to the peer communication/catmux session'; "
         f"{first_start}; "
         "echo; "
-        f"echo '[INFO] remote peer {first_peer.name} communication exited; live status is in the lower pane'; "
+        f"echo '[INFO] remote peer {first_peer.name} communication exited'; "
         "exec bash"
     )
     created = subprocess.run(
@@ -2271,7 +2270,7 @@ def _ota_create_tmux(
             "-t",
             session_name,
             "status-right",
-            " ota smoke | windows: C-b n/p | peer tmux/catmux: C-b C-b ",
+            " ota smoke | windows: C-b n/p | inner catmux: C-b C-b ",
         ),
         check=True,
     )
@@ -2284,42 +2283,19 @@ def _ota_create_tmux(
         first_pane,
         instance.logs_host_dir / "ota-smoke" / f"{first_peer.name}-communication.log",
     )
-    first_status_script = (
-        f"echo '[INFO] starting live remote status watch for {first_peer.name}'; "
-        f"echo '[INFO] waiting for status artifacts from instance {instance.instance_id}'; "
-        f"exec {first_status}"
-    )
-    _create_tmux_split_below(
-        runtime,
-        first_pane,
-        f"{first_peer.name}:status",
-        _ota_quote_cmd(_ota_remote_argv(first_peer, first_status_script, tty=bool(first_peer.ssh))),
-        log_path=instance.logs_host_dir / "ota-smoke" / f"{first_peer.name}-status.log",
-    )
-    subprocess.run(
-        _tmux_command(
-            runtime,
-            "select-layout",
-            "-t",
-            f"{session_name}:{_safe_path_token(f'{first_peer.name}_communication')}",
-            "even-vertical",
-        ),
-        check=True,
-    )
 
     for peer in peers[1:]:
         start = _ota_rosotacom_command(
             plan,
             _ota_start_parts(target, peer.name, instance.instance_id, peer_args, mode="attach"),
         )
-        status = _ota_status_watch_script(plan, target, instance.instance_id, peer.name)
         script = (
             "set -e; "
             f"echo '[INFO] starting interactive communication for remote peer {peer.name}'; "
             "echo '[INFO] this pane attaches to the peer communication/catmux session'; "
             f"{start}; "
             "echo; "
-            f"echo '[INFO] remote peer {peer.name} communication exited; live status is in the lower pane'; "
+            f"echo '[INFO] remote peer {peer.name} communication exited'; "
             "exec bash"
         )
         created_window = subprocess.run(
@@ -2346,51 +2322,48 @@ def _ota_create_tmux(
             check=True,
         )
         _attach_tmux_pipe(runtime, pane_id, instance.logs_host_dir / "ota-smoke" / f"{peer.name}-communication.log")
-        status_script = (
-            f"echo '[INFO] starting live remote status watch for {peer.name}'; "
-            f"echo '[INFO] waiting for status artifacts from instance {instance.instance_id}'; "
-            f"exec {status}"
-        )
-        _create_tmux_split_below(
-            runtime,
-            pane_id,
-            f"{peer.name}:status",
-            _ota_quote_cmd(_ota_remote_argv(peer, status_script, tty=bool(peer.ssh))),
-            log_path=instance.logs_host_dir / "ota-smoke" / f"{peer.name}-status.log",
-        )
-        subprocess.run(
-            _tmux_command(
-                runtime,
-                "select-layout",
-                "-t",
-                f"{session_name}:{_safe_path_token(f'{peer.name}_communication')}",
-                "even-vertical",
-            ),
-            check=True,
-        )
 
-    for peer in peers:
-        shell_script = _ota_debug_shell_script(plan)
-        created_shell = subprocess.run(
-            _tmux_command(
-                runtime,
-                "new-window",
-                "-d",
-                "-P",
-                "-F",
-                "#{pane_id}",
-                "-t",
-                session_name,
-                "-n",
-                _safe_path_token(f"{peer.name}_shell"),
-                _ota_quote_cmd(_ota_remote_argv(peer, shell_script, tty=bool(peer.ssh))),
-            ),
-            text=True,
-            capture_output=True,
-            check=True,
-        )
-        pane_id = created_shell.stdout.strip()
-        subprocess.run(_tmux_command(runtime, "select-pane", "-t", pane_id, "-T", f"{peer.name}:shell"), check=True)
+    if target.scenario_definition:
+        for peer in peers:
+            for application in target.scenario_definition.applications.get(peer.name, ()):
+                application_script = _ota_application_attach_script(target, peer.name, application)
+                created_application = subprocess.run(
+                    _tmux_command(
+                        runtime,
+                        "new-window",
+                        "-d",
+                        "-P",
+                        "-F",
+                        "#{pane_id}",
+                        "-t",
+                        session_name,
+                        "-n",
+                        _safe_path_token(f"{peer.name}_{application.name}"),
+                        _ota_quote_cmd(_ota_remote_argv(peer, application_script, tty=bool(peer.ssh))),
+                    ),
+                    text=True,
+                    capture_output=True,
+                    check=True,
+                )
+                pane_id = created_application.stdout.strip()
+                subprocess.run(
+                    _tmux_command(
+                        runtime,
+                        "select-pane",
+                        "-t",
+                        pane_id,
+                        "-T",
+                        f"{peer.name}:application:{application.name}",
+                    ),
+                    check=True,
+                )
+                _attach_tmux_pipe(
+                    runtime,
+                    pane_id,
+                    instance.logs_host_dir
+                    / "ota-smoke"
+                    / f"{peer.name}-application-{_safe_path_token(application.name)}.log",
+                )
 
     verify_parts = [
         sys.executable,

--- a/src/rosotacom/resources/ws/session/content/base/session_plugin_base.yaml
+++ b/src/rosotacom/resources/ws/session/content/base/session_plugin_base.yaml
@@ -349,7 +349,7 @@ windows:
       - commands:
         - status_out_dir="$(dirname "${ROSOTACOM_CATMUX_LOG_DIR:-/tmp/rosotacom_logs/catmux}")/status"
         - status_txt="$status_out_dir/status.txt"
-        - while true; do clear; echo "[INFO] watching status overview file: $status_txt"; if [ -f "$status_txt" ]; then cat "$status_txt"; else echo "[INFO] waiting for status_overview to write status.txt"; fi; sleep "${status_write_interval_s:-2.0}"; done
+        - 'while true; do clear; echo "[INFO] watching status overview file: $status_txt"; if [ -f "$status_txt" ]; then cat "$status_txt"; else echo "[INFO] waiting for status_overview to write status.txt"; fi; sleep "${status_write_interval_s:-2.0}"; done'
   - name: NET
     if: network_monitor
     splits:

--- a/tests/contract/test_packaged_resources.py
+++ b/tests/contract/test_packaged_resources.py
@@ -5,6 +5,8 @@ import subprocess
 from importlib import resources
 from pathlib import Path
 
+import yaml
+
 import rosotacom.cli as cli
 
 PACKAGE_ROOT = Path(__file__).resolve().parents[2]
@@ -71,6 +73,23 @@ def test_shell_entrypoints_pass_syntax_check() -> None:
         ["python3", "-m", "py_compile", str(cli.WS_DIR / "session" / "creation" / "strip_ansi.py")],
         check=True,
     )
+
+
+def test_base_plugin_catmux_commands_are_strings() -> None:
+    plugin = yaml.safe_load(
+        (cli.WS_DIR / "session" / "content" / "base" / "session_plugin_base.yaml").read_text(encoding="utf-8")
+    )
+
+    offenders: list[str] = []
+    for window in plugin["windows"]:
+        for split_index, split in enumerate(window.get("splits", [])):
+            for command_index, command in enumerate(split.get("commands", [])):
+                if not isinstance(command, str):
+                    offenders.append(
+                        f"{window.get('name', '<unnamed>')}.splits[{split_index}].commands[{command_index}]"
+                    )
+
+    assert not offenders
 
 
 def test_native_chatter_waiter_reads_topic_info_without_broken_pipe(tmp_path: Path) -> None:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -792,7 +792,7 @@ def test_interactive_ota_smoke_tmux_uses_control_windows_and_metadata(
         for command in calls
         if ("new-session" in command or "new-window" in command) and "-n" in command
     ]
-    assert window_names == ["a_communication", "b_communication", "a_shell", "b_shell", "verification"]
+    assert window_names == ["a_communication", "b_communication", "a_local_app", "b_local_app", "verification"]
     assert any(command[-2:] == ["@rosotacom_ota_smoke_target", "demo"] for command in calls)
     assert any(command[-2:] == ["@rosotacom_ota_smoke_target_type", "scenario"] for command in calls)
     assert any(command[-2:] == ["@rosotacom_ota_smoke_instance", "ota-interactive"] for command in calls)
@@ -800,9 +800,9 @@ def test_interactive_ota_smoke_tmux_uses_control_windows_and_metadata(
     joined = "\n".join(" ".join(command) for command in calls)
     assert "scenario start demo --identity a --mode attach --instance-id ota-interactive" in joined
     assert "scenario start demo --identity b --mode attach --instance-id ota-interactive" in joined
-    assert "status demo --identity a --instance-id ota-interactive --watch" in joined
-    assert "status demo --identity b --instance-id ota-interactive --watch" in joined
-    assert any("split-window" in command for command in calls)
+    assert "waiting for native application container" in joined
+    assert "docker attach" in joined
+    assert not any("split-window" in command for command in calls)
     assert "ota-smoke demo --state-file" in joined
     assert "--verify-only" in joined
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -798,10 +798,14 @@ def test_interactive_ota_smoke_tmux_uses_control_windows_and_metadata(
     assert any(command[-2:] == ["@rosotacom_ota_smoke_instance", "ota-interactive"] for command in calls)
     assert any(command[-2:] == ["@rosotacom_ota_smoke_state", str(plan.state_path)] for command in calls)
     joined = "\n".join(" ".join(command) for command in calls)
-    assert "scenario start demo --identity a --mode attach --instance-id ota-interactive" in joined
-    assert "scenario start demo --identity b --mode attach --instance-id ota-interactive" in joined
-    assert "waiting for native application container" in joined
-    assert "docker attach" in joined
+    assert "start demo --identity a --mode attach --instance-id ota-interactive --smoke-managed" in joined
+    assert "start demo --identity b --mode attach --instance-id ota-interactive --smoke-managed" in joined
+    assert "scenario _run-application demo --identity a --application local_app" in joined
+    assert "scenario _run-application demo --identity b --application local_app" in joined
+    assert "waiting for running container" in joined
+    assert "docker attach" not in joined
+    assert "scenario start demo --identity a --mode attach" not in joined
+    assert "scenario start demo --identity b --mode attach" not in joined
     assert not any("split-window" in command for command in calls)
     assert "ota-smoke demo --state-file" in joined
     assert "--verify-only" in joined


### PR DESCRIPTION
## Summary
- quote generated STAT/status watcher commands so catmux receives shell strings, not YAML mappings
- remove OTA interactive status-artifact splits and debug-shell windows
- flatten OTA interactive communication windows so they run the peer communication/catmux directly instead of attaching to a remote scenario tmux
- start OTA scenario native application containers in their own windows, after visibly waiting for the peer communication container
- document the updated OTA interactive layout

## Tests
- python -m ruff format src/rosotacom/cli.py tests/unit/test_cli.py
- python -m ruff check src/rosotacom/cli.py tests/unit/test_cli.py
- python -m pytest -q tests/unit/test_cli.py
- python -m pytest -q tests/contract/test_readme_examples.py tests/contract/test_markdown_links.py
- python -m pytest -q