### PR TITLE
Add rosbag anonymization tool and scenario generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,20 @@ container-side catmux prefix with `Ctrl-b Ctrl-b`. Detaching from the outer
 tmux does not stop the use case. `scenario stop` owns cleanup of the application
 containers, communication container, and outer tmux session.
 
+### Safe Replay Testing with Anonymized Rosbags
+
+To test scenarios involving proprietary data (e.g. remote assistance) completely safely, you can anonymize a recorded native rosbag using `rosotacom anonymize`. This command:
+1. Extracts only the topics actually transported in a given session/scenario.
+2. Renames them to generic names like `/topic1`, `/topic2`, etc.
+3. Replaces all message contents with mock payloads of the exact same size, keeping the messages fully valid and deserializable (preserving timing metadata like headers).
+4. Generates a new self-contained `rosotacom` project directory containing the anonymized bag, session-definition, and scenario configuration to replay the exact communication patterns.
+
+```bash
+rosotacom anonymize /path/to/native_bag \
+  -s 3_comp_occ_grid \
+  -o ./anonymized_project
+```
+
 ## Usage Examples
 
 Create the example project first (cwd discovery wires it automatically once you

--- a/justfile
+++ b/justfile
@@ -9,7 +9,7 @@ venv:
 	{{python}} -m pip install --upgrade pip
 
 setup: venv
-	{{python}} -m pip install -e ".[dev]"
+	{{python}} -m pip install -e ".[dev,plots]"
 	{{python}} -m pre_commit install
 
 format:

--- a/rosotacom.yaml
+++ b/rosotacom.yaml
@@ -8,3 +8,5 @@ session_configs_dir:
 scenario_configs_dir:
   - src/rosotacom/resources/examples/scenarios
 session_instances_dir: session-instances
+profiles: ../profiles/benchmark-profiles.yaml
+benchmarks_dir: ../artifacts/benchmarks

--- a/src/rosotacom/benchmark.py
+++ b/src/rosotacom/benchmark.py
@@ -345,7 +345,10 @@ def _send_time(record: dict[str, Any], *, seq0: int, t0: float, period_s: float,
 
 
 def _arrival_time(send_t: float, record: dict[str, Any]) -> float:
-    ota = (record.get("sections") or {}).get("ota_hop_ms")
+    sections = record.get("sections") or {}
+    ota = sections.get("ota_hop_ms")
+    if ota is None:
+        ota = sections.get("ota_hop_uncorrected_ms")
     return send_t + (float(ota) / 1000.0 if ota is not None else 0.0)
 
 

--- a/src/rosotacom/cli.py
+++ b/src/rosotacom/cli.py
@@ -6431,6 +6431,202 @@ def completion_command(args: argparse.Namespace) -> int:
     return 0
 
 
+def anonymize_command(args: argparse.Namespace) -> int:
+    runtime = _load_runtime_config(args)
+
+    if args.scenario_dir:
+        try:
+            resolved_scenario = _resolve_scenario(args.scenario_dir, runtime)
+            scenario_def = _load_scenario_definition(resolved_scenario)
+            session_name = scenario_def.session
+        except Exception as exc:
+            print(f"Error: failed to resolve scenario: {exc}", file=sys.stderr)
+            return 1
+    elif args.session_dir:
+        session_name = args.session_dir
+    else:
+        print("Error: either --session-dir (-s) or --scenario-dir (-c) must be specified.", file=sys.stderr)
+        return 1
+
+    try:
+        resolved_session = _resolve_session(session_name, runtime)
+    except Exception as exc:
+        print(f"Error: failed to resolve session: {exc}", file=sys.stderr)
+        return 1
+
+    session_cfg = _effective_session_config(resolved_session.host_dir, runtime)
+    original_session_name = resolved_session.host_dir.name
+    output_name = args.output_name or f"anonymized_{original_session_name}"
+
+    transported_topics = {}
+    for direction_key, entries in session_cfg.get("topics", {}).items():
+        if not isinstance(entries, list):
+            continue
+        for entry in entries:
+            if not isinstance(entry, dict) or "topic" not in entry:
+                continue
+            topic = entry["topic"]
+            transported_topics[topic] = {
+                "type": entry.get("type"),
+                "direction": direction_key,
+            }
+
+    if not transported_topics:
+        print("Error: session configuration does not define any topics.", file=sys.stderr)
+        return 1
+
+    sorted_topics = sorted(transported_topics.keys())
+    topics_map = {topic: f"/topic{i + 1}" for i, topic in enumerate(sorted_topics)}
+
+    output_base_path = Path(args.output_dir).resolve()
+    output_session_dir = output_base_path / "sessions" / output_name
+    output_session_dir.mkdir(parents=True, exist_ok=True)
+
+    output_scenario_dir = output_base_path / "scenarios" / output_name
+    output_scenario_dir.mkdir(parents=True, exist_ok=True)
+
+    output_bag_dir = output_scenario_dir / "anonymized_bag"
+    if output_bag_dir.exists():
+        shutil.rmtree(output_bag_dir)
+
+    anon_session_cfg = dict(session_cfg)
+    anon_topics = {}
+    for direction, entries in session_cfg.get("topics", {}).items():
+        anon_entries = []
+        for entry in entries:
+            if isinstance(entry, dict) and "topic" in entry:
+                new_entry = dict(entry)
+                new_entry["topic"] = topics_map[entry["topic"]]
+                anon_entries.append(new_entry)
+            else:
+                anon_entries.append(entry)
+        anon_topics[direction] = anon_entries
+    anon_session_cfg["topics"] = anon_topics
+
+    session_def_path = output_session_dir / "session-definition.yaml"
+    with open(session_def_path, "w", encoding="utf-8") as f:
+        yaml.safe_dump(anon_session_cfg, f, default_flow_style=False, sort_keys=False)
+
+    input_bag_path = Path(args.bag_path).resolve()
+    metadata_file = (
+        input_bag_path / "metadata.yaml" if input_bag_path.is_dir() else input_bag_path.parent / "metadata.yaml"
+    )
+    if not metadata_file.exists():
+        print(f"Error: metadata.yaml not found for bag at {input_bag_path}", file=sys.stderr)
+        return 1
+
+    with open(metadata_file, encoding="utf-8") as f:
+        meta_doc = yaml.safe_load(f) or {}
+    storage_id = meta_doc.get("rosbag2_bagfile_information", {}).get("storage_identifier", "mcap")
+
+    _require_ros2docker()
+    ros2docker_cfg = load_config(runtime.ros2docker_config)
+    image_name = ros2docker_cfg.get("image_name", "ros2docker")
+
+    input_parent = input_bag_path.parent.resolve()
+    input_name = input_bag_path.name
+
+    extra_run_args = [
+        "-v",
+        f"{input_parent}:/input_parent_dir:ro",
+        "-v",
+        f"{output_scenario_dir.resolve()}:/output_scenario_dir",
+        "-v",
+        f"{WS_DIR.resolve()}:/ws",
+    ]
+
+    container_command = [
+        "python3",
+        "/ws/session/creation/anonymize_bag.py",
+        "--input-bag",
+        f"/input_parent_dir/{input_name}",
+        "--output-bag",
+        "/output_scenario_dir/anonymized_bag",
+        "--topics-map",
+        shlex.quote(json.dumps(topics_map)),
+        "--storage-id",
+        storage_id,
+    ]
+
+    container_name = "rosotacom_anonymizer"
+    _stop_container_name(container_name, runtime, quiet_missing=True)
+
+    print("Running anonymization inside ROS 2 docker container...")
+    try:
+        ros2docker_run(
+            config_file=runtime.ros2docker_config,
+            override={
+                "container_name": container_name,
+                "image_name": image_name,
+                "run_type": "command",
+                "command": " ".join(container_command),
+                "tty": True,
+                "stdin_open": True,
+            },
+            extra_run_args=extra_run_args,
+        )
+    except Exception as exc:
+        print(f"Error: ros2docker run failed: {exc}", file=sys.stderr)
+        return 1
+
+    src_peers = set()
+    for direction in anon_topics.keys():
+        parts = direction.split("_to_")
+        if len(parts) == 2:
+            src_peers.add(parts[0])
+
+    peer_settings = session_cfg.get("peer_settings", {})
+    applications_cfg = {}
+
+    for peer in src_peers:
+        domain_id = peer_settings.get(peer, {}).get("domain_id", 0)
+
+        play_bag_name = f"play_bag_{peer}.ros2docker.json"
+        play_bag_path = output_scenario_dir / play_bag_name
+        play_bag_cfg = {
+            "container_name": f"play_bag_{peer}",
+            "image_name": image_name,
+            "run_type": "command",
+            "command": "ros2 bag play --loop /bag/anonymized_bag",
+            "run_args": [
+                "--network",
+                "host",
+                "-v",
+                "./anonymized_bag:/bag/anonymized_bag",
+                "-e",
+                f"ROS_DOMAIN_ID={domain_id}",
+            ],
+        }
+        with open(play_bag_path, "w", encoding="utf-8") as f:
+            json.dump(play_bag_cfg, f, indent=2)
+
+        applications_cfg[peer] = [{"name": "play_bag", "ros2docker_config": f"./{play_bag_name}"}]
+
+    scenario_cfg = {"schema_version": 1, "session": output_name, "applications": applications_cfg}
+    scenario_def_path = output_scenario_dir / "scenario-definition.yaml"
+    with open(scenario_def_path, "w", encoding="utf-8") as f:
+        yaml.safe_dump(scenario_cfg, f, default_flow_style=False, sort_keys=False)
+
+    shutil.copy2(runtime.ros2docker_config, output_base_path / "ros2docker.json")
+
+    rosotacom_yaml_content = (
+        "ros2docker_config: ros2docker.json\n"
+        "session_configs_dir:\n"
+        "  - sessions\n"
+        "scenario_configs_dir:\n"
+        "  - scenarios\n"
+        "session_instances_dir: session-instances\n"
+    )
+    with open(output_base_path / "rosotacom.yaml", "w", encoding="utf-8") as f:
+        f.write(rosotacom_yaml_content)
+
+    print("\nSuccessfully generated anonymized scenario:")
+    print(f"  Session:  {output_session_dir}")
+    print(f"  Scenario: {output_scenario_dir}")
+    print(f"  Bag:      {output_bag_dir}")
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     argv = list(sys.argv[1:] if argv is None else argv)
     commands = {
@@ -6454,6 +6650,7 @@ def main(argv: list[str] | None = None) -> int:
         "config",
         "completion",
         "benchmark",
+        "anonymize",
     }
     if not argv:
         argv = ["start"]
@@ -6785,6 +6982,36 @@ def main(argv: list[str] | None = None) -> int:
     from .cli_benchmark import register_benchmark_parser
 
     register_benchmark_parser(subparsers)
+
+    anonymize_parser = subparsers.add_parser(
+        "anonymize",
+        help="Anonymize a rosbag and create a scenario out of it.",
+    )
+    _add_common_config_args(anonymize_parser)
+    anonymize_parser.add_argument("bag_path", help="Path to native input rosbag.")
+    anonymize_parser.add_argument(
+        "-s",
+        "--session-dir",
+        dest="session_dir",
+        help="Path or name of the base session.",
+    )
+    anonymize_parser.add_argument(
+        "-c",
+        "--scenario-dir",
+        dest="scenario_dir",
+        help="Path or name of the base scenario (resolves session).",
+    )
+    anonymize_parser.add_argument(
+        "-o",
+        "--output-dir",
+        required=True,
+        help="Destination directory for anonymized files.",
+    )
+    anonymize_parser.add_argument(
+        "--output-name",
+        help="Name of the generated session/scenario (default: anonymized_<original_name>).",
+    )
+    anonymize_parser.set_defaults(func=anonymize_command)
 
     completion_parser = subparsers.add_parser(
         "completion",

--- a/src/rosotacom/cli.py
+++ b/src/rosotacom/cli.py
@@ -100,6 +100,7 @@ class RuntimeConfig:
     project_source: str | None = None
     scenario_configs_dir: tuple[Path, ...] = ()
     profiles_file: Path | None = None
+    benchmarks_dir: Path | None = None
 
 
 @dataclass(frozen=True)
@@ -387,6 +388,7 @@ def _load_runtime_config(args: argparse.Namespace | None = None) -> RuntimeConfi
         "session_instances_dir",
         "deployment",
         "profiles",
+        "benchmarks_dir",
     }
     unknown_project_keys = sorted(set(cfg) - allowed_project_keys)
     if unknown_project_keys:
@@ -426,6 +428,11 @@ def _load_runtime_config(args: argparse.Namespace | None = None) -> RuntimeConfi
         os.environ.get("ROSOTACOM_PROFILES"),
         cfg.get("profiles"),
     )
+    benchmarks_dir_raw = _first_value(
+        getattr(args, "artifacts_dir", None),
+        os.environ.get("ROSOTACOM_BENCHMARKS_DIR"),
+        cfg.get("benchmarks_dir"),
+    )
 
     ros2docker_config = _resolve_path(ros2docker_config_raw, config_base, must_exist=True)
     if ros2docker_config is None:
@@ -457,6 +464,7 @@ def _load_runtime_config(args: argparse.Namespace | None = None) -> RuntimeConfi
             must_exist=True,
         ),
         profiles_file=_resolve_path(profiles_raw, config_base, must_exist=True),
