### PR TITLE
Fix benchmark result pane and sudo modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,8 +479,11 @@ project-specific session or scenario instead. Add `--interactive` to open a tmux
 operator view with a high-level run window, one fullscreen attachable catmux
 window per local peer, a network window split into qdisc status and tc/netem
 command logs, and a results window that prints the final result once. Shaped OTA
-benchmark profiles require passwordless non-interactive sudo for `tc`/`ip` on the
-remote peers; preflight checks this before arming the profile.
+benchmark profiles need sudo on the remote peers for the generated `tc`/`ip`
+commands. The default `--sudo-mode passwordless` checks `sudo -n` and is the right
+mode for unattended runs. For attended operator runs, pass `--sudo-mode askpass`
+to prompt locally once per peer and feed the password to remote `sudo -S` over SSH
+stdin without printing or storing it.
 
 ## Development
 

--- a/docs/rfcs/0005-benchmark-genres-and-ci.md
+++ b/docs/rfcs/0005-benchmark-genres-and-ci.md
@@ -183,10 +183,10 @@ slice and reuses RFC 0003 + 0004.
   with a high-level run window, one fullscreen catmux attach window per local
   peer, a network window split into qdisc status and tc/netem command logs, and a
   one-shot final result window (`cli_benchmark --interactive`).
