### PR TITLE
Refine benchmark operator feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,9 +476,11 @@ rosotacom ota-benchmark capacity --profile cellular-4g-degraded --knob size --lo
 OTA benchmarks default to the benchmark session for the selected genre. Pass
 `--target` and `--target-type` only when you deliberately want to benchmark a
 project-specific session or scenario instead. Add `--interactive` to open a tmux
-operator view with a high-level run window, one attachable catmux plus launch-log
-window per local peer, and a network window split into qdisc status and tc/netem
-command logs.
+operator view with a high-level run window, one fullscreen attachable catmux
+window per local peer, a network window split into qdisc status and tc/netem
+command logs, and a results window that prints the final result once. Shaped OTA
+benchmark profiles require passwordless non-interactive sudo for `tc`/`ip` on the
+remote peers; preflight checks this before arming the profile.
 
 ## Development
 

--- a/docs/rfcs/0005-benchmark-genres-and-ci.md
+++ b/docs/rfcs/0005-benchmark-genres-and-ci.md
@@ -180,9 +180,13 @@ slice and reuses RFC 0003 + 0004.
   same benchmark grammar as local runs and only need deployment peer bindings
   such as `--peer a=seat_tks --peer b=majestic_tks` for the common case.
 - [x] Add an interactive benchmark operator view that opens a local tmux session
