### PR TITLE
Fix requirements search typecheck

### DIFF
--- a/src/rosotacom/cli_benchmark.py
+++ b/src/rosotacom/cli_benchmark.py
@@ -2669,7 +2669,7 @@ def drive_requirements(
             "\n".join(json.dumps(row, sort_keys=True) for row in rows) + "\n",
             encoding="utf-8",
         )
-        analysis = {
+        failure_analysis = {
             "status": "ideal_failed",
             "tight": False,
             "loss_coupling": loss_coupling,
@@ -2713,7 +2713,7 @@ def drive_requirements(
                 "profile": None,
                 "bounds": {},
                 "rows": rows,
-                "analysis": analysis,
+                "analysis": failure_analysis,
             },
             measurements={"points": measurements},
             verdict={"passed": False, "status": "ideal_failed"},
@@ -2724,7 +2724,7 @@ def drive_requirements(
                 "probes_dir": "probes",
             },
         )
-        return {"profile": None, "bounds": {}, "rows": rows, "analysis": analysis}
+        return {"profile": None, "bounds": {}, "rows": rows, "analysis": failure_analysis}
 
     for round_index in range(1, search_rounds + 1):
         for axis in selected_axes:


### PR DESCRIPTION
Closes #87.\n\n## Summary\n- Rename the ideal-failed requirements analysis local to avoid mypy no-redef after #86.\n\n## Validation\n- /home/go914/dev/rosotacom_test/ros_communication_devcontainer/.venv/bin/python -m mypy\n- python3 -m pytest -q tests/unit/test_cli_benchmark.py -q\n- python3 -m ruff check src/rosotacom/cli_benchmark.py tests/unit/test_cli_benchmark.py\n- git diff --check