### PR TITLE
fix: ignore outbound quality for receiver-side contracts

### DIFF
--- a/src/rosotacom/status_eval.py
+++ b/src/rosotacom/status_eval.py
@@ -370,10 +370,11 @@ def evaluate_report(
             # only need to have reached OK, which they have.
             if mode == "stream":
                 if stage and stage.get("quality") == "BAD":
-                    reason = stage.get("quality_reason")
-                    detail = f": {reason}" if reason else ""
-                    failures.append(f"[{peer}] {base}: contract violated (quality BAD{detail})")
-                    continue
+                    if topic.get("direction") == "inbound":
+                        reason = stage.get("quality_reason")
+                        detail = f": {reason}" if reason else ""
+                        failures.append(f"[{peer}] {base}: contract violated (quality BAD{detail})")
+                        continue
                 if expect and topic.get("direction") == "inbound" and stage is not None:
                     failures += _check_expect(peer, base, topic, stage, expect)
                     failures += _check_completeness(peer, base, topic, expect)

--- a/tests/unit/test_status_eval.py
+++ b/tests/unit/test_status_eval.py
@@ -65,6 +65,23 @@ def test_expect_only_checked_on_inbound_side() -> None:
     assert evaluate_report(OK_REPORT, {"/heartbeat_b": {"hz": {"min": 50}}}) == []
 
 
+def test_bad_outbound_quality_does_not_fail_receiver_side_contract() -> None:
+    # 11_trickle is the concrete regression: the sender publishes the base topic
+    # at 1 Hz, while the receiver-side trickle output is contracted at 2..8 Hz.
+    # The sender report may therefore classify the outbound base topic as BAD,
+    # but the contract is asserted on the receiver's inbound final stage.
+    bad_outbound_stage = {
+        "stage": "ota_sent",
+        "hz": 1.0,
+        "latency_ms": None,
+        "state": "FLOWING",
+        "quality": "BAD",
+        "quality_reason": "hz",
+    }
+    report = {"peer": "b", "topics": [_topic("/trickle_demo", "outbound", "OK", [bad_outbound_stage])]}
+    assert evaluate_report(report, {"/trickle_demo": {"hz": {"min": 2, "max": 8}}}) == []
+
+
 def test_expectations_from_cfg_collects_only_expect_blocks() -> None:
     cfg = {"topics": {"b_to_a": [{"topic": "/c", "expect": {"hz": {"min": 1}}}, {"topic": "/d"}, "/e"]}}
     assert expectations_from_cfg(cfg) == {"/c": {"hz": {"min": 1}}}


### PR DESCRIPTION
## Summary
- keep stream contract quality failures scoped to inbound delivered topics
- add a regression test for the `11_trickle` sender-side 1 Hz report with a receiver-side 2..8 Hz trickle contract

## Why
The multi-machine OTA job failed because `rosotacom test` treated peer `b`'s outbound `/trickle_demo` status as a contract failure. That peer is the source and correctly publishes at 1 Hz; the configured 2..8 Hz contract applies to peer `a`'s receive-side `/trickle_demo/trickle` output.

## Validation
- `python3 -m pytest tests/unit/test_status_eval.py -q`
- `PYTHONPATH=src python3 - <<'PY' ...` replayed the failed job artifact's two `11_trickle` status reports through `status_eval.evaluate_reports(...)` and returned `[]`
- `python3 -m pytest tests/unit/test_cli.py::test_trickle_example_asserts_the_trickle_output_stage tests/unit/test_status_eval.py -q`
- `python3 -m ruff check src/rosotacom/status_eval.py tests/unit/test_status_eval.py`