-  with a high-level run window, one catmux attach plus launch-log window per
-  local peer, and a network window split into qdisc status and tc/netem command
-  logs (`cli_benchmark --interactive`).
+  with a high-level run window, one fullscreen catmux attach window per local
+  peer, a network window split into qdisc status and tc/netem command logs, and a
+  one-shot final result window (`cli_benchmark --interactive`).
+- [x] Require shaped OTA benchmark runs to prove passwordless non-interactive sudo
+  for `tc`/`ip` during preflight, and run profile commands through `sudo -n` so
+  missing privileges fail early instead of hanging or failing mid-run
+  (`cli._ota_preflight`, `cli._peer_command_runner`).
 - [x] Build the recovery driver on timeline profiles (RFC 0004) + the recovery
   metric set (`t_recover`, `t_steady`, backlog/burst, lost-during-outage, latched
   re-arrival) (`benchmark.recovery_metrics`; arming the timeline profile is RFC
@@ -233,14 +237,19 @@ reviewed rather than asserted in a blocking test.
 - [x] **Simple OTA benchmark command** (`rosotacom ota-benchmark ... --peer
   a=... --peer b=...`) — host unit test for parser defaults and peer bindings.
   Automatable. *(`test_benchmark_subcommand_arg_parsing`.)*
-- [x] **Interactive operator view** (tmux high-level run window, per-peer catmux
-  attach plus launch-log windows, network status plus command-log panes) — host
-  unit test for the dry-run command plan, peer catmux attach script, and parser
-  flags; live tmux attachment remains an operator workflow. Automatable for
-  command planning, manual for actual attachment.
+- [x] **Interactive operator view** (tmux high-level run window, fullscreen
+  per-peer catmux attach windows, network status plus command-log panes, one-shot
+  final result window) — host unit test for the dry-run command plan, peer catmux
+  attach script, and parser flags; live tmux attachment remains an operator
+  workflow. Automatable for command planning, manual for actual attachment.
   *(`test_interactive_benchmark_dry_run_prints_operator_view`,
   `test_peer_catmux_attach_script_waits_for_container_and_tmux`,
   `test_benchmark_subcommand_arg_parsing`.)*
+- [x] **OTA profile shaping privilege check** (passwordless non-interactive sudo
+  for `tc`/`ip`) — host unit tests assert the preflight check and `sudo -n`
+  wrapping for shaping/watchdog commands. Automatable.
+  *(`test_ota_preflight_can_require_passwordless_network_shaping`,
+  `test_ota_profile_shaping_uses_noninteractive_sudo`.)*
 - [x] **Recovery driver + metric set** (`t_recover`, `t_steady`, backlog/burst,
   lost-during-outage, latched re-arrival) — host unit test extracting the metrics
   from a synthetic timeline of transit records (RFC 0003); the **live recovery run

--- a/src/rosotacom/cli.py
+++ b/src/rosotacom/cli.py
@@ -1948,6 +1948,7 @@ def _ota_preflight(
     require_tmux: bool,
     check_peer_reachability: bool,
     dry_run: bool,
+    require_network_shaping_sudo: bool = False,
 ) -> None:
     for peer in plan.peers.values():
         if peer.ssh:
@@ -1971,6 +1972,14 @@ def _ota_preflight(
             batch=True,
         )
         _ota_run(peer, "docker ps >/dev/null", label=f"{peer.name}: docker access", dry_run=dry_run, batch=True)
+        if require_network_shaping_sudo:
+            _ota_run(
+                peer,
+                "command -v tc >/dev/null 2>&1 && command -v ip >/dev/null 2>&1 && sudo -n true",
+                label=f"{peer.name}: passwordless sudo for network shaping",
+                dry_run=dry_run,
+                batch=True,
+            )
 
     if check_peer_reachability:
         for src in plan.peers.values():
@@ -2262,7 +2271,7 @@ def _peer_command_runner(peer: OtaSmokePeer, *, dry_run: bool) -> Callable[[Sequ
     """A CommandRunner that runs one privileged argv on ``peer`` via the SSH path."""
 
     def run(argv: Sequence[str]) -> None:
-        _ota_run(peer, "sudo " + shlex.join(list(argv)), label=f"{peer.name}: tc/netem", dry_run=dry_run)
+        _ota_run(peer, "sudo -n " + shlex.join(list(argv)), label=f"{peer.name}: tc/netem", dry_run=dry_run)
 
     return run
 
@@ -2271,7 +2280,7 @@ def _peer_watchdog_launcher(peer: OtaSmokePeer, *, dry_run: bool) -> Callable[[S
     """Launch the safety-watchdog argv detached on ``peer`` so it survives a crash."""
 
     def launch(argv: Sequence[str]) -> None:
-        detached = f"nohup sudo {shlex.join(list(argv))} >/dev/null 2>&1 &"
+        detached = f"nohup sudo -n {shlex.join(list(argv))} >/dev/null 2>&1 &"
         _ota_run(peer, detached, label=f"{peer.name}: profile safety watchdog", dry_run=dry_run, check=False)
 
     return launch

--- a/src/rosotacom/cli_benchmark.py
+++ b/src/rosotacom/cli_benchmark.py
@@ -490,23 +490,7 @@ def _peer_catmux_attach_script(identity: str, container_name: str, full_log: Pat
     )
 
 
-def _peer_launch_watch_script(identity: str, container_name: str, full_log: Path) -> str:
-    launch_pattern = f"{container_name}|--identity {identity}|identity {identity}|rosotacom session started"
-    return (
-        "while true; do "
-        "clear; date; "
-        f"container={shlex.quote(container_name)}; identity={shlex.quote(identity)}; "
-        'echo "[INFO] benchmark peer $identity launch/container log"; '
-        "docker ps --filter name=\"$container\" --format 'table {{.Names}}\\t{{.Status}}' 2>/dev/null || true; "
-        "echo; echo '[INFO] orchestrator lines'; " + _grep_log_fragment(full_log, launch_pattern, lines=60) + "; "
-        "echo; echo '[INFO] docker logs tail'; "
-        'docker logs --tail 40 "$container" 2>&1 || true; '
-        "sleep 2; "
-        "done"
-    )
-
-
-def _benchmark_peer_windows(args: argparse.Namespace, genre: str, full_log: Path) -> list[tuple[str, str, str, str]]:
+def _benchmark_peer_windows(args: argparse.Namespace, genre: str, full_log: Path) -> list[tuple[str, str, str]]:
     from .cli import (
         _container_name,
         _effective_session_config,
@@ -525,19 +509,50 @@ def _benchmark_peer_windows(args: argparse.Namespace, genre: str, full_log: Path
     peers = cfg.get("peers")
     if not isinstance(peers, dict):
         return []
-    windows: list[tuple[str, str, str, str]] = []
+    windows: list[tuple[str, str, str]] = []
     for identity in sorted(str(peer) for peer in peers):
         container_name = _container_name(_remote_peer_name(cfg, identity), runtime)
         window_name = _safe_path_token(f"{identity}_catmux")
-        windows.append(
-            (
-                window_name,
-                identity,
-                _peer_catmux_attach_script(identity, container_name, full_log),
-                _peer_launch_watch_script(identity, container_name, full_log),
-            )
-        )
+        windows.append((window_name, identity, _peer_catmux_attach_script(identity, container_name, full_log)))
     return windows
+
+
+def _result_once_script(full_log: Path) -> str:
+    script = f"""
+import json
+import pathlib
+import re
+import sys
+import time
+
+log_path = pathlib.Path({str(full_log)!r})
+result_re = re.compile(r"Benchmark result saved to (.+)")
+exit_re = re.compile(r"benchmark exited with status (\\d+)")
+
+print("[INFO] waiting for final benchmark result in", log_path, flush=True)
+while True:
+    if log_path.is_file():
+        text = log_path.read_text(encoding="utf-8", errors="replace")
+        matches = result_re.findall(text)
+        if matches:
+            result_path = pathlib.Path(matches[-1].strip())
+            print("[INFO] final benchmark result:", result_path)
+            if result_path.is_file():
+                with result_path.open(encoding="utf-8") as handle:
+                    print(json.dumps(json.load(handle), indent=2, sort_keys=True))
+            else:
+                print("[WARN] result path was reported but is not readable yet:", result_path)
+            print()
+            print("[INFO] result printed once; pane remains open for inspection")
+            sys.exit(0)
+        exit_match = exit_re.search(text)
+        if exit_match:
+            print("[WARN] benchmark exited with status", exit_match.group(1), "before reporting a result file")
+            print("[INFO] inspect the run window or full orchestrator log:", log_path)
+            sys.exit(1)
+    time.sleep(1)
+""".strip()
+    return shlex.join([sys.executable, "-c", script])
 
 
 def _network_command_watch_script(full_log: Path, *, is_ota: bool) -> str:
@@ -598,19 +613,21 @@ def _start_interactive_benchmark(args: argparse.Namespace, genre: str) -> int:
     run_script = _benchmark_run_script(command, full_log, session_name)
     network_script = _network_watch_script(is_ota=is_ota)
     network_command_script = _network_command_watch_script(full_log, is_ota=is_ota)
+    result_script = _result_once_script(full_log)
     peer_windows = _benchmark_peer_windows(args, genre, full_log) if not is_ota else []
 
     if getattr(args, "dry_run", False):
         print(f"Would create benchmark tmux session: {session_name}")
         print(f"Run window: high-level orchestrator (full log {full_log})")
         print("Child command: " + shlex.join(command))
-        for window_name, identity, _attach_script, _launch_script in peer_windows:
-            print(f"Peer window {identity}: {window_name} catmux attach + launch log")
+        for window_name, identity, _attach_script in peer_windows:
+            print(f"Peer window {identity}: {window_name} fullscreen catmux attach")
         print(
             "Network window: qdisc monitor + tc command log"
             if not is_ota
             else "Network window: OTA shaping monitor + remote tc command log"
         )
+        print("Results window: final result printed once")
         return 0
 
     _require_tmux()
@@ -654,7 +671,7 @@ def _start_interactive_benchmark(args: argparse.Namespace, genre: str) -> int:
         check=True,
     )
 
-    for window_name, identity, attach_script, launch_script in peer_windows:
+    for window_name, identity, attach_script in peer_windows:
         created_window = subprocess.run(
             _tmux_command(
                 runtime,
@@ -676,16 +693,6 @@ def _start_interactive_benchmark(args: argparse.Namespace, genre: str) -> int:
         pane_id = created_window.stdout.strip()
         subprocess.run(_tmux_command(runtime, "select-pane", "-t", pane_id, "-T", f"{identity}:catmux"), check=True)
         _attach_tmux_pipe(runtime, pane_id, interactive_logs / f"{identity}_catmux.log")
-        _create_tmux_split_below(
-            runtime,
-            pane_id,
-            f"{identity}:launch",
-            _host_shell(launch_script),
-            log_path=interactive_logs / f"{identity}_launch.log",
-        )
-        subprocess.run(
-            _tmux_command(runtime, "select-layout", "-t", f"{session_name}:{window_name}", "even-vertical"), check=True
-        )
 
     created_network = subprocess.run(
         _tmux_command(
@@ -718,6 +725,28 @@ def _start_interactive_benchmark(args: argparse.Namespace, genre: str) -> int:
     subprocess.run(
         _tmux_command(runtime, "select-layout", "-t", f"{session_name}:network", "even-vertical"), check=True
     )
+
+    created_results = subprocess.run(
+        _tmux_command(
+            runtime,
+            "new-window",
+            "-d",
+            "-P",
+            "-F",
+            "#{pane_id}",
+            "-t",
+            session_name,
+            "-n",
+            "results",
+            _host_shell(result_script),
+        ),
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    results_pane = created_results.stdout.strip()
+    subprocess.run(_tmux_command(runtime, "select-pane", "-t", results_pane, "-T", "results:final"), check=True)
+    _attach_tmux_pipe(runtime, results_pane, interactive_logs / "results.log")
 
     subprocess.run(_tmux_command(runtime, "select-window", "-t", f"{session_name}:run"), check=True)
     print(f"Benchmark tmux session: {session_name}")
@@ -1512,6 +1541,7 @@ def _make_live_run_point(args: argparse.Namespace, session_name: str) -> RunPoin
 
             runtime, plan, target = _resolve_ota_smoke_context(smoke_args)
             dry_run = smoke_args.dry_run
+            _profile_name, profile_obj = _resolve_ota_profile(runtime, target, smoke_args)
 
             if not smoke_args.skip_preflight:
                 _ota_preflight(
@@ -1519,6 +1549,7 @@ def _make_live_run_point(args: argparse.Namespace, session_name: str) -> RunPoin
                     require_tmux=target.target_type == "scenario",
                     check_peer_reachability=False,
                     dry_run=dry_run,
+                    require_network_shaping_sudo=profile_obj is not None,
                 )
             _ota_prepare_hosts(smoke_args, runtime, plan)
             instance = _resolve_session_instance(
@@ -1539,7 +1570,6 @@ def _make_live_run_point(args: argparse.Namespace, session_name: str) -> RunPoin
                 interactive=False,
                 phase="running",
             )
-            profile_name, profile_obj = _resolve_ota_profile(runtime, target, smoke_args)
             directions = _profile_directions(plan, target.cfg) if profile_obj is not None else {}
             shapers = []
             try:

--- a/tests/unit/test_cli_benchmark.py
+++ b/tests/unit/test_cli_benchmark.py
@@ -782,6 +782,62 @@ def test_peer_catmux_attach_script_waits_for_container_and_tmux() -> None:
     assert "orchestrator.full.log" in script
     assert 'docker exec "$container" tmux -L catmux list-sessions' in script
     assert 'docker exec -it "$container" tmux -L catmux attach-session -t "$session"' in script
+    assert "split-window" not in script
+
+
+def test_ota_profile_shaping_uses_noninteractive_sudo(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[str, dict[str, object]]] = []
+    peer = cli.OtaSmokePeer(name="a", ssh="robot-a", address="10.0.0.10")
+
+    def fake_ota_run(_peer: cli.OtaSmokePeer, script: str, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append((script, kwargs))
+        return subprocess.CompletedProcess(["ssh"], 0, "", "")
+
+    monkeypatch.setattr(cli, "_ota_run", fake_ota_run)
+
+    cli._peer_command_runner(peer, dry_run=False)(["tc", "qdisc", "show", "dev", "tun0"])
+    cli._peer_watchdog_launcher(peer, dry_run=False)(["sh", "-c", "sleep 1; tc qdisc del dev tun0 root"])
+
+    assert calls[0][0] == "sudo -n tc qdisc show dev tun0"
+    assert calls[0][1]["label"] == "a: tc/netem"
+    assert calls[1][0].startswith("nohup sudo -n sh -c ")
+    assert calls[1][1]["label"] == "a: profile safety watchdog"
+
+
+def test_ota_preflight_can_require_passwordless_network_shaping(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[str, str]] = []
+    plan = cli.OtaSmokePlan(
+        state_path=None,
+        workdir="/tmp/rosotacom_ota",
+        rosotacom="rosotacom",
+        project="project/rosotacom.yaml",
+        peers={"a": cli.OtaSmokePeer(name="a", ssh="robot-a", address="10.0.0.10")},
+    )
+
+    def fake_ota_run(
+        _peer: cli.OtaSmokePeer,
+        script: str,
+        *,
+        label: str,
+        **_kwargs: object,
+    ) -> subprocess.CompletedProcess[str]:
+        calls.append((label, script))
+        return subprocess.CompletedProcess(["ssh"], 0, "", "")
+
+    monkeypatch.setattr(cli, "_ota_run", fake_ota_run)
+
+    cli._ota_preflight(
+        plan,
+        require_tmux=False,
+        check_peer_reachability=False,
+        dry_run=False,
+        require_network_shaping_sudo=True,
+    )
+
+    assert (
+        "a: passwordless sudo for network shaping",
+        "command -v tc >/dev/null 2>&1 && command -v ip >/dev/null 2>&1 && sudo -n true",
+    ) in calls
 
 
 def test_interactive_benchmark_dry_run_prints_operator_view(
@@ -850,10 +906,11 @@ def test_interactive_benchmark_dry_run_prints_operator_view(
     output = capsys.readouterr().out
     assert "Would create benchmark tmux session: benchmark-capacity-p" in output
     assert "Run window: high-level orchestrator" in output
-    assert "Peer window a: a_catmux catmux attach + launch log" in output
-    assert "Peer window b: b_catmux catmux attach + launch log" in output
+    assert "Peer window a: a_catmux fullscreen catmux attach" in output
+    assert "Peer window b: b_catmux fullscreen catmux attach" in output
     assert "Network window: qdisc monitor + tc command log" in output
-    assert "Results window" not in output
+    assert "Results window: final result printed once" in output
+    assert "launch log" not in output
     child = " ".join(_benchmark_child_command())
     assert "--interactive" not in child
     assert "--no-attach" not in child


### PR DESCRIPTION
## Summary
- make local benchmark catmux windows fullscreen again, while keeping wait-time container/orchestrator diagnostics in the attach pane
- restore a results window that prints the final `result.json` once, instead of continuously polling and repainting results
- keep the network window split into qdisc status plus tc/netem command logs
- require shaped OTA benchmark runs to prove passwordless non-interactive sudo for `tc`/`ip` during preflight, and run shaping/watchdog commands through `sudo -n`

## Validation
- `python3 -m pytest -q tests/unit/test_cli_benchmark.py`
- `python3 -m ruff check src/rosotacom/cli.py src/rosotacom/cli_benchmark.py tests/unit/test_cli_benchmark.py`
- `python3 -m ruff format --check src/rosotacom/cli.py src/rosotacom/cli_benchmark.py tests/unit/test_cli_benchmark.py`
- `git diff --check`
- `PYTHONPATH=src python3 -m rosotacom benchmark capacity --rosotacom-config src/rosotacom/resources/examples/rosotacom.yaml --profile cellular-4g-degraded --knob size --low 1 --high 1 --max-loss 30 --max-latency-ms 1000 --duration 10 --repeats 1 --interactive --dry-run --no-attach`
- `PYTHONPATH=src python3 -m rosotacom ota-benchmark capacity --rosotacom-config src/rosotacom/resources/examples/rosotacom.yaml --profile cellular-4g-degraded --knob size --low 1 --high 1 --max-loss 30 --max-latency-ms 1000 --duration 10 --repeats 1 --peer a=seat_tks --peer b=majestic_tks --interactive --dry-run --no-attach`
- `PYTHONPATH=/home/go914/dev/rosotacom-benchmark-operator/src python3 -m rosotacom ota-benchmark capacity --rosotacom-config /home/go914/dev/rosotacom_test/fzi_projects/remote_assist/rosotacom.yaml --profiles-file /home/go914/dev/rosotacom_test/fzi_projects/remote_assist/profiles/benchmark-profiles.yaml --profile cellular-4g-degraded --knob size --low 1 --high 1 --max-loss 30 --max-latency-ms 1000 --duration 10 --repeats 1 --peer a=seat_tks --peer b=majestic_tks --dry-run`

Refs #61