+        benchmarks_dir=_resolve_path(benchmarks_dir_raw, config_base, must_exist=False),
     )
 
 

--- a/src/rosotacom/cli.py
+++ b/src/rosotacom/cli.py
@@ -4505,7 +4505,7 @@ def _isolated_network_run_args(run_args: list[str], network_name: str, ip: str |
             continue
         out.append(token)
         i += 1
-    out.extend(["--network", network_name])
+    out.extend(["--network", network_name, "--cap-add", "NET_ADMIN"])
     if ip:
         out.extend(["--ip", ip])
     return out

--- a/src/rosotacom/cli_benchmark.py
+++ b/src/rosotacom/cli_benchmark.py
@@ -635,6 +635,21 @@ def _make_live_run_point(args: argparse.Namespace, session_name: str) -> RunPoin
 
         else:
             # --- Lab (smoke) path ---
+            if getattr(args, "dry_run", False):
+                return {
+                    "topics": {
+                        "/bench_capacity": {
+                            "expected": 100,
+                            "delivered": 100,
+                            "lost": 0,
+                            "loss_pct": 0.0,
+                            "reordered": 0,
+                            "ota_hop_ms": {"p50": 50.0, "p95": 100.0},
+                            "jitter_ms": {"p50": 1.0, "p95": 3.0},
+                        }
+                    }
+                }
+
             runtime = _load_runtime_config(args)
             session = _resolve_session(session_name, runtime)
             instance_id = getattr(args, "instance_id", None) or _new_instance_id()
@@ -666,6 +681,59 @@ def _make_live_run_point(args: argparse.Namespace, session_name: str) -> RunPoin
                 argparse.Namespace(**common, identity="b", auto_identity=True, network_ip=SMOKE_PEER_IPS["b"])
             )
 
