### PR TITLE
feat: RFC 0004 network profiles (emulated-cellular environment axis)

### DIFF
--- a/docs/rfcs/0004-network-profiles.md
+++ b/docs/rfcs/0004-network-profiles.md
@@ -1,6 +1,12 @@
 # RFC 0004 — Network profiles & the fidelity ladder
 
-**Status:** Draft — design agreed, not yet implemented · **Scope:** the
+**Status:** Implemented (pure half) — the schema, `tc`/`netem` command generation,
+fail-safe arm/teardown controller, timeline expansion, both outage kinds,
+`--profile` selection and the `expect.per_profile` invariant/conditional split are
+in `rosotacom.network_profiles` / `network_shaper` / `status_eval`, host-tested. The
+**privileged per-direction live arming** (wiring the controller into the ota-smoke
+SSH path) and the **manual bench checks** (crash teardown, post-shaping link bytes,
+real two-shaped-interface application) remain. · **Scope:** the
 environment / fidelity axis (the condition the transport runs *in*) · extends
 [RFC 0002](0002-expectation-concepts.md) (expectations), consumes
 [RFC 0003](0003-metric-backbone.md) (the measured metrics it asserts on), feeds
@@ -190,26 +196,40 @@ RFC 0002's `calibrate` / `--suggest` machinery, **per profile**:
 Roughly in dependency order; the fail-safe teardown (second item) is the highest
 risk — a stuck `qdisc` silently corrupts every later result on the machine.
 
-- [ ] Define the profile schema (static + per-direction `{rate, delay, jitter,
-  distribution, loss, loss_correlation, reorder, duplicate}`) at project scope, and
-  resolve selection via `--profile <name>` / `shared.profile` / `none`.
-- [ ] Arm a named static profile on the OTA-interface egress with fail-safe
-  teardown (revert on stop, on error, and via a safety max-duration); target the
-  data interface only, never the SSH/control interface.
+- [x] Define the profile schema (static + per-direction `{rate, delay, jitter,
+  distribution, loss, loss_correlation, reorder, duplicate}`) at project scope
+  (`network_profiles.parse_profiles` / `load_profiles_file`; project-scoped
+  `profiles.yaml` referenced from `rosotacom.yaml`), and resolve selection via
+  `--profile <name>` / `shared.profile` / `none` (`resolve_profile_selection`,
+  `cli._resolve_active_profile`).
+- [x] Arm a named static profile on the OTA-interface egress with fail-safe
+  teardown (revert on stop, on error, and via a safety max-duration watchdog);
+  target the data interface only, never the SSH/control interface
+  (`network_shaper.ProfileShaper`, `network_profiles.safety_teardown_command`). The
+  controller logic + command generation are host-tested; arming it over the live
+  ota-smoke SSH path is the remaining wiring.
 - [ ] Apply profiles per direction — `uplink` on the sending peer's egress,
   `downlink` on the receiver's — and reject profile selection on a real-deployment
-  run.
-- [ ] Add `expect.per_profile` overrides and the invariant/conditional split to
+  run. *(Per-direction `expand_timeline` and the `allow_shaping` reject rule exist
+  and are host-tested; the live wiring into ota-smoke is pending.)*
+- [x] Add `expect.per_profile` overrides and the invariant/conditional split to
   `status_eval`, so `rosotacom test --profile P` asserts the invariant block plus
-  `P`'s conditional band (default conditional where `P` has no override).
-- [ ] Add timeline profiles (ordered segments + `outage`) — the substrate for the
-  recovery genre in RFC 0005.
-- [ ] Add `rosotacom calibrate --profile P` to emit per-profile conditional bands
-  from a reference replay.
+  `P`'s conditional band (default conditional where `P` has no override)
+  (`status_eval.resolve_expect_for_profile`; threaded through `evaluate_report(s)`).
+- [x] Add timeline profiles (ordered segments + `outage`) — the substrate for the
+  recovery genre in RFC 0005 (`network_profiles.TimelineSegment` / `expand_timeline`;
+  both `outage` kinds — see Open questions).
+- [x] Add per-profile calibration — realized as `rosotacom test --suggest --profile
+  P`, which emits `P`'s conditional band nested under `per_profile`
+  (`status_eval.suggest_profile_band`), reusing the RFC 0002 `--suggest` machinery.
 - [ ] Confirm the `/proc/net/dev` link sampler (RFC 0003 / `link_bytes.py`) reports
-  post-shaping wire bytes so link-overhead stays meaningful under a profile.
-- [ ] Cover schema parsing, arm/teardown (including crash teardown), per-direction
-  application, and `per_profile` evaluation with tests.
+  post-shaping wire bytes so link-overhead stays meaningful under a profile. *(Bench
+  check.)*
+- [x] Cover schema parsing, command generation, the arm/teardown controller
+  (including missing-qdisc/crash teardown and the control-interface guard),
+  selection resolution, and `per_profile` evaluation with host tests
+  (`test_network_profiles.py`, `test_network_shaper.py`, `test_status_eval.py`).
+  Live per-direction application + crash teardown on real hardware stay a bench check.
 
 ## Validation checklist
 
@@ -217,31 +237,36 @@ How each capability will be proven once built (forward-looking — fill in and c
 off during implementation). Notes whether automation is feasible; privileged
 `tc`/`netem` arming is the part that resists pure host testing.
 
-- [ ] **Profile schema parsing** (static + per-direction fields) — host unit test
-  on the parser. Fully automatable.
-- [ ] **Selection resolution** (`--profile` / `shared.profile` / `none`, and the
-  *reject a profile on a real-deployment run* rule) — host unit test. Automatable.
-- [ ] **`tc`/`netem` command generation** — host unit test asserting the argv built
+- [x] **Profile schema parsing** (static + per-direction fields) — host unit test
+  on the parser (`test_network_profiles.py::test_parse_*`). Done.
+- [x] **Selection resolution** (`--profile` / `shared.profile` / `none`, and the
+  *reject a profile on a real-deployment run* rule) — host unit test
+  (`test_resolve_profile_selection`). Done.
+- [x] **`tc`/`netem` command generation** — host unit test asserting the argv built
   for a given profile/direction (rate/delay/jitter/loss/correlation → `tbf`+`netem`
-  string), without touching a real interface. Automatable.
-- [ ] **Fail-safe teardown** (revert on stop, on error, on safety max-duration; the
+  string), without touching a real interface (`test_shaping_commands_*`,
+  `test_netem_arg_ordering_is_valid`). Done.
+- [~] **Fail-safe teardown** (revert on stop, on error, on safety max-duration; the
   idempotent `tc qdisc del … root` always runs; data-interface-only, never the
-  SSH/control interface) — host unit test on the teardown/targeting logic; **plus a
-  manual bench check** that a killed run leaves no `qdisc` behind. Highest-risk
-  item — the manual check is required, not optional.
-- [ ] **Per-direction application** (uplink on the sender's OTA egress, downlink on
-  the receiver's) — host unit test on the peer→direction mapping; live application
-  is an **operator bench check** (privileged, needs two shaped interfaces).
-- [ ] **Invariant/conditional split + `expect.per_profile` evaluation** — host unit
-  test in `status_eval` (invariant asserted under every profile; `P`'s conditional
-  used under `--profile P`, default conditional where `P` has no override).
-  Automatable.
-- [ ] **Timeline profiles** (ordered segments + `outage`) — host unit test on the
-  schedule expansion; live stepping is a **bench check** (and the substrate for the
-  RFC 0005 recovery genre).
-- [ ] **`rosotacom calibrate --profile P`** — host unit test that a reference
-  status/bag fixture yields the expected conditional band (reuses RFC 0002
-  calibrate machinery). Automatable.
+  SSH/control interface) — host unit test on the teardown/targeting logic done
+  (`test_network_shaper.py`: revert on stop/error, missing-qdisc tolerance,
+  control-interface refusal, watchdog command); **the manual bench check** that a
+  killed run leaves no `qdisc` behind is still **required, not optional**.
+- [~] **Per-direction application** (uplink on the sender's OTA egress, downlink on
+  the receiver's) — host unit test on the peer→direction mapping done
+  (`expand_timeline(direction=…)`); live application is the pending **operator bench
+  check** (privileged, needs two shaped interfaces).
+- [x] **Invariant/conditional split + `expect.per_profile` evaluation** — host unit
+  test in `status_eval` (`test_status_eval.py`: invariant asserted under every
+  profile; `P`'s conditional used under `--profile P`, default conditional where
+  `P` has no override; invariant/unknown overrides rejected). Done.
+- [x] **Timeline profiles** (ordered segments + `outage`) — host unit test on the
+  schedule expansion (`test_expand_timeline_*`, both outage kinds); live stepping is
+  a **bench check** (and the substrate for the RFC 0005 recovery genre).
+- [x] **Per-profile calibration** (`rosotacom test --suggest --profile P`) — host
+  unit test that a reference status fixture yields `P`'s conditional band nested
+  under `per_profile` (`test_suggest_profile_band_*`), reusing the RFC 0002
+  `--suggest` machinery. Done.
 - [ ] **Emulated-profile gate (rung 2)** — an example session run under one
   canonical profile in the per-promotion CI smoke, asserting a conditional bound
   that differs from the unshaped run. Automatable in the smoke matrix.
@@ -254,13 +279,15 @@ off during implementation). Notes whether automation is feasible; privileged
 
 ## Open questions
 
-- **Config home.** Project-scoped `profiles.yaml` referenced from `rosotacom.yaml`
-  (reusable across sessions) vs inline `shared.profiles`. Leaning project-scoped —
-  a profile is environment, reused across many sessions, not part of one session's
-  contract.
-- **Outage = `loss 100%` vs link-down.** Which models the real reconnect the
-  baseline describes (multi-second backlog, simultaneous arrival)? Possibly both,
-  as two named outage kinds.
+- **Config home.** *Resolved:* project-scoped `profiles.yaml` referenced from
+  `rosotacom.yaml` (`profiles:` key) — a profile is environment, reused across many
+  sessions, not part of one session's contract.
+- **Outage = `loss 100%` vs link-down.** *Resolved (2026-06):* **both, as two named
+  kinds.** `outage: catchup` is `loss 100%` with the interface up (DDS endpoints
+  survive → recovery is "catch up"); `outage: reconnect` is link-down (forces RMW
+  re-discovery → the harsher reconnect with the multi-second backlog/simultaneous
+  arrival the baseline describes). A bare `outage: true` defaults to the milder
+  `catchup`. Implemented in `network_profiles.outage_commands` / `OUTAGE_KINDS`.
 - **Where the metric backbone reads the link during emulation.** The same
   `/proc/net/dev` link sampler (RFC 0003 / `link_bytes.py`) measures the shaped
   interface — confirm `tbf`/`netem` byte counts reflect post-shaping wire bytes so

--- a/src/rosotacom/cli.py
+++ b/src/rosotacom/cli.py
@@ -26,7 +26,7 @@ import sys
 import tarfile
 import tempfile
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass, replace
 from datetime import datetime
 from pathlib import Path
@@ -99,6 +99,7 @@ class RuntimeConfig:
     session_instances_dir: Path | None = None
     project_source: str | None = None
     scenario_configs_dir: tuple[Path, ...] = ()
+    profiles_file: Path | None = None
 
 
 @dataclass(frozen=True)
@@ -385,6 +386,7 @@ def _load_runtime_config(args: argparse.Namespace | None = None) -> RuntimeConfi
         "scenario_configs_dir",
         "session_instances_dir",
         "deployment",
+        "profiles",
     }
     unknown_project_keys = sorted(set(cfg) - allowed_project_keys)
     if unknown_project_keys:
@@ -419,6 +421,11 @@ def _load_runtime_config(args: argparse.Namespace | None = None) -> RuntimeConfi
         os.environ.get("ROSOTACOM_DEPLOYMENT"),
         cfg.get("deployment"),
     )
+    profiles_raw = _first_value(
+        getattr(args, "profiles_file", None),
+        os.environ.get("ROSOTACOM_PROFILES"),
+        cfg.get("profiles"),
+    )
 
     ros2docker_config = _resolve_path(ros2docker_config_raw, config_base, must_exist=True)
     if ros2docker_config is None:
@@ -449,6 +456,7 @@ def _load_runtime_config(args: argparse.Namespace | None = None) -> RuntimeConfi
             "scenario_configs_dir",
             must_exist=True,
         ),
+        profiles_file=_resolve_path(profiles_raw, config_base, must_exist=True),
     )
 
 
