### PR TITLE
Automate zero-loss requirement search policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,12 +472,16 @@ conditions, uses a geometric boundary search for bandwidth, linear boundary
 searches for latency-like axes, and finishes with an extra refinement pass around
 the final candidate. By default jitter and loss are searched as a coupled
 practical tradeoff curve; pass `--loss-coupling independent` if you want network
-loss treated as its own axis. The chosen profile, target slack, all probes, and
-the nearby failing neighbors are written to `result.json`, `requirements.jsonl`,
-and `generated-profiles.yaml`:
+loss treated as its own axis. For an exact `--max-loss 0` target, rosotacom
+automatically keeps shaped network loss at `0%` and searches jitter separately,
+so the reproducible command encodes the same policy used for the measurement.
+The chosen profile, target slack, all probes, and the nearby failing neighbors
+are written to `result.json`, `requirements.jsonl`, and
+`generated-profiles.yaml`:
 
 ```bash
 rosotacom benchmark requirements --rate-hz 20 --size 18000 --qos-reliability best_effort --qos-depth 1 --max-loss 5 --max-latency-ms 250
+rosotacom benchmark requirements --rate-hz 20 --size 18000 --qos-reliability best_effort --qos-depth 1 --max-loss 0 --max-latency-ms 250
 ```
 
 Use `rosotacom ota-benchmark` for the same probes over deployment peers, without

--- a/src/rosotacom/cli_benchmark.py
+++ b/src/rosotacom/cli_benchmark.py
@@ -2290,7 +2290,15 @@ def _requirements_jitter_loss_pct(jitter_ms: float) -> float:
 def _requirements_target_quality(row: dict[str, Any], *, max_loss_pct: float, max_latency_ms: float) -> dict[str, Any]:
     loss_pct = row.get("loss_pct")
     latency_p95_ms = row.get("latency_p95_ms")
-    loss_ratio = float(loss_pct) / max_loss_pct if loss_pct is not None and max_loss_pct > 0 else None
+    loss_ratio: float | None
+    if loss_pct is None:
+        loss_ratio = None
+    elif max_loss_pct > 0:
+        loss_ratio = float(loss_pct) / max_loss_pct
+    elif float(loss_pct) <= 0.0:
+        loss_ratio = 0.0
+    else:
+        loss_ratio = math.inf
     latency_ratio = (
         float(latency_p95_ms) / max_latency_ms if latency_p95_ms is not None and max_latency_ms > 0 else None
     )
@@ -2316,7 +2324,19 @@ def _format_requirements_target_quality(quality: dict[str, Any]) -> str:
     limiting = quality.get("limiting_metric") or "unknown"
     if utilization is None:
         return "target=unknown"
+    if math.isinf(float(utilization)):
+        return f"target=over-limit({limiting})"
     return f"target={utilization * 100:.1f}%({limiting})"
