### PR TITLE
feat: extract full per-peer artifacts for OTA smoke runs

### DIFF
--- a/src/rosotacom/cli.py
+++ b/src/rosotacom/cli.py
@@ -10,9 +10,12 @@ ros2docker remains the generic Docker runner underneath.
 from __future__ import annotations
 
 import argparse
+import base64
+import binascii
 import hashlib
 import importlib.resources as importlib_resources
 import importlib.util
+import io
 import json
 import os
 import re
@@ -20,6 +23,7 @@ import shlex
 import shutil
 import subprocess
 import sys
+import tarfile
 import tempfile
 import time
 from collections.abc import Callable
@@ -2307,16 +2311,56 @@ def _ota_collect_logs(
         'relative=${instance_dir#"$project_dir"/}; '
         'tar cz -C "$project_dir" "$relative" 2>/dev/null | base64; fi'
     )
-    out_dir = instance.logs_host_dir / "ota-smoke"
-    out_dir.mkdir(parents=True, exist_ok=True)
     for peer in plan.peers.values():
         result = _ota_run(peer, script, label=f"{peer.name}: collect session-instances", dry_run=dry_run, check=False)
         if dry_run or not result.stdout.strip():
             continue
-        (out_dir / f"{_safe_path_token(peer.name)}-session-instances.tar.gz.b64").write_text(
-            result.stdout,
-            encoding="utf-8",
-        )
+        _ota_extract_peer_artifacts(instance, peer, result.stdout)
+
+
+def _ota_extract_peer_artifacts(instance: SessionInstance, peer: OtaSmokePeer, encoded: str) -> None:
+    """Extract a peer's base64 ``session-instances/<date>/<name>`` tarball into the
+    local instance directory, reproducing the layout a local run writes
+    (``config/<id>``, ``logs/<id>/{catmux,status,launcher.log,...}``).
+
+    Each peer host names its instance directory with its own timestamp (only the
+    instance-id suffix matches), so the leading ``session-instances/<date>/<name>/``
+    prefix (3 path components) is stripped rather than matched. The per-peer
+    ``manifest.yaml`` is skipped so the orchestration manifest is preserved.
+    """
+    try:
+        raw = base64.b64decode(encoded, validate=False)
+    except (binascii.Error, ValueError):
+        print(f"OTA smoke: could not decode collected artifacts from peer {peer.name}", file=sys.stderr)
+        return
+    dest_root = instance.host_dir.resolve()
+    try:
+        with tarfile.open(fileobj=io.BytesIO(raw), mode="r:gz") as archive:
+            for member in archive.getmembers():
+                parts = [part for part in member.name.split("/") if part not in ("", ".")]
+                if len(parts) <= 3:
+                    continue  # the stripped session-instances/<date>/<name> prefix itself
+                rel = Path(*parts[3:])
+                if str(rel) == "manifest.yaml":
+                    continue
+                target = (dest_root / rel).resolve()
+                try:
+                    target.relative_to(dest_root)
+                except ValueError:
+                    continue  # refuse paths escaping the instance directory
+                if member.isdir():
+                    target.mkdir(parents=True, exist_ok=True)
+                    continue
+                if not member.isreg():
+                    continue
+                target.parent.mkdir(parents=True, exist_ok=True)
+                extracted = archive.extractfile(member)
+                if extracted is None:
+                    continue
+                with extracted, target.open("wb") as handle:
+                    shutil.copyfileobj(extracted, handle)
+    except tarfile.TarError:
+        print(f"OTA smoke: could not unpack collected artifacts from peer {peer.name}", file=sys.stderr)
 
 
 def _ota_stop_peers(
@@ -2387,22 +2431,6 @@ def _ota_application_run_script(
     )
 
 
-def _ota_status_parts(target: InteractiveSmokeTarget, instance_id: str, identity: str, *, watch: bool) -> list[str]:
-    parts = ["status", _ota_target_session_arg(target), "--identity", identity, "--instance-id", instance_id]
-    if watch:
-        parts.append("--watch")
-    return parts
-
-
-def _ota_status_watch_script(
-    plan: OtaSmokePlan,
-    target: InteractiveSmokeTarget,
-    instance_id: str,
-    peer_name: str,
-) -> str:
-    return _ota_rosotacom_command(plan, _ota_status_parts(target, instance_id, peer_name, watch=True))
-
-
 def _ota_create_tmux(
     runtime: RuntimeConfig,
     target: InteractiveSmokeTarget,
@@ -2424,7 +2452,7 @@ def _ota_create_tmux(
         "echo '[INFO] this pane attaches to the peer communication/catmux session'; "
         f"{first_start}; "
         "echo; "
-        f"echo '[INFO] remote peer {first_peer.name} communication exited; live status is in the lower pane'; "
+        f"echo '[INFO] remote peer {first_peer.name} communication exited'; "
         "exec bash"
     )
     created = subprocess.run(
@@ -2484,29 +2512,6 @@ def _ota_create_tmux(
         first_pane,
         instance.logs_host_dir / "ota-smoke" / f"{first_peer.name}-communication.log",
     )
-    first_status = _ota_status_watch_script(plan, target, instance.instance_id, first_peer.name)
-    first_status_script = (
-        f"echo '[INFO] starting live remote status watch for {first_peer.name}'; "
-        f"echo '[INFO] waiting for status artifacts from instance {instance.instance_id}'; "
-        f"exec {first_status}"
-    )
-    _create_tmux_split_below(
-        runtime,
-        first_pane,
-        f"{first_peer.name}:status",
-        _ota_quote_cmd(_ota_remote_argv(first_peer, first_status_script, tty=bool(first_peer.ssh))),
-        log_path=instance.logs_host_dir / "ota-smoke" / f"{first_peer.name}-status.log",
-    )
-    subprocess.run(
-        _tmux_command(
-            runtime,
-            "select-layout",
-            "-t",
-            f"{session_name}:{_safe_path_token(f'{first_peer.name}_communication')}",
-            "even-vertical",
-        ),
-        check=True,
-    )
 
     for peer in peers[1:]:
         start = _ota_rosotacom_command(
@@ -2519,7 +2524,7 @@ def _ota_create_tmux(
             "echo '[INFO] this pane attaches to the peer communication/catmux session'; "
             f"{start}; "
             "echo; "
-            f"echo '[INFO] remote peer {peer.name} communication exited; live status is in the lower pane'; "
+            f"echo '[INFO] remote peer {peer.name} communication exited'; "
             "exec bash"
         )
         created_window = subprocess.run(
@@ -2546,29 +2551,6 @@ def _ota_create_tmux(
             check=True,
         )
         _attach_tmux_pipe(runtime, pane_id, instance.logs_host_dir / "ota-smoke" / f"{peer.name}-communication.log")
-        status = _ota_status_watch_script(plan, target, instance.instance_id, peer.name)
-        status_script = (
-            f"echo '[INFO] starting live remote status watch for {peer.name}'; "
-            f"echo '[INFO] waiting for status artifacts from instance {instance.instance_id}'; "
-            f"exec {status}"
-        )
-        _create_tmux_split_below(
-            runtime,
-            pane_id,
-            f"{peer.name}:status",
-            _ota_quote_cmd(_ota_remote_argv(peer, status_script, tty=bool(peer.ssh))),
-            log_path=instance.logs_host_dir / "ota-smoke" / f"{peer.name}-status.log",
-        )
-        subprocess.run(
-            _tmux_command(
-                runtime,
-                "select-layout",
-                "-t",
-                f"{session_name}:{_safe_path_token(f'{peer.name}_communication')}",
-                "even-vertical",
-            ),
-            check=True,
-        )
 
     if target.scenario_definition:
         for peer in peers:
@@ -2831,6 +2813,9 @@ def _stop_ota_smoke(args: argparse.Namespace) -> int:
         print(f"Stopped OTA smoke tmux session: {tmux_session}")
     if instance_id and not dry_run:
         instance = _resolve_session_instance(runtime, target.session, instance_id)
+        # Collect the full per-peer artifacts (config, catmux, status, launcher, ...)
+        # before the remote workdir is wiped below.
+        _ota_collect_logs(instance, plan, dry_run=dry_run)
         _ota_write_manifest(
             instance,
             target,

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 import argparse
+import base64
+import io
 import os
 import subprocess
 import sys
+import tarfile
 from collections.abc import Callable
 from pathlib import Path
 
@@ -867,11 +870,100 @@ def test_interactive_ota_smoke_tmux_uses_control_windows_and_metadata(
     assert "docker attach" not in joined
     assert "scenario start demo --identity a --mode attach" not in joined
     assert "scenario start demo --identity b --mode attach" not in joined
-    assert "status demo --identity a --instance-id ota-interactive --watch" in joined
-    assert "status demo --identity b --instance-id ota-interactive --watch" in joined
-    assert any("split-window" in command for command in calls)
+    # Communication windows are full-screen now: no status-watch split pane.
+    assert "--watch" not in joined
+    assert not any("split-window" in command for command in calls)
     assert "ota-smoke demo --state-file" in joined
     assert "--verify-only" in joined
+
+
+def _make_session_instance(host_dir: Path, instance_id: str) -> rosotacom.SessionInstance:
+    return rosotacom.SessionInstance(
+        instance_id=instance_id,
+        host_dir=host_dir,
+        container_dir="/c",
+        config_host_dir=host_dir / "config",
+        config_container_dir="/c/config",
+        logs_host_dir=host_dir / "logs",
+        logs_container_dir="/c/logs",
+        rosbags_host_dir=host_dir / "rosbags",
+        rosbags_container_dir="/c/rosbags",
+    )
+
+
+def test_ota_extract_peer_artifacts_merges_full_layout_and_skips_manifest(tmp_path: Path) -> None:
+    host_dir = tmp_path / "inst"
+    host_dir.mkdir()
+    # The orchestration manifest must survive peer collection.
+    (host_dir / "manifest.yaml").write_text("orchestration: keep\n", encoding="utf-8")
+    instance = _make_session_instance(host_dir, "abcd")
+    peer = rosotacom.OtaSmokePeer("a", None, "10.0.0.10")
+
+    # The remote instance dir carries its own per-host timestamp (suffix matches only).
+    prefix = "session-instances/2026-06-22/sess_2026-06-22_00-00-09_abcd"
+    members = {
+        f"{prefix}/manifest.yaml": b"peer: should-be-skipped\n",
+        f"{prefix}/config/a/plugin.yaml": b"plugin: a\n",
+        f"{prefix}/logs/a/launcher.log": b"launcher\n",
+        f"{prefix}/logs/a/catmux/00-COM/0.log": b"com\n",
+        f"{prefix}/logs/a/status/events.jsonl": b'{"e":1}\n',
+    }
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w:gz") as archive:
+        for name, data in members.items():
+            info = tarfile.TarInfo(name)
+            info.size = len(data)
+            archive.addfile(info, io.BytesIO(data))
+        evil = b"evil\n"
+        escape = tarfile.TarInfo(f"{prefix}/../../escape.txt")
+        escape.size = len(evil)
+        archive.addfile(escape, io.BytesIO(evil))
+    encoded = base64.b64encode(buffer.getvalue()).decode("ascii")
+
+    rosotacom._ota_extract_peer_artifacts(instance, peer, encoded)
+
+    assert (host_dir / "config" / "a" / "plugin.yaml").read_text(encoding="utf-8") == "plugin: a\n"
+    assert (host_dir / "logs" / "a" / "launcher.log").read_text(encoding="utf-8") == "launcher\n"
+    assert (host_dir / "logs" / "a" / "catmux" / "00-COM" / "0.log").read_text(encoding="utf-8") == "com\n"
+    assert (host_dir / "logs" / "a" / "status" / "events.jsonl").read_text(encoding="utf-8") == '{"e":1}\n'
+    # Per-peer manifest skipped so the orchestration manifest stays intact.
+    assert (host_dir / "manifest.yaml").read_text(encoding="utf-8") == "orchestration: keep\n"
+    # Path-traversal members are refused.
+    assert not (tmp_path / "escape.txt").exists()
+    assert not (tmp_path.parent / "escape.txt").exists()
+
+
+def test_ota_collect_logs_extracts_each_peer_into_instance(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    host_dir = tmp_path / "inst"
+    host_dir.mkdir()
+    instance = _make_session_instance(host_dir, "abcd")
+    plan = _ota_plan(tmp_path)
+
+    def encoded_for(identity: str) -> str:
+        prefix = f"session-instances/2026-06-22/sess_{identity}_abcd"
+        buffer = io.BytesIO()
+        with tarfile.open(fileobj=buffer, mode="w:gz") as archive:
+            data = f"{identity}-launcher\n".encode()
+            info = tarfile.TarInfo(f"{prefix}/logs/{identity}/launcher.log")
+            info.size = len(data)
+            archive.addfile(info, io.BytesIO(data))
+        return base64.b64encode(buffer.getvalue()).decode("ascii")
+
+    def fake_ota_run(
+        peer: rosotacom.OtaSmokePeer, *_args: object, **_kwargs: object
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess([], 0, encoded_for(peer.name), "")
+
+    monkeypatch.setattr(rosotacom, "_ota_run", fake_ota_run)
+    rosotacom._ota_collect_logs(instance, plan, dry_run=False)
+
+    assert (host_dir / "logs" / "a" / "launcher.log").read_text(encoding="utf-8") == "a-launcher\n"
+    assert (host_dir / "logs" / "b" / "launcher.log").read_text(encoding="utf-8") == "b-launcher\n"
+    # No opaque base64 blob is left behind.
+    assert not list(host_dir.glob("**/*.tar.gz.b64"))
 
 
 def test_ota_smoke_parser_accepts_stop_without_peer_arguments(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## What

Collect and **extract** the full per-peer session-instance artifacts after an OTA smoke run, so a multi-host run leaves the same on-disk layout a local run does.

### Changes
- **`_ota_extract_peer_artifacts` (new):** decodes each peer's base64 `session-instances/<date>/<name>` tarball and merges it into the local instance directory, reproducing `config/<id>` and `logs/<id>/{catmux,status,launcher.log,…}`.
  - Strips the leading `session-instances/<date>/<name>/` prefix (each host names its instance dir with its own timestamp; only the instance-id suffix matches).
  - Skips the per-peer `manifest.yaml` so the orchestration manifest is preserved.
  - Refuses any member that would escape the instance directory (path-traversal guard); decode/unpack errors are reported on stderr, not fatal.
- **`_ota_collect_logs`** now extracts instead of dumping `<peer>-session-instances.tar.gz.b64` blobs, and is invoked from **`_stop_ota_smoke` before the remote workdir is wiped**.
- **Interactive tmux layout:** removed the live status-watch split pane — communication windows are now full-screen. Drops the now-unused `_ota_status_parts` / `_ota_status_watch_script` helpers and the `split-window` / `select-layout` calls.

### Tests
- `test_ota_extract_peer_artifacts_merges_full_layout_and_skips_manifest` — full layout merge, manifest preserved, prefix stripping.
- Updated `test_interactive_ota_smoke_tmux_*` to assert no `--watch` / no `split-window`.

Single commit, branched off `develop`.