@@ -1633,8 +1641,8 @@ def _ota_publish_parts(
     return parts
 
 
-def _ota_test_parts(target: InteractiveSmokeTarget, instance_id: str) -> list[str]:
-    return [
+def _ota_test_parts(target: InteractiveSmokeTarget, instance_id: str, *, profile: str | None = None) -> list[str]:
+    parts = [
         "test",
         _ota_target_session_arg(target),
         "--instance-id",
@@ -1644,6 +1652,9 @@ def _ota_test_parts(target: InteractiveSmokeTarget, instance_id: str) -> list[st
         "--interval",
         "2",
     ]
+    if profile:
+        parts += ["--profile", profile]  # assert P's conditional band (RFC 0004)
+    return parts
 
 
 def _ota_probe_publish_parts(
@@ -2146,6 +2157,137 @@ def _ota_prepare_hosts(args: argparse.Namespace, runtime: RuntimeConfig, plan: O
             shutil.rmtree(temporary_bundle, ignore_errors=True)
 
 
+# --- RFC 0004 network-profile arming (bench-only; privileged tc/netem) ------ #
+
+# A watchdog reverts a crashed run's shaping within this bound, so a killed OTA
+# smoke can never leave a qdisc corrupting later results.
+_PROFILE_SAFETY_MAX_S = 3600.0
+
+
+def _resolve_ota_profile(
+    runtime: RuntimeConfig, target: InteractiveSmokeTarget, args: argparse.Namespace
+) -> tuple[str | None, Any]:
+    """Resolve the selected static network profile for an OTA run (RFC 0004).
+
+    Returns ``(name, Profile)``, or ``(None, None)`` when unshaped. ota-smoke is the
+    bench tool, so shaping is allowed; a timeline profile is rejected here — its
+    stepping is the RFC 0005 recovery driver's job, not a one-shot smoke."""
+    name = _resolve_active_profile(runtime, target.cfg, args, allow_shaping=True)
+    if name is None:
+        return None, None
+    if runtime.profiles_file is None:
+        raise RuntimeError(
+            f"--profile {name!r} needs a profiles file: set 'profiles:' in rosotacom.yaml or pass --profiles-file."
+        )
+    from .network_profiles import load_profiles_file
+
+    profile = load_profiles_file(runtime.profiles_file)[name]
+    if profile.is_timeline:
+        raise RuntimeError(
+            f"profile {name!r} is a timeline profile; ota-smoke applies a static condition only. "
+            "Timeline / recovery runs are driven by the benchmark recovery genre (RFC 0005)."
+        )
+    return name, profile
+
+
+def _profile_directions(plan: OtaSmokePlan, cfg: dict[str, Any]) -> dict[str, str]:
+    """Map each peer to the profile direction its egress carries (RFC 0004).
+
+    Default for the a/b convention: the first peer (center / receiver) shapes
+    ``downlink``, the second (vehicle / sender) shapes ``uplink`` — the dominant
+    telemetry direction. Override with ``shared.profile_directions: { a: …, b: … }``."""
+    peers = sorted(plan.peers)
+    directions: dict[str, str] = {peers[0]: "downlink", peers[1]: "uplink"} if len(peers) == 2 else {}
+    shared = cfg.get("shared")
+    override = shared.get("profile_directions") if isinstance(shared, dict) else None
+    if isinstance(override, dict):
+        for peer_name, direction in override.items():
+            directions[str(peer_name)] = str(direction)
+    invalid = {peer: direction for peer, direction in directions.items() if direction not in ("uplink", "downlink")}
+    if invalid:
+        raise RuntimeError(f"shared.profile_directions values must be 'uplink' or 'downlink'; got {invalid}")
+    return directions
+
+
+def _ota_resolve_interfaces(peer: OtaSmokePeer, peer_addr: str, *, dry_run: bool) -> tuple[str, str | None]:
+    """Discover ``(OTA egress, control)`` interfaces on ``peer`` from the kernel, not
+    guesses: the OTA interface is the route to the other peer's data address; the
+    control interface is the route back to the SSH client, so it is never shaped."""
+    from .network_shaper import ota_interface_from_route
+
+    script = (
+        f"ip route get {shlex.quote(peer_addr)}; echo '---CTRL---'; "
+        '{ [ -n "$SSH_CONNECTION" ] && ip route get "${SSH_CONNECTION%% *}"; } || true'
+    )
+    result = _ota_run(peer, script, label=f"{peer.name}: resolve OTA + control interface", dry_run=dry_run)
+    ota_text, _, ctrl_text = (result.stdout or "").partition("---CTRL---")
+    ota_iface = ota_interface_from_route(ota_text)
+    try:
+        control_iface: str | None = ota_interface_from_route(ctrl_text)
+    except ValueError:
+        control_iface = None  # local run / no SSH_CONNECTION
+    return ota_iface, control_iface
+
+
+def _peer_command_runner(peer: OtaSmokePeer, *, dry_run: bool) -> Callable[[Sequence[str]], None]:
+    """A CommandRunner that runs one privileged argv on ``peer`` via the SSH path."""
+
+    def run(argv: Sequence[str]) -> None:
+        _ota_run(peer, "sudo " + shlex.join(list(argv)), label=f"{peer.name}: tc/netem", dry_run=dry_run)
+
+    return run
+
+
+def _peer_watchdog_launcher(peer: OtaSmokePeer, *, dry_run: bool) -> Callable[[Sequence[str]], None]:
+    """Launch the safety-watchdog argv detached on ``peer`` so it survives a crash."""
+
+    def launch(argv: Sequence[str]) -> None:
+        detached = f"nohup sudo {shlex.join(list(argv))} >/dev/null 2>&1 &"
+        _ota_run(peer, detached, label=f"{peer.name}: profile safety watchdog", dry_run=dry_run, check=False)
+
+    return launch
+
+
+def _ota_arm_profile(plan: OtaSmokePlan, profile: Any, directions: dict[str, str], *, dry_run: bool) -> list[Any]:
+    """Arm the static profile per direction on every peer's OTA egress (RFC 0004),
+    returning the ``ProfileShaper`` handles to revert in the run's ``finally``."""
+    from .network_profiles import shaping_commands
+    from .network_shaper import ProfileShaper
+
+    shapers: list[Any] = []
+    peer_names = sorted(plan.peers)
+    for peer_name in peer_names:
+        peer = plan.peers[peer_name]
+        direction = directions.get(peer_name)
+        shaping = profile.uplink if direction == "uplink" else profile.downlink
+        if shaping is None or shaping.is_empty:
+            print(f"OTA profile: {peer_name} ({direction}) — nothing to shape.")
+            continue
+        other_addr = next(plan.peers[name].address for name in peer_names if name != peer_name)
+        if dry_run:
+            ota_iface, control_iface = "<ota-if>", None
+        else:
+            ota_iface, control_iface = _ota_resolve_interfaces(peer, other_addr, dry_run=False)
+        shaper = ProfileShaper(
+            ota_iface,
+            _peer_command_runner(peer, dry_run=dry_run),
+            control_interface=control_iface,
+            safety_max_duration_s=_PROFILE_SAFETY_MAX_S,
+            watchdog_launcher=_peer_watchdog_launcher(peer, dry_run=dry_run),
+        )
+        # Register before arming so a mid-arm failure is still reverted in `finally`.
+        shapers.append(shaper)
+        print(f"OTA profile: arming {profile.name!r} {direction} on {peer_name}:{ota_iface}")
+        shaper.arm(shaping_commands(ota_iface, shaping))
+    return shapers
+
+
+def _ota_teardown_profile(shapers: list[Any]) -> None:
+    """Revert every armed profile (always runs in the run's ``finally``)."""
+    for shaper in shapers:
+        shaper.teardown()
+
+
 def _ota_start_peers(
     target: InteractiveSmokeTarget,
     plan: OtaSmokePlan,
@@ -2204,12 +2346,13 @@ def _ota_verify_delivery(
     instance_id: str,
     *,
     dry_run: bool,
+    profile: str | None = None,
 ) -> list[str]:
     errors: list[str] = []
     print("OTA smoke: running status/expectation checks on every peer.")
     for peer_name in sorted(plan.peers):
         peer = plan.peers[peer_name]
-        command = _ota_rosotacom_command(plan, _ota_test_parts(target, instance_id))
+        command = _ota_rosotacom_command(plan, _ota_test_parts(target, instance_id, profile=profile))
         result = _ota_run(peer, command, label=f"{peer_name}: rosotacom test", dry_run=dry_run, check=False)
         if result.returncode != 0:
             _ota_print_failure_output(f"{peer_name}: rosotacom test", result)
@@ -2749,13 +2892,18 @@ def _start_noninteractive_ota_smoke(args: argparse.Namespace) -> int:
         interactive=False,
         phase="running",
     )
+    profile_name, profile = _resolve_ota_profile(runtime, target, args)
+    directions = _profile_directions(plan, target.cfg) if profile is not None else {}
+    shapers: list[Any] = []
     errors: list[str] = []
     try:
+        if profile is not None:
+            shapers = _ota_arm_profile(plan, profile, directions, dry_run=dry_run)
         _ota_start_peers(target, plan, instance.instance_id, dry_run=dry_run)
         if not dry_run:
             time.sleep(12)
         _ota_start_session_publishers(target, plan, dry_run=dry_run)
-        errors += _ota_verify_delivery(target, plan, instance.instance_id, dry_run=dry_run)
+        errors += _ota_verify_delivery(target, plan, instance.instance_id, dry_run=dry_run, profile=profile_name)
         errors += _ota_verify_isolation(target, plan, dry_run=dry_run)
         errors += _ota_verify_content_integrity(target, plan, target.cfg, dry_run=dry_run)
         if errors:
@@ -2763,6 +2911,8 @@ def _start_noninteractive_ota_smoke(args: argparse.Namespace) -> int:
         print("OTA SMOKE OK")
         return 0
     finally:
+        # Revert shaping first — a stuck qdisc must never outlive the run (RFC 0004).
+        _ota_teardown_profile(shapers)
         _ota_collect_logs(instance, plan, dry_run=dry_run)
         if not getattr(args, "keep_running", False):
             _ota_stop_peers(target, plan, instance.instance_id, dry_run=dry_run)
@@ -2839,6 +2989,12 @@ def ota_smoke(args: argparse.Namespace) -> int:
     if getattr(args, "stop", False):
         return _stop_ota_smoke(args)
     if getattr(args, "interactive", False):
+        requested_profile = getattr(args, "profile", None)
+        if requested_profile and requested_profile != "none":
+            raise RuntimeError(
+                "--profile is not supported in interactive mode (no clean teardown hook for a detached tmux "
+                "session). Run the non-interactive ota-smoke to shape the link, or apply the profile manually."
+            )
         return _start_interactive_ota_smoke(args)
     return _start_noninteractive_ota_smoke(args)
 
@@ -5150,6 +5306,28 @@ def publish_test_topics_command(args: argparse.Namespace) -> int:
     return 0
 
 
+def _resolve_active_profile(
+    runtime: RuntimeConfig,
+    cfg: dict[str, Any],
+    args: argparse.Namespace,
+    *,
+    allow_shaping: bool = True,
+) -> str | None:
+    """Resolve the selected network profile name (RFC 0004): `--profile` > `shared.profile`
+    > unshaped. Validated against the configured profiles file when one is set."""
+    from .network_profiles import load_profiles_file, resolve_profile_selection
+
+    available = set(load_profiles_file(runtime.profiles_file)) if runtime.profiles_file is not None else None
+    shared = cfg.get("shared")
+    shared_default = shared.get("profile") if isinstance(shared, dict) else None
+    return resolve_profile_selection(
+        getattr(args, "profile", None),
+        shared_default=shared_default,
+        available=available,
+        allow_shaping=allow_shaping,
+    )
+
+
 def _load_status_reports(logs_dir: Path) -> dict[str, Any]:
     reports: dict[str, Any] = {}
     for peer_dir in sorted(p for p in logs_dir.iterdir() if p.is_dir()):
@@ -5216,6 +5394,7 @@ def test_command(args: argparse.Namespace) -> int:
     interval = max(0.5, float(getattr(args, "interval", 2.0)))
     expect_by_topic = status_eval.expectations_from_cfg(cfg)
     link_expect = status_eval.link_expect_from_cfg(cfg)
+    profile = _resolve_active_profile(runtime, cfg, args)
     ground_truth: dict[str, Any] | None = None
     bag = getattr(args, "bag", None)
     if bag:
@@ -5231,12 +5410,18 @@ def test_command(args: argparse.Namespace) -> int:
         if not reports:
             print(f"rosotacom test --suggest: no status.json under {logs_dir}.", file=sys.stderr)
             return 1
-        suggestions = status_eval.suggest_expectations(reports)
-        print("# Suggested expect blocks from this run (author/narrow before committing):")
+        if profile:
+            suggestions = status_eval.suggest_profile_band(reports, profile)
+            print(f"# Suggested per-profile '{profile}' conditional band from this run (RFC 0004; author/narrow):")
+        else:
+            suggestions = status_eval.suggest_expectations(reports)
+            print("# Suggested expect blocks from this run (author/narrow before committing):")
         print(yaml.safe_dump(suggestions, sort_keys=True, default_flow_style=False).rstrip())
         return 0
 
     wait_timeout = max(0.0, float(getattr(args, "timeout", 30.0)))
+    if profile:
+        print(f"rosotacom test: asserting the '{profile}' conditional band (RFC 0004 per-profile expect)")
     print(f"rosotacom test: waiting up to {wait_timeout:g}s for status reports under {logs_dir}")
     saw_reports = False
     while True:
@@ -5245,7 +5430,7 @@ def test_command(args: argparse.Namespace) -> int:
             if not saw_reports:
                 print(f"rosotacom test: evaluating {len(reports)} peer status report(s)")
                 saw_reports = True
-            failures = status_eval.evaluate_reports(reports, expect_by_topic, link_expect, ground_truth)
+            failures = status_eval.evaluate_reports(reports, expect_by_topic, link_expect, ground_truth, profile)
             if not failures:
                 topic_count = sum(len(r.get("topics", [])) for r in reports.values())
                 print(f"TEST OK: {len(reports)} peer(s), {topic_count} topic(s) meet status + expectations")
@@ -6084,6 +6269,22 @@ def _add_common_config_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--session-instances-dir", help="Host directory for generated session instances and logs.")
     deployment = parser.add_argument("--deployment", help="Deployment YAML containing named hosts and values.")
     cast(Any, deployment).completer = DirectoriesCompleter()
+    profiles = parser.add_argument(
+        "--profiles-file",
+        dest="profiles_file",
+        help="Path to the project's network-profiles YAML (RFC 0004 emulated conditions).",
+    )
+    cast(Any, profiles).completer = DirectoriesCompleter()
+
+
+def _add_profile_arg(parser: argparse.ArgumentParser) -> None:
+    """Select an emulated network profile (RFC 0004); 'none' / omitted is unshaped."""
+    parser.add_argument(
+        "--profile",
+        dest="profile",
+        metavar="NAME",
+        help="Emulated network profile to run under (a name from the profiles file, or 'none').",
+    )
 
 
 def _add_session_arg(parser: argparse.ArgumentParser, *args: str, **kwargs: Any) -> argparse.Action:
@@ -6274,6 +6475,7 @@ def main(argv: list[str] | None = None) -> int:
 
     smoke_parser = subparsers.add_parser("smoke", help="Run a local smoke test.")
     _add_common_config_args(smoke_parser)
+    _add_profile_arg(smoke_parser)
     smoke_target = smoke_parser.add_argument("session_dir", nargs="?")
     cast(Any, smoke_target).completer = _smoke_target_completer
     smoke_parser.add_argument("--local", action="store_true", default=True)
@@ -6305,6 +6507,7 @@ def main(argv: list[str] | None = None) -> int:
 
     ota_smoke_parser = subparsers.add_parser("ota-smoke", help="Run a generic multi-machine OTA smoke test.")
     _add_common_config_args(ota_smoke_parser)
+    _add_profile_arg(ota_smoke_parser)
     ota_target = ota_smoke_parser.add_argument("target", nargs="?")
     cast(Any, ota_target).completer = _smoke_target_completer
     _add_peer_arg(ota_smoke_parser)
@@ -6374,6 +6577,7 @@ def main(argv: list[str] | None = None) -> int:
         "test", help="Assert a running/recent session meets its status + per-topic expect contract."
     )
     _add_common_config_args(test_parser)
+    _add_profile_arg(test_parser)
     _add_session_arg(test_parser, "session_dir", nargs="?", default=DEFAULT_SMOKE_SESSION)
     test_parser.add_argument("--instance-id", help="Evaluate a specific instance id (default: most recent).")
     test_parser.add_argument("--timeout", type=float, default=30.0, help="Seconds to wait for status to settle.")

--- a/src/rosotacom/cli.py
+++ b/src/rosotacom/cli.py
@@ -10,9 +10,12 @@ ros2docker remains the generic Docker runner underneath.
 from __future__ import annotations
 
 import argparse
+import base64
+import binascii
 import hashlib
 import importlib.resources as importlib_resources
 import importlib.util
+import io
 import json
 import os
 import re
@@ -20,6 +23,7 @@ import shlex
 import shutil
 import subprocess
 import sys
+import tarfile
 import tempfile
 import time
 from collections.abc import Callable
@@ -2307,16 +2311,56 @@ def _ota_collect_logs(
         'relative=${instance_dir#"$project_dir"/}; '
         'tar cz -C "$project_dir" "$relative" 2>/dev/null | base64; fi'
     )
-    out_dir = instance.logs_host_dir / "ota-smoke"
-    out_dir.mkdir(parents=True, exist_ok=True)
     for peer in plan.peers.values():
         result = _ota_run(peer, script, label=f"{peer.name}: collect session-instances", dry_run=dry_run, check=False)
         if dry_run or not result.stdout.strip():
             continue
-        (out_dir / f"{_safe_path_token(peer.name)}-session-instances.tar.gz.b64").write_text(
-            result.stdout,
-            encoding="utf-8",
-        )
+        _ota_extract_peer_artifacts(instance, peer, result.stdout)
+
+
+def _ota_extract_peer_artifacts(instance: SessionInstance, peer: OtaSmokePeer, encoded: str) -> None:
+    """Extract a peer's base64 ``session-instances/<date>/<name>`` tarball into the
+    local instance directory, reproducing the layout a local run writes
+    (``config/<id>``, ``logs/<id>/{catmux,status,launcher.log,...}``).
+
+    Each peer host names its instance directory with its own timestamp (only the
+    instance-id suffix matches), so the leading ``session-instances/<date>/<name>/``
+    prefix (3 path components) is stripped rather than matched. The per-peer
+    ``manifest.yaml`` is skipped so the orchestration manifest is preserved.
+    """
+    try:
+        raw = base64.b64decode(encoded, validate=False)
+    except (binascii.Error, ValueError):
+        print(f"OTA smoke: could not decode collected artifacts from peer {peer.name}", file=sys.stderr)
+        return
+    dest_root = instance.host_dir.resolve()
+    try:
+        with tarfile.open(fileobj=io.BytesIO(raw), mode="r:gz") as archive:
+            for member in archive.getmembers():
+                parts = [part for part in member.name.split("/") if part not in ("", ".")]
+                if len(parts) <= 3:
+                    continue  # the stripped session-instances/<date>/<name> prefix itself
+                rel = Path(*parts[3:])
+                if str(rel) == "manifest.yaml":
+                    continue
+                target = (dest_root / rel).resolve()
+                try:
+                    target.relative_to(dest_root)
+                except ValueError:
+                    continue  # refuse paths escaping the instance directory
+                if member.isdir():
+                    target.mkdir(parents=True, exist_ok=True)
+                    continue
+                if not member.isreg():
+                    continue
+                target.parent.mkdir(parents=True, exist_ok=True)
+                extracted = archive.extractfile(member)
+                if extracted is None:
+                    continue
+                with extracted, target.open("wb") as handle:
+                    shutil.copyfileobj(extracted, handle)
+    except tarfile.TarError:
+        print(f"OTA smoke: could not unpack collected artifacts from peer {peer.name}", file=sys.stderr)
 
 
 def _ota_stop_peers(
@@ -2387,22 +2431,6 @@ def _ota_application_run_script(
     )
 
 
-def _ota_status_parts(target: InteractiveSmokeTarget, instance_id: str, identity: str, *, watch: bool) -> list[str]:
-    parts = ["status", _ota_target_session_arg(target), "--identity", identity, "--instance-id", instance_id]
-    if watch:
-        parts.append("--watch")
-    return parts
-
-
-def _ota_status_watch_script(
-    plan: OtaSmokePlan,
-    target: InteractiveSmokeTarget,
-    instance_id: str,
-    peer_name: str,
-) -> str:
-    return _ota_rosotacom_command(plan, _ota_status_parts(target, instance_id, peer_name, watch=True))
-
-
 def _ota_create_tmux(
     runtime: RuntimeConfig,
     target: InteractiveSmokeTarget,
@@ -2424,7 +2452,7 @@ def _ota_create_tmux(
         "echo '[INFO] this pane attaches to the peer communication/catmux session'; "
         f"{first_start}; "
         "echo; "
-        f"echo '[INFO] remote peer {first_peer.name} communication exited; live status is in the lower pane'; "
+        f"echo '[INFO] remote peer {first_peer.name} communication exited'; "
         "exec bash"
     )
     created = subprocess.run(
@@ -2484,29 +2512,6 @@ def _ota_create_tmux(
         first_pane,
         instance.logs_host_dir / "ota-smoke" / f"{first_peer.name}-communication.log",
     )
-    first_status = _ota_status_watch_script(plan, target, instance.instance_id, first_peer.name)
-    first_status_script = (
-        f"echo '[INFO] starting live remote status watch for {first_peer.name}'; "
-        f"echo '[INFO] waiting for status artifacts from instance {instance.instance_id}'; "
-        f"exec {first_status}"
-    )
-    _create_tmux_split_below(
-        runtime,
-        first_pane,
-        f"{first_peer.name}:status",
-        _ota_quote_cmd(_ota_remote_argv(first_peer, first_status_script, tty=bool(first_peer.ssh))),
-        log_path=instance.logs_host_dir / "ota-smoke" / f"{first_peer.name}-status.log",
-    )
-    subprocess.run(
-        _tmux_command(
-            runtime,
-            "select-layout",
-            "-t",
-            f"{session_name}:{_safe_path_token(f'{first_peer.name}_communication')}",
-            "even-vertical",
-        ),
-        check=True,
-    )
 
     for peer in peers[1:]:
         start = _ota_rosotacom_command(
@@ -2519,7 +2524,7 @@ def _ota_create_tmux(
             "echo '[INFO] this pane attaches to the peer communication/catmux session'; "
             f"{start}; "
             "echo; "
-            f"echo '[INFO] remote peer {peer.name} communication exited; live status is in the lower pane'; "
+            f"echo '[INFO] remote peer {peer.name} communication exited'; "
             "exec bash"
         )
         created_window = subprocess.run(
@@ -2546,29 +2551,6 @@ def _ota_create_tmux(
             check=True,
         )
         _attach_tmux_pipe(runtime, pane_id, instance.logs_host_dir / "ota-smoke" / f"{peer.name}-communication.log")
-        status = _ota_status_watch_script(plan, target, instance.instance_id, peer.name)
-        status_script = (
-            f"echo '[INFO] starting live remote status watch for {peer.name}'; "
-            f"echo '[INFO] waiting for status artifacts from instance {instance.instance_id}'; "
-            f"exec {status}"
-        )
-        _create_tmux_split_below(
-            runtime,
-            pane_id,
-            f"{peer.name}:status",
-            _ota_quote_cmd(_ota_remote_argv(peer, status_script, tty=bool(peer.ssh))),
-            log_path=instance.logs_host_dir / "ota-smoke" / f"{peer.name}-status.log",
-        )
-        subprocess.run(
-            _tmux_command(
-                runtime,
-                "select-layout",
-                "-t",
-                f"{session_name}:{_safe_path_token(f'{peer.name}_communication')}",
-                "even-vertical",
-            ),
-            check=True,
-        )
 
     if target.scenario_definition:
         for peer in peers:
@@ -2831,6 +2813,9 @@ def _stop_ota_smoke(args: argparse.Namespace) -> int:
         print(f"Stopped OTA smoke tmux session: {tmux_session}")
     if instance_id and not dry_run:
         instance = _resolve_session_instance(runtime, target.session, instance_id)
+        # Collect the full per-peer artifacts (config, catmux, status, launcher, ...)
+        # before the remote workdir is wiped below.
+        _ota_collect_logs(instance, plan, dry_run=dry_run)
         _ota_write_manifest(
             instance,
             target,

--- a/src/rosotacom/network_profiles.py
+++ b/src/rosotacom/network_profiles.py
@@ -1,0 +1,545 @@
+"""RFC 0004 — network profiles: schema + ``tc``/``netem`` command generation.
+
+The environment axis of the fidelity ladder (RFC 0004): a declarative, named,
+per-direction `tc`/`netem` condition applied *below* rosotacom on the OTA
+interface, so the transport sees a realistic pipe and is unaware of it.
+
+This module is the **pure, host-testable** half — everything that can be exercised
+without a privileged interface:
+
+* the profile **schema** (static + timeline, per-direction parameters);
+* the **argv generation** (a profile/direction → the exact `tc`/`netem` command
+  list), so a host test asserts the built command without touching a real `qdisc`;
+* the **outage kinds** (`catchup` = `loss 100%` with the interface up, vs
+  ``reconnect`` = link-down forcing RMW re-discovery — the two recovery semantics
+  RFC 0004 left as an open question, resolved here as named variants);
+* **timeline expansion** (ordered segments + outage → a stepping schedule).
+
+The *privileged* half — actually arming/tearing down on a real interface with the
+fail-safe revert — lives next to the orchestration that owns the SSH/staging path,
+and consumes the argv this module builds.
+"""
+
+from __future__ import annotations
+
+import re
+import shlex
+from collections.abc import Collection, Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+# --------------------------------------------------------------------------- #
+# Outage kinds — the two recovery semantics (RFC 0004 open question, resolved)
+# --------------------------------------------------------------------------- #
+
+OUTAGE_CATCHUP = "catchup"  # netem loss 100%, interface stays up — DDS survives, "catch up"
+OUTAGE_RECONNECT = "reconnect"  # link-down — forces RMW re-discovery, the harsher reconnect
+OUTAGE_KINDS = (OUTAGE_CATCHUP, OUTAGE_RECONNECT)
+
+# Default token-bucket buffer/latency, mirroring the calibrated baseline profile
+# (`tbf rate <r> burst 32kbit latency 100ms`); overridable per direction.
+_DEFAULT_TBF_BURST = "32kbit"
+_DEFAULT_TBF_LATENCY_MS = 100.0
+
+
+# --------------------------------------------------------------------------- #
+# Value parsing (human strings → normalized numbers)
+# --------------------------------------------------------------------------- #
+
+
+def _num(value: Any, what: str) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{what}: expected a number, got {value!r}") from exc
+
+
+def parse_rate_bps(value: Any) -> float:
+    """``"4mbit"`` / ``"500kbit"`` / ``2.5e6`` → bits per second.
+
+    Bit-oriented (rosotacom profiles are stated in bit/s, like the operator's
+    baseline); a bare number is taken as bit/s. Byte suffixes are rejected to keep
+    the unit unambiguous on the wire.
+    """
+    if isinstance(value, (int, float)):
+        rate = float(value)
+    else:
+        text = str(value).strip().lower()
+        match = re.fullmatch(r"(\d+(?:\.\d+)?)\s*(g|m|k)?bit", text) or re.fullmatch(r"(\d+(?:\.\d+)?)", text)
+        if not match:
+            raise ValueError(f"rate: expected e.g. '4mbit', '500kbit' or a bit/s number, got {value!r}")
+        scale = {"k": 1e3, "m": 1e6, "g": 1e9, None: 1.0}[match.group(2) if match.lastindex == 2 else None]
+        rate = float(match.group(1)) * scale
+    if rate <= 0:
+        raise ValueError(f"rate must be > 0, got {value!r}")
+    return rate
+
+
+def parse_ms(value: Any, what: str = "duration") -> float:
+    """``"120ms"`` / ``"0.18s"`` / ``120`` → milliseconds (a bare number is ms)."""
+    if isinstance(value, (int, float)):
+        ms = float(value)
+    else:
+        text = str(value).strip().lower()
+        match = re.fullmatch(r"(\d+(?:\.\d+)?)\s*(ms|s)?", text)
+        if not match:
+            raise ValueError(f"{what}: expected e.g. '120ms' or '0.5s', got {value!r}")
+        ms = float(match.group(1)) * (1000.0 if match.group(2) == "s" else 1.0)
+    if ms < 0:
+        raise ValueError(f"{what} must be >= 0, got {value!r}")
+    return ms
+
+
+def parse_seconds(value: Any, what: str = "duration") -> float:
+    """``"30s"`` / ``"500ms"`` / ``30`` → seconds (a bare number is seconds)."""
+    if isinstance(value, (int, float)):
+        seconds = float(value)
+    else:
+        text = str(value).strip().lower()
+        match = re.fullmatch(r"(\d+(?:\.\d+)?)\s*(ms|s)?", text)
+        if not match:
+            raise ValueError(f"{what}: expected e.g. '30s' or '500ms', got {value!r}")
+        seconds = float(match.group(1)) / 1000.0 if match.group(2) == "ms" else float(match.group(1))
+    if seconds <= 0:
+        raise ValueError(f"{what} must be > 0, got {value!r}")
+    return seconds
+
+
+def parse_pct(value: Any, what: str = "percentage") -> float:
+    """``"2%"`` / ``2`` → percent (0–100)."""
+    text = str(value).strip().rstrip("%") if isinstance(value, str) else value
+    pct = _num(text, what)
+    if not 0.0 <= pct <= 100.0:
+        raise ValueError(f"{what} must be within [0, 100]%, got {value!r}")
+    return pct
+
+
+# --------------------------------------------------------------------------- #
+# Schema
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class DirectionShaping:
+    """`tc`/`netem` parameters for one direction's egress. Every field optional;
+    ``None`` means "not applied". An all-``None`` instance shapes nothing."""
+
+    rate_bps: float | None = None
+    delay_ms: float | None = None
+    jitter_ms: float | None = None
+    distribution: str | None = None  # normal | pareto | paretonormal (needs jitter)
+    loss_pct: float | None = None
+    loss_correlation_pct: float | None = None  # netem correlated loss (needs loss)
+    reorder_pct: float | None = None  # netem reorder (needs delay)
+    duplicate_pct: float | None = None
+    burst: str = _DEFAULT_TBF_BURST  # tbf buffer, only used when rate_bps is set
+    tbf_latency_ms: float = _DEFAULT_TBF_LATENCY_MS
+
+    @property
+    def is_empty(self) -> bool:
+        return all(
+            getattr(self, name) is None
+            for name in (
+                "rate_bps",
+                "delay_ms",
+                "jitter_ms",
+                "loss_pct",
+                "reorder_pct",
+                "duplicate_pct",
+            )
+        )
+
+    @property
+    def has_netem(self) -> bool:
+        return any(
+            getattr(self, name) is not None
+            for name in ("delay_ms", "jitter_ms", "loss_pct", "reorder_pct", "duplicate_pct")
+        )
+
+    def __post_init__(self) -> None:
+        if self.jitter_ms is not None and self.delay_ms is None:
+            raise ValueError("jitter requires a delay")
+        if self.distribution is not None and self.jitter_ms is None:
+            raise ValueError("distribution requires a jitter")
+        if self.loss_correlation_pct is not None and self.loss_pct is None:
+            raise ValueError("loss_correlation requires a loss")
+        if self.reorder_pct is not None and self.delay_ms is None:
+            raise ValueError("reorder requires a delay (netem reorders within the delay window)")
+        if self.distribution is not None and self.distribution not in ("normal", "pareto", "paretonormal"):
+            raise ValueError(f"unsupported distribution {self.distribution!r}")
+
+
+@dataclass(frozen=True)
+class TimelineSegment:
+    """One ordered step of a timeline profile: hold ``shaping`` (per direction) for
+    ``for_s`` seconds, or apply an ``outage`` of one of the named kinds."""
+
+    for_s: float
+    uplink: DirectionShaping | None = None
+    downlink: DirectionShaping | None = None
+    outage: str | None = None  # None | OUTAGE_CATCHUP | OUTAGE_RECONNECT
+
+    def __post_init__(self) -> None:
+        if self.outage is not None and self.outage not in OUTAGE_KINDS:
+            raise ValueError(f"outage must be one of {OUTAGE_KINDS}, got {self.outage!r}")
+        if self.outage is not None and (self.uplink is not None or self.downlink is not None):
+            raise ValueError("an outage segment cannot also carry direction shaping")
+
+
+@dataclass(frozen=True)
+class Profile:
+    """A named environment spec: either ``static`` (constant per-direction shaping)
+    or ``timeline`` (ordered segments — the substrate for the recovery genre)."""
+
+    name: str
+    kind: str  # "static" | "timeline"
+    uplink: DirectionShaping | None = None
+    downlink: DirectionShaping | None = None
+    timeline: Sequence[TimelineSegment] = field(default_factory=tuple)
+
+    @property
+    def is_timeline(self) -> bool:
+        return self.kind == "timeline"
+
+    @property
+    def total_duration_s(self) -> float | None:
+        return sum(segment.for_s for segment in self.timeline) if self.is_timeline else None
+
+
+# --------------------------------------------------------------------------- #
+# Schema parsing (profiles.yaml → Profile objects)
+# --------------------------------------------------------------------------- #
+
+_DIRECTION_KEYS = frozenset(
+    {
+        "rate",
+        "delay",
+        "jitter",
+        "distribution",
+        "loss",
+        "loss_correlation",
+        "reorder",
+        "duplicate",
+        "burst",
+        "tbf_latency",
+    }
+)
+
+
+def parse_direction(spec: Mapping[str, Any] | None) -> DirectionShaping | None:
+    """Parse one ``uplink``/``downlink`` block into a :class:`DirectionShaping`."""
+    if spec is None:
+        return None
+    unknown = sorted(set(spec) - _DIRECTION_KEYS)
+    if unknown:
+        raise ValueError(f"unsupported direction keys {unknown}; allowed: {sorted(_DIRECTION_KEYS)}")
+    return DirectionShaping(
+        rate_bps=parse_rate_bps(spec["rate"]) if "rate" in spec else None,
+        delay_ms=parse_ms(spec["delay"], "delay") if "delay" in spec else None,
+        jitter_ms=parse_ms(spec["jitter"], "jitter") if "jitter" in spec else None,
+        distribution=str(spec["distribution"]) if "distribution" in spec else None,
+        loss_pct=parse_pct(spec["loss"], "loss") if "loss" in spec else None,
+        loss_correlation_pct=(
+            parse_pct(spec["loss_correlation"], "loss_correlation") if "loss_correlation" in spec else None
+        ),
+        reorder_pct=parse_pct(spec["reorder"], "reorder") if "reorder" in spec else None,
+        duplicate_pct=parse_pct(spec["duplicate"], "duplicate") if "duplicate" in spec else None,
+        burst=str(spec.get("burst", _DEFAULT_TBF_BURST)),
+        tbf_latency_ms=parse_ms(spec["tbf_latency"], "tbf_latency")
+        if "tbf_latency" in spec
+        else _DEFAULT_TBF_LATENCY_MS,
+    )
+
+
+def _parse_outage(value: Any) -> str:
+    """``outage: catchup|reconnect`` (a bare ``true`` defaults to the milder ``catchup``)."""
+    if value is True:
+        return OUTAGE_CATCHUP
+    kind = str(value).strip().lower()
+    if kind not in OUTAGE_KINDS:
+        raise ValueError(f"outage must be one of {OUTAGE_KINDS} (or true → {OUTAGE_CATCHUP}), got {value!r}")
+    return kind
+
+
+def parse_timeline_segment(spec: Mapping[str, Any]) -> TimelineSegment:
+    unknown = sorted(set(spec) - {"for", "outage", "uplink", "downlink"})
+    if unknown:
+        raise ValueError(f"unsupported timeline-segment keys {unknown}; use for/outage/uplink/downlink")
+    if "for" not in spec:
+        raise ValueError("a timeline segment requires a 'for' duration")
+    for_s = parse_seconds(spec["for"], "for")
+    if "outage" in spec:
+        if "uplink" in spec or "downlink" in spec:
+            raise ValueError("an outage segment cannot also carry direction shaping")
+        return TimelineSegment(for_s=for_s, outage=_parse_outage(spec["outage"]))
+    return TimelineSegment(
+        for_s=for_s,
+        uplink=parse_direction(spec.get("uplink")),
+        downlink=parse_direction(spec.get("downlink")),
+    )
+
+
+def parse_profile(name: str, spec: Mapping[str, Any]) -> Profile:
+    """Parse one named profile block (static or timeline)."""
+    if "timeline" in spec:
+        unknown = sorted(set(spec) - {"timeline"})
+        if unknown:
+            raise ValueError(f"profile {name!r}: a timeline profile cannot also have {unknown}")
+        segments = [parse_timeline_segment(segment) for segment in spec["timeline"]]
+        if not segments:
+            raise ValueError(f"profile {name!r}: timeline must have at least one segment")
+        return Profile(name=name, kind="timeline", timeline=tuple(segments))
+    unknown = sorted(set(spec) - {"uplink", "downlink"})
+    if unknown:
+        raise ValueError(f"profile {name!r}: unsupported keys {unknown}; use 'uplink'/'downlink' or 'timeline'")
+    return Profile(
+        name=name,
+        kind="static",
+        uplink=parse_direction(spec.get("uplink")),
+        downlink=parse_direction(spec.get("downlink")),
+    )
+
+
+def parse_profiles(doc: Mapping[str, Any]) -> dict[str, Profile]:
+    """Parse a ``profiles.yaml`` document (``{profiles: {<name>: <spec>}}``)."""
+    profiles_block = doc.get("profiles", doc) if isinstance(doc, Mapping) else {}
+    if not isinstance(profiles_block, Mapping):
+        raise ValueError("profiles.yaml: top-level 'profiles' must be a mapping of name → spec")
+    return {str(name): parse_profile(str(name), spec or {}) for name, spec in profiles_block.items()}
+
+
+def load_profiles_file(path: str | Path) -> dict[str, Profile]:
+    """Load a project-scoped ``profiles.yaml`` into ``{name: Profile}``."""
+    import yaml
+
+    doc = yaml.safe_load(Path(path).read_text(encoding="utf-8")) or {}
+    if not isinstance(doc, Mapping):
+        raise ValueError(f"{path}: profiles file must be a mapping (with a top-level 'profiles:' block)")
+    return parse_profiles(doc)
+
+
+# Selecting nothing — the unshaped rung (0/1) or the "no emulation" sentinel.
+PROFILE_NONE = "none"
+
+
+def resolve_profile_selection(
+    requested: str | None,
+    *,
+    shared_default: str | None = None,
+    available: Collection[str] | None = None,
+    allow_shaping: bool = True,
+) -> str | None:
+    """Resolve the active profile name (RFC 0004 selection rule).
+
+    ``--profile <name>`` wins; otherwise ``shared.profile`` is the default; ``none``
+    (or nothing) is the unshaped rung → ``None``. A requested name is validated
+    against ``available`` when a profiles file is configured (catching typos). A
+    profile selected on a run that may not be shaped — the real fleet, where the link
+    *is* the condition and is measured, never imposed — is an error."""
+    name = requested if requested is not None else shared_default
+    if name is None or name == PROFILE_NONE:
+        return None
+    if not allow_shaping:
+        raise ValueError(
+            f"profile {name!r} selected, but this run may not be shaped: the real fleet's link is the "
+            "condition and is measured, never imposed (RFC 0004). Use --profile none."
+        )
+    if available is not None and name not in available:
+        raise ValueError(f"unknown profile {name!r}; configured profiles: {sorted(available)}")
+    return name
+
+
+# --------------------------------------------------------------------------- #
+# tc / netem command generation (argv lists — no shell)
+# --------------------------------------------------------------------------- #
+
+
+def _ms(value: float) -> str:
+    return f"{value:g}ms"
+
+
+def _pct(value: float) -> str:
+    return f"{value:g}%"
+
+
+def _netem_args(shaping: DirectionShaping) -> list[str]:
+    """The netem parameter tokens (delay/jitter/distribution, loss, duplicate, reorder).
+
+    Ordered so each modifier follows the base it qualifies (netem requires
+    ``delay`` before ``reorder``, and the correlation value follows its base loss).
+    """
+    args: list[str] = []
+    if shaping.delay_ms is not None:
+        args += ["delay", _ms(shaping.delay_ms)]
+        if shaping.jitter_ms is not None:
+            args.append(_ms(shaping.jitter_ms))
+            if shaping.distribution is not None:
+                args += ["distribution", shaping.distribution]
+    if shaping.loss_pct is not None:
+        args += ["loss", _pct(shaping.loss_pct)]
+        if shaping.loss_correlation_pct is not None:
+            args.append(_pct(shaping.loss_correlation_pct))
+    if shaping.duplicate_pct is not None:
+        args += ["duplicate", _pct(shaping.duplicate_pct)]
+    if shaping.reorder_pct is not None:
+        args += ["reorder", _pct(shaping.reorder_pct)]
+    return args
+
+
+def shaping_commands(interface: str, shaping: DirectionShaping) -> list[list[str]]:
+    """The ordered ``tc`` argv list that arms ``shaping`` on ``interface`` egress.
+
+    Layout mirrors the calibrated baseline: a ``tbf`` root for rate limiting with a
+    child ``netem`` for delay/jitter/loss. When only one of the two is requested it
+    becomes the root qdisc; an empty shaping arms nothing.
+    """
+    if shaping.is_empty:
+        return []
+    commands: list[list[str]] = []
+    if shaping.rate_bps is not None:
+        commands.append(
+            [
+                "tc",
+                "qdisc",
+                "add",
+                "dev",
+                interface,
+                "root",
+                "handle",
+                "1:",
+                "tbf",
+                "rate",
+                f"{int(round(shaping.rate_bps))}bit",
+                "burst",
+                shaping.burst,
+                "latency",
+                _ms(shaping.tbf_latency_ms),
+            ]
+        )
+        if shaping.has_netem:
+            commands.append(
+                [
+                    "tc",
+                    "qdisc",
+                    "add",
+                    "dev",
+                    interface,
+                    "parent",
+                    "1:",
+                    "handle",
+                    "10:",
+                    "netem",
+                    *_netem_args(shaping),
+                ]
+            )
+    elif shaping.has_netem:
+        commands.append(
+            ["tc", "qdisc", "add", "dev", interface, "root", "handle", "10:", "netem", *_netem_args(shaping)]
+        )
+    return commands
+
+
+def teardown_command(interface: str) -> list[str]:
+    """Idempotent root-qdisc removal. Always safe to run; non-zero exit (no qdisc
+    present) is expected and tolerated by the caller — it must *always* run on
+    teardown so a crashed run cannot leave a ``qdisc`` shaping later results."""
+    return ["tc", "qdisc", "del", "dev", interface, "root"]
+
+
+def restore_link_command(interface: str) -> list[str]:
+    """Bring the interface back up — undoes a ``reconnect`` outage. Idempotent on an
+    already-up interface, so it is safe to run unconditionally on teardown."""
+    return ["ip", "link", "set", "dev", interface, "up"]
+
+
+def safety_teardown_command(interface: str, max_duration_s: float) -> list[str]:
+    """A self-contained watchdog that reverts ``interface`` after ``max_duration_s``.
+
+    The hard fail-safe (RFC 0004): launched **detached** at arm time, it survives an
+    orchestrator crash and still tears the qdisc down (and brings the link back up),
+    so a killed run cannot leave shaping on the machine. The detachment itself is the
+    launcher's job; this builds the inner argv it runs."""
+    iface = shlex.quote(interface)
+    seconds = max(1, int(round(max_duration_s)))
+    return ["sh", "-c", f"sleep {seconds}; tc qdisc del dev {iface} root; ip link set dev {iface} up"]
+
+
+def outage_commands(interface: str, kind: str) -> list[list[str]]:
+    """Arm an outage of the given kind on ``interface``.
+
+    ``catchup`` drops every packet but keeps the interface up (DDS endpoints
+    survive → recovery is "catch up"); ``reconnect`` brings the interface down
+    (forces RMW re-discovery → the harsher reconnect). The matching restore is
+    :func:`outage_restore_commands`.
+    """
+    if kind == OUTAGE_CATCHUP:
+        return [
+            teardown_command(interface),
+            ["tc", "qdisc", "add", "dev", interface, "root", "handle", "10:", "netem", "loss", "100%"],
+        ]
+    if kind == OUTAGE_RECONNECT:
+        return [["ip", "link", "set", "dev", interface, "down"]]
+    raise ValueError(f"outage must be one of {OUTAGE_KINDS}, got {kind!r}")
+
+
+def outage_restore_commands(interface: str, kind: str) -> list[list[str]]:
+    """Undo an outage. ``catchup`` clears the 100%-loss qdisc; ``reconnect`` brings
+    the interface back up. The caller re-arms the following segment's shaping after."""
+    if kind == OUTAGE_CATCHUP:
+        return [teardown_command(interface)]
+    if kind == OUTAGE_RECONNECT:
+        return [["ip", "link", "set", "dev", interface, "up"]]
+    raise ValueError(f"outage must be one of {OUTAGE_KINDS}, got {kind!r}")
+
+
+# --------------------------------------------------------------------------- #
+# Timeline expansion (segments → a stepping schedule)
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class TimelineStep:
+    """A timeline segment placed on the absolute run clock: hold from ``start_s``
+    to ``end_s``. ``commands`` arms the step; ``outage`` names the kind if any."""
+
+    index: int
+    start_s: float
+    end_s: float
+    outage: str | None
+    commands: list[list[str]]
+
+
+def expand_timeline(
+    profile: Profile,
+    interface: str,
+    *,
+    direction: str = "uplink",
+) -> list[TimelineStep]:
+    """Expand a timeline profile into absolute-clock steps for the given direction.
+
+    Each step first tears the previous shaping down (the idempotent root delete),
+    then arms its own — shaping segments arm ``shaping_commands``; outage segments
+    arm ``outage_commands``. The stepping driver runs ``commands`` at ``start_s``;
+    the recovery genre (RFC 0005) reads ``outage`` to know which restore semantics
+    a given ``end_s`` represents.
+    """
+    if not profile.is_timeline:
+        raise ValueError(f"profile {profile.name!r} is not a timeline profile")
+    if direction not in ("uplink", "downlink"):
+        raise ValueError(f"direction must be 'uplink' or 'downlink', got {direction!r}")
+
+    steps: list[TimelineStep] = []
+    clock = 0.0
+    for index, segment in enumerate(profile.timeline):
+        start_s, end_s = clock, clock + segment.for_s
+        if segment.outage is not None:
+            commands = outage_commands(interface, segment.outage)
+        else:
+            shaping = segment.uplink if direction == "uplink" else segment.downlink
+            commands = [teardown_command(interface)]
+            if shaping is not None:
+                commands += shaping_commands(interface, shaping)
+        steps.append(TimelineStep(index=index, start_s=start_s, end_s=end_s, outage=segment.outage, commands=commands))
+        clock = end_s
+    return steps

--- a/src/rosotacom/network_shaper.py
+++ b/src/rosotacom/network_shaper.py
@@ -1,0 +1,124 @@
+"""RFC 0004 — fail-safe profile arming on a real OTA interface (privileged half).
+
+The pure schema/argv lives in :mod:`rosotacom.network_profiles`; this is the
+controller that *arms* those commands on a live interface with the hard fail-safe
+RFC 0004 demands — the highest-risk item, because a stuck ``qdisc`` silently
+corrupts every later result on the machine:
+
+* **revert on stop and on error** (a context manager that tears down on normal exit
+  *and* on an exception, without suppressing it);
+* a **detached safety watchdog** that reverts after a max duration even if the
+  orchestrator crashes mid-run;
+* an **idempotent teardown** that always runs (clears the root qdisc and brings the
+  link back up, tolerating a missing qdisc / already-up link);
+* a **refusal to shape the SSH/control interface** — shaping it would cut the very
+  orchestration applying the profile.
+
+Command execution is injected (a ``CommandRunner``), so the guard, the arm/teardown
+ordering and the revert-on-exception are all host-testable with a fake runner; the
+live adapter merely runs the argv over SSH/subprocess.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable, Iterable, Sequence
+from types import TracebackType
+from typing import Literal
+
+from rosotacom.network_profiles import (
+    restore_link_command,
+    safety_teardown_command,
+    teardown_command,
+)
+
+# Runs one argv; raises on failure (e.g. subprocess.CalledProcessError).
+CommandRunner = Callable[[Sequence[str]], None]
+
+
+def ota_interface_from_route(route_output: str) -> str:
+    """Egress interface from ``ip route get <peer-address>`` output.
+
+    The profile shapes the interface that actually carries traffic to the peer —
+    found by asking the kernel which ``dev`` the route to the peer's *data* address
+    uses, never guessed. This is also how a caller checks the OTA interface differs
+    from the SSH/control one before arming."""
+    match = re.search(r"\bdev\s+(\S+)", route_output)
+    if not match:
+        raise ValueError(f"no egress interface ('dev <if>') in route output: {route_output!r}")
+    return match.group(1)
+
+
+class ProfileShaper:
+    """Arms profile shaping on one interface with a guaranteed revert."""
+
+    def __init__(
+        self,
+        interface: str,
+        runner: CommandRunner,
+        *,
+        control_interface: str | None = None,
+        safety_max_duration_s: float | None = None,
+        watchdog_launcher: CommandRunner | None = None,
+    ) -> None:
+        if not interface:
+            raise ValueError("interface must be a non-empty name")
+        if control_interface is not None and interface == control_interface:
+            raise ValueError(
+                f"refusing to shape {interface!r}: it is the SSH/control interface — shaping it would "
+                "cut the orchestration applying the profile (RFC 0004: target the data interface only)"
+            )
+        self.interface = interface
+        self._runner = runner
+        self._safety_max_duration_s = safety_max_duration_s
+        self._watchdog_launcher = watchdog_launcher
+        self.armed = False
+
+    def _run(self, argv: Sequence[str]) -> None:
+        self._runner(list(argv))
+
+    def teardown(self) -> None:
+        """Always-safe revert: clear any root qdisc and bring the link back up.
+
+        Tolerates failure of either step — a missing qdisc or an already-up link is
+        the expected case, not an error — so teardown can run unconditionally."""
+        for argv in (teardown_command(self.interface), restore_link_command(self.interface)):
+            try:
+                self._run(argv)
+            except Exception:
+                pass  # idempotent revert: nothing to undo is success, not failure
+        self.armed = False
+
+    def arm(self, commands: Iterable[Sequence[str]]) -> None:
+        """Arm ``commands`` from a clean slate, launching the safety watchdog first.
+
+        Order matters: the detached watchdog is launched *before* the shaping, so a
+        crash at any point after this still reverts the interface."""
+        self.teardown()  # clean slate (idempotent)
+        if self._safety_max_duration_s is not None and self._watchdog_launcher is not None:
+            self._watchdog_launcher(safety_teardown_command(self.interface, self._safety_max_duration_s))
+        for argv in commands:
+            self._run(argv)
+        self.armed = True
+
+    def apply(self, commands: Iterable[Sequence[str]]) -> None:
+        """Run ``commands`` as-is, without a fresh clean-slate or watchdog.
+
+        Used to step a timeline (each :func:`~rosotacom.network_profiles.expand_timeline`
+        step already begins with its own teardown); the watchdog is launched once via
+        :meth:`arm` at the start of the run, not per step."""
+        for argv in commands:
+            self._run(argv)
+        self.armed = True
+
+    def __enter__(self) -> ProfileShaper:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> Literal[False]:
+        self.teardown()
+        return False  # never suppress: an error during the run still propagates

--- a/src/rosotacom/resources/examples/profiles.yaml
+++ b/src/rosotacom/resources/examples/profiles.yaml
@@ -1,0 +1,25 @@
+# Illustrative network profiles (RFC 0004 — the emulated environment axis).
+#
+# A profile is a declarative tc/netem condition applied *below* rosotacom on the
+# OTA interface, per direction (uplink != downlink — the defining feature of
+# cellular). Select one with `rosotacom <cmd> --profile <name>`; `--profile none`
+# (or omission) is the unshaped rung.
+#
+# These NUMBERS ARE ILLUSTRATIVE. Real, calibrated per-link profiles live in the
+# operator's private baseline, not in this public example. Re-measure per link.
+profiles:
+
+  # Static "typical cellular" — the standard reproducible point condition.
+  cellular-typical:
+    uplink:   { rate: 4mbit,  delay: 120ms, jitter: 30ms, distribution: normal, loss: 2%, loss_correlation: 25% }
+    downlink: { rate: 25mbit, delay: 60ms,  jitter: 20ms, loss: 0.5% }
+
+  # Timeline — the substrate for the recovery genre (good -> degrade -> outage ->
+  # restore). `outage: catchup` keeps the interface up (loss 100%; DDS survives,
+  # recovery is "catch up"); use `reconnect` for the harsher link-down recovery.
+  cellular-handover:
+    timeline:
+      - { for: 30s, uplink: { rate: 4mbit,   delay: 60ms,  loss: 0.1% } }
+      - { for: 15s, uplink: { rate: 1mbit,   delay: 180ms, loss: 3%   } }
+      - { for: 5s,  outage: catchup }
+      - { for: 40s, uplink: { rate: 2.5mbit, delay: 90ms,  loss: 1%   } }

--- a/src/rosotacom/resources/examples/rosotacom.yaml
+++ b/src/rosotacom/resources/examples/rosotacom.yaml
@@ -9,3 +9,4 @@ session_configs_dir:
 scenario_configs_dir:
   - scenarios
 session_instances_dir: session-instances
+profiles: profiles.yaml

--- a/src/rosotacom/status_eval.py
+++ b/src/rosotacom/status_eval.py
@@ -58,6 +58,52 @@ _DELIVERED_STATES = {"FLOWING", "STALE"}  # a message was observed at least once
 _VALID_MODES = {"stream", "latched", "existence"}
 _VALID_PRESENCE = {"required", "optional"}
 
+# RFC 0004 invariant/conditional split. Invariant (correctness) holds under every
+# profile and stays top-level; conditional (performance) is asserted per profile and
+# may be overridden via expect.per_profile.<name>.
+_INVARIANT_KEYS = frozenset({"presence", "mode"})
+_CONDITIONAL_KEYS = frozenset({"hz", "latency_ms", "loss_pct", "completeness", "min_count"})
+
+
+def resolve_expect_for_profile(expect: dict[str, Any], profile: str | None) -> dict[str, Any]:
+    """Resolve a topic's effective `expect` under a network profile (RFC 0004).
+
+    The invariant block (presence/mode — correctness) holds under every profile and
+    is kept verbatim; the conditional block (hz / latency_ms / loss_pct /
+    completeness / min_count — performance) defaults to the top-level values and is
+    overridden, key by key, by `expect.per_profile[profile]` where present. An
+    unshaped run (`profile is None`) uses the default conditional. The `per_profile`
+    key is stripped from the result, so the evaluator never sees it.
+
+    Raises if a per-profile block tries to override an invariant key (those stay
+    profile-independent) or names an unknown conditional key — an authoring bug worth
+    catching at the gate."""
+    resolved = {key: value for key, value in expect.items() if key != "per_profile"}
+    per_profile = expect.get("per_profile")
+    if per_profile is None or profile is None:
+        return resolved
+    if not isinstance(per_profile, dict):
+        raise ValueError("expect.per_profile must be a mapping of profile name -> conditional overrides")
+    overrides = per_profile.get(profile)
+    if overrides is None:
+        return resolved
+    if not isinstance(overrides, dict):
+        raise ValueError(f"expect.per_profile.{profile} must be a mapping of conditional overrides")
+    invalid = sorted(set(overrides) & _INVARIANT_KEYS)
+    if invalid:
+        raise ValueError(
+            f"expect.per_profile.{profile} may only override conditional (performance) keys; invariant "
+            f"keys {invalid} stay top-level and profile-independent (RFC 0004)"
+        )
+    unknown = sorted(set(overrides) - _CONDITIONAL_KEYS)
+    if unknown:
+        raise ValueError(
+            f"expect.per_profile.{profile} has unsupported keys {unknown}; "
+            f"conditional keys are {sorted(_CONDITIONAL_KEYS)}"
+        )
+    resolved.update(overrides)
+    return resolved
+
 
 def expectations_from_cfg(cfg: dict[str, Any]) -> dict[str, dict[str, Any]]:
     """Map a topic's base name -> its `expect` block, from a session config."""
@@ -298,8 +344,13 @@ def evaluate_report(
     expect_by_topic: dict[str, dict[str, Any]],
     link_expect: dict[str, Any] | None = None,
     ground_truth: dict[str, Any] | None = None,
+    profile: str | None = None,
 ) -> list[str]:
-    """Failures for one peer's status.json (empty == all good)."""
+    """Failures for one peer's status.json (empty == all good).
+
+    Under `--profile P` the invariant block is asserted as always and each topic's
+    conditional bounds come from `P`'s `per_profile` override (RFC 0004); an unshaped
+    run (`profile is None`) uses the default conditional."""
     peer = report.get("peer", "?")
     topics = report.get("topics", [])
     if not topics:
@@ -307,7 +358,7 @@ def evaluate_report(
     failures: list[str] = _check_link(peer, report.get("link"), link_expect or {})
     for topic in topics:
         base = topic.get("base", "?")
-        expect = expect_by_topic.get(base) or {}
+        expect = resolve_expect_for_profile(expect_by_topic.get(base) or {}, profile)
         mode = _topic_mode(expect)
         optional = _is_optional(expect)
         overall = topic.get("overall")
@@ -354,11 +405,12 @@ def evaluate_reports(
     expect_by_topic: dict[str, dict[str, Any]],
     link_expect: dict[str, Any] | None = None,
     ground_truth: dict[str, Any] | None = None,
+    profile: str | None = None,
 ) -> list[str]:
     """Failures across every peer's status.json (empty == all good)."""
     failures: list[str] = []
     for report in reports.values():
-        failures += evaluate_report(report, expect_by_topic, link_expect, ground_truth)
+        failures += evaluate_report(report, expect_by_topic, link_expect, ground_truth, profile)
     return failures
 
 
@@ -401,4 +453,20 @@ def suggest_expectations(reports: dict[str, dict[str, Any]]) -> dict[str, dict[s
             suggestion = _suggest_one(topic)
             if suggestion is not None:
                 out[str(base)] = suggestion
+    return out
+
+
+def suggest_profile_band(reports: dict[str, dict[str, Any]], profile: str) -> dict[str, dict[str, Any]]:
+    """A per-topic ``per_profile[profile]`` conditional band from a reference replay
+    run under profile `P` (RFC 0004 per-profile calibration).
+
+    Reuses the RFC 0002 `--suggest` machinery but keeps only the conditional
+    (performance) keys, nested under `per_profile[profile]` — the invariant block is
+    authored once and is profile-independent, so it is not re-emitted here. The
+    result merges straight into an existing topic's `expect`. Pure and order-stable."""
+    out: dict[str, dict[str, Any]] = {}
+    for topic, expect in suggest_expectations(reports).items():
+        conditional = {key: value for key, value in expect.items() if key in _CONDITIONAL_KEYS}
+        if conditional:
+            out[topic] = {"per_profile": {profile: conditional}}
     return out

--- a/tests/contract/test_packaged_resources.py
+++ b/tests/contract/test_packaged_resources.py
@@ -21,6 +21,7 @@ def test_packaged_resources_include_curated_examples_and_runtime_workspace() -> 
         "resources/examples/rosotacom.yaml",
         "resources/examples/.gitignore",
         "resources/examples/ros2docker.json",
+        "resources/examples/profiles.yaml",
         "resources/examples/deployment.example.yaml",
         "resources/examples/sessions/1_heartbeat/session-definition.yaml",
         "resources/examples/sessions/1_heartbeat_status/session-definition.yaml",
@@ -43,6 +44,17 @@ def test_packaged_resources_include_curated_examples_and_runtime_workspace() -> 
     assert "builtin_interfaces/Time echo_t1" in echo
     assert "builtin_interfaces/Time echo_t2" in echo
     assert "builtin_interfaces/Time echo_t3" in echo
+
+
+def test_packaged_example_profiles_parse() -> None:
+    # The shipped illustrative profiles must actually load — a malformed example
+    # (bad tc/netem combo, unknown key) would be a packaging regression.
+    from rosotacom.network_profiles import load_profiles_file
+
+    path = resources.files("rosotacom").joinpath("resources/examples/profiles.yaml")
+    profiles = load_profiles_file(Path(str(path)))
+    assert {"cellular-typical", "cellular-handover"} <= set(profiles)
+    assert profiles["cellular-handover"].is_timeline
 
 
 def test_cli_resource_constants_point_inside_package_resources() -> None:

--- a/tests/contract/test_readme_examples.py
+++ b/tests/contract/test_readme_examples.py
@@ -37,6 +37,7 @@ def test_packaged_example_setup_paths_are_relative_to_example_root() -> None:
         "session_configs_dir": ["sessions"],
         "scenario_configs_dir": ["scenarios"],
         "session_instances_dir": "session-instances",
+        "profiles": "profiles.yaml",
     }
 
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 import argparse
+import base64
+import io
 import os
 import subprocess
 import sys
+import tarfile
 from collections.abc import Callable
 from pathlib import Path
 
@@ -867,11 +870,100 @@ def test_interactive_ota_smoke_tmux_uses_control_windows_and_metadata(
     assert "docker attach" not in joined
     assert "scenario start demo --identity a --mode attach" not in joined
     assert "scenario start demo --identity b --mode attach" not in joined
-    assert "status demo --identity a --instance-id ota-interactive --watch" in joined
-    assert "status demo --identity b --instance-id ota-interactive --watch" in joined
-    assert any("split-window" in command for command in calls)
+    # Communication windows are full-screen now: no status-watch split pane.
+    assert "--watch" not in joined
+    assert not any("split-window" in command for command in calls)
     assert "ota-smoke demo --state-file" in joined
     assert "--verify-only" in joined
+
+
+def _make_session_instance(host_dir: Path, instance_id: str) -> rosotacom.SessionInstance:
+    return rosotacom.SessionInstance(
+        instance_id=instance_id,
+        host_dir=host_dir,
+        container_dir="/c",
+        config_host_dir=host_dir / "config",
+        config_container_dir="/c/config",
+        logs_host_dir=host_dir / "logs",
+        logs_container_dir="/c/logs",
+        rosbags_host_dir=host_dir / "rosbags",
+        rosbags_container_dir="/c/rosbags",
+    )
+
+
+def test_ota_extract_peer_artifacts_merges_full_layout_and_skips_manifest(tmp_path: Path) -> None:
+    host_dir = tmp_path / "inst"
+    host_dir.mkdir()
+    # The orchestration manifest must survive peer collection.
+    (host_dir / "manifest.yaml").write_text("orchestration: keep\n", encoding="utf-8")
+    instance = _make_session_instance(host_dir, "abcd")
+    peer = rosotacom.OtaSmokePeer("a", None, "10.0.0.10")
+
+    # The remote instance dir carries its own per-host timestamp (suffix matches only).
+    prefix = "session-instances/2026-06-22/sess_2026-06-22_00-00-09_abcd"
+    members = {
+        f"{prefix}/manifest.yaml": b"peer: should-be-skipped\n",
+        f"{prefix}/config/a/plugin.yaml": b"plugin: a\n",
+        f"{prefix}/logs/a/launcher.log": b"launcher\n",
+        f"{prefix}/logs/a/catmux/00-COM/0.log": b"com\n",
+        f"{prefix}/logs/a/status/events.jsonl": b'{"e":1}\n',
+    }
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w:gz") as archive:
+        for name, data in members.items():
+            info = tarfile.TarInfo(name)
+            info.size = len(data)
+            archive.addfile(info, io.BytesIO(data))
+        evil = b"evil\n"
+        escape = tarfile.TarInfo(f"{prefix}/../../escape.txt")
+        escape.size = len(evil)
+        archive.addfile(escape, io.BytesIO(evil))
+    encoded = base64.b64encode(buffer.getvalue()).decode("ascii")
+
+    rosotacom._ota_extract_peer_artifacts(instance, peer, encoded)
+
+    assert (host_dir / "config" / "a" / "plugin.yaml").read_text(encoding="utf-8") == "plugin: a\n"
+    assert (host_dir / "logs" / "a" / "launcher.log").read_text(encoding="utf-8") == "launcher\n"
+    assert (host_dir / "logs" / "a" / "catmux" / "00-COM" / "0.log").read_text(encoding="utf-8") == "com\n"
+    assert (host_dir / "logs" / "a" / "status" / "events.jsonl").read_text(encoding="utf-8") == '{"e":1}\n'
+    # Per-peer manifest skipped so the orchestration manifest stays intact.
+    assert (host_dir / "manifest.yaml").read_text(encoding="utf-8") == "orchestration: keep\n"
+    # Path-traversal members are refused.
+    assert not (tmp_path / "escape.txt").exists()
+    assert not (tmp_path.parent / "escape.txt").exists()
+
+
+def test_ota_collect_logs_extracts_each_peer_into_instance(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    host_dir = tmp_path / "inst"
+    host_dir.mkdir()
+    instance = _make_session_instance(host_dir, "abcd")
+    plan = _ota_plan(tmp_path)
+
+    def encoded_for(identity: str) -> str:
+        prefix = f"session-instances/2026-06-22/sess_{identity}_abcd"
+        buffer = io.BytesIO()
+        with tarfile.open(fileobj=buffer, mode="w:gz") as archive:
+            data = f"{identity}-launcher\n".encode()
+            info = tarfile.TarInfo(f"{prefix}/logs/{identity}/launcher.log")
+            info.size = len(data)
+            archive.addfile(info, io.BytesIO(data))
+        return base64.b64encode(buffer.getvalue()).decode("ascii")
+
+    def fake_ota_run(
+        peer: rosotacom.OtaSmokePeer, *_args: object, **_kwargs: object
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess([], 0, encoded_for(peer.name), "")
+
+    monkeypatch.setattr(rosotacom, "_ota_run", fake_ota_run)
+    rosotacom._ota_collect_logs(instance, plan, dry_run=False)
+
+    assert (host_dir / "logs" / "a" / "launcher.log").read_text(encoding="utf-8") == "a-launcher\n"
+    assert (host_dir / "logs" / "b" / "launcher.log").read_text(encoding="utf-8") == "b-launcher\n"
+    # No opaque base64 blob is left behind.
+    assert not list(host_dir.glob("**/*.tar.gz.b64"))
 
 
 def test_ota_smoke_parser_accepts_stop_without_peer_arguments(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_network_profiles.py
+++ b/tests/unit/test_network_profiles.py
@@ -1,0 +1,335 @@
+"""RFC 0004 validation checklist — host tests for the network-profile schema and
+``tc``/``netem`` command generation (the pure half; privileged arming is a bench check)."""
+
+from __future__ import annotations
+
+import pytest
+
+from rosotacom.network_profiles import (
+    OUTAGE_CATCHUP,
+    OUTAGE_RECONNECT,
+    DirectionShaping,
+    Profile,
+    TimelineSegment,
+    expand_timeline,
+    load_profiles_file,
+    outage_commands,
+    outage_restore_commands,
+    parse_direction,
+    parse_ms,
+    parse_pct,
+    parse_profile,
+    parse_profiles,
+    parse_rate_bps,
+    parse_seconds,
+    resolve_profile_selection,
+    shaping_commands,
+    teardown_command,
+)
+
+# --- value parsing --------------------------------------------------------- #
+
+
+def test_rate_parsing_is_bit_oriented() -> None:
+    assert parse_rate_bps("4mbit") == 4_000_000
+    assert parse_rate_bps("500kbit") == 500_000
+    assert parse_rate_bps("2.5mbit") == 2_500_000
+    assert parse_rate_bps(4_000_000) == 4_000_000
+    with pytest.raises(ValueError):
+        parse_rate_bps("4mbps")  # byte units rejected — ambiguous on the wire
+    with pytest.raises(ValueError):
+        parse_rate_bps("0mbit")
+
+
+def test_duration_and_pct_parsing() -> None:
+    assert parse_ms("120ms") == 120.0
+    assert parse_ms("0.5s") == 500.0
+    assert parse_ms(30) == 30.0
+    assert parse_seconds("30s") == 30.0
+    assert parse_seconds("500ms") == 0.5
+    assert parse_pct("2%") == 2.0
+    assert parse_pct(100) == 100.0
+    with pytest.raises(ValueError):
+        parse_pct("150%")
+    with pytest.raises(ValueError):
+        parse_seconds("0s")
+
+
+# --- direction schema + validation ----------------------------------------- #
+
+
+def test_parse_direction_full_block() -> None:
+    shaping = parse_direction(
+        {"rate": "4mbit", "delay": "120ms", "jitter": "30ms", "distribution": "normal", "loss": "2%"}
+    )
+    assert shaping is not None
+    assert shaping.rate_bps == 4_000_000
+    assert shaping.delay_ms == 120.0
+    assert shaping.jitter_ms == 30.0
+    assert shaping.distribution == "normal"
+    assert shaping.loss_pct == 2.0
+    assert not shaping.is_empty and shaping.has_netem
+
+
+def test_parse_direction_rejects_unknown_keys_and_invalid_combos() -> None:
+    with pytest.raises(ValueError):
+        parse_direction({"bandwidth": "4mbit"})  # unknown key
+    with pytest.raises(ValueError):
+        DirectionShaping(jitter_ms=30.0)  # jitter without delay
+    with pytest.raises(ValueError):
+        DirectionShaping(delay_ms=120.0, distribution="normal")  # distribution without jitter
+    with pytest.raises(ValueError):
+        DirectionShaping(loss_correlation_pct=25.0)  # correlation without loss
+    with pytest.raises(ValueError):
+        DirectionShaping(reorder_pct=5.0)  # reorder without delay
+
+
+# --- tc/netem command generation ------------------------------------------- #
+
+
+def test_shaping_commands_tbf_root_with_netem_child() -> None:
+    # The canonical static cellular profile from the calibrated baseline.
+    shaping = DirectionShaping(rate_bps=4_000_000, delay_ms=120.0, jitter_ms=30.0, distribution="normal", loss_pct=2.0)
+    commands = shaping_commands("tun0", shaping)
+    assert commands == [
+        [
+            "tc",
+            "qdisc",
+            "add",
+            "dev",
+            "tun0",
+            "root",
+            "handle",
+            "1:",
+            "tbf",
+            "rate",
+            "4000000bit",
+            "burst",
+            "32kbit",
+            "latency",
+            "100ms",
+        ],
+        [
+            "tc",
+            "qdisc",
+            "add",
+            "dev",
+            "tun0",
+            "parent",
+            "1:",
+            "handle",
+            "10:",
+            "netem",
+            "delay",
+            "120ms",
+            "30ms",
+            "distribution",
+            "normal",
+            "loss",
+            "2%",
+        ],
+    ]
+
+
+def test_shaping_commands_netem_only_becomes_root() -> None:
+    commands = shaping_commands("tun0", DirectionShaping(delay_ms=60.0, loss_pct=1.0))
+    assert commands == [
+        ["tc", "qdisc", "add", "dev", "tun0", "root", "handle", "10:", "netem", "delay", "60ms", "loss", "1%"]
+    ]
+
+
+def test_shaping_commands_rate_only_and_empty() -> None:
+    rate_only = shaping_commands("eth0", DirectionShaping(rate_bps=1_000_000))
+    assert rate_only == [
+        [
+            "tc",
+            "qdisc",
+            "add",
+            "dev",
+            "eth0",
+            "root",
+            "handle",
+            "1:",
+            "tbf",
+            "rate",
+            "1000000bit",
+            "burst",
+            "32kbit",
+            "latency",
+            "100ms",
+        ]
+    ]
+    assert shaping_commands("eth0", DirectionShaping()) == []
+
+
+def test_netem_arg_ordering_is_valid() -> None:
+    # netem requires delay before reorder, and the correlation value follows its base loss.
+    shaping = DirectionShaping(
+        delay_ms=100.0, jitter_ms=20.0, loss_pct=3.0, loss_correlation_pct=25.0, duplicate_pct=1.0, reorder_pct=5.0
+    )
+    netem = shaping_commands("tun0", shaping)[0]
+    assert netem[netem.index("netem") :] == [
+        "netem",
+        "delay",
+        "100ms",
+        "20ms",
+        "loss",
+        "3%",
+        "25%",
+        "duplicate",
+        "1%",
+        "reorder",
+        "5%",
+    ]
+
+
+def test_teardown_is_root_delete() -> None:
+    assert teardown_command("tun0") == ["tc", "qdisc", "del", "dev", "tun0", "root"]
+
+
+# --- outage kinds (both named variants) ------------------------------------ #
+
+
+def test_outage_catchup_is_full_loss_interface_up() -> None:
+    assert outage_commands("tun0", OUTAGE_CATCHUP) == [
+        ["tc", "qdisc", "del", "dev", "tun0", "root"],
+        ["tc", "qdisc", "add", "dev", "tun0", "root", "handle", "10:", "netem", "loss", "100%"],
+    ]
+    assert outage_restore_commands("tun0", OUTAGE_CATCHUP) == [["tc", "qdisc", "del", "dev", "tun0", "root"]]
+
+
+def test_outage_reconnect_is_link_down() -> None:
+    assert outage_commands("tun0", OUTAGE_RECONNECT) == [["ip", "link", "set", "dev", "tun0", "down"]]
+    assert outage_restore_commands("tun0", OUTAGE_RECONNECT) == [["ip", "link", "set", "dev", "tun0", "up"]]
+
+
+# --- profile parsing (static + timeline) ----------------------------------- #
+
+
+def test_parse_static_profile() -> None:
+    profile = parse_profile(
+        "cellular-typical",
+        {"uplink": {"rate": "4mbit", "delay": "120ms", "loss": "2%"}, "downlink": {"rate": "25mbit", "delay": "60ms"}},
+    )
+    assert profile.kind == "static" and not profile.is_timeline
+    assert profile.uplink is not None and profile.uplink.rate_bps == 4_000_000
+    assert profile.downlink is not None and profile.downlink.rate_bps == 25_000_000
+
+
+def test_parse_profiles_document() -> None:
+    profiles = parse_profiles(
+        {"profiles": {"none-ish": {"uplink": {"delay": "10ms"}}, "cellular": {"uplink": {"rate": "4mbit"}}}}
+    )
+    assert set(profiles) == {"none-ish", "cellular"}
+    assert profiles["cellular"].uplink is not None and profiles["cellular"].uplink.rate_bps == 4_000_000
+
+
+def test_timeline_outage_kinds_and_default() -> None:
+    profile = parse_profile(
+        "handover",
+        {
+            "timeline": [
+                {"for": "30s", "uplink": {"rate": "4mbit", "delay": "60ms", "loss": "0.1%"}},
+                {"for": "15s", "uplink": {"rate": "1mbit", "delay": "180ms", "loss": "3%"}},
+                {"for": "5s", "outage": "reconnect"},
+                {"for": "40s", "uplink": {"rate": "2.5mbit", "delay": "90ms", "loss": "1%"}},
+            ]
+        },
+    )
+    assert profile.is_timeline and profile.total_duration_s == 90.0
+    assert profile.timeline[2].outage == OUTAGE_RECONNECT
+    # A bare `outage: true` defaults to the milder catchup kind.
+    assert parse_profile("o", {"timeline": [{"for": "5s", "outage": True}]}).timeline[0].outage == OUTAGE_CATCHUP
+
+
+def test_parse_profile_rejects_mixed_and_unknown() -> None:
+    with pytest.raises(ValueError):
+        parse_profile("bad", {"timeline": [{"for": "5s"}], "uplink": {"rate": "4mbit"}})  # timeline + static
+    with pytest.raises(ValueError):
+        parse_profile("bad", {"sidelink": {"rate": "4mbit"}})  # unknown direction key
+    with pytest.raises(ValueError):
+        parse_profile("bad", {"timeline": [{"for": "5s", "outage": "reconnect", "uplink": {"rate": "4mbit"}}]})
+
+
+# --- timeline expansion ----------------------------------------------------- #
+
+
+def test_expand_timeline_places_steps_on_absolute_clock() -> None:
+    profile = parse_profile(
+        "handover",
+        {
+            "timeline": [
+                {"for": "30s", "uplink": {"rate": "4mbit", "delay": "60ms"}},
+                {"for": "5s", "outage": "catchup"},
+                {"for": "40s", "uplink": {"rate": "2.5mbit", "delay": "90ms"}},
+            ]
+        },
+    )
+    steps = expand_timeline(profile, "tun0", direction="uplink")
+    assert [(step.start_s, step.end_s, step.outage) for step in steps] == [
+        (0.0, 30.0, None),
+        (30.0, 35.0, OUTAGE_CATCHUP),
+        (35.0, 75.0, None),
+    ]
+    # Every shaping step first tears the previous qdisc down (idempotent), then arms its own.
+    assert steps[0].commands[0] == teardown_command("tun0")
+    assert steps[0].commands[1][:9] == ["tc", "qdisc", "add", "dev", "tun0", "root", "handle", "1:", "tbf"]
+    assert steps[1].commands == outage_commands("tun0", OUTAGE_CATCHUP)
+
+
+def test_expand_timeline_uses_the_requested_direction() -> None:
+    profile = Profile(
+        name="asym",
+        kind="timeline",
+        timeline=(
+            TimelineSegment(
+                for_s=10.0,
+                uplink=DirectionShaping(rate_bps=1_000_000),
+                downlink=DirectionShaping(rate_bps=25_000_000),
+            ),
+        ),
+    )
+    up = expand_timeline(profile, "tun0", direction="uplink")[0]
+    down = expand_timeline(profile, "tun0", direction="downlink")[0]
+    assert "1000000bit" in up.commands[1]
+    assert "25000000bit" in down.commands[1]
+    with pytest.raises(ValueError):
+        expand_timeline(profile, "tun0", direction="sideways")
+
+
+# --- profile file loading + selection resolution --------------------------- #
+
+
+def test_load_profiles_file(tmp_path) -> None:
+    path = tmp_path / "profiles.yaml"
+    path.write_text(
+        "profiles:\n"
+        "  cellular-typical:\n"
+        "    uplink: { rate: 4mbit, delay: 120ms, loss: 2% }\n"
+        "  handover:\n"
+        "    timeline:\n"
+        "      - { for: 30s, uplink: { rate: 4mbit } }\n"
+        "      - { for: 5s, outage: reconnect }\n",
+        encoding="utf-8",
+    )
+    profiles = load_profiles_file(path)
+    assert set(profiles) == {"cellular-typical", "handover"}
+    assert profiles["handover"].is_timeline
+
+
+def test_resolve_profile_selection() -> None:
+    available = {"cellular", "handover"}
+    # Explicit selection wins and is validated against the configured set.
+    assert resolve_profile_selection("cellular", available=available) == "cellular"
+    # Omitted → the shared default; 'none' and omission with no default → unshaped.
+    assert resolve_profile_selection(None, shared_default="handover", available=available) == "handover"
+    assert resolve_profile_selection(None) is None
+    assert resolve_profile_selection("none", available=available) is None
+    # A typo is caught when a profiles file is configured.
+    with pytest.raises(ValueError):
+        resolve_profile_selection("celluar", available=available)
+    # A profile on a run that may not be shaped (the real fleet) is an error.
+    with pytest.raises(ValueError):
+        resolve_profile_selection("cellular", available=available, allow_shaping=False)
+    # ...but 'none' is always fine, shaping or not.
+    assert resolve_profile_selection("none", allow_shaping=False) is None

--- a/tests/unit/test_network_shaper.py
+++ b/tests/unit/test_network_shaper.py
@@ -1,0 +1,112 @@
+"""RFC 0004 validation checklist — host tests for the fail-safe arming controller
+(the highest-risk item: a stuck qdisc silently corrupts every later result)."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import pytest
+
+from rosotacom.network_profiles import (
+    restore_link_command,
+    safety_teardown_command,
+    teardown_command,
+)
+from rosotacom.network_shaper import ProfileShaper, ota_interface_from_route
+
+
+class FakeRunner:
+    """Records every argv it is asked to run; optionally fails matching ones."""
+
+    def __init__(self, fail_on: object = None) -> None:
+        self.calls: list[list[str]] = []
+        self._fail_on = fail_on
+
+    def __call__(self, argv: Sequence[str]) -> None:
+        recorded = list(argv)
+        self.calls.append(recorded)
+        if self._fail_on is not None and self._fail_on in recorded:
+            raise RuntimeError(f"boom on {self._fail_on!r}")
+
+
+# --- interface resolution + the control-interface guard -------------------- #
+
+
+def test_ota_interface_is_read_from_the_route() -> None:
+    out = "10.8.0.2 dev tun0 src 10.8.0.7 uid 1000 \n    cache"
+    assert ota_interface_from_route(out) == "tun0"
+    with pytest.raises(ValueError):
+        ota_interface_from_route("no device here")
+
+
+def test_refuses_to_shape_the_control_interface() -> None:
+    with pytest.raises(ValueError):
+        ProfileShaper("eth0", FakeRunner(), control_interface="eth0")
+    # A distinct data interface is fine.
+    ProfileShaper("tun0", FakeRunner(), control_interface="eth0")
+
+
+# --- arm / teardown ordering and the safety watchdog ----------------------- #
+
+
+def test_arm_cleans_first_launches_watchdog_then_shapes() -> None:
+    runner = FakeRunner()
+    watchdog = FakeRunner()
+    shaper = ProfileShaper("tun0", runner, safety_max_duration_s=300, watchdog_launcher=watchdog)
+    shaping = [["tc", "qdisc", "add", "dev", "tun0", "root", "handle", "1:", "tbf", "rate", "4000000bit"]]
+    shaper.arm(shaping)
+
+    # Clean slate (del + link up) runs before the shaping command.
+    assert runner.calls[0] == teardown_command("tun0")
+    assert runner.calls[1] == restore_link_command("tun0")
+    assert runner.calls[-1] == shaping[0]
+    assert shaper.armed
+    # The watchdog is launched detached, before shaping, with the configured timeout.
+    assert watchdog.calls == [safety_teardown_command("tun0", 300)]
+
+
+def test_no_watchdog_without_launcher_or_duration() -> None:
+    watchdog = FakeRunner()
+    ProfileShaper("tun0", FakeRunner(), watchdog_launcher=watchdog).arm([])
+    assert watchdog.calls == []  # no max-duration → no watchdog
+
+
+def test_teardown_tolerates_a_missing_qdisc() -> None:
+    # Runner raises on the qdisc delete (no qdisc present) — teardown must not blow up.
+    runner = FakeRunner(fail_on="del")
+    shaper = ProfileShaper("tun0", runner)
+    shaper.teardown()
+    assert runner.calls[0] == teardown_command("tun0")
+    assert runner.calls[1] == restore_link_command("tun0")  # still brings the link up
+    assert not shaper.armed
+
+
+# --- revert on stop and on error (the context manager) --------------------- #
+
+
+def test_context_manager_reverts_on_normal_exit() -> None:
+    runner = FakeRunner()
+    with ProfileShaper("tun0", runner) as shaper:
+        shaper.apply([["tc", "qdisc", "add", "dev", "tun0", "root", "handle", "10:", "netem", "loss", "1%"]])
+        assert shaper.armed
+    assert runner.calls[-2:] == [teardown_command("tun0"), restore_link_command("tun0")]
+    assert not shaper.armed
+
+
+def test_context_manager_reverts_on_error_and_reraises() -> None:
+    runner = FakeRunner()
+    with pytest.raises(ValueError, match="run blew up"):
+        with ProfileShaper("tun0", runner) as shaper:
+            shaper.apply([["tc", "qdisc", "add", "dev", "tun0", "root", "handle", "10:", "netem", "loss", "1%"]])
+            raise ValueError("run blew up")
+    # The error propagates, but the interface is still reverted.
+    assert runner.calls[-2:] == [teardown_command("tun0"), restore_link_command("tun0")]
+
+
+def test_safety_teardown_command_reverts_after_the_timeout() -> None:
+    argv = safety_teardown_command("tun0", 90)
+    assert argv[0] == "sh" and argv[1] == "-c"
+    script = argv[2]
+    assert "sleep 90" in script
+    assert "tc qdisc del dev tun0 root" in script
+    assert "ip link set dev tun0 up" in script

--- a/tests/unit/test_status_eval.py
+++ b/tests/unit/test_status_eval.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 
 import pytest
 
-from rosotacom.status_eval import evaluate_report, evaluate_reports, expectations_from_cfg
+from rosotacom.status_eval import (
+    evaluate_report,
+    evaluate_reports,
+    expectations_from_cfg,
+    resolve_expect_for_profile,
+)
 
 
 def _stage(stage: str, hz: float, latency_ms: float | None, state: str = "FLOWING", publishers: int = 1) -> dict:
@@ -416,3 +421,63 @@ def test_loss_pct_without_sequence_metric_fails_honestly() -> None:
     rep = {"peer": "a", "topics": [_wrapped_topic()]}
     failures = evaluate_report(rep, {"/wrapped": {"loss_pct": {"max": 3.0}}})
     assert len(failures) == 1 and "loss None" in failures[0]
+
+
+# --- RFC 0004: per-profile conditional overrides --------------------------- #
+
+
+def test_resolve_keeps_invariant_overrides_conditional_and_strips_per_profile() -> None:
+    expect = {
+        "presence": "required",
+        "mode": "stream",
+        "hz": {"min": 9},
+        "latency_ms": {"max": 200},
+        "per_profile": {"cellular": {"hz": {"min": 6}, "loss_pct": {"max": 5}}},
+    }
+    default = resolve_expect_for_profile(expect, None)
+    assert "per_profile" not in default
+    assert default["hz"] == {"min": 9} and default["latency_ms"] == {"max": 200}
+
+    cellular = resolve_expect_for_profile(expect, "cellular")
+    assert cellular["presence"] == "required"  # invariant kept verbatim
+    assert cellular["hz"] == {"min": 6}  # conditional overridden by the profile
+    assert cellular["latency_ms"] == {"max": 200}  # not overridden -> default conditional
+    assert cellular["loss_pct"] == {"max": 5}  # added by the profile
+    assert "per_profile" not in cellular
+
+    # A profile with no override block falls back entirely to the default conditional.
+    assert resolve_expect_for_profile(expect, "unknown")["hz"] == {"min": 9}
+
+
+def test_resolve_rejects_invariant_and_unknown_overrides() -> None:
+    with pytest.raises(ValueError):
+        resolve_expect_for_profile({"mode": "stream", "per_profile": {"c": {"mode": "latched"}}}, "c")
+    with pytest.raises(ValueError):
+        resolve_expect_for_profile({"per_profile": {"c": {"bogus": 1}}}, "c")
+
+
+def test_per_profile_relaxes_the_conditional_bound_end_to_end() -> None:
+    # /heartbeat_a is delivered inbound at ~6.9 ms; a 5 ms LAN bound fails, but the
+    # cellular profile's laxer bound passes -- the same report, two verdicts.
+    expect = {
+        "/heartbeat_a": {
+            "presence": "required",
+            "latency_ms": {"max": 5},
+            "per_profile": {"cellular": {"latency_ms": {"max": 600}}},
+        }
+    }
+    assert evaluate_report(OK_REPORT, expect) != []  # unshaped: default conditional fails
+    assert evaluate_report(OK_REPORT, expect, profile="cellular") == []  # cellular: relaxed, passes
+    assert evaluate_report(OK_REPORT, expect, profile="other") != []  # no override -> default fails
+
+
+def test_suggest_profile_band_nests_conditional_keys_under_per_profile() -> None:
+    # A reference replay under 'cellular' -> the conditional band for that profile,
+    # nested under per_profile so it merges into an authored invariant block.
+    from rosotacom.status_eval import suggest_profile_band
+
+    band = suggest_profile_band({"b": OK_REPORT}, "cellular")
+    assert "/heartbeat_a" in band
+    entry = band["/heartbeat_a"]["per_profile"]["cellular"]
+    assert "hz" in entry and "latency_ms" in entry  # conditional keys only
+    assert "presence" not in entry and "mode" not in entry  # invariant stays top-level


### PR DESCRIPTION
Implements the pure / host-tested half of **RFC 0004** (network profiles — the
emulated-cellular environment axis) plus the live per-direction arming in ota-smoke.

### What lands
- **network_profiles.py** — schema (static + timeline, per-direction
  rate/delay/jitter/distribution/loss/loss_correlation/reorder/duplicate), tc/netem
  argv generation, **both outage kinds** (`catchup` = loss 100% iface-up, `reconnect`
  = link-down), timeline expansion, safety-watchdog command, profile loading +
  selection.
- **network_shaper.py** — fail-safe `ProfileShaper` (revert on stop/error, detached
  safety watchdog, idempotent teardown, refuses the SSH/control interface) +
  `ota_interface_from_route`.
- **status_eval** — `expect.per_profile` invariant/conditional split (RFC 0004),
  threaded through `evaluate_report(s)`; per-profile calibration via
  `test --suggest --profile P`.
- **cli** — `--profile` / `--profiles-file`, `profiles:` key in rosotacom.yaml, and
  the live per-direction arming in the non-interactive ota-smoke flow (arm before
  start, revert in `finally`, watchdog, `--profile` into the remote `rosotacom test`).
- Packaged illustrative `profiles.yaml`; RFC 0004 doc marked *Implemented (pure half)*.

### Verification
ruff + mypy clean; full unit + contract suite green (258 tests); ota-smoke
`--profile … --dry-run` confirms the generated tc/netem commands, per-direction
mapping, watchdog and teardown. The privileged per-direction live arming still needs
an operator bench check (RFC 0004 requirement, not host-testable).

### Note
This PR is stacked on `feat/ota-smoke-artifact-logging`, so it also carries the prior
commit `1966be8` (ota-smoke artifact extraction & logging) — included intentionally.