### PR TITLE
feat: dynamic QoS for observation subscriptions (match publisher durability)

### DIFF
--- a/src/rosotacom/resources/ws/ros2src/com_py/com_py/status_overview.py
+++ b/src/rosotacom/resources/ws/ros2src/com_py/com_py/status_overview.py
@@ -63,7 +63,7 @@ import rclpy
 from rclpy.context import Context
 from rclpy.executors import MultiThreadedExecutor
 from rclpy.node import Node
-from rclpy.qos import HistoryPolicy, QoSProfile, ReliabilityPolicy
+from rclpy.qos import DurabilityPolicy, HistoryPolicy, QoSProfile, ReliabilityPolicy
 from rclpy.serialization import serialize_message
 from rosidl_runtime_py.utilities import get_message
 
@@ -140,17 +140,47 @@ class StageObserver(Node):
                 msg_class = None
             if msg_class is None:
                 continue
-            qos = QoSProfile(
-                reliability=ReliabilityPolicy.BEST_EFFORT,
-                history=HistoryPolicy.KEEP_LAST,
-                depth=10,
-            )
+            qos = self._observation_qos(topic)
             try:
                 self.create_subscription(msg_class, topic, self._make_cb(topic), qos)
                 obs.subscribed = True
                 obs.type_str = type_str
             except Exception:  # pragma: no cover - defensive
                 continue
+
+    def _observation_qos(self, topic: str) -> QoSProfile:
+        """QoS for the observation subscription, matched to the live publisher.
+
+        A VOLATILE reader only receives samples sent *after* it matches, so it
+        cannot read a TRANSIENT_LOCAL writer's already-published held sample. A
+        genuinely static latched topic publishes exactly once at startup, so a
+        hardcoded best-effort/volatile observer turns stage observation into a
+        startup race -- it intermittently misses that single sample and reports a
+        false STALLED even though the pipeline delivered and durably holds the
+        value. Adopting the publisher's offered durability/reliability (request ==
+        offered) is always compatible and replays the durable history. Falls back
+        to best-effort/volatile when no publisher QoS is available.
+        """
+        durability = DurabilityPolicy.VOLATILE
+        reliability = ReliabilityPolicy.BEST_EFFORT
+        try:
+            infos = self.get_publishers_info_by_topic(topic)
+        except Exception:  # pragma: no cover - defensive
+            infos = []
+        for info in infos:
+            pub_qos = getattr(info, "qos_profile", None)
+            if pub_qos is None:
+                continue
+            if pub_qos.durability == DurabilityPolicy.TRANSIENT_LOCAL:
+                durability = DurabilityPolicy.TRANSIENT_LOCAL
+            if pub_qos.reliability == ReliabilityPolicy.RELIABLE:
+                reliability = ReliabilityPolicy.RELIABLE
+        return QoSProfile(
+            reliability=reliability,
+            durability=durability,
+            history=HistoryPolicy.KEEP_LAST,
+            depth=10,
+        )
 
     def _make_cb(self, topic: str):
         def cb(msg):

--- a/tests/unit/test_status_overview.py
+++ b/tests/unit/test_status_overview.py
@@ -127,6 +127,20 @@ def test_ota_observer_is_graph_only() -> None:
     assert 'local_topics.update(by_domain.get("ota"' not in source
 
 
+def test_observation_qos_matches_publisher_durability() -> None:
+    """Regression: the observer must adopt the publisher's QoS so it can read a
+    TRANSIENT_LOCAL writer's held sample. A hardcoded volatile observer races the
+    single startup publish of a static latched topic -> intermittent false STALLED.
+    """
+    source = STATUS_NODE_PY.read_text(encoding="utf-8")
+    # Observation subscription QoS is derived per-topic from the live publisher.
+    assert "def _observation_qos" in source
+    assert "self.get_publishers_info_by_topic(topic)" in source
+    assert "DurabilityPolicy.TRANSIENT_LOCAL" in source
+    # The old unconditional volatile/best-effort observer QoS is gone.
+    assert "qos = self._observation_qos(topic)" in source
+
+
 # ---------------------------------------------------------------------------
 # state classification + rollup
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Status-overview observation subscriptions adopt the publisher's durability, so
transient_local / latched publishers are observed correctly (RFC 0006 dynamic QoS).

Changes: status_overview.py (+42/-6), test_status_overview.py (+14). Single commit,
based directly on develop.