-- [x] Require shaped OTA benchmark runs to prove passwordless non-interactive sudo
-  for `tc`/`ip` during preflight, and run profile commands through `sudo -n` so
-  missing privileges fail early instead of hanging or failing mid-run
-  (`cli._ota_preflight`, `cli._peer_command_runner`).
+- [x] Let shaped OTA benchmark runs choose explicit sudo handling:
+  passwordless non-interactive sudo for unattended runs, or a local per-peer
+  askpass prompt that feeds `sudo -S` over SSH stdin for attended operator runs
+  (`--sudo-mode`, `cli._ota_preflight`, `cli._peer_command_runner`).
 - [x] Build the recovery driver on timeline profiles (RFC 0004) + the recovery
   metric set (`t_recover`, `t_steady`, backlog/burst, lost-during-outage, latched
   re-arrival) (`benchmark.recovery_metrics`; arming the timeline profile is RFC
@@ -245,11 +245,15 @@ reviewed rather than asserted in a blocking test.
   *(`test_interactive_benchmark_dry_run_prints_operator_view`,
   `test_peer_catmux_attach_script_waits_for_container_and_tmux`,
   `test_benchmark_subcommand_arg_parsing`.)*
-- [x] **OTA profile shaping privilege check** (passwordless non-interactive sudo
-  for `tc`/`ip`) — host unit tests assert the preflight check and `sudo -n`
-  wrapping for shaping/watchdog commands. Automatable.
-  *(`test_ota_preflight_can_require_passwordless_network_shaping`,
-  `test_ota_profile_shaping_uses_noninteractive_sudo`.)*
+- [x] **OTA profile shaping privilege handling** (passwordless non-interactive
+  sudo or local askpass prompt for `tc`/`ip`) — host unit tests assert the
+  preflight checks, `sudo -n` wrapping, `sudo -S` stdin handling, and per-peer
+  prompt flow. Automatable.
+  *(`test_ota_preflight_can_require_network_shaping_sudo`,
+  `test_ota_preflight_askpass_authenticates_via_stdin`,
+  `test_ota_profile_shaping_uses_noninteractive_sudo`,
+  `test_ota_profile_shaping_askpass_uses_stdin`,
+  `test_ota_askpass_prompts_once_per_peer`.)*
 - [x] **Recovery driver + metric set** (`t_recover`, `t_steady`, backlog/burst,
   lost-during-outage, latched re-arrival) — host unit test extracting the metrics
   from a synthetic timeline of transit records (RFC 0003); the **live recovery run

--- a/src/rosotacom/cli.py
+++ b/src/rosotacom/cli.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import argparse
 import base64
 import binascii
+import getpass
 import hashlib
 import importlib
 import importlib.resources as importlib_resources
@@ -27,7 +28,7 @@ import sys
 import tarfile
 import tempfile
 import time
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, replace
 from datetime import datetime
 from pathlib import Path
@@ -79,6 +80,8 @@ SESSION_INSTANCE_CONTAINER_DIR = "/session/instances"
 EXTERNAL_SESSION_CONTAINER_DIR = "/session/current"
 RUN_SESSION_CONTAINER_PATH = "/ws/session/creation/run_session.py"
 DEFAULT_SMOKE_SESSION = "1_heartbeat"
+OTA_SUDO_MODES = ("passwordless", "askpass")
+OTA_DEFAULT_SUDO_MODE = "passwordless"
 
 ws_creation_dir = WS_DIR / "session" / "creation"
 session_gen_path = ws_creation_dir / "generate_session_files.py"
@@ -1461,7 +1464,7 @@ def _ota_run(
     timeout: float | None = None,
 ) -> subprocess.CompletedProcess[str]:
     argv = _ota_remote_argv(peer, script, tty=tty, batch=batch)
-    print(f"+ {label}: {_ota_quote_cmd(argv)}")
+    print(f"+ {label}: running remote command")
     if dry_run:
         return subprocess.CompletedProcess(argv, 0, "", "")
     result = subprocess.run(argv, text=True, capture_output=not tty, check=False, timeout=timeout)
@@ -1469,6 +1472,31 @@ def _ota_run(
         detail = ((result.stdout or "") + (result.stderr or "")).strip()
         raise RuntimeError(f"{label} failed with exit code {result.returncode}:\n{detail}")
     return result
+
+
+def _ota_run_with_secret_stdin(
+    peer: OtaSmokePeer,
+    script: str,
+    *,
+    label: str,
+    secret_stdin: str,
+    dry_run: bool = False,
+    check: bool = True,
+    batch: bool = False,
+    timeout: float | None = None,
+) -> subprocess.CompletedProcess[str]:
+    argv = _ota_remote_argv(peer, script, batch=batch)
+    if dry_run:
+        return subprocess.CompletedProcess(argv, 0, "", "")
+    result = subprocess.run(argv, input=secret_stdin, text=True, capture_output=True, check=False, timeout=timeout)
+    if check and result.returncode != 0:
+        detail = ((result.stdout or "") + (result.stderr or "")).strip()
+        raise RuntimeError(f"{label} failed with exit code {result.returncode}:\n{detail}")
+    return result
+
+
+def _ota_log_action(label: str, detail: str) -> None:
+    print(f"+ {label}: {detail}")
 
 
 def _ota_print_failure_output(label: str, result: subprocess.CompletedProcess[str]) -> None:
@@ -1942,6 +1970,53 @@ def _resolve_ota_smoke_context(
     return runtime, plan, target
 
 
+def _validate_ota_sudo_mode(sudo_mode: str) -> str:
+    if sudo_mode not in OTA_SUDO_MODES:
+        raise RuntimeError(f"Unsupported OTA sudo mode {sudo_mode!r}; expected one of {', '.join(OTA_SUDO_MODES)}.")
+    return sudo_mode
+
+
+def _ota_network_sudo_passwords(
+    plan: OtaSmokePlan,
+    *,
+    sudo_mode: str,
+    require_network_shaping_sudo: bool,
+    dry_run: bool,
+) -> dict[str, str]:
+    sudo_mode = _validate_ota_sudo_mode(sudo_mode)
+    if not require_network_shaping_sudo or sudo_mode != "askpass":
+        return {}
+    if dry_run:
+        return {peer.name: "" for peer in plan.peers.values()}
+    passwords: dict[str, str] = {}
+    for peer in plan.peers.values():
+        target = peer.ssh or "local shell"
+        passwords[peer.name] = getpass.getpass(f"sudo password for {peer.name} ({target}) [network shaping only]: ")
+    return passwords
+
+
+def _sudo_stdin(sudo_password: str | None) -> str | None:
+    return None if sudo_password is None else sudo_password + "\n"
+
+
+def _sudo_command(argv: Sequence[str], *, askpass: bool = False) -> str:
+    mode = "sudo -S -p ''" if askpass else "sudo -n"
+    return f"{mode} {shlex.join(list(argv))}"
+
+
+def _passwordless_watchdog_command(argv: Sequence[str]) -> str:
+    argv = list(argv)
+    if len(argv) >= 3 and argv[0] == "sh" and argv[1] == "-c":
+        script = str(argv[2])
+        script = script.replace("; tc ", "; sudo -n tc ").replace("; ip ", "; sudo -n ip ")
+        if script.startswith("tc "):
+            script = "sudo -n " + script
+        if script.startswith("ip "):
+            script = "sudo -n " + script
+        return f"nohup sh -c {shlex.quote(script)} >/dev/null 2>&1 &"
+    return f"nohup sudo -n {shlex.join(argv)} >/dev/null 2>&1 &"
+
+
 def _ota_preflight(
     plan: OtaSmokePlan,
     *,
@@ -1949,7 +2024,11 @@ def _ota_preflight(
     check_peer_reachability: bool,
     dry_run: bool,
     require_network_shaping_sudo: bool = False,
+    sudo_mode: str = OTA_DEFAULT_SUDO_MODE,
+    sudo_passwords: Mapping[str, str] | None = None,
 ) -> None:
+    sudo_mode = _validate_ota_sudo_mode(sudo_mode)
+    sudo_passwords = sudo_passwords or {}
     for peer in plan.peers.values():
         if peer.ssh:
             _ota_run(peer, "true", label=f"{peer.name}: SSH reachable", dry_run=dry_run, batch=True)
@@ -1975,11 +2054,31 @@ def _ota_preflight(
         if require_network_shaping_sudo:
             _ota_run(
                 peer,
-                "command -v tc >/dev/null 2>&1 && command -v ip >/dev/null 2>&1 && sudo -n true",
-                label=f"{peer.name}: passwordless sudo for network shaping",
+                "command -v tc >/dev/null 2>&1 && command -v ip >/dev/null 2>&1",
+                label=f"{peer.name}: required commands for network shaping",
                 dry_run=dry_run,
                 batch=True,
             )
+            if sudo_mode == "askpass":
+                script = "sudo -S -p '' true"
+                label = f"{peer.name}: sudo authentication for network shaping"
+                _ota_log_action(label, "authenticating sudo via stdin")
+                _ota_run_with_secret_stdin(
+                    peer,
+                    script,
+                    label=label,
+                    dry_run=dry_run,
+                    batch=True,
+                    secret_stdin=_sudo_stdin(sudo_passwords.get(peer.name)) or "",
+                )
+            else:
+                _ota_run(
+                    peer,
+                    "sudo -n tc qdisc show >/dev/null && sudo -n ip link show >/dev/null",
+                    label=f"{peer.name}: passwordless sudo for network shaping",
+                    dry_run=dry_run,
+                    batch=True,
+                )
 
     if check_peer_reachability:
         for src in plan.peers.values():
@@ -2267,26 +2366,64 @@ def _ota_resolve_interfaces(peer: OtaSmokePeer, peer_addr: str, *, dry_run: bool
     return ota_iface, control_iface
 
 
-def _peer_command_runner(peer: OtaSmokePeer, *, dry_run: bool) -> Callable[[Sequence[str]], None]:
+def _peer_command_runner(
+    peer: OtaSmokePeer, *, dry_run: bool, sudo_password: str | None = None
+) -> Callable[[Sequence[str]], None]:
     """A CommandRunner that runs one privileged argv on ``peer`` via the SSH path."""
 
     def run(argv: Sequence[str]) -> None:
-        _ota_run(peer, "sudo -n " + shlex.join(list(argv)), label=f"{peer.name}: tc/netem", dry_run=dry_run)
+        label = f"{peer.name}: tc/netem"
+        if sudo_password is None:
+            script = _sudo_command(argv)
+            _ota_run(peer, script, label=label, dry_run=dry_run)
+        else:
+            script = _sudo_command(argv, askpass=True)
+            _ota_log_action(label, "running remote sudo command via stdin")
+            _ota_run_with_secret_stdin(
+                peer,
+                script,
+                label=label,
+                dry_run=dry_run,
+                secret_stdin=_sudo_stdin(sudo_password) or "",
+            )
 
     return run
 
 
-def _peer_watchdog_launcher(peer: OtaSmokePeer, *, dry_run: bool) -> Callable[[Sequence[str]], None]:
+def _peer_watchdog_launcher(
+    peer: OtaSmokePeer, *, dry_run: bool, sudo_password: str | None = None
+) -> Callable[[Sequence[str]], None]:
     """Launch the safety-watchdog argv detached on ``peer`` so it survives a crash."""
 
     def launch(argv: Sequence[str]) -> None:
-        detached = f"nohup sudo -n {shlex.join(list(argv))} >/dev/null 2>&1 &"
-        _ota_run(peer, detached, label=f"{peer.name}: profile safety watchdog", dry_run=dry_run, check=False)
+        if sudo_password is None:
+            detached = _passwordless_watchdog_command(argv)
+            _ota_run(peer, detached, label=f"{peer.name}: profile safety watchdog", dry_run=dry_run, check=False)
+        else:
+            inner = f"nohup {shlex.join(list(argv))} >/dev/null 2>&1 &"
+            detached = f"sudo -S -p '' sh -c {shlex.quote(inner)}"
+            label = f"{peer.name}: profile safety watchdog"
+            _ota_log_action(label, "arming remote sudo watchdog via stdin")
+            _ota_run_with_secret_stdin(
+                peer,
+                detached,
+                label=label,
+                dry_run=dry_run,
+                check=False,
+                secret_stdin=_sudo_stdin(sudo_password) or "",
+            )
 
     return launch
 
 
-def _ota_arm_profile(plan: OtaSmokePlan, profile: Any, directions: dict[str, str], *, dry_run: bool) -> list[Any]:
+def _ota_arm_profile(
+    plan: OtaSmokePlan,
+    profile: Any,
+    directions: dict[str, str],
+    *,
+    dry_run: bool,
+    sudo_passwords: Mapping[str, str] | None = None,
+) -> list[Any]:
     """Arm the static profile per direction on every peer's OTA egress (RFC 0004),
     returning the ``ProfileShaper`` handles to revert in the run's ``finally``."""
     from .network_profiles import shaping_commands
@@ -2306,12 +2443,13 @@ def _ota_arm_profile(plan: OtaSmokePlan, profile: Any, directions: dict[str, str
             ota_iface, control_iface = "<ota-if>", None
         else:
             ota_iface, control_iface = _ota_resolve_interfaces(peer, other_addr, dry_run=False)
+        sudo_password = (sudo_passwords or {}).get(peer_name)
         shaper = ProfileShaper(
             ota_iface,
-            _peer_command_runner(peer, dry_run=dry_run),
+            _peer_command_runner(peer, dry_run=dry_run, sudo_password=sudo_password),
             control_interface=control_iface,
             safety_max_duration_s=_PROFILE_SAFETY_MAX_S,
-            watchdog_launcher=_peer_watchdog_launcher(peer, dry_run=dry_run),
+            watchdog_launcher=_peer_watchdog_launcher(peer, dry_run=dry_run, sudo_password=sudo_password),
         )
         # Register before arming so a mid-arm failure is still reverted in `finally`.
         shapers.append(shaper)

--- a/src/rosotacom/cli_benchmark.py
+++ b/src/rosotacom/cli_benchmark.py
@@ -410,6 +410,20 @@ def _benchmark_child_command() -> list[str]:
     return [sys.executable, "-m", "rosotacom", *_strip_interactive_args(sys.argv[1:])]
 
 
+def _initialize_interactive_log(full_log: Path, command: Sequence[str]) -> None:
+    full_log.parent.mkdir(parents=True, exist_ok=True)
+    full_log.write_text(
+        "\n".join(
+            [
+                f"--- benchmark operator log initialized {datetime.now().isoformat(timespec='seconds')} ---",
+                "command: " + " ".join(command),
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
 def _benchmark_run_script(command: Sequence[str], full_log: Path, session_name: str) -> str:
     pattern = (
         r"probe\(|Benchmark result saved|Capacity result|Capacity:|Ramp curve copied|Recovery metrics copied|"
@@ -522,12 +536,16 @@ def _result_once_script(full_log: Path) -> str:
 import json
 import pathlib
 import re
-import sys
 import time
 
 log_path = pathlib.Path({str(full_log)!r})
 result_re = re.compile(r"Benchmark result saved to (.+)")
 exit_re = re.compile(r"benchmark exited with status (\\d+)")
+
+def hold_open(message):
+    print(message, flush=True)
+    while True:
+        time.sleep(3600)
 
 print("[INFO] waiting for final benchmark result in", log_path, flush=True)
 while True:
@@ -543,13 +561,12 @@ while True:
             else:
                 print("[WARN] result path was reported but is not readable yet:", result_path)
             print()
-            print("[INFO] result printed once; pane remains open for inspection")
-            sys.exit(0)
+            hold_open("[INFO] result printed once; pane stays alive for inspection")
         exit_match = exit_re.search(text)
         if exit_match:
             print("[WARN] benchmark exited with status", exit_match.group(1), "before reporting a result file")
             print("[INFO] inspect the run window or full orchestrator log:", log_path)
-            sys.exit(1)
+            hold_open("[INFO] pane stays alive for inspection")
     time.sleep(1)
 """.strip()
     return shlex.join([sys.executable, "-c", script])
@@ -639,7 +656,7 @@ def _start_interactive_benchmark(args: argparse.Namespace, genre: str) -> int:
             print(f"Attach with: rosotacom {subcommand} {genre} ... --interactive")
         return 0
 
-    interactive_logs.mkdir(parents=True, exist_ok=True)
+    _initialize_interactive_log(full_log, command)
     created = subprocess.run(
         _tmux_command(
             runtime,
@@ -1412,7 +1429,14 @@ def _parse_values(raw: str) -> list[float]:
 
 
 def _add_benchmark_common_args(parser: argparse.ArgumentParser, *, ota_benchmark: bool = False) -> None:
-    from .cli import _add_common_config_args, _add_peer_address_arg, _add_peer_arg, _add_peer_ssh_arg
+    from .cli import (
+        OTA_DEFAULT_SUDO_MODE,
+        OTA_SUDO_MODES,
+        _add_common_config_args,
+        _add_peer_address_arg,
+        _add_peer_arg,
+        _add_peer_ssh_arg,
+    )
 
     _add_common_config_args(parser)
     _add_peer_arg(parser)
@@ -1439,6 +1463,15 @@ def _add_benchmark_common_args(parser: argparse.ArgumentParser, *, ota_benchmark
         "--reuse",
         action="store_true",
         help="Reuse already staged OTA source/project on remote hosts.",
+    )
+    parser.add_argument(
+        "--sudo-mode",
+        choices=OTA_SUDO_MODES,
+        default=OTA_DEFAULT_SUDO_MODE,
+        help=(
+            "How OTA benchmark profile shaping obtains sudo for tc/ip "
+            "(passwordless: require sudo -n; askpass: prompt locally per peer and feed sudo -S)."
+        ),
     )
     parser.add_argument("--interactive", action="store_true", help="Open a tmux operator view for this benchmark run.")
     parser.add_argument(
@@ -1470,6 +1503,7 @@ def _make_live_run_point(args: argparse.Namespace, session_name: str) -> RunPoin
         _ota_arm_profile,
         _ota_cleanup_hosts,
         _ota_collect_logs,
+        _ota_network_sudo_passwords,
         _ota_preflight,
         _ota_prepare_hosts,
         _ota_resolve_interfaces,
@@ -1537,11 +1571,18 @@ def _make_live_run_point(args: argparse.Namespace, session_name: str) -> RunPoin
                 instance_id=getattr(args, "instance_id", None),
                 profile=profile,
                 benchmark_stepping=True,
+                sudo_mode=getattr(args, "sudo_mode", "passwordless"),
             )
 
             runtime, plan, target = _resolve_ota_smoke_context(smoke_args)
             dry_run = smoke_args.dry_run
             _profile_name, profile_obj = _resolve_ota_profile(runtime, target, smoke_args)
+            sudo_passwords = _ota_network_sudo_passwords(
+                plan,
+                sudo_mode=smoke_args.sudo_mode,
+                require_network_shaping_sudo=profile_obj is not None,
+                dry_run=dry_run,
+            )
 
             if not smoke_args.skip_preflight:
                 _ota_preflight(
@@ -1550,6 +1591,8 @@ def _make_live_run_point(args: argparse.Namespace, session_name: str) -> RunPoin
                     check_peer_reachability=False,
                     dry_run=dry_run,
                     require_network_shaping_sudo=profile_obj is not None,
+                    sudo_mode=smoke_args.sudo_mode,
+                    sudo_passwords=sudo_passwords,
                 )
             _ota_prepare_hosts(smoke_args, runtime, plan)
             instance = _resolve_session_instance(
@@ -1588,10 +1631,14 @@ def _make_live_run_point(args: argparse.Namespace, session_name: str) -> RunPoin
                                 ota_iface, control_iface = _ota_resolve_interfaces(peer, other_addr, dry_run=False)
                             shaper = ProfileShaper(
                                 ota_iface,
-                                _peer_command_runner(peer, dry_run=dry_run),
+                                _peer_command_runner(
+                                    peer, dry_run=dry_run, sudo_password=sudo_passwords.get(peer_name)
+                                ),
                                 control_interface=control_iface,
                                 safety_max_duration_s=_PROFILE_SAFETY_MAX_S,
-                                watchdog_launcher=_peer_watchdog_launcher(peer, dry_run=dry_run),
+                                watchdog_launcher=_peer_watchdog_launcher(
+                                    peer, dry_run=dry_run, sudo_password=sudo_passwords.get(peer_name)
+                                ),
                             )
                             shapers.append(shaper)
                             steps = expand_timeline(profile_obj, ota_iface, direction=direction)
@@ -1600,7 +1647,9 @@ def _make_live_run_point(args: argparse.Namespace, session_name: str) -> RunPoin
                         for shaper in shapers:
                             shaper.arm([])
                     else:
-                        shapers = _ota_arm_profile(plan, profile_obj, directions, dry_run=dry_run)
+                        shapers = _ota_arm_profile(
+                            plan, profile_obj, directions, dry_run=dry_run, sudo_passwords=sudo_passwords
+                        )
 
                 _ota_start_peers(target, plan, instance.instance_id, dry_run=dry_run)
                 if not dry_run:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1139,15 +1139,15 @@ def test_ota_smoke_dry_run_exercises_generic_remote_flow(
     assert "install rosotacom" in out
     assert "required command tmux" in out
     assert "Python venv support" in out
-    assert 'grep -Eq "[1-9][0-9]* received"' in out
-    assert "ssh -o BatchMode=yes robot-b true" in out
-    assert "scenario start demo --identity a --mode detached --instance-id ota-dry" in out
-    assert "scenario start demo --identity b --mode detached --instance-id ota-dry" in out
-    assert "test demo --instance-id ota-dry" in out
-    assert "probe-publish demo --identity a --topic /local_only" in out
-    assert "probe-check demo --identity b --topic /local_only --expect absent" in out
-    assert "scenario stop demo --identity a --instance-id ota-dry" in out
-    assert "*_ota-dry" in out
+    assert "reach peer b (10.0.0.11): running remote command" in out
+    assert "b: SSH reachable: running remote command" in out
+    assert "a: start demo: running remote command" in out
+    assert "b: start demo: running remote command" in out
+    assert "a: rosotacom test: running remote command" in out
+    assert "a: publish isolation probe: running remote command" in out
+    assert "b: check isolation probe absent: running remote command" in out
+    assert "a: stop demo: running remote command" in out
+    assert "a: collect session-instances: running remote command" in out
     assert "OTA SMOKE OK" in out
 
 

--- a/tests/unit/test_cli_benchmark.py
+++ b/tests/unit/test_cli_benchmark.py
@@ -24,10 +24,12 @@ from rosotacom.cli_benchmark import (
     _benchmark_child_command,
     _benchmark_ota_target,
     _benchmark_profiles_file,
+    _initialize_interactive_log,
     _is_ota_benchmark,
     _parse_values,
     _peer_catmux_attach_script,
     _prepare_benchmark_session_config,
+    _result_once_script,
     _start_interactive_benchmark,
     collect_transit_summary,
     drive_capacity,
@@ -509,6 +511,7 @@ def test_benchmark_subcommand_arg_parsing() -> None:
     assert args.knob == "size"
     assert args.rmw == DEFAULT_BENCHMARK_RMW
     assert args.ota_benchmark is False
+    assert args.sudo_mode == "passwordless"
     assert _is_ota_benchmark(args) is False
 
     args = parser.parse_args(
@@ -609,6 +612,8 @@ def test_benchmark_subcommand_arg_parsing() -> None:
             "a=seat_tks",
             "--peer",
             "b=majestic_tks",
+            "--sudo-mode",
+            "askpass",
         ]
     )
     assert args.command == "ota-benchmark"
@@ -617,6 +622,7 @@ def test_benchmark_subcommand_arg_parsing() -> None:
     assert args.target is None
     assert args.target_type is None
     assert args.peer == ["a=seat_tks", "b=majestic_tks"]
+    assert args.sudo_mode == "askpass"
     assert _is_ota_benchmark(args) is True
 
 
@@ -796,15 +802,51 @@ def test_ota_profile_shaping_uses_noninteractive_sudo(monkeypatch: pytest.Monkey
     monkeypatch.setattr(cli, "_ota_run", fake_ota_run)
 
     cli._peer_command_runner(peer, dry_run=False)(["tc", "qdisc", "show", "dev", "tun0"])
-    cli._peer_watchdog_launcher(peer, dry_run=False)(["sh", "-c", "sleep 1; tc qdisc del dev tun0 root"])
+    cli._peer_watchdog_launcher(peer, dry_run=False)(
+        ["sh", "-c", "sleep 1; tc qdisc del dev tun0 root; ip link set dev tun0 up"]
+    )
 
     assert calls[0][0] == "sudo -n tc qdisc show dev tun0"
     assert calls[0][1]["label"] == "a: tc/netem"
-    assert calls[1][0].startswith("nohup sudo -n sh -c ")
+    assert calls[1][0].startswith("nohup sh -c ")
+    assert "sudo -n tc qdisc del dev tun0 root" in calls[1][0]
+    assert "sudo -n ip link set dev tun0 up" in calls[1][0]
     assert calls[1][1]["label"] == "a: profile safety watchdog"
 
 
-def test_ota_preflight_can_require_passwordless_network_shaping(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_ota_profile_shaping_askpass_uses_stdin(monkeypatch: pytest.MonkeyPatch) -> None:
+    action_calls: list[tuple[str, str]] = []
+    secret_calls: list[tuple[str, dict[str, object]]] = []
+    peer = cli.OtaSmokePeer(name="a", ssh="robot-a", address="10.0.0.10")
+
+    def fake_log_action(label: str, detail: str) -> None:
+        action_calls.append((label, detail))
+
+    def fake_ota_run_with_secret_stdin(
+        _peer: cli.OtaSmokePeer, script: str, **kwargs: object
+    ) -> subprocess.CompletedProcess[str]:
+        secret_calls.append((script, kwargs))
+        return subprocess.CompletedProcess(["ssh"], 0, "", "")
+
+    monkeypatch.setattr(cli, "_ota_log_action", fake_log_action)
+    monkeypatch.setattr(cli, "_ota_run_with_secret_stdin", fake_ota_run_with_secret_stdin)
+
+    cli._peer_command_runner(peer, dry_run=False, sudo_password="secret")(["tc", "qdisc", "show", "dev", "tun0"])
+    cli._peer_watchdog_launcher(peer, dry_run=False, sudo_password="secret")(
+        ["sh", "-c", "sleep 1; tc qdisc del dev tun0 root; ip link set dev tun0 up"]
+    )
+
+    assert action_calls[0] == ("a: tc/netem", "running remote sudo command via stdin")
+    assert secret_calls[0][0] == "sudo -S -p '' tc qdisc show dev tun0"
+    assert secret_calls[0][1]["secret_stdin"] == "secret\n"
+    assert "secret" not in secret_calls[0][0]
+    assert action_calls[1] == ("a: profile safety watchdog", "arming remote sudo watchdog via stdin")
+    assert secret_calls[1][0].startswith("sudo -S -p '' sh -c ")
+    assert secret_calls[1][1]["secret_stdin"] == "secret\n"
+    assert "secret" not in secret_calls[1][0]
+
+
+def test_ota_preflight_can_require_network_shaping_sudo(monkeypatch: pytest.MonkeyPatch) -> None:
     calls: list[tuple[str, str]] = []
     plan = cli.OtaSmokePlan(
         state_path=None,
@@ -835,9 +877,132 @@ def test_ota_preflight_can_require_passwordless_network_shaping(monkeypatch: pyt
     )
 
     assert (
-        "a: passwordless sudo for network shaping",
-        "command -v tc >/dev/null 2>&1 && command -v ip >/dev/null 2>&1 && sudo -n true",
+        "a: required commands for network shaping",
+        "command -v tc >/dev/null 2>&1 && command -v ip >/dev/null 2>&1",
     ) in calls
+    assert (
+        "a: passwordless sudo for network shaping",
+        "sudo -n tc qdisc show >/dev/null && sudo -n ip link show >/dev/null",
+    ) in calls
+
+
+def test_ota_preflight_askpass_authenticates_via_stdin(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[str, str]] = []
+    action_calls: list[tuple[str, str]] = []
+    secret_calls: list[tuple[str, str, str]] = []
+    plan = cli.OtaSmokePlan(
+        state_path=None,
+        workdir="/tmp/rosotacom_ota",
+        rosotacom="rosotacom",
+        project="project/rosotacom.yaml",
+        peers={"a": cli.OtaSmokePeer(name="a", ssh="robot-a", address="10.0.0.10")},
+    )
+
+    def fake_ota_run(
+        _peer: cli.OtaSmokePeer,
+        script: str,
+        *,
+        label: str,
+        **_kwargs: object,
+    ) -> subprocess.CompletedProcess[str]:
+        calls.append((label, script))
+        return subprocess.CompletedProcess(["ssh"], 0, "", "")
+
+    def fake_log_action(label: str, detail: str) -> None:
+        action_calls.append((label, detail))
+
+    def fake_ota_run_with_secret_stdin(
+        _peer: cli.OtaSmokePeer,
+        script: str,
+        *,
+        label: str,
+        secret_stdin: str,
+        **_kwargs: object,
+    ) -> subprocess.CompletedProcess[str]:
+        secret_calls.append((label, script, secret_stdin))
+        return subprocess.CompletedProcess(["ssh"], 0, "", "")
+
+    monkeypatch.setattr(cli, "_ota_run", fake_ota_run)
+    monkeypatch.setattr(cli, "_ota_log_action", fake_log_action)
+    monkeypatch.setattr(cli, "_ota_run_with_secret_stdin", fake_ota_run_with_secret_stdin)
+
+    cli._ota_preflight(
+        plan,
+        require_tmux=False,
+        check_peer_reachability=False,
+        dry_run=False,
+        require_network_shaping_sudo=True,
+        sudo_mode="askpass",
+        sudo_passwords={"a": "secret"},
+    )
+
+    assert (
+        "a: sudo authentication for network shaping",
+        "authenticating sudo via stdin",
+    ) in action_calls
+    assert ("a: sudo authentication for network shaping", "sudo -S -p '' true", "secret\n") in secret_calls
+    assert all("secret" not in script for _label, script in calls)
+    assert all("secret" not in detail for _label, detail in action_calls)
+    assert all("secret" not in script for _label, script, _stdin in secret_calls)
+
+
+def test_ota_askpass_prompts_once_per_peer(monkeypatch: pytest.MonkeyPatch) -> None:
+    prompts: list[str] = []
+    plan = cli.OtaSmokePlan(
+        state_path=None,
+        workdir="/tmp/rosotacom_ota",
+        rosotacom="rosotacom",
+        project="project/rosotacom.yaml",
+        peers={
+            "a": cli.OtaSmokePeer(name="a", ssh="robot-a", address="10.0.0.10"),
+            "b": cli.OtaSmokePeer(name="b", ssh="robot-b", address="10.0.0.11"),
+        },
+    )
+
+    def fake_getpass(prompt: str) -> str:
+        prompts.append(prompt)
+        return f"pw-{len(prompts)}"
+
+    monkeypatch.setattr(cli.getpass, "getpass", fake_getpass)
+
+    passwords = cli._ota_network_sudo_passwords(
+        plan,
+        sudo_mode="askpass",
+        require_network_shaping_sudo=True,
+        dry_run=False,
+    )
+
+    assert passwords == {"a": "pw-1", "b": "pw-2"}
+    assert prompts == [
+        "sudo password for a (robot-a) [network shaping only]: ",
+        "sudo password for b (robot-b) [network shaping only]: ",
+    ]
+
+    dry_run_passwords = cli._ota_network_sudo_passwords(
+        plan,
+        sudo_mode="askpass",
+        require_network_shaping_sudo=True,
+        dry_run=True,
+    )
+    assert dry_run_passwords == {"a": "", "b": ""}
+    assert len(prompts) == 2
+
+
+def test_interactive_result_log_is_reset_between_runs(tmp_path: Path) -> None:
+    full_log = tmp_path / "interactive" / "benchmark-capacity-p" / "orchestrator.full.log"
+    full_log.parent.mkdir(parents=True)
+    full_log.write_text("Benchmark result saved to /old/result.json\n", encoding="utf-8")
+
+    _initialize_interactive_log(full_log, ["rosotacom", "benchmark", "capacity"])
+
+    text = full_log.read_text(encoding="utf-8")
+    assert "Benchmark result saved" not in text
+    assert "benchmark operator log initialized" in text
+    assert "command: rosotacom benchmark capacity" in text
+
+    script = _result_once_script(full_log)
+    assert "result printed once; pane stays alive" in script
+    assert "sys.exit" not in script
 
 
 def test_interactive_benchmark_dry_run_prints_operator_view(


### PR DESCRIPTION
## Summary
- reset the interactive benchmark orchestrator log before creating panes so the result pane cannot read a previous run's `Benchmark result saved ...` line
- keep the one-shot result pane alive after printing the final result, avoiding an immediate tmux dead pane
- add `--sudo-mode {passwordless,askpass}` for OTA benchmark profile shaping
- keep `passwordless` as the unattended default, checking actual `sudo -n tc` / `sudo -n ip` access and using only tc/ip sudo calls in the passwordless watchdog path
- add attended `askpass` mode that prompts once per peer locally and feeds the password to remote `sudo -S` via SSH stdin without printing or storing it

## Validation
- `python3 -m pytest -q tests/unit/test_cli_benchmark.py`
- `python3 -m ruff check src/rosotacom/cli.py src/rosotacom/cli_benchmark.py tests/unit/test_cli_benchmark.py`
- `python3 -m ruff format --check src/rosotacom/cli.py src/rosotacom/cli_benchmark.py tests/unit/test_cli_benchmark.py`
- `git diff --check`
- `PYTHONPATH=src python3 -m rosotacom benchmark capacity --rosotacom-config src/rosotacom/resources/examples/rosotacom.yaml --profile cellular-4g-degraded --knob size --low 1 --high 1 --max-loss 30 --max-latency-ms 1000 --duration 10 --repeats 1 --interactive --dry-run --no-attach`
- `PYTHONPATH=src python3 -m rosotacom ota-benchmark capacity --rosotacom-config src/rosotacom/resources/examples/rosotacom.yaml --profile cellular-4g-degraded --knob size --low 1 --high 1 --max-loss 30 --max-latency-ms 1000 --duration 10 --repeats 1 --peer a=seat_tks --peer b=majestic_tks --interactive --dry-run --no-attach --sudo-mode askpass`
- `PYTHONPATH=/home/go914/dev/rosotacom-benchmark-operator/src python3 -m rosotacom ota-benchmark capacity --rosotacom-config /home/go914/dev/rosotacom_test/fzi_projects/remote_assist/rosotacom.yaml --profiles-file /home/go914/dev/rosotacom_test/fzi_projects/remote_assist/profiles/benchmark-profiles.yaml --profile cellular-4g-degraded --knob size --low 1 --high 1 --max-loss 30 --max-latency-ms 1000 --duration 10 --repeats 1 --peer a=seat_tks --peer b=majestic_tks --dry-run --sudo-mode askpass`

Refs #61