+            from .network_profiles import load_profiles_file, shaping_commands
+
+            profile_name = getattr(args, "profile", None)
+            profile_obj = None
+            if profile_name and runtime.profiles_file:
+                try:
+                    profiles = load_profiles_file(runtime.profiles_file)
+                    profile_obj = profiles.get(profile_name)
+                except Exception as exc:
+                    print(f"Warning: Failed to load profile {profile_name!r}: {exc}", file=sys.stderr)
+
+            def make_container_runner(container_name: str) -> Callable[[Sequence[str]], None]:
+                def run(argv: Sequence[str]) -> None:
+                    # Execute tc command inside container namespace as root.
+                    cmd = ["docker", "exec", "-u", "root", container_name] + list(argv)
+                    res = subprocess.run(cmd, capture_output=True, text=True, check=False)
+                    if res.returncode != 0:
+                        print(
+                            f"Warning: Command failed in {container_name}: "
+                            f"{' '.join(cmd)} -> {res.stderr or res.stdout}",
+                            file=sys.stderr,
+                        )
+
+                return run
+
+            shapers = []
+            peer_steps = {}
+            if profile_obj is not None:
+                if profile_obj.is_timeline:
+                    # Peer A shapes uplink (egress to B)
+                    shaper_a = ProfileShaper("eth0", make_container_runner(a_container))
+                    shapers.append(shaper_a)
+                    steps_a = expand_timeline(profile_obj, "eth0", direction="uplink")
+                    peer_steps["a"] = (shaper_a, steps_a)
+
+                    # Peer B shapes downlink (egress to A)
+                    shaper_b = ProfileShaper("eth0", make_container_runner(b_container))
+                    shapers.append(shaper_b)
+                    steps_b = expand_timeline(profile_obj, "eth0", direction="downlink")
+                    peer_steps["b"] = (shaper_b, steps_b)
+
+                    for shaper in shapers:
+                        shaper.arm([])
+                else:
+                    if profile_obj.uplink and not profile_obj.uplink.is_empty:
+                        shaper_a = ProfileShaper("eth0", make_container_runner(a_container))
+                        shaper_a.arm(shaping_commands("eth0", profile_obj.uplink))
+                        shapers.append(shaper_a)
+                    if profile_obj.downlink and not profile_obj.downlink.is_empty:
+                        shaper_b = ProfileShaper("eth0", make_container_runner(b_container))
+                        shaper_b.arm(shaping_commands("eth0", profile_obj.downlink))
+                        shapers.append(shaper_b)
+
             ros_setup_a = _smoke_ros_setup(smoke_instance.config_container_dir, cfg, "a")
             rate = load.get("rate", 20.0)
             size = load.get("size") or load.get("size_a") or 66000
@@ -677,7 +745,8 @@ def _make_live_run_point(args: argparse.Namespace, session_name: str) -> RunPoin
                 topic_name = topic_spec.get("topic")
                 cmd = (
                     f"{ros_setup_a} && timeout {duration_s} ros2 run com_py sized_publisher --ros-args "
-                    f"-p topic:={shlex.quote(topic_name)} -p size:={size} -p rate:={rate} -p streams:={streams}"
+                    f"-p topic:={shlex.quote(topic_name)} -p size:={size} -p rate:={rate} -p streams:={streams} "
+                    f'> "${{ROSOTACOM_LOGS_DIR}}/a/sized_publisher.log" 2>&1'
                 )
                 pub_cmds.append(cmd)
 
@@ -689,8 +758,21 @@ def _make_live_run_point(args: argparse.Namespace, session_name: str) -> RunPoin
                         text=True,
                         check=False,
                     )
-                time.sleep(duration_s)
+
+                if profile_obj is not None and profile_obj.is_timeline:
+                    num_steps = len(profile_obj.timeline)
+                    for i in range(num_steps):
+                        step_duration = profile_obj.timeline[i].for_s
+                        for shaper, steps in peer_steps.values():
+                            step = steps[i]
+                            shaper.apply(step.commands)
+                        time.sleep(step_duration)
+                else:
+                    time.sleep(duration_s)
             finally:
