### PR TITLE
chore: ignore benchmark run outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ __pycache__
 .pytest_cache/
 .ruff_cache/
 .venv/
+/artifacts/
+/budgets.jsonl
 /build/
 /dist/
 coverage.xml

--- a/justfile
+++ b/justfile
@@ -38,7 +38,7 @@ test-nondocker-cov:
 	{{python}} -m pytest -q tests/unit tests/contract --cov=rosotacom --cov-report=term-missing --cov-report=xml:coverage.xml
 
 test-e2e-smoke:
-	ROSOTACOM_RUN_E2E=1 {{python}} -m pytest -q tests/e2e/test_smoke.py -m e2e
+	ROSOTACOM_RUN_E2E=1 {{python}} -m pytest -q tests/e2e/ -m e2e
 
 test-e2e-fast: test-e2e-smoke
 


### PR DESCRIPTION
## Summary
- ignore generated benchmark artifact directories under `artifacts/`
- ignore root-level benchmark budget output written as `budgets.jsonl`

## Validation
- `git check-ignore -v artifacts budgets.jsonl artifacts/benchmarks/capacity_cellular-4g-degraded_2026-06-25_09-42-01/stdout.txt`
- `git ls-files --others --exclude-standard` no longer reports the generated benchmark files
