### PR TITLE
Fix domain bridge OTA config startup

### DIFF
--- a/src/rosotacom/resources/ws/session/content/base/session_plugin_base.yaml
+++ b/src/rosotacom/resources/ws/session/content/base/session_plugin_base.yaml
@@ -271,7 +271,7 @@ windows:
     if: use_domain_bridge
     splits:
       - commands:
-        - if [ '${ota_config_template}' != "None" ] && [ -n '${ota_config_template}' ]; then case ${rmw_ota} in cyclone) export CYCLONEDDS_URI="file://${ota_config_file}";; fastdds) export FASTDDS_DEFAULT_PROFILES_FILE="${ota_config_file}"; export RMW_FASTRTPS_USE_QOS_FROM_XML=1;; esac; fi
+        - if [ '${ota_config_template}' != "None" ] && [ -n '${ota_config_template}' ]; then ota_args=(--config "${ota_config_template}" --host-ip "${ip_local}" --peer "${ip_remote}"); [ '${ota_easy_mode_ip}' != "None" ] && [ -n '${ota_easy_mode_ip}' ] && ota_args+=(--easy-mode-ip "${ota_easy_mode_ip}"); /ws/ota_configs/get_ota_xml.py "${ota_args[@]}" > "${ota_config_file}"; case ${rmw_ota} in cyclone) export CYCLONEDDS_URI="file://${ota_config_file}";; fastdds) export FASTDDS_DEFAULT_PROFILES_FILE="${ota_config_file}"; export RMW_FASTRTPS_USE_QOS_FROM_XML=1;; esac; fi
         - ros2 run domain_bridge domain_bridge --wait-for-publisher false ${domain_bridge_config_file}
   - name: IN
     if: in

--- a/tests/contract/test_packaged_resources.py
+++ b/tests/contract/test_packaged_resources.py
@@ -105,6 +105,17 @@ def test_base_plugin_catmux_commands_are_strings() -> None:
     assert not offenders
 
 
+def test_domain_bridge_generates_ota_dds_config_before_launch() -> None:
+    plugin = yaml.safe_load(
+        (cli.WS_DIR / "session" / "content" / "base" / "session_plugin_base.yaml").read_text(encoding="utf-8")
+    )
+    com_window = next(window for window in plugin["windows"] if window["name"] == "COM")
+    commands = com_window["splits"][0]["commands"]
+
+    assert "/ws/ota_configs/get_ota_xml.py" in commands[0]
+    assert commands[1].startswith("ros2 run domain_bridge domain_bridge")
+
+
 def test_native_chatter_waiter_reads_topic_info_without_broken_pipe(tmp_path: Path) -> None:
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()


### PR DESCRIPTION
Fixes #74

## Summary
- Generate the OTA DDS config in the COM/domain_bridge pane before launching `domain_bridge`.
- Add a contract test that guards the COM pane startup order.

## Root cause
The COM pane exported `CYCLONEDDS_URI=file://${ota_config_file}` before `${ota_config_file}` was guaranteed to exist. In the failed CI run, `domain_bridge` started before the IN/OUT panes generated `ota_dds.xml`, aborted, and later status self-report checks saw OTA publishers without local-domain bridge flow.

CI failure inspected: https://github.com/develNor/ros_communication_devcontainer/actions/runs/28221103141/job/83602383796

## Validation
- `PYTHONPATH=/home/go914/dev/rosotacom_test/ros_communication_devcontainer-issue-74/src /home/go914/dev/rosotacom_test/ros_communication_devcontainer/.venv/bin/python -m pytest -q tests/contract/test_packaged_resources.py`
- `PYTHONPATH=/home/go914/dev/rosotacom_test/ros_communication_devcontainer-issue-74/src /home/go914/dev/rosotacom_test/ros_communication_devcontainer/.venv/bin/python -m pytest -q tests/unit/test_status_overview.py::test_pipeline_spec_generated_for_heartbeat tests/unit/test_status_overview.py::test_heartbeat_monitor_thresholds_overridden_from_expect tests/unit/test_status_overview.py::test_metric_stage_bag_is_generated_from_local_pipeline`
- `PYTHONPATH=/home/go914/dev/rosotacom_test/ros_communication_devcontainer-issue-74/src ROSOTACOM_RUN_E2E=1 /home/go914/dev/rosotacom_test/ros_communication_devcontainer/.venv/bin/python -m pytest -q tests/e2e/test_smoke.py::test_native_chatter_scenario_starts_apps_and_communication_together`
- `PYTHONPATH=/home/go914/dev/rosotacom_test/ros_communication_devcontainer-issue-74/src ROSOTACOM_RUN_E2E=1 /home/go914/dev/rosotacom_test/ros_communication_devcontainer/.venv/bin/python -m pytest -q 'tests/e2e/test_smoke.py::test_local_link_latency_smoke_exposes_metric_backbone[link-latency]'`