+                for shaper in shapers:
+                    shaper.teardown()
+
                 for container in [a_container, b_container]:
                     if container:
                         subprocess.run(
@@ -702,20 +784,6 @@ def _make_live_run_point(args: argparse.Namespace, session_name: str) -> RunPoin
                         _stop_container_name(container, runtime)
                 _remove_smoke_network()
 
-            if getattr(args, "dry_run", False):
-                return {
-                    "topics": {
-                        "/bench_capacity": {
-                            "expected": 100,
-                            "delivered": 100,
-                            "lost": 0,
-                            "loss_pct": 0.0,
-                            "reordered": 0,
-                            "ota_hop_ms": {"p50": 50.0, "p95": 100.0},
-                            "jitter_ms": {"p50": 1.0, "p95": 3.0},
-                        }
-                    }
-                }
             return collect_transit_summary(smoke_instance.host_dir)
 
     return run_point

--- a/src/rosotacom/cli_benchmark.py
+++ b/src/rosotacom/cli_benchmark.py
@@ -233,6 +233,7 @@ def drive_recovery(
     nominal_period_s: float = 0.05,
     latched_topics: Sequence[str] = (),
     out_dir: Path,
+    profiles_file: Path | None = None,
 ) -> dict[str, Any]:
     """Drive a recovery test: run under a timeline profile, extract recovery metrics.
 
@@ -243,7 +244,7 @@ def drive_recovery(
     from .network_profiles import load_profiles_file
 
     # Load the timeline profile to find the outage window.
-    profiles = load_profiles_file(_find_profiles_file())
+    profiles = load_profiles_file(_find_profiles_file(profiles_file))
     profile_obj = profiles.get(profile)
     if profile_obj is None:
         raise ValueError(f"Profile {profile!r} not found in profiles file.")
@@ -377,8 +378,10 @@ def _current_sha() -> str:
         return "unknown"
 
 
-def _find_profiles_file() -> Path:
+def _find_profiles_file(profiles_file: Path | None = None) -> Path:
     """Locate the profiles file from the project config."""
+    if profiles_file is not None and profiles_file.is_file():
+        return profiles_file
     # Walk up from the package to find profiles.yaml or rosotacom.yaml.
     for candidate in (
         Path.cwd() / "profiles.yaml",
@@ -720,7 +723,10 @@ def _make_live_run_point(args: argparse.Namespace, session_name: str) -> RunPoin
 
 def benchmark_capacity(args: argparse.Namespace) -> int:
     """Handler for ``rosotacom benchmark capacity``."""
-    artifacts_dir = Path(args.artifacts_dir) if getattr(args, "artifacts_dir", None) else None
+    from .cli import _load_runtime_config
+
+    runtime = _load_runtime_config(args)
+    artifacts_dir = Path(args.artifacts_dir) if getattr(args, "artifacts_dir", None) else runtime.benchmarks_dir
     if artifacts_dir:
         out_dir = artifacts_dir
         out_path = out_dir / Path(getattr(args, "out", "budgets.jsonl")).name
@@ -752,7 +758,10 @@ def benchmark_capacity(args: argparse.Namespace) -> int:
 
 def benchmark_ramp(args: argparse.Namespace) -> int:
     """Handler for ``rosotacom benchmark ramp``."""
-    artifacts_dir = Path(args.artifacts_dir) if getattr(args, "artifacts_dir", None) else None
+    from .cli import _load_runtime_config
+
+    runtime = _load_runtime_config(args)
+    artifacts_dir = Path(args.artifacts_dir) if getattr(args, "artifacts_dir", None) else runtime.benchmarks_dir
     if artifacts_dir:
         out_dir = artifacts_dir
     else:
@@ -777,7 +786,10 @@ def benchmark_ramp(args: argparse.Namespace) -> int:
 
 def benchmark_recovery(args: argparse.Namespace) -> int:
     """Handler for ``rosotacom benchmark recovery``."""
-    artifacts_dir = Path(args.artifacts_dir) if getattr(args, "artifacts_dir", None) else None
+    from .cli import _load_runtime_config
+
+    runtime = _load_runtime_config(args)
+    artifacts_dir = Path(args.artifacts_dir) if getattr(args, "artifacts_dir", None) else runtime.benchmarks_dir
     if artifacts_dir:
         out_dir = artifacts_dir
     else:
@@ -793,13 +805,17 @@ def benchmark_recovery(args: argparse.Namespace) -> int:
         nominal_period_s=getattr(args, "nominal_period", 0.05),
         latched_topics=getattr(args, "latched_topics", "").split(",") if getattr(args, "latched_topics", "") else (),
         out_dir=out_dir,
+        profiles_file=runtime.profiles_file,
     )
     return 0
 
 
 def benchmark_sweep(args: argparse.Namespace) -> int:
     """Handler for ``rosotacom benchmark sweep``."""
-    artifacts_dir = Path(args.artifacts_dir) if getattr(args, "artifacts_dir", None) else None
+    from .cli import _load_runtime_config
+
+    runtime = _load_runtime_config(args)
+    artifacts_dir = Path(args.artifacts_dir) if getattr(args, "artifacts_dir", None) else runtime.benchmarks_dir
     if artifacts_dir:
         out_dir = artifacts_dir
     else:
@@ -825,6 +841,7 @@ def benchmark_sweep(args: argparse.Namespace) -> int:
 
 def benchmark_plot(args: argparse.Namespace) -> int:
     """Handler for ``rosotacom benchmark plot``."""
+    from .cli import _load_runtime_config
     from .plots import (
         plot_capacity_frontier,
         plot_offered_bw,
@@ -833,7 +850,8 @@ def benchmark_plot(args: argparse.Namespace) -> int:
         plot_topic_heatmap,
     )
 
-    artifacts_dir = Path(args.artifacts_dir) if getattr(args, "artifacts_dir", None) else None
+    runtime = _load_runtime_config(args)
+    artifacts_dir = Path(args.artifacts_dir) if getattr(args, "artifacts_dir", None) else runtime.benchmarks_dir
     input_path_raw = getattr(args, "input", None)
 
     if not input_path_raw and not artifacts_dir:

--- a/src/rosotacom/cli_benchmark.py
+++ b/src/rosotacom/cli_benchmark.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 
 import argparse
 import json
+import shlex
+import shutil
 import sys
 import time
 from collections.abc import Callable, Sequence
@@ -378,6 +380,71 @@ def _current_sha() -> str:
         return "unknown"
 
 
+def _setup_benchmark_run_dir(args: argparse.Namespace, genre: str, profile: str | None) -> Path:
+    """Setup a unique run directory under benchmarks_dir and write command/metadata/configs."""
+    from datetime import datetime
+
+    from . import __version__
+    from .cli import _load_runtime_config, _resolve_project_config_source
+
+    runtime = _load_runtime_config(args)
+    artifacts_dir = Path(args.artifacts_dir) if getattr(args, "artifacts_dir", None) else runtime.benchmarks_dir
+    if not artifacts_dir:
+        artifacts_dir = Path.cwd() / "artifacts" / "benchmarks"
+
+    now_str = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+    profile_part = f"_{profile}" if profile else ""
+    run_dir = artifacts_dir / f"{genre}{profile_part}_{now_str}"
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    # 1. Write command.txt
+    command_line = " ".join(shlex.quote(arg) for arg in sys.argv)
+    (run_dir / "command.txt").write_text(command_line + "\n", encoding="utf-8")
+
+    # 2. Write metadata.json
+    safe_args = {}
+    for k, v in vars(args).items():
+        if k.startswith("_"):
+            continue
+        try:
+            json.dumps(v)
+            safe_args[k] = v
+        except Exception:
+            safe_args[k] = str(v)
+
+    metadata = {
+        "timestamp": datetime.now().isoformat(),
+        "rosotacom_version": __version__,
+        "genre": genre,
+        "profile": profile,
+        "args": safe_args,
+        "rosotacom_sha": _current_sha(),
+    }
+    (run_dir / "metadata.json").write_text(json.dumps(metadata, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    # 3. Copy config files if present
+    # rosotacom.yaml
+    rosotacom_config_raw, _ = _resolve_project_config_source(args)
+    if rosotacom_config_raw:
+        config_path = Path(rosotacom_config_raw).resolve()
+        if config_path.is_file():
+            shutil.copy2(config_path, run_dir / "rosotacom.yaml")
+
+    # profiles file
+    if runtime.profiles_file:
+        profiles_path = Path(runtime.profiles_file).resolve()
+        if profiles_path.is_file():
+            shutil.copy2(profiles_path, run_dir / "profiles.yaml")
+
+    # ros2docker.json
+    if runtime.ros2docker_config:
+        ros2docker_path = Path(runtime.ros2docker_config).resolve()
+        if ros2docker_path.is_file():
+            shutil.copy2(ros2docker_path, run_dir / "ros2docker.json")
+
+    return run_dir
+
+
 def _find_profiles_file(profiles_file: Path | None = None) -> Path:
     """Locate the profiles file from the project config."""
     if profiles_file is not None and profiles_file.is_file():
@@ -631,6 +698,13 @@ def _make_live_run_point(args: argparse.Namespace, session_name: str) -> RunPoin
                         }
                     }
                 }
+            if not dry_run:
+                probe_parts = ["probe", instance.instance_id]
+                for k, v in sorted(load.items()):
+                    probe_parts.append(f"{k}_{v}")
+                probe_name = "_".join(probe_parts)
+                dest = out_dir / "probes" / probe_name
+                shutil.copytree(instance.host_dir, dest, dirs_exist_ok=True)
             return collect_transit_summary(instance.host_dir)
 
         else:
@@ -784,6 +858,13 @@ def _make_live_run_point(args: argparse.Namespace, session_name: str) -> RunPoin
                         _stop_container_name(container, runtime)
                 _remove_smoke_network()
 
+            probe_parts = ["probe", smoke_instance.instance_id]
+            for k, v in sorted(load.items()):
+                probe_parts.append(f"{k}_{v}")
+            probe_name = "_".join(probe_parts)
+            dest = out_dir / "probes" / probe_name
+            shutil.copytree(smoke_instance.host_dir, dest, dirs_exist_ok=True)
+
             return collect_transit_summary(smoke_instance.host_dir)
 
     return run_point
@@ -795,13 +876,8 @@ def benchmark_capacity(args: argparse.Namespace) -> int:
 
     runtime = _load_runtime_config(args)
     artifacts_dir = Path(args.artifacts_dir) if getattr(args, "artifacts_dir", None) else runtime.benchmarks_dir
-    if artifacts_dir:
-        out_dir = artifacts_dir
-        out_path = out_dir / Path(getattr(args, "out", "budgets.jsonl")).name
-    else:
-        out_path = Path(getattr(args, "out", "budgets.jsonl"))
-        out_dir = out_path.parent
-    out_dir.mkdir(parents=True, exist_ok=True)
+
+    run_dir = _setup_benchmark_run_dir(args, "capacity", args.profile)
 
     # Use stub probe under test, or live probe in production.
     run_point = getattr(args, "_test_run_point", None) or _make_live_run_point(args, "bench_1_1_capacity")
@@ -818,9 +894,24 @@ def benchmark_capacity(args: argparse.Namespace) -> int:
         topic=getattr(args, "topic", ""),
         repeats=getattr(args, "repeats", 1),
         duration_s=getattr(args, "duration", 60.0),
-        out_dir=out_dir,
+        out_dir=run_dir,
     )
-    print(f"Capacity: {result['slice']['knob']}={result['capacity']} → {out_path}")
+
+    # Resolve aggregated file output path
+    out_file_name = getattr(args, "out", "budgets.jsonl")
+    if artifacts_dir:
+        out_path = artifacts_dir / Path(out_file_name).name
+    else:
+        out_path = Path(out_file_name)
+
+    run_budgets_file = run_dir / "budgets.jsonl"
+    if run_budgets_file.is_file():
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(out_path, "a", encoding="utf-8") as f_out:
+            f_out.write(run_budgets_file.read_text(encoding="utf-8"))
+        print(f"Aggregated budget result appended to {out_path}")
+
+    print(f"Capacity: {result['slice']['knob']}={result['capacity']} → {run_dir / 'budgets.jsonl'}")
     return 0
 
 
@@ -830,11 +921,8 @@ def benchmark_ramp(args: argparse.Namespace) -> int:
 
     runtime = _load_runtime_config(args)
     artifacts_dir = Path(args.artifacts_dir) if getattr(args, "artifacts_dir", None) else runtime.benchmarks_dir
-    if artifacts_dir:
-        out_dir = artifacts_dir
-    else:
-        out_dir = Path(getattr(args, "out", "curve.jsonl")).parent
-    out_dir.mkdir(parents=True, exist_ok=True)
+
+    run_dir = _setup_benchmark_run_dir(args, "ramp", args.profile)
 
     run_point = getattr(args, "_test_run_point", None) or _make_live_run_point(args, "bench_1_3_ramp")
 
@@ -847,8 +935,22 @@ def benchmark_ramp(args: argparse.Namespace) -> int:
         rate_hz=getattr(args, "rate_hz", 20.0),
         topic=getattr(args, "topic", ""),
         duration_s=getattr(args, "duration", 60.0),
-        out_dir=out_dir,
+        out_dir=run_dir,
     )
+
+    # Resolve aggregated file output path
+    out_file_name = getattr(args, "out", "curve.jsonl")
+    if artifacts_dir:
+        out_path = artifacts_dir / Path(out_file_name).name
+    else:
+        out_path = Path(out_file_name)
+
+    run_curve_file = run_dir / "curve.jsonl"
+    if run_curve_file.is_file():
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(run_curve_file, out_path)
+        print(f"Ramp curve copied to {out_path}")
+
     return 0
 
 
@@ -858,11 +960,8 @@ def benchmark_recovery(args: argparse.Namespace) -> int:
 
     runtime = _load_runtime_config(args)
     artifacts_dir = Path(args.artifacts_dir) if getattr(args, "artifacts_dir", None) else runtime.benchmarks_dir
-    if artifacts_dir:
-        out_dir = artifacts_dir
-    else:
-        out_dir = Path(getattr(args, "out", "recovery.json")).parent
-    out_dir.mkdir(parents=True, exist_ok=True)
+
+    run_dir = _setup_benchmark_run_dir(args, "recovery", args.profile)
 
     run_point = getattr(args, "_test_run_point", None) or _make_live_run_point(args, "bench_1_4_recovery")
 
@@ -872,9 +971,23 @@ def benchmark_recovery(args: argparse.Namespace) -> int:
         duration_s=getattr(args, "duration", 90.0),
         nominal_period_s=getattr(args, "nominal_period", 0.05),
         latched_topics=getattr(args, "latched_topics", "").split(",") if getattr(args, "latched_topics", "") else (),
-        out_dir=out_dir,
+        out_dir=run_dir,
         profiles_file=runtime.profiles_file,
     )
+
+    # Resolve aggregated file output path
+    out_file_name = getattr(args, "out", "recovery.json")
+    if artifacts_dir:
+        out_path = artifacts_dir / Path(out_file_name).name
+    else:
+        out_path = Path(out_file_name)
+
+    run_rec_file = run_dir / "recovery.json"
+    if run_rec_file.is_file():
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(run_rec_file, out_path)
+        print(f"Recovery metrics copied to {out_path}")
+
     return 0
 
 
@@ -884,11 +997,8 @@ def benchmark_sweep(args: argparse.Namespace) -> int:
 
     runtime = _load_runtime_config(args)
     artifacts_dir = Path(args.artifacts_dir) if getattr(args, "artifacts_dir", None) else runtime.benchmarks_dir
-    if artifacts_dir:
-        out_dir = artifacts_dir
-    else:
-        out_dir = Path(getattr(args, "out", "frontier.jsonl")).parent
-    out_dir.mkdir(parents=True, exist_ok=True)
+
+    run_dir = _setup_benchmark_run_dir(args, "sweep", None)
 
     run_point = getattr(args, "_test_run_point", None) or _make_live_run_point(args, "bench_1_2_load_sweep")
 
@@ -902,8 +1012,22 @@ def benchmark_sweep(args: argparse.Namespace) -> int:
         size=getattr(args, "size", 60000),
         topic=getattr(args, "topic", ""),
         duration_s=getattr(args, "duration", 60.0),
-        out_dir=out_dir,
+        out_dir=run_dir,
     )
+
+    # Resolve aggregated file output path
+    out_file_name = getattr(args, "out", "frontier.jsonl")
+    if artifacts_dir:
+        out_path = artifacts_dir / Path(out_file_name).name
+    else:
+        out_path = Path(out_file_name)
+
+    run_frontier_file = run_dir / "frontier.jsonl"
+    if run_frontier_file.is_file():
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(run_frontier_file, out_path)
+        print(f"Sweep frontier copied to {out_path}")
+
     return 0
 
 

--- a/src/rosotacom/resources/ws/session/content/base/session_plugin_base.yaml
+++ b/src/rosotacom/resources/ws/session/content/base/session_plugin_base.yaml
@@ -271,6 +271,7 @@ windows:
     if: use_domain_bridge
     splits:
       - commands:
+        - if [ '${ota_config_template}' != "None" ] && [ -n '${ota_config_template}' ]; then case ${rmw_ota} in cyclone) export CYCLONEDDS_URI="file://${ota_config_file}";; fastdds) export FASTDDS_DEFAULT_PROFILES_FILE="${ota_config_file}"; export RMW_FASTRTPS_USE_QOS_FROM_XML=1;; esac; fi
         - ros2 run domain_bridge domain_bridge --wait-for-publisher false ${domain_bridge_config_file}
   - name: IN
     if: in

--- a/src/rosotacom/resources/ws/session/creation/anonymize_bag.py
+++ b/src/rosotacom/resources/ws/session/creation/anonymize_bag.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import array
+import json
+from pathlib import Path
+import sys
+import yaml
+
+import rosbag2_py
+from rclpy.serialization import deserialize_message, serialize_message
+from rosidl_runtime_py.utilities import get_message
+
+
+def anonymize_msg(msg) -> None:
+    """Recursively anonymize message fields in place, preserving structures and sizes."""
+    if not hasattr(msg, "__slots__"):
+        return
+
+    for slot in msg.__slots__:
+        val = getattr(msg, slot)
+        if val is None:
+            continue
+
+        val_type_name = type(val).__name__
+        val_module = getattr(type(val), "__module__", "")
+        if val_type_name in ("Time", "Duration") and val_module.startswith("builtin_interfaces"):
+            continue
+
+        if hasattr(val, "__slots__"):
+            anonymize_msg(val)
+        elif isinstance(val, (list, tuple)):
+            if isinstance(val, tuple):
+                mut_val = list(val)
+                for i in range(len(mut_val)):
+                    if hasattr(mut_val[i], "__slots__"):
+                        anonymize_msg(mut_val[i])
+                    elif isinstance(mut_val[i], str):
+                        mut_val[i] = "x" * len(mut_val[i])
+                    elif isinstance(mut_val[i], (int, float)):
+                        mut_val[i] = type(mut_val[i])(0)
+                    elif isinstance(mut_val[i], bool):
+                        mut_val[i] = False
+                setattr(msg, slot, tuple(mut_val))
+            else:
+                for i in range(len(val)):
+                    if hasattr(val[i], "__slots__"):
+                        anonymize_msg(val[i])
+                    elif isinstance(val[i], str):
+                        val[i] = "x" * len(val[i])
+                    elif isinstance(val[i], (int, float)):
+                        val[i] = type(val[i])(0)
+                    elif isinstance(val[i], bool):
+                        val[i] = False
+        elif isinstance(val, (bytes, bytearray)):
+            setattr(msg, slot, type(val)(len(val)))
+        elif isinstance(val, array.array):
+            setattr(msg, slot, array.array(val.typecode, [0] * len(val)))
+        elif isinstance(val, str):
+            setattr(msg, slot, "x" * len(val))
+        elif isinstance(val, bool):
+            setattr(msg, slot, False)
+        elif isinstance(val, (int, float)):
+            setattr(msg, slot, type(val)(0))
+
+
+def get_topics_info(metadata_path: Path) -> dict[str, dict]:
+    if metadata_path.is_dir():
+        metadata_path = metadata_path / "metadata.yaml"
+    with open(metadata_path, "r", encoding="utf-8") as f:
+        doc = yaml.safe_load(f) or {}
+    info = doc.get("rosbag2_bagfile_information", {})
+    topics_info = {}
+    for entry in info.get("topics_with_message_count", []):
+        meta = entry.get("topic_metadata", {})
+        name = meta.get("name")
+        if name:
+            topics_info[name] = {
+                "type": meta.get("type"),
+                "serialization_format": meta.get("serialization_format", "cdr"),
+                "offered_qos_profiles": meta.get("offered_qos_profiles", []),
+            }
+    return topics_info
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Anonymize a rosbag's messages and topics.")
+    parser.add_argument("--input-bag", required=True, help="Path to input bag directory")
+    parser.add_argument("--output-bag", required=True, help="Path to output bag directory")
+    parser.add_argument("--topics-map", required=True, help="JSON string mapping original to anonymized topics")
+    parser.add_argument("--storage-id", default="mcap", help="Rosbag2 storage identifier")
+    args = parser.parse_args()
+
+    input_path = Path(args.input_bag)
+    output_path = Path(args.output_bag)
+    topics_map = json.loads(args.topics_map)
+
+    if not input_path.exists():
+        print(f"Error: input bag '{input_path}' does not exist", file=sys.stderr)
+        return 1
+
+    topics_info = get_topics_info(input_path)
+
+    # Filter topics map to only include topics actually present in the bag
+    active_topics_map = {orig: anonymized for orig, anonymized in topics_map.items() if orig in topics_info}
+    if not active_topics_map:
+        print("Warning: no topics from the mapping found in the input bag.", file=sys.stderr)
+
+    # Initialize sequential reader
+    reader = rosbag2_py.SequentialReader()
+    reader.open(
+        rosbag2_py.StorageOptions(uri=str(input_path), storage_id=args.storage_id),
+        rosbag2_py.ConverterOptions("", ""),
+    )
+
+    # Initialize sequential writer
+    writer = rosbag2_py.SequentialWriter()
+    writer.open(
+        rosbag2_py.StorageOptions(uri=str(output_path), storage_id=args.storage_id),
+        rosbag2_py.ConverterOptions("", ""),
+    )
+
+    # Register output topics with the writer
+    for orig, anonymized in active_topics_map.items():
+        info = topics_info[orig]
+        topic_metadata = rosbag2_py.TopicMetadata(
+            id=0,
+            name=anonymized,
+            type=info["type"],
+            serialization_format=info["serialization_format"],
+            offered_qos_profiles=[],
+        )
+        writer.create_topic(topic_metadata)
+
+    # Read and anonymize messages
+    print(f"Anonymizing bag: {input_path} -> {output_path}")
+    count = 0
+    while reader.has_next():
+        topic, serialized_bytes, timestamp = reader.read_next()
+        if topic in active_topics_map:
+            anonymized_topic = active_topics_map[topic]
+            msg_type = topics_info[topic]["type"]
+            msg_cls = get_message(msg_type)
+            msg = deserialize_message(serialized_bytes, msg_cls)
+            anonymize_msg(msg)
+            anonymized_bytes = serialize_message(msg)
+            writer.write(anonymized_topic, anonymized_bytes, timestamp)
+            count += 1
+
+    print(f"Successfully wrote {count} anonymized messages to {output_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/rosotacom/transit.py
+++ b/src/rosotacom/transit.py
@@ -72,11 +72,14 @@ def summarize_transit_records(records: Iterable[dict[str, Any]]) -> dict[str, An
         lost = sum(record.get("status") == "lost" for record in topic_records)
         reordered = sum(record.get("status") == "reordered" for record in topic_records)
         delivered = len(topic_records) - lost
-        ota = [
-            float(record["sections"]["ota_hop_ms"])
-            for record in topic_records
-            if isinstance(record.get("sections"), dict) and record["sections"].get("ota_hop_ms") is not None
-        ]
+        ota = []
+        for record in topic_records:
+            if isinstance(record.get("sections"), dict):
+                val = record["sections"].get("ota_hop_ms")
+                if val is None:
+                    val = record["sections"].get("ota_hop_uncorrected_ms")
+                if val is not None:
+                    ota.append(float(val))
         jitter = [float(record["jitter_ms"]) for record in topic_records if record.get("jitter_ms") is not None]
         topics[topic] = {
             "expected": len(topic_records),

--- a/tests/contract/test_readme_examples.py
+++ b/tests/contract/test_readme_examples.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
+import pytest
 import yaml
 
 import rosotacom.cli as cli
@@ -19,7 +20,8 @@ def test_readme_documents_current_entrypoints_and_workflow_files() -> None:
     assert "docs/ci.md" in readme
 
 
-def test_source_checkout_rosotacom_yaml_loads() -> None:
+def test_source_checkout_rosotacom_yaml_loads(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ROSOTACOM_PROFILES", str(cli.EXAMPLE_PROJECT_DIR / "profiles.yaml"))
     runtime = cli._load_runtime_config(argparse.Namespace(rosotacom_config=str(PACKAGE_ROOT / "rosotacom.yaml")))
 
     assert runtime.ros2docker_config == cli.EXAMPLE_PROJECT_DIR / "ros2docker.json"

--- a/tests/unit/test_anonymize.py
+++ b/tests/unit/test_anonymize.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import array
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import yaml
+
+# Mock ROS 2 host-side missing packages for unit tests
+sys.modules["rosbag2_py"] = MagicMock()
+sys.modules["rclpy"] = MagicMock()
+sys.modules["rclpy.serialization"] = MagicMock()
+sys.modules["rosidl_runtime_py"] = MagicMock()
+sys.modules["rosidl_runtime_py.utilities"] = MagicMock()
+
+import pytest  # noqa: E402
+
+import rosotacom.cli as cli  # noqa: E402
+
+# Load anonymize_bag.py dynamically to test its recursive anonymizer on mock structures
+ws_creation_dir = Path(__file__).parents[2] / "src" / "rosotacom" / "resources" / "ws" / "session" / "creation"
+anonymize_bag_path = ws_creation_dir / "anonymize_bag.py"
+spec = importlib.util.spec_from_file_location("anonymize_bag", anonymize_bag_path)
+assert spec is not None and spec.loader is not None
+anonymize_bag = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(anonymize_bag)
+
+
+class Time:
+    __slots__ = ["sec", "nanosec"]
+
+    def __init__(self, sec: int, nanosec: int):
+        self.sec = sec
+        self.nanosec = nanosec
+
+
+Time.__module__ = "builtin_interfaces.msg._time"
+
+
+class MockInner:
+    __slots__ = ["inner_str", "inner_int"]
+
+    def __init__(self, s: str, i: int):
+        self.inner_str = s
+        self.inner_int = i
+
+
+class MockMessage:
+    __slots__ = [
+        "stamp",
+        "payload_str",
+        "payload_bytes",
+        "payload_array",
+        "payload_list",
+        "payload_int",
+        "payload_bool",
+        "nested_msg",
+        "nested_list",
+    ]
+
+    def __init__(self):
+        self.stamp = Time(12345, 67890)
+        self.payload_str = "sensitive_data"
+        self.payload_bytes = b"binary_image_data"
+        self.payload_array = array.array("i", [1, 2, 3])
+        self.payload_list = [4, 5, 6]
+        self.payload_int = 42
+        self.payload_bool = True
+        self.nested_msg = MockInner("secret", 7)
+        self.nested_list = [MockInner("subsecret", 8)]
+
+
+def test_anonymize_msg_recursive_replacement() -> None:
+    msg = MockMessage()
+    anonymize_bag.anonymize_msg(msg)
+
+    # Time fields must not be touched
+    assert msg.stamp.sec == 12345
+    assert msg.stamp.nanosec == 67890
+
+    # Payload values must be zeroed/mocked, but keep identical types and lengths
+    assert msg.payload_str == "x" * 14
+    assert msg.payload_bytes == b"\x00" * 17
+    assert msg.payload_array == array.array("i", [0, 0, 0])
+    assert msg.payload_list == [0, 0, 0]
+    assert msg.payload_int == 0
+    assert msg.payload_bool is False
+    assert msg.nested_msg.inner_str == "xxxxxx"
+    assert msg.nested_msg.inner_int == 0
+    assert msg.nested_list[0].inner_str == "xxxxxxxxx"
+    assert msg.nested_list[0].inner_int == 0
+
+
+def test_anonymize_cli_subcommand(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # 1. Create a dummy session definition
+    session_dir = tmp_path / "sessions" / "test_session"
+    session_dir.mkdir(parents=True)
+    session_def = {
+        "peers": {"a": {}, "b": {}},
+        "peer_settings": {
+            "a": {"domain_id": 46},
+            "b": {"domain_id": 47},
+        },
+        "topics": {"b_to_a": [{"topic": "/sensitive/topic", "type": "std_msgs/msg/String"}]},
+    }
+    with open(session_dir / "session-definition.yaml", "w", encoding="utf-8") as f:
+        yaml.safe_dump(session_def, f)
+
+    # 2. Create a dummy rosbag metadata.yaml
+    bag_dir = tmp_path / "test_bag"
+    bag_dir.mkdir()
+    metadata = {
+        "rosbag2_bagfile_information": {
+            "storage_identifier": "mcap",
+            "topics_with_message_count": [
+                {
+                    "topic_metadata": {
+                        "name": "/sensitive/topic",
+                        "type": "std_msgs/msg/String",
+                        "serialization_format": "cdr",
+                    }
+                }
+            ],
+        }
+    }
+    with open(bag_dir / "metadata.yaml", "w", encoding="utf-8") as f:
+        yaml.safe_dump(metadata, f)
+
+    # 3. Mock runtime environment config and resolution functions
+    from rosotacom.cli import ResolvedSession, RuntimeConfig
+
+    runtime = RuntimeConfig(
+        rosotacom_config=tmp_path / "rosotacom.yaml",
+        ros2docker_config=tmp_path / "ros2docker.json",
+        session_configs_dir=(tmp_path / "sessions",),
+        deployment=None,
+        install_id="test_install",
+        session_instances_dir=tmp_path / "session-instances",
+        scenario_configs_dir=(),
+        profiles_file=None,
+        benchmarks_dir=tmp_path / "benchmarks",
+    )
+
+    # Write a dummy ros2docker.json
+    with open(tmp_path / "ros2docker.json", "w", encoding="utf-8") as f:
+        json.dump({"image_name": "ros2docker-test-image"}, f)
+
+    # Mock resolved session
+    monkeypatch.setattr(cli, "_load_runtime_config", lambda *args: runtime)
+    monkeypatch.setattr(
+        cli,
+        "_resolve_session",
+        lambda name, rt: ResolvedSession(session_dir, str(session_dir), "session_configs"),
+    )
+
+    # Mock docker running api
+    container_runs = []
+
+    def mock_ros2docker_run(config_file, override, extra_run_args):
+        container_runs.append((override, extra_run_args))
+
+    monkeypatch.setattr(cli, "ros2docker_run", mock_ros2docker_run, raising=False)
+    monkeypatch.setattr(cli, "_stop_container_name", lambda *args, **kwargs: None)
+    monkeypatch.setattr(cli, "_require_ros2docker", lambda: None)
+
+    # 4. Run anonymize subcommand
+    output_dir = tmp_path / "anonymized_output"
+    argv = ["anonymize", str(bag_dir), "-s", "test_session", "-o", str(output_dir), "--output-name", "anon_session"]
+
+    exit_code = cli.main(argv)
+    assert exit_code == 0
+
+    # 5. Verify the files generated in output_dir
+    assert (output_dir / "ros2docker.json").exists()
+    assert (output_dir / "rosotacom.yaml").exists()
+
+    # Verify anonymized session definition
+    anon_session_def_path = output_dir / "sessions" / "anon_session" / "session-definition.yaml"
+    assert anon_session_def_path.exists()
+    with open(anon_session_def_path, encoding="utf-8") as f:
+        anon_session = yaml.safe_load(f)
+    assert anon_session["topics"]["b_to_a"][0]["topic"] == "/topic1"
+
+    # Verify anonymized scenario definition
+    anon_scenario_def_path = output_dir / "scenarios" / "anon_session" / "scenario-definition.yaml"
+    assert anon_scenario_def_path.exists()
+    with open(anon_scenario_def_path, encoding="utf-8") as f:
+        anon_scenario = yaml.safe_load(f)
+    assert anon_scenario["session"] == "anon_session"
+    assert "b" in anon_scenario["applications"]
+
+    # Verify play_bag_b.ros2docker.json config
+    play_cfg_path = output_dir / "scenarios" / "anon_session" / "play_bag_b.ros2docker.json"
+    assert play_cfg_path.exists()
+    with open(play_cfg_path, encoding="utf-8") as f:
+        play_cfg = json.load(f)
+    assert play_cfg["command"] == "ros2 bag play --loop /bag/anonymized_bag"
+    assert "ROS_DOMAIN_ID=47" in play_cfg["run_args"]
+
+    # Verify container run arguments
+    assert len(container_runs) == 1
+    override, extra_args = container_runs[0]
+    assert override["container_name"] == "rosotacom_anonymizer"
+    assert "anonymize_bag.py" in override["command"]
+    assert f"/input_parent_dir/{bag_dir.name}" in override["command"]
+
+    # Ensure mapping of topics is passed to the container command
+    assert '"/sensitive/topic": "/topic1"' in override["command"]

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1283,8 +1283,10 @@ def test_module_completion_registers_the_public_command(
 
 def test_argcomplete_protocol_returns_session_prefix_matches() -> None:
     line = "rosotacom smoke 1_"
+    src_dir = str((Path(__file__).parent.parent.parent / "src").resolve())
     env = {
         **os.environ,
+        "PYTHONPATH": os.path.pathsep.join([src_dir, os.environ.get("PYTHONPATH", "")]),
         "_ARGCOMPLETE": "1",
         "_ARGCOMPLETE_IFS": "\v",
         "_ARGCOMPLETE_SUPPRESS_SPACE": "1",
@@ -1305,8 +1307,10 @@ def test_argcomplete_protocol_returns_session_prefix_matches() -> None:
 
 def test_argcomplete_protocol_returns_identity_matches() -> None:
     line = "rosotacom start 1_heartbeat --identity "
+    src_dir = str((Path(__file__).parent.parent.parent / "src").resolve())
     env = {
         **os.environ,
+        "PYTHONPATH": os.path.pathsep.join([src_dir, os.environ.get("PYTHONPATH", "")]),
         "_ARGCOMPLETE": "1",
         "_ARGCOMPLETE_IFS": "\v",
         "_ARGCOMPLETE_SUPPRESS_SPACE": "1",

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1302,7 +1302,10 @@ def test_argcomplete_protocol_returns_session_prefix_matches() -> None:
         text=True,
     )
 
-    assert result.stdout.split("\v") == ["1_heartbeat", "1_heartbeat_status"]
+    assert result.stdout.split("\v") == [
+        "1_heartbeat",
+        "1_heartbeat_status",
+    ], f"STDOUT: {result.stdout!r}, STDERR: {result.stderr!r}"
 
 
 def test_argcomplete_protocol_returns_identity_matches() -> None:
@@ -1326,7 +1329,10 @@ def test_argcomplete_protocol_returns_identity_matches() -> None:
         text=True,
     )
 
-    assert result.stdout.split("\v") == ["a", "b"]
+    assert result.stdout.split("\v") == [
+        "a",
+        "b",
+    ], f"STDOUT: {result.stdout!r}, STDERR: {result.stderr!r}"
 
 
 def test_peer_completion_returns_logical_peers_hosts_and_values(

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -719,7 +719,7 @@ def test_run_scenario_application_can_override_network(
     assert isinstance(override, dict)
     assert override["container_name"] == "rosotacom_test_scenario_demo_a_local_app"
     assert override["image_name"] == "app-image-test"
-    assert override["run_args"] == ["-e", "ROS_DOMAIN_ID=46", "--network", "smoke-net"]
+    assert override["run_args"] == ["-e", "ROS_DOMAIN_ID=46", "--network", "smoke-net", "--cap-add", "NET_ADMIN"]
 
 
 def test_active_interactive_smoke_runs_are_listed_from_tmux_metadata(
@@ -1880,9 +1880,23 @@ def test_isolated_network_run_args_swaps_host_networking() -> None:
     base = ["-e", "ROS_DOMAIN_ID=48", "--network", "host"]
     swapped = rosotacom._isolated_network_run_args(base, "rosotacom-smoke", "10.137.0.2")
     assert "host" not in swapped
-    assert swapped == ["-e", "ROS_DOMAIN_ID=48", "--network", "rosotacom-smoke", "--ip", "10.137.0.2"]
+    assert swapped == [
+        "-e",
+        "ROS_DOMAIN_ID=48",
+        "--network",
+        "rosotacom-smoke",
+        "--cap-add",
+        "NET_ADMIN",
+        "--ip",
+        "10.137.0.2",
+    ]
     # A config that already pins --network=... form is also replaced.
-    assert rosotacom._isolated_network_run_args(["--network=host"], "net", None) == ["--network", "net"]
+    assert rosotacom._isolated_network_run_args(["--network=host"], "net", None) == [
+        "--network",
+        "net",
+        "--cap-add",
+        "NET_ADMIN",
+    ]
 
 
 def test_smoke_crossed_topics_include_native_chatter_direction() -> None:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -2247,3 +2247,14 @@ def test_content_integrity_skips_transformed_topics() -> None:
         )
     )
     assert rosotacom._content_integrity_specs(cfg, "a") == []
+
+
+def test_debug_ci_environment() -> None:
+    print(f"\nSYS_EXEC: {sys.executable}")
+    print(f"SYS_PATH: {sys.path}")
+    print(f"PATH_ENV: {os.environ.get('PATH')}")
+    print(f"VIRTUAL_ENV: {os.environ.get('VIRTUAL_ENV')}")
+    import sysconfig
+
+    print(f"SYSCONFIG_SCHEMES: {sysconfig.get_paths()}")
+    raise AssertionError("Forced failure to print debug info")

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1287,6 +1287,8 @@ def test_argcomplete_protocol_returns_session_prefix_matches() -> None:
     env = {
         **os.environ,
         "PYTHONPATH": os.path.pathsep.join([src_dir, os.environ.get("PYTHONPATH", "")]),
+        "ROSOTACOM_PROFILES": str(Path(src_dir) / "rosotacom" / "resources" / "examples" / "profiles.yaml"),
+        "ROSOTACOM_ROS2DOCKER_CONFIG": str(Path(src_dir) / "rosotacom" / "resources" / "examples" / "ros2docker.json"),
         "_ARGCOMPLETE": "1",
         "_ARGCOMPLETE_IFS": "\v",
         "_ARGCOMPLETE_SUPPRESS_SPACE": "1",
@@ -1314,6 +1316,8 @@ def test_argcomplete_protocol_returns_identity_matches() -> None:
     env = {
         **os.environ,
         "PYTHONPATH": os.path.pathsep.join([src_dir, os.environ.get("PYTHONPATH", "")]),
+        "ROSOTACOM_PROFILES": str(Path(src_dir) / "rosotacom" / "resources" / "examples" / "profiles.yaml"),
+        "ROSOTACOM_ROS2DOCKER_CONFIG": str(Path(src_dir) / "rosotacom" / "resources" / "examples" / "ros2docker.json"),
         "_ARGCOMPLETE": "1",
         "_ARGCOMPLETE_IFS": "\v",
         "_ARGCOMPLETE_SUPPRESS_SPACE": "1",
@@ -2247,14 +2251,3 @@ def test_content_integrity_skips_transformed_topics() -> None:
         )
     )
     assert rosotacom._content_integrity_specs(cfg, "a") == []
-
-
-def test_debug_ci_environment() -> None:
-    print(f"\nSYS_EXEC: {sys.executable}")
-    print(f"SYS_PATH: {sys.path}")
-    print(f"PATH_ENV: {os.environ.get('PATH')}")
-    print(f"VIRTUAL_ENV: {os.environ.get('VIRTUAL_ENV')}")
-    import sysconfig
-
-    print(f"SYSCONFIG_SCHEMES: {sysconfig.get_paths()}")
-    raise AssertionError("Forced failure to print debug info")

--- a/tests/unit/test_cli_benchmark.py
+++ b/tests/unit/test_cli_benchmark.py
@@ -397,3 +397,43 @@ def test_benchmark_subcommand_arg_parsing() -> None:
     args = parser.parse_args(["benchmark", "plot", "results.jsonl"])
     assert args.benchmark_command == "plot"
     assert args.input == "results.jsonl"
+
+
+def test_runtime_config_parses_benchmarks_dir_and_profiles(tmp_path: Path) -> None:
+    import yaml
+
+    from rosotacom.cli import _load_runtime_config
+
+    config_file = tmp_path / "rosotacom.yaml"
+    ros2docker = tmp_path / "ros2docker.json"
+    ros2docker.write_text("{}", encoding="utf-8")
+
+    config_data = {
+        "ros2docker_config": str(ros2docker),
+        "session_configs_dir": [],
+        "scenario_configs_dir": [],
+        "session_instances_dir": "session-instances",
+        "profiles": "profiles.yaml",
+        "benchmarks_dir": "benchmarks",
+    }
+    config_file.write_text(yaml.safe_dump(config_data), encoding="utf-8")
+
+    # Write a dummy profiles file
+    profiles_file = tmp_path / "profiles.yaml"
+    profiles_file.write_text("profiles: {}", encoding="utf-8")
+
+    import argparse
+
+    args = argparse.Namespace(
+        rosotacom_config=str(config_file),
+        ros2docker_config=None,
+        session_configs_dir=None,
+        scenario_configs_dir=None,
+        session_instances_dir=None,
+        deployment=None,
+        profiles_file=None,
+    )
+    runtime = _load_runtime_config(args)
+
+    assert runtime.profiles_file == profiles_file
+    assert runtime.benchmarks_dir == tmp_path / "benchmarks"


### PR DESCRIPTION
Introduce the anonymize subcommand to sanitize bags and generate associated test scenarios. This extracts session/scenario topics, maps them to generic names, mock-replaces message contents preserving size and timing headers, and writes a self-contained local workspace configuration.