+
+
+def _format_requirements_profile(candidate: _RequirementCandidate, *, downlink_ratio: float) -> str:
+    downlink_latency_ms = candidate.latency_ms * downlink_ratio
+    return (
+        f"uplink(rate={_format_bps(candidate.bandwidth_bps)}, delay={candidate.latency_ms:g}ms, "
+        f"jitter={candidate.jitter_ms:g}ms, loss={candidate.loss_pct:g}%), "
+        f"downlink(rate={_format_bps(candidate.bandwidth_bps)}, delay={downlink_latency_ms:g}ms, "
+        f"jitter={candidate.jitter_ms:g}ms, loss={candidate.loss_pct:g}%)"
+    )
 
 
 def drive_requirements(
@@ -2365,8 +2385,15 @@ def drive_requirements(
         raise ValueError("loss_coupling must be 'independent' or 'jitter'.")
 
     thresholds = OracleThresholds(max_loss_pct=max_loss_pct, max_latency_ms=max_latency_ms)
-    selected_axes = list(axes)
-    if loss_coupling == "jitter" and "jitter" in selected_axes and "loss" in selected_axes:
+    requested_axes = list(axes)
+    selected_axes = list(requested_axes)
+    strict_zero_loss_target = max_loss_pct <= 0.0
+    effective_loss_coupling = "zero_loss" if strict_zero_loss_target else loss_coupling
+    skipped_axes: list[str] = []
+    if strict_zero_loss_target:
+        skipped_axes = [axis for axis in selected_axes if axis == "loss"]
+        selected_axes = [axis for axis in selected_axes if axis != "loss"]
+    elif loss_coupling == "jitter" and "jitter" in selected_axes and "loss" in selected_axes:
         selected_axes = ["jitter_loss" if axis == "jitter" else axis for axis in selected_axes if axis != "loss"]
     load = {"size_a": size, "rate": rate_hz, "streams": streams}
     load_info = _load_context(load)
@@ -2392,7 +2419,9 @@ def drive_requirements(
                 "latency_quantile": thresholds.latency_quantile,
             },
             "search": {
+                "requested_axes": requested_axes,
                 "axes": selected_axes,
+                "skipped_axes": skipped_axes,
                 "bandwidth_low_bps": bandwidth_low_bps,
                 "bandwidth_high_bps": bandwidth_high_bps,
                 "latency_high_ms": latency_high_ms,
@@ -2403,6 +2432,8 @@ def drive_requirements(
                 "final_refine_iterations": final_refine_iterations,
                 "distribution": distribution,
                 "loss_coupling": loss_coupling,
+                "effective_loss_coupling": effective_loss_coupling,
+                "strict_zero_loss_target": strict_zero_loss_target,
                 "downlink_ratio": downlink_ratio,
             },
         },
@@ -2477,7 +2508,7 @@ def drive_requirements(
     def candidate_at_axis(base: _RequirementCandidate, axis: str, value: float) -> _RequirementCandidate:
         effective_axis = "jitter" if axis == "jitter_loss" else axis
         candidate_at_value = _requirements_with_axis(base, effective_axis, value)
-        if loss_coupling == "jitter" and axis in {"jitter", "jitter_loss"}:
+        if effective_loss_coupling == "jitter" and axis in {"jitter", "jitter_loss"}:
             modeled_loss = min(loss_high_pct, max(0.0, _requirements_jitter_loss_pct(value)))
             candidate_at_value = _requirements_with_axis(candidate_at_value, "loss", modeled_loss)
         return candidate_at_value
@@ -2638,6 +2669,16 @@ def drive_requirements(
             "\n".join(json.dumps(row, sort_keys=True) for row in rows) + "\n",
             encoding="utf-8",
         )
+        analysis = {
+            "status": "ideal_failed",
+            "tight": False,
+            "loss_coupling": loss_coupling,
+            "effective_loss_coupling": effective_loss_coupling,
+            "strict_zero_loss_target": strict_zero_loss_target,
+            "requested_axes": requested_axes,
+            "searched_axes": selected_axes,
+            "skipped_axes": skipped_axes,
+        }
         _write_benchmark_result(
             out_dir,
             genre="requirements",
@@ -2651,6 +2692,20 @@ def drive_requirements(
                     "latency_quantile": thresholds.latency_quantile,
                 },
                 "topic": topic or None,
+                "requested_axes": requested_axes,
+                "axes": selected_axes,
+                "skipped_axes": skipped_axes,
+                "bounds": {
+                    "bandwidth_low_bps": bandwidth_low_bps,
+                    "bandwidth_high_bps": bandwidth_high_bps,
+                    "latency_high_ms": latency_high_ms,
+                    "jitter_high_ms": jitter_high_ms,
+                    "loss_high_pct": loss_high_pct,
+                },
+                "final_refine_iterations": final_refine_iterations,
+                "loss_coupling": loss_coupling,
+                "effective_loss_coupling": effective_loss_coupling,
+                "strict_zero_loss_target": strict_zero_loss_target,
                 "generated_profiles_file": generated_profiles_file.name if generated_profiles_file else None,
             },
             result={
@@ -2658,7 +2713,7 @@ def drive_requirements(
                 "profile": None,
                 "bounds": {},
                 "rows": rows,
-                "analysis": {"status": "ideal_failed", "tight": False},
+                "analysis": analysis,
             },
             measurements={"points": measurements},
             verdict={"passed": False, "status": "ideal_failed"},
@@ -2669,7 +2724,7 @@ def drive_requirements(
                 "probes_dir": "probes",
             },
         )
-        return {"profile": None, "bounds": {}, "rows": rows, "analysis": {"status": "ideal_failed", "tight": False}}
+        return {"profile": None, "bounds": {}, "rows": rows, "analysis": analysis}
 
     for round_index in range(1, search_rounds + 1):
         for axis in selected_axes:
@@ -2724,7 +2779,11 @@ def drive_requirements(
         "search_iterations": search_iterations,
         "final_refine_iterations": final_refine_iterations,
         "loss_coupling": loss_coupling,
+        "effective_loss_coupling": effective_loss_coupling,
+        "strict_zero_loss_target": strict_zero_loss_target,
+        "requested_axes": requested_axes,
         "searched_axes": selected_axes,
+        "skipped_axes": skipped_axes,
     }
     result: dict[str, Any] = {
         "stream": {
@@ -2759,7 +2818,9 @@ def drive_requirements(
                 "latency_quantile": thresholds.latency_quantile,
             },
             "topic": topic or None,
+            "requested_axes": requested_axes,
             "axes": selected_axes,
+            "skipped_axes": skipped_axes,
             "bounds": {
                 "bandwidth_low_bps": bandwidth_low_bps,
                 "bandwidth_high_bps": bandwidth_high_bps,
@@ -2769,6 +2830,8 @@ def drive_requirements(
             },
             "final_refine_iterations": final_refine_iterations,
             "loss_coupling": loss_coupling,
+            "effective_loss_coupling": effective_loss_coupling,
+            "strict_zero_loss_target": strict_zero_loss_target,
             "generated_profiles_file": generated_profiles_file.name if generated_profiles_file else None,
         },
         result=result,
@@ -2783,11 +2846,8 @@ def drive_requirements(
     )
     print(f"Requirements rows saved to {requirements_path}")
     print(
-        "Required profile: "
-        f"bw={_format_bps(candidate.bandwidth_bps)}, "
-        f"latency={candidate.latency_ms:g}ms, "
-        f"jitter={candidate.jitter_ms:g}ms, "
-        f"loss={candidate.loss_pct:g}% "
+        "Required network profile: "
+        f"{_format_requirements_profile(candidate, downlink_ratio=downlink_ratio)} "
         f"{_format_requirements_target_quality(final_row['target_quality'])} "
         f"({'tight' if tight else 'not tight within configured bounds'})"
     )
@@ -4293,7 +4353,10 @@ def _register_benchmark_driver_parsers(benchmark_subparsers: Any, *, ota_benchma
         "--loss-coupling",
         choices=["jitter", "independent"],
         default="jitter",
-        help="Use a practical jitter/loss tradeoff curve or search network loss as its own independent axis.",
+        help=(
+            "Use a practical jitter/loss tradeoff curve or search network loss as its own independent axis. "
+            "For --max-loss 0, generated network loss is clamped to 0 and jitter is searched separately."
+        ),
     )
     requirements_parser.add_argument(
         "--min-duration",

--- a/tests/unit/test_cli_benchmark.py
+++ b/tests/unit/test_cli_benchmark.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import subprocess
 from pathlib import Path
 from typing import Any
@@ -34,6 +35,7 @@ from rosotacom.cli_benchmark import (
     _peer_catmux_attach_script,
     _prepare_benchmark_session_config,
     _requirements_jitter_loss_pct,
+    _requirements_target_quality,
     _result_once_script,
     _start_interactive_benchmark,
     collect_transit_summary,
@@ -597,6 +599,75 @@ def test_requirements_driver_can_search_coupled_jitter_loss(tmp_path: Path) -> N
     assert result["analysis"]["final_target_quality"]["utilization"] == pytest.approx(0.99375)
 
 
+def test_requirements_zero_loss_target_clamps_network_loss(tmp_path: Path) -> None:
+    from rosotacom.network_profiles import parse_ms, parse_pct
+
+    generated_file = tmp_path / "generated-profiles.yaml"
+    seen_losses: list[float] = []
+
+    def probe(*, profile: str | None, load: dict[str, Any], duration_s: float, out_dir: Path) -> dict[str, Any]:
+        assert profile is not None
+        generated = yaml.safe_load(generated_file.read_text(encoding="utf-8"))
+        spec = generated["profiles"][profile]["uplink"]
+        jitter = parse_ms(spec.get("jitter", 0), "jitter")
+        loss = parse_pct(spec.get("loss", 0), "loss")
+        seen_losses.append(loss)
+        latency_p95 = 40.0 + jitter * 3.0
+        return {
+            "topics": {
+                "/test": {
+                    "expected": 100,
+                    "delivered": 100,
+                    "lost": 0,
+                    "loss_pct": 0.0,
+                    "reordered": 0,
+                    "ota_hop_ms": {"p50": latency_p95 * 0.6, "p95": latency_p95},
+                    "jitter_ms": {"p50": jitter * 0.5, "p95": jitter},
+                }
+            }
+        }
+
+    result = drive_requirements(
+        probe,
+        max_loss_pct=0.0,
+        max_latency_ms=100.0,
+        rate_hz=20.0,
+        size=18_000,
+        streams=1,
+        qos_reliability="best_effort",
+        qos_depth=1,
+        topic="/test",
+        out_dir=tmp_path,
+        bandwidth_high_bps=100_000_000.0,
+        bandwidth_low_bps=10_000_000.0,
+        latency_high_ms=0.0,
+        jitter_high_ms=40.0,
+        loss_high_pct=10.0,
+        axes=_parse_requirements_axes("jitter,loss"),
+        min_duration_s=20.0,
+        min_messages=100,
+        search_iterations=3,
+        search_rounds=1,
+        distribution="normal",
+        final_refine_iterations=0,
+        loss_coupling="jitter",
+        result_context={"test": True},
+        generated_profiles_file=generated_file,
+    )
+
+    assert set(seen_losses) == {0.0}
+    assert result["profile"]["candidate"]["loss_pct"] == 0.0
+    assert "jitter" in result["bounds"]
+    assert "jitter_loss" not in result["bounds"]
+    assert "loss" not in result["bounds"]
+    assert result["analysis"]["loss_coupling"] == "jitter"
+    assert result["analysis"]["effective_loss_coupling"] == "zero_loss"
+    assert result["analysis"]["strict_zero_loss_target"] is True
+    assert result["analysis"]["skipped_axes"] == ["loss"]
+    generated = yaml.safe_load(generated_file.read_text(encoding="utf-8"))
+    assert generated["metadata"]["search"]["effective_loss_coupling"] == "zero_loss"
+
+
 def test_requirements_bandwidth_refine_recovers_when_previous_fail_becomes_pass(tmp_path: Path) -> None:
     from rosotacom.network_profiles import parse_rate_bps
 
@@ -658,6 +729,17 @@ def test_requirements_bandwidth_refine_recovers_when_previous_fail_becomes_pass(
     assert result["bounds"]["bandwidth"]["status"] == "bounded_after_floor_reset"
     assert result["bounds"]["bandwidth"]["tight"] is True
     assert result["bounds"]["bandwidth"]["last_fail"]
+
+
+def test_requirements_zero_loss_target_reports_loss_as_limiter() -> None:
+    quality = _requirements_target_quality(
+        {"loss_pct": 0.25, "latency_p95_ms": 10.0},
+        max_loss_pct=0.0,
+        max_latency_ms=250.0,
+    )
+
+    assert quality["limiting_metric"] == "loss"
+    assert quality["utilization"] == math.inf
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
Closes #85.\n\n## Summary\n- Treat exact 0% ROS 2 loss targets as a strict zero-network-loss search policy.\n- Record requested axes, effective axes, skipped axes, and effective loss coupling in both successful and ideal-failed requirement artifacts.\n- Print the full uplink/downlink network profile in the final CLI summary.\n- Document the reproducible 5% and 0% requirement commands.\n\n## Validation\n- python3 -m pytest -q tests/unit/test_cli_benchmark.py -q\n- python3 -m ruff check src/rosotacom/cli_benchmark.py tests/unit/test_cli_benchmark.py\n- git diff --check\n- Live 0% local command with default zero-loss policy: /home/go914/dev/rosotacom_test/artifacts/benchmarks/requirements-18kb-tight-0pct-v2/requirements_2026-06-26_17-46-48/result.json\n- Existing 5% local comparison artifact: /home/go914/dev/rosotacom_test/artifacts/benchmarks/requirements-18kb-tight-5pct-v4/requirements_2026-06-26_16-54-13/result.json\n\n## Notes\nThe live 0% run requested axes bandwidth, latency, jitter, loss; the effective search skipped loss, used effective_loss_coupling=zero_loss, and generated loss_pct=0.0 profiles. It passed the final sample but is marked not_tight because jitter reached the configured 20 ms ceiling without failing.