### PR TITLE
Fix benchmark operator panes and profile shaping fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,7 +469,8 @@ shaping context, thresholds, verdict, and per-topic loss/latency/jitter metrics.
 For OTA benchmark runs (`--deployment ...`), the default target is the benchmark
 session for the selected genre; pass `--target` and `--target-type` to benchmark a
 project-specific session or scenario instead. Add `--interactive` to open a tmux
-operator view with separate run, network-shaping, and result windows.
+operator view with separate run, per-peer catmux, network-shaping, and result
+windows.
 
 ## Development
 

--- a/docs/rfcs/0005-benchmark-genres-and-ci.md
+++ b/docs/rfcs/0005-benchmark-genres-and-ci.md
@@ -177,8 +177,9 @@ slice and reuses RFC 0003 + 0004.
   `--target-type` for project-specific sessions or scenarios
   (`cli_benchmark._benchmark_ota_target`).
 - [x] Add an interactive benchmark operator view that opens a local tmux session
-  with separate run, network-shaping, and result windows for local runs and an OTA
-  shaping monitor note for remote runs (`cli_benchmark --interactive`).
+  with separate run, per-peer catmux, network-shaping, and result windows for
+  local runs and an OTA shaping monitor note for remote runs
+  (`cli_benchmark --interactive`).
 - [x] Build the recovery driver on timeline profiles (RFC 0004) + the recovery
   metric set (`t_recover`, `t_steady`, backlog/burst, lost-during-outage, latched
   re-arrival) (`benchmark.recovery_metrics`; arming the timeline profile is RFC
@@ -226,10 +227,12 @@ reviewed rather than asserted in a blocking test.
 - [x] **OTA target selection** (default to benchmark genre session, explicit
   target override for sessions/scenarios) — host unit test for default and
   override resolution. Automatable. *(`test_benchmark_ota_target_defaults_to_benchmark_session`.)*
-- [x] **Interactive operator view** (tmux run/network/results windows) — host unit
-  test for the dry-run command plan and parser flags; live tmux attachment remains
-  an operator workflow. Automatable for command planning, manual for actual
-  attachment. *(`test_interactive_benchmark_dry_run_prints_operator_view`,
+- [x] **Interactive operator view** (tmux run/per-peer catmux/network/results
+  windows) — host unit test for the dry-run command plan, peer catmux attach
+  script, and parser flags; live tmux attachment remains an operator workflow.
+  Automatable for command planning, manual for actual attachment.
+  *(`test_interactive_benchmark_dry_run_prints_operator_view`,
+  `test_peer_catmux_attach_script_waits_for_container_and_tmux`,
   `test_benchmark_subcommand_arg_parsing`.)*
 - [x] **Recovery driver + metric set** (`t_recover`, `t_steady`, backlog/burst,
   lost-during-outage, latched re-arrival) — host unit test extracting the metrics

--- a/src/rosotacom/cli_benchmark.py
+++ b/src/rosotacom/cli_benchmark.py
@@ -32,6 +32,12 @@ import yaml
 
 DEFAULT_BENCHMARK_RMW = "cyclone"
 BENCHMARK_RESULT_FILE = "result.json"
+BENCHMARK_SESSIONS_BY_GENRE = {
+    "capacity": "bench_1_1_capacity",
+    "sweep": "bench_1_2_load_sweep",
+    "ramp": "bench_1_3_ramp",
+    "recovery": "bench_1_4_recovery",
+}
 
 
 class TeeStream:
@@ -289,6 +295,7 @@ def _benchmark_result_context(
 
     runtime = _load_runtime_config(args)
     rmw = _benchmark_rmw(args)
+    profiles_file = _benchmark_profiles_file(profile, runtime.profiles_file)
     return cast(
         dict[str, Any],
         _jsonable(
@@ -303,13 +310,13 @@ def _benchmark_result_context(
                     "requested": rmw,
                     "runtime_implementation": _rmw_runtime_implementation(rmw),
                 },
-                "profile": _profile_context(profile, runtime.profiles_file),
+                "profile": _profile_context(profile, profiles_file),
                 "session": session,
                 "paths": {
                     "run_dir": run_dir,
                     "rosotacom_config": runtime.rosotacom_config,
                     "ros2docker_config": runtime.ros2docker_config,
-                    "profiles_file": runtime.profiles_file,
+                    "profiles_file": profiles_file,
                     "benchmarks_dir": runtime.benchmarks_dir,
                 },
             }
@@ -365,6 +372,17 @@ def _benchmark_ota_target(args: argparse.Namespace, session_name: str) -> tuple[
     return session_name, "session"
 
 
+def _benchmark_profiles_file(profile: str | None, profiles_file: Path | None) -> Path | None:
+    if profiles_file is not None:
+        return _find_profiles_file(profiles_file)
+    try:
+        return _find_profiles_file(None)
+    except FileNotFoundError:
+        if profile:
+            raise
+        return None
+
+
 def _benchmark_artifacts_root(args: argparse.Namespace) -> Path:
     from .cli import _load_runtime_config
 
@@ -386,6 +404,58 @@ def _strip_interactive_args(argv: Sequence[str]) -> list[str]:
 
 def _benchmark_child_command() -> list[str]:
     return [sys.executable, "-m", "rosotacom", *_strip_interactive_args(sys.argv[1:])]
+
+
+def _peer_catmux_attach_script(identity: str, container_name: str) -> str:
+    inner = (
+        "while true; do "
+        "session=$(tmux list-sessions -F '#{session_name}' 2>/dev/null | head -1); "
+        'if [ -n "$session" ]; then exec tmux attach-session -t "$session"; fi; '
+        "echo '[INFO] waiting for catmux/tmux session inside container'; "
+        "sleep 1; "
+        "done"
+    )
+    return (
+        "while true; do "
+        "clear; date; "
+        f"container={shlex.quote(container_name)}; identity={shlex.quote(identity)}; "
+        'if ! docker inspect -f "{{.State.Running}}" "$container" >/dev/null 2>&1; then '
+        'echo "[INFO] waiting for benchmark peer $identity container: $container"; '
+        "sleep 1; continue; "
+        "fi; "
+        'echo "[INFO] attaching to benchmark peer $identity in $container"; '
+        f'docker exec -it "$container" bash -lc {shlex.quote(inner)}; '
+        "rc=$?; echo; echo '[INFO] catmux attach exited with status' \"$rc\"; "
+        "sleep 1; "
+        "done"
+    )
+
+
+def _benchmark_peer_windows(args: argparse.Namespace, genre: str) -> list[tuple[str, str, str]]:
+    from .cli import (
+        _container_name,
+        _effective_session_config,
+        _load_runtime_config,
+        _remote_peer_name,
+        _resolve_session,
+        _safe_path_token,
+    )
+
+    if getattr(args, "deployment", None):
+        return []
+    session_name = BENCHMARK_SESSIONS_BY_GENRE[genre]
+    runtime = _load_runtime_config(args)
+    session = _resolve_session(session_name, runtime)
+    cfg = _effective_session_config(session.host_dir, runtime)
+    peers = cfg.get("peers")
+    if not isinstance(peers, dict):
+        return []
+    windows: list[tuple[str, str, str]] = []
+    for identity in sorted(str(peer) for peer in peers):
+        container_name = _container_name(_remote_peer_name(cfg, identity), runtime)
+        window_name = _safe_path_token(f"{identity}_catmux")
+        windows.append((window_name, identity, _peer_catmux_attach_script(identity, container_name)))
+    return windows
 
 
 def _latest_result_watch_script(artifacts_root: Path) -> str:
@@ -462,10 +532,13 @@ def _start_interactive_benchmark(args: argparse.Namespace, genre: str) -> int:
     )
     network_script = _network_watch_script(is_ota=is_ota)
     results_script = _latest_result_watch_script(artifacts_root)
+    peer_windows = _benchmark_peer_windows(args, genre) if not is_ota else []
 
     if getattr(args, "dry_run", False):
         print(f"Would create benchmark tmux session: {session_name}")
         print("Run window: " + shlex.join(command))
+        for window_name, identity, _script in peer_windows:
+            print(f"Peer window {identity}: {window_name} catmux attach")
         print("Network window: qdisc monitor" if not is_ota else "Network window: OTA shaping monitor")
         print(f"Results window: latest result under {artifacts_root}")
         return 0
@@ -510,10 +583,12 @@ def _start_interactive_benchmark(args: argparse.Namespace, genre: str) -> int:
         check=True,
     )
 
-    for window_name, script, log_name in (
-        ("network", network_script, "network.log"),
-        ("results", results_script, "results.log"),
-    ):
+    window_specs = [
+        *(window for window in peer_windows),
+        ("network", "network", network_script),
+        ("results", "results", results_script),
+    ]
+    for window_name, log_name, script in window_specs:
         created_window = subprocess.run(
             _tmux_command(
                 runtime,
@@ -532,7 +607,8 @@ def _start_interactive_benchmark(args: argparse.Namespace, genre: str) -> int:
             capture_output=True,
             check=True,
         )
-        _attach_tmux_pipe(runtime, created_window.stdout.strip(), interactive_logs / log_name)
+        pane_id = created_window.stdout.strip()
+        _attach_tmux_pipe(runtime, pane_id, interactive_logs / f"{log_name}.log")
 
     subprocess.run(_tmux_command(runtime, "select-window", "-t", f"{session_name}:run"), check=True)
     print(f"Benchmark tmux session: {session_name}")
@@ -1134,8 +1210,9 @@ def _setup_benchmark_run_dir(args: argparse.Namespace, genre: str, profile: str 
             shutil.copy2(config_path, run_dir / "rosotacom.yaml")
 
     # profiles file
-    if runtime.profiles_file:
-        profiles_path = Path(runtime.profiles_file).resolve()
+    profiles_file = _benchmark_profiles_file(profile, runtime.profiles_file)
+    if profiles_file:
+        profiles_path = Path(profiles_file).resolve()
         if profiles_path.is_file():
             shutil.copy2(profiles_path, run_dir / "profiles.yaml")
 
@@ -1298,6 +1375,7 @@ def _make_live_run_point(args: argparse.Namespace, session_name: str) -> RunPoin
                 if candidate.is_file():
                     args.rosotacom_config = str(candidate)
             target_name, target_type = _benchmark_ota_target(args, session_name)
+            profiles_file = _benchmark_profiles_file(profile, _load_runtime_config(args).profiles_file)
 
             smoke_args = argparse.Namespace(
                 rosotacom_config=getattr(args, "rosotacom_config", None),
@@ -1306,7 +1384,7 @@ def _make_live_run_point(args: argparse.Namespace, session_name: str) -> RunPoin
                 scenario_configs_dir=getattr(args, "scenario_configs_dir", None),
                 session_instances_dir=getattr(args, "session_instances_dir", None),
                 deployment=getattr(args, "deployment", None),
-                profiles_file=getattr(args, "profiles_file", None),
+                profiles_file=str(profiles_file) if profiles_file else None,
                 target=target_name,
                 target_type=target_type,
                 peer=getattr(args, "peer", None),
@@ -1484,14 +1562,14 @@ def _make_live_run_point(args: argparse.Namespace, session_name: str) -> RunPoin
 
             from .network_profiles import load_profiles_file, shaping_commands
 
-            profile_name = getattr(args, "profile", None)
+            profile_name = profile
             profile_obj = None
-            if profile_name and runtime.profiles_file:
-                try:
-                    profiles = load_profiles_file(runtime.profiles_file)
-                    profile_obj = profiles.get(profile_name)
-                except Exception as exc:
-                    print(f"Warning: Failed to load profile {profile_name!r}: {exc}", file=sys.stderr)
+            profiles_file = _benchmark_profiles_file(profile_name, runtime.profiles_file)
+            if profile_name and profiles_file:
+                profiles = load_profiles_file(profiles_file)
+                profile_obj = profiles.get(profile_name)
+                if profile_obj is None:
+                    raise ValueError(f"Profile {profile_name!r} not found in profiles file {profiles_file}.")
 
             def make_container_runner(container_name: str) -> Callable[[Sequence[str]], None]:
                 def run(argv: Sequence[str]) -> None:
@@ -1798,6 +1876,7 @@ def benchmark_recovery(args: argparse.Namespace) -> int:
 
     run_dir = _setup_benchmark_run_dir(args, "recovery", args.profile)
     session_context = _prepare_benchmark_session_config(args, "bench_1_4_recovery", run_dir)
+    profiles_file = _benchmark_profiles_file(args.profile, runtime.profiles_file)
     result_context = _benchmark_result_context(
         args,
         genre="recovery",
@@ -1818,7 +1897,7 @@ def benchmark_recovery(args: argparse.Namespace) -> int:
             if getattr(args, "latched_topics", "")
             else (),
             out_dir=run_dir,
-            profiles_file=runtime.profiles_file,
+            profiles_file=profiles_file,
             result_context=result_context,
         )
 

--- a/tests/unit/test_cli_benchmark.py
+++ b/tests/unit/test_cli_benchmark.py
@@ -23,7 +23,9 @@ from rosotacom.cli_benchmark import (
     DEFAULT_BENCHMARK_RMW,
     _benchmark_child_command,
     _benchmark_ota_target,
+    _benchmark_profiles_file,
     _parse_values,
+    _peer_catmux_attach_script,
     _prepare_benchmark_session_config,
     _start_interactive_benchmark,
     collect_transit_summary,
@@ -371,6 +373,17 @@ def test_live_lab_run_point_uses_instance_scoped_smoke_network(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    profiles_file = tmp_path / "profiles" / "benchmark-profiles.yaml"
+    profiles_file.parent.mkdir()
+    profiles_file.write_text(
+        "profiles:\n"
+        "  cellular-4g-degraded:\n"
+        "    uplink: { rate: 1mbit, delay: 180ms, jitter: 50ms, loss: 3% }\n"
+        "    downlink: { rate: 10mbit, delay: 100ms, jitter: 30ms, loss: 1% }\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+
     sessions_root = tmp_path / "sessions"
     session_dir = sessions_root / "bench_1_1_capacity"
     session_dir.mkdir(parents=True)
@@ -418,8 +431,10 @@ def test_live_lab_run_point_uses_instance_scoped_smoke_network(
     monkeypatch.setattr(cli, "_remove_smoke_network", lambda name: networks_removed.append(name))
     monkeypatch.setattr(benchmark_cli, "collect_transit_summary", lambda instance_dir: {"topics": {}})
     monkeypatch.setattr(benchmark_cli.time, "sleep", lambda seconds: None)
+    commands: list[list[str]] = []
 
     def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        commands.append(command)
         return subprocess.CompletedProcess(command, 0, "Subscription count: 1\n", "")
 
     monkeypatch.setattr(subprocess, "run", fake_run)
@@ -438,7 +453,9 @@ def test_live_lab_run_point_uses_instance_scoped_smoke_network(
 
     run_point = benchmark_cli._make_live_run_point(args, "bench_1_1_capacity")
 
-    assert run_point(profile="p", load={"size": 1}, duration_s=0.1, out_dir=out_dir) == {"topics": {}}
+    assert run_point(profile="cellular-4g-degraded", load={"size": 1}, duration_s=0.1, out_dir=out_dir) == {
+        "topics": {}
+    }
     assert networks_created == [(smoke_network.name, smoke_network.subnet)]
     assert [(args.identity, args.network_name, args.network_ip) for args in started] == [
         ("a", smoke_network.name, smoke_network.peer_ips["a"]),
@@ -447,6 +464,12 @@ def test_live_lab_run_point_uses_instance_scoped_smoke_network(
     assert all(args.peer_address == cli._smoke_peer_address_args(smoke_network.peer_ips) for args in started)
     assert stopped == ["container_a", "container_b"]
     assert networks_removed == [smoke_network.name]
+    assert any(
+        command[:6] == ["docker", "exec", "-u", "root", "container_a", "tc"] and "3%" in command for command in commands
+    )
+    assert any(
+        command[:6] == ["docker", "exec", "-u", "root", "container_b", "tc"] and "1%" in command for command in commands
+    )
 
 
 # --------------------------------------------------------------------------- #
@@ -599,6 +622,15 @@ def test_runtime_config_parses_benchmarks_dir_and_profiles(tmp_path: Path) -> No
     assert runtime.benchmarks_dir == tmp_path / "benchmarks"
 
 
+def test_benchmark_profiles_file_falls_back_to_cwd(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    profiles_file = tmp_path / "profiles" / "benchmark-profiles.yaml"
+    profiles_file.parent.mkdir()
+    profiles_file.write_text("profiles: {}\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    assert _benchmark_profiles_file("cellular-4g-degraded", None) == profiles_file
+
+
 def test_benchmark_session_copy_pins_requested_rmw(tmp_path: Path) -> None:
     import argparse
 
@@ -662,6 +694,15 @@ def test_benchmark_ota_target_defaults_to_benchmark_session() -> None:
         _benchmark_ota_target(args, "bench_1_1_capacity")
 
 
+def test_peer_catmux_attach_script_waits_for_container_and_tmux() -> None:
+    script = _peer_catmux_attach_script("a", "rosotacom_id_com_to_b")
+
+    assert "waiting for benchmark peer $identity container" in script
+    assert 'docker exec -it "$container" bash -lc' in script
+    assert "tmux list-sessions" in script
+    assert 'tmux attach-session -t "$session"' in script
+
+
 def test_interactive_benchmark_dry_run_prints_operator_view(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -676,7 +717,9 @@ def test_interactive_benchmark_dry_run_prints_operator_view(
         yaml.safe_dump(
             {
                 "ros2docker_config": str(ros2docker),
-                "session_configs_dir": [],
+                "session_configs_dir": [
+                    str(Path(benchmark_cli.__file__).resolve().parent / "resources" / "examples" / "sessions")
+                ],
                 "scenario_configs_dir": [],
                 "session_instances_dir": "session-instances",
                 "benchmarks_dir": "benchmarks",
@@ -725,6 +768,8 @@ def test_interactive_benchmark_dry_run_prints_operator_view(
 
     output = capsys.readouterr().out
     assert "Would create benchmark tmux session: benchmark-capacity-p" in output
+    assert "Peer window a: a_catmux catmux attach" in output
+    assert "Peer window b: b_catmux catmux attach" in output
     assert "Network window: qdisc monitor" in output
     assert "Results window: latest result under" in output
     child = " ".join(_benchmark_child_command())


### PR DESCRIPTION
## Summary
- add local benchmark operator tmux windows for each benchmark peer, attaching into the peer container's catmux/tmux session while the benchmark run owns the container lifecycle
- resolve the same benchmark profiles file for local shaping, OTA benchmark smoke args, copied artifacts, and `result.json` context
- fail loudly when a requested profile is missing instead of silently running local benchmarks unshaped
- document the per-peer catmux operator view and update RFC validation traceability

Follows #67.
Refs #61.

## Validation
- `python3 -m pytest -q tests/unit/test_cli_benchmark.py`
- `python3 -m ruff check src/rosotacom/cli_benchmark.py tests/unit/test_cli_benchmark.py`
- `python3 -m ruff format --check src/rosotacom/cli_benchmark.py tests/unit/test_cli_benchmark.py`
- `python3 -m py_compile src/rosotacom/cli_benchmark.py`
- `git diff --check`
- Same diff before rebasing onto merged #67: `.venv/bin/python -m pytest -q tests/unit` (`282 passed`), `.venv/bin/python -m pytest -q tests/contract` (`26 passed`), mypy, ruff, package checks, and `ROSOTACOM_RUN_E2E=1 .venv/bin/python -m pytest -q tests/e2e/test_benchmark_capacity.py -m e2e` (`2 passed in 172.99s`)
- Manual local degraded-profile check in the harness with active remote-assist config: qdisc diagnostics showed `loss 3% 25%` on uplink and `loss 1%` on downlink, and the probe reported nonzero loss (`27/167`, `16.168%`)
