### PR TITLE
Add benchmark OTA target controls and operator view

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,6 +466,10 @@ fastdds`, `--rmw cyclone`, or another supported session RMW value to pin a run.
 Each run writes a self-contained `result.json` under its benchmark artifact
 directory with the selected RMW, configured load and offered bandwidth, profile
 shaping context, thresholds, verdict, and per-topic loss/latency/jitter metrics.
+For OTA benchmark runs (`--deployment ...`), the default target is the benchmark
+session for the selected genre; pass `--target` and `--target-type` to benchmark a
+project-specific session or scenario instead. Add `--interactive` to open a tmux
+operator view with separate run, network-shaping, and result windows.
 
 ## Development
 

--- a/docs/rfcs/0005-benchmark-genres-and-ci.md
+++ b/docs/rfcs/0005-benchmark-genres-and-ci.md
@@ -172,6 +172,13 @@ slice and reuses RFC 0003 + 0004.
   mode, configured load, offered bandwidth, profile shaping context, thresholds,
   verdict, and per-topic loss/latency/jitter metrics; keep `budgets.jsonl` as the
   budget/baseline feed (`cli_benchmark._write_benchmark_result`).
+- [x] Make OTA benchmark runs default to the selected genre's benchmark session
+  instead of a hard-coded project target, while allowing `--target` /
+  `--target-type` for project-specific sessions or scenarios
+  (`cli_benchmark._benchmark_ota_target`).
+- [x] Add an interactive benchmark operator view that opens a local tmux session
+  with separate run, network-shaping, and result windows for local runs and an OTA
+  shaping monitor note for remote runs (`cli_benchmark --interactive`).
 - [x] Build the recovery driver on timeline profiles (RFC 0004) + the recovery
   metric set (`t_recover`, `t_steady`, backlog/burst, lost-during-outage, latched
   re-arrival) (`benchmark.recovery_metrics`; arming the timeline profile is RFC
@@ -216,6 +223,14 @@ reviewed rather than asserted in a blocking test.
   *(`test_capacity_driver_finds_breakpoint_with_stubbed_probe`,
   `test_ramp_driver_builds_curve_with_stubbed_probe`,
   `test_sweep_driver_runs_grid_with_stubbed_probe`.)*
+- [x] **OTA target selection** (default to benchmark genre session, explicit
+  target override for sessions/scenarios) — host unit test for default and
+  override resolution. Automatable. *(`test_benchmark_ota_target_defaults_to_benchmark_session`.)*
+- [x] **Interactive operator view** (tmux run/network/results windows) — host unit
+  test for the dry-run command plan and parser flags; live tmux attachment remains
+  an operator workflow. Automatable for command planning, manual for actual
+  attachment. *(`test_interactive_benchmark_dry_run_prints_operator_view`,
+  `test_benchmark_subcommand_arg_parsing`.)*
 - [x] **Recovery driver + metric set** (`t_recover`, `t_steady`, backlog/burst,
   lost-during-outage, latched re-arrival) — host unit test extracting the metrics
   from a synthetic timeline of transit records (RFC 0003); the **live recovery run

--- a/src/rosotacom/cli_benchmark.py
+++ b/src/rosotacom/cli_benchmark.py
@@ -19,6 +19,7 @@ import contextlib
 import json
 import shlex
 import shutil
+import subprocess
 import sys
 import time
 from collections.abc import Callable, Iterator, Sequence
@@ -352,6 +353,195 @@ def _load_context(load: dict[str, Any]) -> dict[str, Any]:
             }
         ),
     )
+
+
+def _benchmark_ota_target(args: argparse.Namespace, session_name: str) -> tuple[str, str]:
+    target = getattr(args, "target", None)
+    target_type = getattr(args, "target_type", None)
+    if target:
+        return str(target), str(target_type or "auto")
+    if target_type not in (None, "session"):
+        raise ValueError("--target-type requires --target unless --target-type=session.")
+    return session_name, "session"
+
+
+def _benchmark_artifacts_root(args: argparse.Namespace) -> Path:
+    from .cli import _load_runtime_config
+
+    runtime = _load_runtime_config(args)
+    artifacts_dir = Path(args.artifacts_dir) if getattr(args, "artifacts_dir", None) else runtime.benchmarks_dir
+    return artifacts_dir or Path.cwd() / "artifacts" / "benchmarks"
+
+
+def _benchmark_tmux_session_name(args: argparse.Namespace, genre: str) -> str:
+    from .cli import _safe_path_token
+
+    profile = getattr(args, "profile", None) or getattr(args, "profile_grid", None) or "run"
+    return _safe_path_token(f"benchmark-{genre}-{profile}")
+
+
+def _strip_interactive_args(argv: Sequence[str]) -> list[str]:
+    return [arg for arg in argv if arg not in {"--interactive", "--no-attach"}]
+
+
+def _benchmark_child_command() -> list[str]:
+    return [sys.executable, "-m", "rosotacom", *_strip_interactive_args(sys.argv[1:])]
+
+
+def _latest_result_watch_script(artifacts_root: Path) -> str:
+    root = shlex.quote(str(artifacts_root))
+    return (
+        "while true; do "
+        "clear; date; "
+        f"root={root}; "
+        "latest=$(find \"$root\" -mindepth 1 -maxdepth 1 -type d -printf '%T@ %p\\n' 2>/dev/null "
+        "| sort -nr | head -1 | cut -d' ' -f2-); "
+        'if [ -z "$latest" ]; then '
+        "echo '[INFO] waiting for benchmark artifacts under' \"$root\"; "
+        'elif [ -f "$latest/result.json" ]; then '
+        "echo '[INFO] latest result:' \"$latest/result.json\"; "
+        'python3 -m json.tool "$latest/result.json" | tail -120; '
+        'elif [ -f "$latest/stdout.txt" ]; then '
+        'echo \'[INFO] latest stdout:\' "$latest/stdout.txt"; tail -80 "$latest/stdout.txt"; '
+        "else "
+        'echo \'[INFO] latest artifact dir:\' "$latest"; find "$latest" -maxdepth 2 -type f | sort; '
+        "fi; "
+        "sleep 2; "
+        "done"
+    )
+
+
+def _network_watch_script(*, is_ota: bool) -> str:
+    if is_ota:
+        return (
+            "while true; do "
+            "clear; date; "
+            "echo '[INFO] OTA benchmark: network shaping is applied on the remote peers.'; "
+            "echo '[INFO] Watch the run pane for tc/netem commands and qdisc diagnostics.'; "
+            "sleep 5; "
+            "done"
+        )
+    return (
+        "while true; do "
+        "clear; date; "
+        "echo '[INFO] local benchmark containers'; "
+        "docker ps --filter name=rosotacom --format 'table {{.Names}}\\t{{.Status}}' 2>/dev/null || true; "
+        "for c in $(docker ps --filter name=rosotacom --format '{{.Names}}' 2>/dev/null); do "
+        "echo; echo '[INFO]' \"$c\" 'eth0 qdisc'; "
+        'docker exec -u root "$c" tc qdisc show dev eth0 2>/dev/null || true; '
+        "done; "
+        "sleep 2; "
+        "done"
+    )
+
+
+def _start_interactive_benchmark(args: argparse.Namespace, genre: str) -> int:
+    from .cli import (
+        _attach_tmux_pipe,
+        _host_shell,
+        _load_runtime_config,
+        _require_tmux,
+        _tmux_command,
+        _tmux_session_exists,
+    )
+
+    runtime = _load_runtime_config(args)
+    session_name = _benchmark_tmux_session_name(args, genre)
+    command = _benchmark_child_command()
+    artifacts_root = _benchmark_artifacts_root(args)
+    interactive_logs = artifacts_root / "interactive" / session_name
+    is_ota = bool(getattr(args, "deployment", None))
+
+    run_script = (
+        f"echo '[INFO] benchmark operator session: {session_name}'; "
+        f"echo '[INFO] running: {shlex.join(command)}'; "
+        f"{shlex.join(command)}; rc=$?; "
+        "echo; echo '[INFO] benchmark exited with status' \"$rc\"; "
+        "echo '[INFO] pane remains open for inspection'; "
+        "exec bash"
+    )
+    network_script = _network_watch_script(is_ota=is_ota)
+    results_script = _latest_result_watch_script(artifacts_root)
+
+    if getattr(args, "dry_run", False):
+        print(f"Would create benchmark tmux session: {session_name}")
+        print("Run window: " + shlex.join(command))
+        print("Network window: qdisc monitor" if not is_ota else "Network window: OTA shaping monitor")
+        print(f"Results window: latest result under {artifacts_root}")
+        return 0
+
+    _require_tmux()
+    if _tmux_session_exists(runtime, session_name):
+        if not getattr(args, "no_attach", False):
+            subprocess.run(_tmux_command(runtime, "attach-session", "-t", session_name), check=True)
+        else:
+            print(f"Attach with: rosotacom benchmark {genre} ... --interactive")
+        return 0
+
+    interactive_logs.mkdir(parents=True, exist_ok=True)
+    created = subprocess.run(
+        _tmux_command(
+            runtime,
+            "new-session",
+            "-d",
+            "-P",
+            "-F",
+            "#{pane_id}",
+            "-s",
+            session_name,
+            "-n",
+            "run",
+            _host_shell(run_script),
+        ),
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    run_pane = created.stdout.strip()
+    _attach_tmux_pipe(runtime, run_pane, interactive_logs / "run.log")
+    subprocess.run(
+        _tmux_command(runtime, "set-window-option", "-g", "-t", session_name, "remain-on-exit", "on"),
+        check=True,
+    )
+    subprocess.run(_tmux_command(runtime, "set-option", "-t", session_name, "prefix", "C-b"), check=True)
+    subprocess.run(_tmux_command(runtime, "bind-key", "-T", "prefix", "C-b", "send-prefix"), check=True)
+    subprocess.run(
+        _tmux_command(runtime, "set-option", "-t", session_name, "status-right", " benchmark | C-b n/p "),
+        check=True,
+    )
+
+    for window_name, script, log_name in (
+        ("network", network_script, "network.log"),
+        ("results", results_script, "results.log"),
+    ):
+        created_window = subprocess.run(
+            _tmux_command(
+                runtime,
+                "new-window",
+                "-d",
+                "-P",
+                "-F",
+                "#{pane_id}",
+                "-t",
+                session_name,
+                "-n",
+                window_name,
+                _host_shell(script),
+            ),
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+        _attach_tmux_pipe(runtime, created_window.stdout.strip(), interactive_logs / log_name)
+
+    subprocess.run(_tmux_command(runtime, "select-window", "-t", f"{session_name}:run"), check=True)
+    print(f"Benchmark tmux session: {session_name}")
+    print("Local control tmux prefix: Ctrl-b.")
+    if not getattr(args, "no_attach", False):
+        subprocess.run(_tmux_command(runtime, "attach-session", "-t", session_name), check=True)
+    else:
+        print("Attach with: " + shlex.join(_tmux_command(runtime, "attach-session", "-t", session_name)))
+    return 0
 
 
 def _format_bps(value: float | None) -> str:
@@ -1018,6 +1208,30 @@ def _add_benchmark_common_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--dry-run", action="store_true", help="Show commands but do not run them.")
     parser.add_argument("--artifacts-dir", help="Output directory for all benchmark artifacts.")
     parser.add_argument(
+        "--target",
+        help="OTA target session or scenario (default for OTA: the benchmark genre session).",
+    )
+    parser.add_argument(
+        "--target-type",
+        choices=["auto", "session", "scenario"],
+        help=(
+            "How to resolve --target for OTA benchmark runs "
+            "(default: session when --target is omitted, auto otherwise)."
+        ),
+    )
+    parser.add_argument("--workdir", help="Remote OTA workdir (default: /tmp/rosotacom_ota).")
+    parser.add_argument(
+        "--reuse",
+        action="store_true",
+        help="Reuse already staged OTA source/project on remote hosts.",
+    )
+    parser.add_argument("--interactive", action="store_true", help="Open a tmux operator view for this benchmark run.")
+    parser.add_argument(
+        "--no-attach",
+        action="store_true",
+        help="Create the interactive tmux session without attaching.",
+    )
+    parser.add_argument(
         "--rmw",
         default=DEFAULT_BENCHMARK_RMW,
         help=f"RMW implementation or rosotacom RMW alias for benchmark sessions (default: {DEFAULT_BENCHMARK_RMW}).",
@@ -1077,13 +1291,13 @@ def _make_live_run_point(args: argparse.Namespace, session_name: str) -> RunPoin
     ) -> dict[str, Any]:
         if is_ota:
             # --- Real-near (ota-smoke) path ---
-            target_name = "remote_assist"
             # Default project to fzi_projects/remote_assist/rosotacom.yaml if not set.
             rosotacom_config = getattr(args, "rosotacom_config", None)
             if not rosotacom_config:
                 candidate = Path.cwd() / "fzi_projects" / "remote_assist" / "rosotacom.yaml"
                 if candidate.is_file():
                     args.rosotacom_config = str(candidate)
+            target_name, target_type = _benchmark_ota_target(args, session_name)
 
             smoke_args = argparse.Namespace(
                 rosotacom_config=getattr(args, "rosotacom_config", None),
@@ -1094,9 +1308,12 @@ def _make_live_run_point(args: argparse.Namespace, session_name: str) -> RunPoin
                 deployment=getattr(args, "deployment", None),
                 profiles_file=getattr(args, "profiles_file", None),
                 target=target_name,
-                target_type="auto",
+                target_type=target_type,
                 peer=getattr(args, "peer", None),
                 peer_address=getattr(args, "peer_address", None),
+                peer_ssh=getattr(args, "peer_ssh", None),
+                workdir=getattr(args, "workdir", None),
+                reuse=getattr(args, "reuse", False),
                 skip_preflight=getattr(args, "skip_preflight", False),
                 keep_workdir=getattr(args, "keep_workdir", False),
                 dry_run=getattr(args, "dry_run", False),
@@ -1463,6 +1680,9 @@ def benchmark_capacity(args: argparse.Namespace) -> int:
     """Handler for ``rosotacom benchmark capacity``."""
     from .cli import _load_runtime_config
 
+    if getattr(args, "interactive", False):
+        return _start_interactive_benchmark(args, "capacity")
+
     runtime = _load_runtime_config(args)
     artifacts_dir = Path(args.artifacts_dir) if getattr(args, "artifacts_dir", None) else runtime.benchmarks_dir
 
@@ -1518,6 +1738,9 @@ def benchmark_ramp(args: argparse.Namespace) -> int:
     """Handler for ``rosotacom benchmark ramp``."""
     from .cli import _load_runtime_config
 
+    if getattr(args, "interactive", False):
+        return _start_interactive_benchmark(args, "ramp")
+
     runtime = _load_runtime_config(args)
     artifacts_dir = Path(args.artifacts_dir) if getattr(args, "artifacts_dir", None) else runtime.benchmarks_dir
 
@@ -1567,6 +1790,9 @@ def benchmark_recovery(args: argparse.Namespace) -> int:
     """Handler for ``rosotacom benchmark recovery``."""
     from .cli import _load_runtime_config
 
+    if getattr(args, "interactive", False):
+        return _start_interactive_benchmark(args, "recovery")
+
     runtime = _load_runtime_config(args)
     artifacts_dir = Path(args.artifacts_dir) if getattr(args, "artifacts_dir", None) else runtime.benchmarks_dir
 
@@ -1615,6 +1841,9 @@ def benchmark_recovery(args: argparse.Namespace) -> int:
 def benchmark_sweep(args: argparse.Namespace) -> int:
     """Handler for ``rosotacom benchmark sweep``."""
     from .cli import _load_runtime_config
+
+    if getattr(args, "interactive", False):
+        return _start_interactive_benchmark(args, "sweep")
 
     runtime = _load_runtime_config(args)
     artifacts_dir = Path(args.artifacts_dir) if getattr(args, "artifacts_dir", None) else runtime.benchmarks_dir

--- a/tests/unit/test_cli_benchmark.py
+++ b/tests/unit/test_cli_benchmark.py
@@ -21,8 +21,11 @@ import rosotacom.cli_benchmark as benchmark_cli
 from rosotacom.cli_benchmark import (
     BENCHMARK_RESULT_FILE,
     DEFAULT_BENCHMARK_RMW,
+    _benchmark_child_command,
+    _benchmark_ota_target,
     _parse_values,
     _prepare_benchmark_session_config,
+    _start_interactive_benchmark,
     collect_transit_summary,
     drive_capacity,
     drive_ramp,
@@ -504,6 +507,40 @@ def test_benchmark_subcommand_arg_parsing() -> None:
     )
     assert args.rmw == "fastdds"
 
+    args = parser.parse_args(
+        [
+            "benchmark",
+            "capacity",
+            "--profile",
+            "p",
+            "--knob",
+            "size",
+            "--low",
+            "1000",
+            "--high",
+            "10000",
+            "--max-loss",
+            "5",
+            "--max-latency-ms",
+            "200",
+            "--target",
+            "remote_assist",
+            "--target-type",
+            "scenario",
+            "--workdir",
+            "/tmp/bench",
+            "--reuse",
+            "--interactive",
+            "--no-attach",
+        ]
+    )
+    assert args.target == "remote_assist"
+    assert args.target_type == "scenario"
+    assert args.workdir == "/tmp/bench"
+    assert args.reuse is True
+    assert args.interactive is True
+    assert args.no_attach is True
+
     # Ramp.
     args = parser.parse_args(["benchmark", "ramp", "--profile", "p", "--values", "1000,2000"])
     assert args.benchmark_command == "ramp"
@@ -608,6 +645,91 @@ def test_benchmark_session_copy_pins_requested_rmw(tmp_path: Path) -> None:
     assert copied["shared"]["rmw"] == "cyclone"
     assert args.session_configs_dir[0] == str(run_dir / "session-configs")
     assert context["runtime_implementation"] == "rmw_cyclonedds_cpp"
+
+
+def test_benchmark_ota_target_defaults_to_benchmark_session() -> None:
+    args = argparse.Namespace(target=None, target_type=None)
+    assert _benchmark_ota_target(args, "bench_1_1_capacity") == ("bench_1_1_capacity", "session")
+
+    args = argparse.Namespace(target="remote_assist", target_type=None)
+    assert _benchmark_ota_target(args, "bench_1_1_capacity") == ("remote_assist", "auto")
+
+    args = argparse.Namespace(target="remote_assist", target_type="scenario")
+    assert _benchmark_ota_target(args, "bench_1_1_capacity") == ("remote_assist", "scenario")
+
+    args = argparse.Namespace(target=None, target_type="scenario")
+    with pytest.raises(ValueError, match="--target-type requires --target"):
+        _benchmark_ota_target(args, "bench_1_1_capacity")
+
+
+def test_interactive_benchmark_dry_run_prints_operator_view(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import yaml
+
+    ros2docker = tmp_path / "ros2docker.json"
+    ros2docker.write_text("{}", encoding="utf-8")
+    config_file = tmp_path / "rosotacom.yaml"
+    config_file.write_text(
+        yaml.safe_dump(
+            {
+                "ros2docker_config": str(ros2docker),
+                "session_configs_dir": [],
+                "scenario_configs_dir": [],
+                "session_instances_dir": "session-instances",
+                "benchmarks_dir": "benchmarks",
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        benchmark_cli.sys,
+        "argv",
+        [
+            "rosotacom",
+            "benchmark",
+            "capacity",
+            "--profile",
+            "p",
+            "--knob",
+            "size",
+            "--low",
+            "1",
+            "--high",
+            "10",
+            "--max-loss",
+            "5",
+            "--max-latency-ms",
+            "200",
+            "--interactive",
+            "--no-attach",
+        ],
+    )
+    args = argparse.Namespace(
+        rosotacom_config=str(config_file),
+        ros2docker_config=None,
+        session_configs_dir=None,
+        scenario_configs_dir=None,
+        session_instances_dir=None,
+        deployment=None,
+        profiles_file=None,
+        artifacts_dir=None,
+        dry_run=True,
+        no_attach=True,
+        profile="p",
+    )
+
+    assert _start_interactive_benchmark(args, "capacity") == 0
+
+    output = capsys.readouterr().out
+    assert "Would create benchmark tmux session: benchmark-capacity-p" in output
+    assert "Network window: qdisc monitor" in output
+    assert "Results window: latest result under" in output
+    child = " ".join(_benchmark_child_command())
+    assert "--interactive" not in child
+    assert "--no-attach" not in child
 
 
 def test_tee_stream_and_stdout_redirection(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- default OTA benchmark runs to the selected genre's benchmark session, with `--target` and `--target-type` overrides for project-specific sessions/scenarios
- pass OTA staging controls through benchmark smoke runs via `--workdir` and `--reuse`
- add `--interactive` / `--no-attach` benchmark mode that opens tmux run, network, and result windows
- document the operator flow and update RFC 0005 implementation/validation checklists

Refs #61

## Validation
- `python3 -m pytest -q tests/unit/test_cli_benchmark.py`
- `python3 -m ruff check src/rosotacom/cli_benchmark.py tests/unit/test_cli_benchmark.py`
- `python3 -m ruff format --check src/rosotacom/cli_benchmark.py tests/unit/test_cli_benchmark.py`
- `.venv/bin/python -m ruff check .`
- `.venv/bin/python -m ruff format --check .`
- `.venv/bin/python -m py_compile src/rosotacom/*.py run_session_in_container.py stop_session_in_container.py`
- `.venv/bin/python -m mypy`
- `.venv/bin/python -m pytest -q tests/unit`
- `.venv/bin/python -m pytest -q tests/contract`
- `.venv/bin/python -m twine check dist/*`
- `.venv/bin/check-wheel-contents dist/*.whl`
- `ROSOTACOM_RUN_E2E=1 .venv/bin/python -m pytest -q tests/e2e/test_benchmark_capacity.py -m e2e`
- `git diff --check`
