### PR TITLE
Stabilize seeded requirements boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,14 +478,23 @@ so the reproducible command encodes the same policy used for the measurement. If
 the zero-loss boundary is noisy, repeat each candidate and require a pass count;
 for example, `--probe-repeats 10 --probe-min-passes 9 --bad-lossy-count 10`
 defines a good case as at least nine clean repeats and records bad-case neighbors
-where all ten repeats lose messages. The chosen profile, target slack, repeat
-statistics, all probes, and the nearby failing neighbors are written to
+where all ten repeats lose messages. Add `--netem-seed <n>` when you want the
+generated jitter/loss draw to be replayable across repeated boundary searches.
+For local Docker benchmarks, rosotacom copies the host `tc` binary into seeded
+benchmark containers when the container distro `tc` is too old for
+`netem seed`; the host `tc` must support `seed SEED`. For a practical good-case
+reference, `--jitter-guard-ratio 0.10` records the tight jitter boundary but
+uses 10% less jitter for later axes and the final profile;
+`--bandwidth-guard-ratio 0.10` does the symmetric thing for bandwidth by using
+10% more bandwidth after finding the lower bound. The chosen profile, target
+slack, repeat statistics, all probes, and the nearby failing neighbors are written to
 `result.json`, `requirements.jsonl`, and `generated-profiles.yaml`:
 
 ```bash
 rosotacom benchmark requirements --rate-hz 20 --size 18000 --qos-reliability best_effort --qos-depth 1 --max-loss 5 --max-latency-ms 250
 rosotacom benchmark requirements --rate-hz 20 --size 18000 --qos-reliability best_effort --qos-depth 1 --max-loss 0 --max-latency-ms 250
-rosotacom benchmark requirements --rate-hz 20 --size 18000 --qos-reliability best_effort --qos-depth 1 --max-loss 0 --max-latency-ms 250 --downlink-mode lan --probe-repeats 10 --probe-min-passes 9 --bad-lossy-count 10
+rosotacom benchmark requirements --rate-hz 20 --size 18000 --qos-reliability best_effort --qos-depth 1 --max-loss 0 --max-latency-ms 250 --latency-base-ms 30 --downlink-mode lan --probe-repeats 10 --probe-min-passes 9 --bad-lossy-count 10 --jitter-guard-ratio 0.10 --bandwidth-guard-ratio 0.10 --netem-seed 424242
+rosotacom benchmark requirements --rate-hz 20 --size 18000 --qos-reliability best_effort --qos-depth 1 --max-loss 0 --max-latency-ms 250 --latency-base-ms 30 --downlink-mode lan --axes jitter,bandwidth --bandwidth-high-factor 8 --bandwidth-low-factor 1 --jitter-high-ms 40 --search-iterations 7 --final-refine-iterations 0 --search-rounds 1 --min-duration 20 --min-messages 100 --probe-repeats 1 --bandwidth-probe-repeats 1 --netem-seed 424242 --jitter-guard-ratio 0.20 --bandwidth-guard-ratio 0.20
 ```
 
 Use `rosotacom ota-benchmark` for the same probes over deployment peers, without

--- a/README.md
+++ b/README.md
@@ -466,6 +466,9 @@ fastdds`, `--rmw cyclone`, or another supported session RMW value to pin a run.
 Each run writes a self-contained `result.json` under its benchmark artifact
 directory with the selected RMW, configured load and offered bandwidth, profile
 shaping context, thresholds, verdict, and per-topic loss/latency/jitter metrics.
+For live benchmark probes, `--duration` is the shaped publish window; after that
+rosotacom stops synthetic publishers and waits `--drain-s` seconds before
+tearing down shaping, so delayed in-flight messages are not miscounted as loss.
 Use `benchmark requirements` when you want rosotacom to search for a tight
 network profile for a stream and quality target. The driver starts from ideal
 conditions, uses a geometric boundary search for bandwidth, linear boundary

--- a/docs/rfcs/0004-network-profiles.md
+++ b/docs/rfcs/0004-network-profiles.md
@@ -90,9 +90,10 @@ profiles:
 ```
 
 - **static** — constant `{rate, delay, jitter, distribution, loss,
-  loss_correlation, reorder, duplicate}` per direction. `loss_correlation` (netem
-  state/`gemodel`) makes loss bursty rather than independent — closer to real
-  radio loss.
+  loss_correlation, reorder, duplicate, seed}` per direction. `loss_correlation`
+  (netem state/`gemodel`) makes loss bursty rather than independent — closer to
+  real radio loss. `seed` maps to `tc netem seed SEED` when supported, making the
+  generated random delay/loss draw replayable.
 - **timeline** — an ordered list of `{ for: <dur>, <static-params> | outage }`
   segments. A recovery benchmark (RFC 0005) *is* a timeline profile; `outage` is
   the step whose recovery is measured.
@@ -183,10 +184,11 @@ RFC 0002's `calibrate` / `--suggest` machinery, **per profile**:
   endpoints survive, recovery is "catch up") vs link-down (forces RMW
   re-discovery, a harsher recovery). They test different recoveries — see Open
   questions.
-- **Run-to-run variation.** `delay`/`loss` draws are RNG-driven; a profile bounds
-  behaviour, it does not make runs byte-identical. That is acceptable (and the
-  conditional bands are calibrated with margin); seed only if exact replay is ever
-  needed.
+- **Run-to-run variation.** `delay`/`loss` draws are RNG-driven; an unseeded
+  profile bounds behaviour, it does not make runs byte-identical. Use `seed` for
+  replayable netem draws when calibrating tight zero-loss boundaries. Local Docker
+  benchmarks can copy a seed-capable host `tc` into benchmark containers when the
+  container distro `tc` does not understand `netem seed`.
 - **Asymmetry, not absolute one-way truth.** Per-direction *shaping* is exact, but
   reading per-direction *latency* back out still depends on the clock-offset
   handling in RFC 0003.

--- a/src/rosotacom/cli_benchmark.py
+++ b/src/rosotacom/cli_benchmark.py
@@ -32,6 +32,7 @@ from typing import Any, cast
 import yaml
 
 DEFAULT_BENCHMARK_RMW = "cyclone"
+DEFAULT_BENCHMARK_DRAIN_S = 2.0
 BENCHMARK_RESULT_FILE = "result.json"
 BENCHMARK_SESSIONS_BY_GENRE = {
     "capacity": "bench_1_1_capacity",
@@ -255,6 +256,13 @@ def _profile_requires_netem_seed(profile: Any) -> bool:
     return _direction_requires_netem_seed(getattr(profile, "uplink", None)) or _direction_requires_netem_seed(
         getattr(profile, "downlink", None)
     )
+
+
+def _benchmark_drain_s(args: argparse.Namespace) -> float:
+    drain_s = float(getattr(args, "drain_s", DEFAULT_BENCHMARK_DRAIN_S))
+    if drain_s < 0.0:
+        raise ValueError("drain-s must be >= 0.")
+    return drain_s
 
 
 def _apply_benchmark_qos_options(
@@ -3428,6 +3436,15 @@ def _add_benchmark_common_args(parser: argparse.ArgumentParser, *, ota_benchmark
     parser.add_argument("--dry-run", action="store_true", help="Show commands but do not run them.")
     parser.add_argument("--artifacts-dir", help="Output directory for all benchmark artifacts.")
     parser.add_argument(
+        "--drain-s",
+        type=float,
+        default=DEFAULT_BENCHMARK_DRAIN_S,
+        help=(
+            "Seconds to keep benchmark peers and shaping alive after stopping synthetic publishers, "
+            f"so delayed in-flight messages can arrive before teardown (default: {DEFAULT_BENCHMARK_DRAIN_S:g})."
+        ),
+    )
+    parser.add_argument(
         "--target",
         help="OTA target session or scenario (default for OTA: the benchmark genre session).",
     )
@@ -3501,6 +3518,7 @@ def _make_live_run_point(args: argparse.Namespace, session_name: str) -> RunPoin
         _ota_start_peers,
         _ota_start_session_publishers,
         _ota_stop_peers,
+        _ota_stop_session_publishers,
         _ota_teardown_profile,
         _ota_write_manifest,
         _ota_write_state,
@@ -3567,6 +3585,7 @@ def _make_live_run_point(args: argparse.Namespace, session_name: str) -> RunPoin
 
             runtime, plan, target = _resolve_ota_smoke_context(smoke_args)
             dry_run = smoke_args.dry_run
+            drain_s = _benchmark_drain_s(args)
             _profile_name, profile_obj = _resolve_ota_profile(runtime, target, smoke_args)
             sudo_passwords = _ota_network_sudo_passwords(
                 plan,
@@ -3660,6 +3679,9 @@ def _make_live_run_point(args: argparse.Namespace, session_name: str) -> RunPoin
                             time.sleep(step_duration)
                     else:
                         time.sleep(duration_s)
+                    _ota_stop_session_publishers(target, plan, dry_run=dry_run)
+                    if drain_s > 0.0:
+                        time.sleep(drain_s)
             finally:
                 _ota_teardown_profile(shapers)
                 _ota_collect_logs(instance, plan, dry_run=dry_run)
@@ -3721,6 +3743,7 @@ def _make_live_run_point(args: argparse.Namespace, session_name: str) -> RunPoin
             instance_id = getattr(args, "instance_id", None) or _new_instance_id()
             smoke_instance = _resolve_session_instance(runtime, session, instance_id)
             smoke_network = _noninteractive_smoke_network_config(runtime, session, smoke_instance.instance_id)
+            drain_s = _benchmark_drain_s(args)
 
             peer_address_args = _smoke_peer_address_args(smoke_network.peer_ips)
             cfg = _effective_session_config(session.host_dir, runtime)
@@ -3807,11 +3830,20 @@ def _make_live_run_point(args: argparse.Namespace, session_name: str) -> RunPoin
                 )
                 pub_cmds.append(cmd)
 
-            a_container = None
-            b_container = None
-            shapers = []
-            peer_steps = {}
+            a_container: str | None = None
+            b_container: str | None = None
+            lab_shapers: list[ProfileShaper] = []
+            lab_peer_steps: dict[str, tuple[ProfileShaper, Any]] = {}
             measurement_window: tuple[float, float] | None = None
+
+            def stop_local_publishers() -> None:
+                if not a_container:
+                    return
+                subprocess.run(
+                    ["docker", "exec", a_container, "pkill", "-f", "sized_publisher"],
+                    capture_output=True,
+                    check=False,
+                )
 
             try:
                 _ensure_smoke_network(smoke_network.name, smoke_network.subnet)
@@ -3890,26 +3922,26 @@ def _make_live_run_point(args: argparse.Namespace, session_name: str) -> RunPoin
                     if profile_obj.is_timeline:
                         # Peer A shapes uplink (egress to B)
                         shaper_a = ProfileShaper("eth0", make_container_runner(a_container))
-                        shapers.append(shaper_a)
+                        lab_shapers.append(shaper_a)
                         steps_a = expand_timeline(profile_obj, "eth0", direction="uplink")
-                        peer_steps["a"] = (shaper_a, steps_a)
+                        lab_peer_steps["a"] = (shaper_a, steps_a)
 
                         # Peer B shapes downlink (egress to A)
                         shaper_b = ProfileShaper("eth0", make_container_runner(b_container))
-                        shapers.append(shaper_b)
+                        lab_shapers.append(shaper_b)
                         steps_b = expand_timeline(profile_obj, "eth0", direction="downlink")
-                        peer_steps["b"] = (shaper_b, steps_b)
+                        lab_peer_steps["b"] = (shaper_b, steps_b)
 
-                        for shaper in shapers:
+                        for shaper in lab_shapers:
                             shaper.arm([])
                     else:
                         if profile_obj.uplink and not profile_obj.uplink.is_empty:
                             shaper_a = ProfileShaper("eth0", make_container_runner(a_container))
-                            shapers.append(shaper_a)
+                            lab_shapers.append(shaper_a)
                             shaper_a.arm(shaping_commands("eth0", profile_obj.uplink))
                         if profile_obj.downlink and not profile_obj.downlink.is_empty:
                             shaper_b = ProfileShaper("eth0", make_container_runner(b_container))
-                            shapers.append(shaper_b)
+                            lab_shapers.append(shaper_b)
                             shaper_b.arm(shaping_commands("eth0", profile_obj.downlink))
 
                 # 4. Verify shaping was applied (diagnostic)
@@ -3930,15 +3962,19 @@ def _make_live_run_point(args: argparse.Namespace, session_name: str) -> RunPoin
                     num_steps = len(profile_obj.timeline)
                     for i in range(num_steps):
                         step_duration = profile_obj.timeline[i].for_s
-                        for shaper, steps in peer_steps.values():
+                        for shaper, steps in lab_peer_steps.values():
                             step = steps[i]
                             shaper.apply(step.commands)
                         time.sleep(step_duration)
                 else:
                     time.sleep(duration_s)
-                measurement_window = (measurement_start_s, time.time())
+                measurement_end_s = time.time()
+                stop_local_publishers()
+                if drain_s > 0.0:
+                    time.sleep(drain_s)
+                measurement_window = (measurement_start_s, measurement_end_s)
             finally:
-                for shaper in shapers:
+                for shaper in lab_shapers:
                     shaper.teardown()
 
                 for cleanup_container in [a_container, b_container]:

--- a/src/rosotacom/cli_benchmark.py
+++ b/src/rosotacom/cli_benchmark.py
@@ -161,9 +161,13 @@ def _find_events_files(instance_dir: Path) -> list[Path]:
     return sorted(instance_dir.rglob("status/events.jsonl"))
 
 
-def collect_transit_summary(instance_dir: Path) -> dict[str, Any]:
+def collect_transit_summary(
+    instance_dir: Path,
+    *,
+    publish_window: tuple[float, float] | None = None,
+) -> dict[str, Any]:
     """Load and summarize transit records from an instance's artifact tree."""
-    from .transit import load_transit_records, summarize_transit_records
+    from .transit import filter_transit_records_by_publish_window, load_transit_records, summarize_transit_records
 
     events_files = _find_events_files(instance_dir)
     if not events_files:
@@ -172,6 +176,12 @@ def collect_transit_summary(instance_dir: Path) -> dict[str, Any]:
             "Did the benchmark point run long enough to produce transit records?"
         )
     records = load_transit_records(events_files)
+    if publish_window is not None:
+        records = filter_transit_records_by_publish_window(
+            records,
+            start_s=publish_window[0],
+            end_s=publish_window[1],
+        )
     return summarize_transit_records(records)
 
 
@@ -225,6 +235,26 @@ def _normalize_benchmark_profile(profile: str | None) -> str | None:
 
 def _benchmark_profile_label(profile: str | None) -> str:
     return _normalize_benchmark_profile(profile) or "none"
+
+
+def _direction_requires_netem_seed(shaping: Any) -> bool:
+    return bool(
+        shaping is not None and getattr(shaping, "seed", None) is not None and getattr(shaping, "has_netem", False)
+    )
+
+
+def _profile_requires_netem_seed(profile: Any) -> bool:
+    if profile is None:
+        return False
+    if getattr(profile, "is_timeline", False):
+        return any(
+            _direction_requires_netem_seed(getattr(segment, "uplink", None))
+            or _direction_requires_netem_seed(getattr(segment, "downlink", None))
+            for segment in getattr(profile, "timeline", ())
+        )
+    return _direction_requires_netem_seed(getattr(profile, "uplink", None)) or _direction_requires_netem_seed(
+        getattr(profile, "downlink", None)
+    )
 
 
 def _apply_benchmark_qos_options(
@@ -1526,6 +1556,7 @@ def _direction_to_yaml(
     distribution: str | None = None,
     loss_pct: float | None = None,
     loss_correlation_pct: float | None = None,
+    seed: int | None = None,
 ) -> dict[str, Any]:
     spec: dict[str, Any] = {}
     if rate is not None:
@@ -1540,6 +1571,8 @@ def _direction_to_yaml(
         spec["loss"] = _format_yaml_pct(loss_pct)
         if loss_correlation_pct is not None and loss_pct > 0.0:
             spec["loss_correlation"] = _format_yaml_pct(loss_correlation_pct)
+    if seed is not None:
+        spec["seed"] = seed
     return spec
 
 
@@ -1557,6 +1590,7 @@ def _profile_to_yaml(profile: Any) -> dict[str, Any]:
             distribution=direction_obj.distribution,
             loss_pct=direction_obj.loss_pct,
             loss_correlation_pct=direction_obj.loss_correlation_pct,
+            seed=direction_obj.seed,
         )
 
     return {"uplink": direction(profile.uplink), "downlink": direction(profile.downlink)}
@@ -2233,6 +2267,7 @@ def _requirements_profile_spec(
     distribution: str,
     downlink_ratio: float,
     downlink_mode: str,
+    netem_seed: int | None = None,
 ) -> dict[str, Any]:
     latency_downlink_ms = candidate.latency_ms * downlink_ratio
     delay_uplink = candidate.latency_ms if candidate.latency_ms > 0.0 or candidate.jitter_ms > 0.0 else None
@@ -2247,6 +2282,7 @@ def _requirements_profile_spec(
             jitter_ms=candidate.jitter_ms if candidate.jitter_ms > 0.0 else None,
             distribution=distribution,
             loss_pct=loss,
+            seed=netem_seed if delay_downlink is not None or loss is not None else None,
         )
     )
     return {
@@ -2256,6 +2292,7 @@ def _requirements_profile_spec(
             jitter_ms=candidate.jitter_ms if candidate.jitter_ms > 0.0 else None,
             distribution=distribution,
             loss_pct=loss,
+            seed=netem_seed if delay_uplink is not None or loss is not None else None,
         ),
         "downlink": downlink,
     }
@@ -2430,6 +2467,7 @@ def drive_requirements(
     out_dir: Path,
     bandwidth_high_bps: float,
     bandwidth_low_bps: float,
+    latency_base_ms: float,
     latency_high_ms: float,
     jitter_high_ms: float,
     loss_high_pct: float,
@@ -2446,7 +2484,11 @@ def drive_requirements(
     probe_repeats: int = 1,
     probe_min_passes: int | None = None,
     bad_lossy_count: int | None = None,
+    bandwidth_probe_repeats: int | None = None,
     search_order: str = "auto",
+    netem_seed: int | None = None,
+    jitter_guard_ratio: float = 0.0,
+    bandwidth_guard_ratio: float = 0.0,
     result_context: dict[str, Any] | None = None,
     generated_profiles_file: Path | None = None,
     profile_prefix: str = "requirements",
@@ -2457,6 +2499,10 @@ def drive_requirements(
         raise ValueError("Bandwidth bounds must be > 0.")
     if bandwidth_low_bps >= bandwidth_high_bps:
         raise ValueError("bandwidth-low must be smaller than bandwidth-high.")
+    if latency_base_ms < 0.0:
+        raise ValueError("latency-base-ms must be >= 0.")
+    if latency_base_ms > latency_high_ms:
+        raise ValueError("latency-base-ms must be <= latency-high-ms.")
     if search_iterations < 1:
         raise ValueError("search_iterations must be >= 1.")
     if search_rounds < 1:
@@ -2467,6 +2513,10 @@ def drive_requirements(
         raise ValueError("loss_coupling must be 'independent' or 'jitter'.")
     if downlink_mode not in {"mirror", "lan"}:
         raise ValueError("downlink_mode must be 'mirror' or 'lan'.")
+    if not 0.0 <= jitter_guard_ratio < 1.0:
+        raise ValueError("jitter-guard-ratio must be within [0, 1).")
+    if bandwidth_guard_ratio < 0.0:
+        raise ValueError("bandwidth-guard-ratio must be >= 0.")
 
     thresholds = OracleThresholds(max_loss_pct=max_loss_pct, max_latency_ms=max_latency_ms)
     required_passes = _requirements_default_min_passes(
@@ -2477,6 +2527,15 @@ def drive_requirements(
     bad_lossy_threshold = bad_lossy_count if bad_lossy_count is not None else probe_repeats
     if not 1 <= bad_lossy_threshold <= probe_repeats:
         raise ValueError("bad_lossy_count must be within [1, probe_repeats].")
+    bandwidth_repeats = bandwidth_probe_repeats if bandwidth_probe_repeats is not None else probe_repeats
+    if bandwidth_repeats < 1:
+        raise ValueError("bandwidth_probe_repeats must be >= 1.")
+    bandwidth_required_passes = _requirements_default_min_passes(
+        probe_repeats=bandwidth_repeats,
+        max_loss_pct=max_loss_pct,
+        explicit_min_passes=min(probe_min_passes, bandwidth_repeats) if probe_min_passes is not None else None,
+    )
+    bandwidth_bad_lossy_threshold = min(bad_lossy_threshold, bandwidth_repeats)
     requested_axes = list(axes)
     selected_axes = list(requested_axes)
     strict_zero_loss_target = max_loss_pct <= 0.0
@@ -2495,7 +2554,7 @@ def drive_requirements(
     load = {"size_a": size, "rate": rate_hz, "streams": streams}
     load_info = _load_context(load)
     duration_s = _duration_for_min_messages(rate_hz, min_duration_s=min_duration_s, min_messages=min_messages)
-    ideal = _RequirementCandidate(bandwidth_bps=bandwidth_high_bps)
+    ideal = _RequirementCandidate(bandwidth_bps=bandwidth_high_bps, latency_ms=latency_base_ms)
     candidate = ideal
     rows: list[dict[str, Any]] = []
     measurements: list[dict[str, Any]] = []
@@ -2521,6 +2580,7 @@ def drive_requirements(
                 "skipped_axes": skipped_axes,
                 "bandwidth_low_bps": bandwidth_low_bps,
                 "bandwidth_high_bps": bandwidth_high_bps,
+                "latency_base_ms": latency_base_ms,
                 "latency_high_ms": latency_high_ms,
                 "jitter_high_ms": jitter_high_ms,
                 "loss_high_pct": loss_high_pct,
@@ -2536,7 +2596,13 @@ def drive_requirements(
                 "probe_repeats": probe_repeats,
                 "probe_min_passes": required_passes,
                 "bad_lossy_count": bad_lossy_threshold,
+                "bandwidth_probe_repeats": bandwidth_repeats,
+                "bandwidth_probe_min_passes": bandwidth_required_passes,
+                "bandwidth_bad_lossy_count": bandwidth_bad_lossy_threshold,
                 "search_order": search_order,
+                "netem_seed": netem_seed,
+                "jitter_guard_ratio": jitter_guard_ratio,
+                "bandwidth_guard_ratio": bandwidth_guard_ratio,
             },
         },
     }
@@ -2548,6 +2614,9 @@ def drive_requirements(
 
     def probe(candidate_to_probe: _RequirementCandidate, *, axis: str, phase: str) -> dict[str, Any]:
         nonlocal profile_counter
+        local_probe_repeats = bandwidth_repeats if axis == "bandwidth" else probe_repeats
+        local_required_passes = bandwidth_required_passes if axis == "bandwidth" else required_passes
+        local_bad_lossy_threshold = bandwidth_bad_lossy_threshold if axis == "bandwidth" else bad_lossy_threshold
         profile_counter += 1
         profile_name = _requirements_profile_name(profile_prefix, profile_counter, axis, candidate_to_probe)
         generated_doc["profiles"][profile_name] = _requirements_profile_spec(
@@ -2555,12 +2624,13 @@ def drive_requirements(
             distribution=distribution,
             downlink_ratio=downlink_ratio,
             downlink_mode=downlink_mode,
+            netem_seed=netem_seed,
         )
         write_profiles()
         samples: list[dict[str, Any]] = []
         sample_measurements: list[dict[str, Any]] = []
         selected_topic = ""
-        for repeat_index in range(1, probe_repeats + 1):
+        for repeat_index in range(1, local_probe_repeats + 1):
             summary = run_point(profile=profile_name, load=load, duration_s=duration_s, out_dir=out_dir)
             sample_topic, topic_data = _selected_topic(summary, topic)
             rows_for_print = _topic_rows(summary, topic)
@@ -2599,6 +2669,14 @@ def drive_requirements(
                     "sample": sample,
                 }
             )
+            running_pass_count = sum(1 for item in samples if item["passes"])
+            running_lossy_count = sum(1 for item in samples if not item["loss_free"])
+            remaining = local_probe_repeats - repeat_index
+            pass_impossible = running_pass_count + remaining < local_required_passes
+            bad_achieved = running_lossy_count >= local_bad_lossy_threshold
+            bad_still_possible = running_lossy_count + remaining >= local_bad_lossy_threshold
+            if pass_impossible and (bad_achieved or not bad_still_possible):
+                break
 
         pass_count = sum(1 for sample in samples if sample["passes"])
         loss_free_count = sum(1 for sample in samples if sample["loss_free"])
@@ -2622,19 +2700,20 @@ def drive_requirements(
             loss_pct = max(loss_values) if loss_values else 100.0
         latency_p95 = max(latency_values) if latency_values else None
         jitter_p95 = max(jitter_values) if jitter_values else None
-        passes = pass_count >= required_passes
+        passes = pass_count >= local_required_passes
         repeat_summary = {
             "sample_count": len(samples),
-            "required_passes": required_passes,
+            "configured_repeats": local_probe_repeats,
+            "required_passes": local_required_passes,
             "pass_count": pass_count,
             "fail_count": len(samples) - pass_count,
             "pass_ratio": pass_count / len(samples) if samples else 0.0,
             "loss_free_count": loss_free_count,
             "loss_free_ratio": loss_free_count / len(samples) if samples else 0.0,
             "lossy_count": lossy_count,
-            "bad_lossy_count": bad_lossy_threshold,
-            "good_case": pass_count >= required_passes,
-            "bad_case": lossy_count >= bad_lossy_threshold,
+            "bad_lossy_count": local_bad_lossy_threshold,
+            "good_case": pass_count >= local_required_passes,
+            "bad_case": lossy_count >= local_bad_lossy_threshold,
         }
         row = {
             "profile": profile_name,
@@ -2665,19 +2744,19 @@ def drive_requirements(
             max_loss_pct=max_loss_pct,
             max_latency_ms=max_latency_ms,
         )
-        if probe_repeats > 1:
+        if local_probe_repeats > 1:
             target_quality.update(
                 {
-                    "repeat_sample_count": probe_repeats,
-                    "repeat_required_passes": required_passes,
+                    "repeat_sample_count": len(samples),
+                    "repeat_required_passes": local_required_passes,
                     "repeat_pass_count": pass_count,
                     "repeat_loss_free_count": loss_free_count,
-                    "repeat_bad_lossy_count": bad_lossy_threshold,
+                    "repeat_bad_lossy_count": local_bad_lossy_threshold,
                 }
             )
             if not passes or strict_zero_loss_target:
                 target_quality["limiting_metric"] = "repeat"
-            target_quality["utilization"] = required_passes / pass_count if pass_count > 0 else math.inf
+            target_quality["utilization"] = local_required_passes / pass_count if pass_count > 0 else math.inf
         row["target_quality"] = target_quality
         rows.append(row)
         measurements.append({"row": row, "samples": sample_measurements})
@@ -2898,6 +2977,34 @@ def drive_requirements(
             "last_bad": last_row_ref(bad_row),
         }
 
+    guarded_axes: dict[str, Any] = {}
+
+    def apply_axis_guard(axis: str, selected: _RequirementCandidate) -> _RequirementCandidate:
+        if axis == "bandwidth" and bandwidth_guard_ratio > 0.0:
+            guarded_bandwidth = min(bandwidth_high_bps, selected.bandwidth_bps * (1.0 + bandwidth_guard_ratio))
+            guarded = _requirements_with_axis(selected, "bandwidth", guarded_bandwidth)
+            guard_ratio = bandwidth_guard_ratio
+        elif axis in {"jitter", "jitter_loss"} and jitter_guard_ratio > 0.0:
+            guarded_jitter = max(0.0, selected.jitter_ms * (1.0 - jitter_guard_ratio))
+            guarded = _requirements_with_axis(selected, "jitter", guarded_jitter)
+            guard_ratio = jitter_guard_ratio
+        else:
+            return selected
+        guarded_axes[axis] = {
+            "guard_ratio": guard_ratio,
+            "selected": _requirements_candidate_context(
+                selected,
+                downlink_ratio=downlink_ratio,
+                downlink_mode=downlink_mode,
+            ),
+            "guarded": _requirements_candidate_context(
+                guarded,
+                downlink_ratio=downlink_ratio,
+                downlink_mode=downlink_mode,
+            ),
+        }
+        return guarded
+
     baseline = probe(candidate, axis="baseline", phase="ideal")
     if not baseline["passes"]:
         requirements_path = out_dir / "requirements.jsonl"
@@ -2918,7 +3025,12 @@ def drive_requirements(
             "probe_repeats": probe_repeats,
             "probe_min_passes": required_passes,
             "bad_lossy_count": bad_lossy_threshold,
+            "bandwidth_probe_repeats": bandwidth_repeats,
+            "bandwidth_probe_min_passes": bandwidth_required_passes,
+            "bandwidth_bad_lossy_count": bandwidth_bad_lossy_threshold,
             "search_order": search_order,
+            "jitter_guard_ratio": jitter_guard_ratio,
+            "bandwidth_guard_ratio": bandwidth_guard_ratio,
         }
         _write_benchmark_result(
             out_dir,
@@ -2939,6 +3051,7 @@ def drive_requirements(
                 "bounds": {
                     "bandwidth_low_bps": bandwidth_low_bps,
                     "bandwidth_high_bps": bandwidth_high_bps,
+                    "latency_base_ms": latency_base_ms,
                     "latency_high_ms": latency_high_ms,
                     "jitter_high_ms": jitter_high_ms,
                     "loss_high_pct": loss_high_pct,
@@ -2952,7 +3065,13 @@ def drive_requirements(
                 "probe_repeats": probe_repeats,
                 "probe_min_passes": required_passes,
                 "bad_lossy_count": bad_lossy_threshold,
+                "bandwidth_probe_repeats": bandwidth_repeats,
+                "bandwidth_probe_min_passes": bandwidth_required_passes,
+                "bandwidth_bad_lossy_count": bandwidth_bad_lossy_threshold,
                 "search_order": search_order,
+                "netem_seed": netem_seed,
+                "jitter_guard_ratio": jitter_guard_ratio,
+                "bandwidth_guard_ratio": bandwidth_guard_ratio,
                 "generated_profiles_file": generated_profiles_file.name if generated_profiles_file else None,
             },
             result={
@@ -2981,6 +3100,7 @@ def drive_requirements(
                 phase_label=f"round{round_index}",
                 iterations=search_iterations,
             )
+            candidate = apply_axis_guard(axis, candidate)
 
     if final_refine_iterations:
         for axis in selected_axes:
@@ -2997,6 +3117,7 @@ def drive_requirements(
                 if axis != "bandwidth"
                 else None,
             )
+            candidate = apply_axis_guard(axis, candidate)
 
     final_profile_name = _safe_case_token(f"{profile_prefix}_final")
     generated_doc["profiles"][final_profile_name] = _requirements_profile_spec(
@@ -3004,6 +3125,7 @@ def drive_requirements(
         distribution=distribution,
         downlink_ratio=downlink_ratio,
         downlink_mode=downlink_mode,
+        netem_seed=netem_seed,
     )
     write_profiles()
     final_row = probe(candidate, axis="combined", phase="final")
@@ -3040,7 +3162,14 @@ def drive_requirements(
         "probe_repeats": probe_repeats,
         "probe_min_passes": required_passes,
         "bad_lossy_count": bad_lossy_threshold,
+        "bandwidth_probe_repeats": bandwidth_repeats,
+        "bandwidth_probe_min_passes": bandwidth_required_passes,
+        "bandwidth_bad_lossy_count": bandwidth_bad_lossy_threshold,
         "search_order": search_order,
+        "netem_seed": netem_seed,
+        "jitter_guard_ratio": jitter_guard_ratio,
+        "bandwidth_guard_ratio": bandwidth_guard_ratio,
+        "guarded_axes": guarded_axes,
         "bad_cases_observed": {
             axis: bound.get("last_bad")
             for axis, bound in bounds.items()
@@ -3086,6 +3215,7 @@ def drive_requirements(
             "bounds": {
                 "bandwidth_low_bps": bandwidth_low_bps,
                 "bandwidth_high_bps": bandwidth_high_bps,
+                "latency_base_ms": latency_base_ms,
                 "latency_high_ms": latency_high_ms,
                 "jitter_high_ms": jitter_high_ms,
                 "loss_high_pct": loss_high_pct,
@@ -3099,7 +3229,13 @@ def drive_requirements(
             "probe_repeats": probe_repeats,
             "probe_min_passes": required_passes,
             "bad_lossy_count": bad_lossy_threshold,
+            "bandwidth_probe_repeats": bandwidth_repeats,
+            "bandwidth_probe_min_passes": bandwidth_required_passes,
+            "bandwidth_bad_lossy_count": bandwidth_bad_lossy_threshold,
             "search_order": search_order,
+            "netem_seed": netem_seed,
+            "jitter_guard_ratio": jitter_guard_ratio,
+            "bandwidth_guard_ratio": bandwidth_guard_ratio,
             "generated_profiles_file": generated_profiles_file.name if generated_profiles_file else None,
         },
         result=result,
@@ -3615,16 +3751,42 @@ def _make_live_run_point(args: argparse.Namespace, session_name: str) -> RunPoin
                 if profile_obj is None:
                     raise ValueError(f"Profile {profile_name!r} not found in profiles file {profiles_file}.")
 
+            container_tc_overrides: dict[str, str] = {}
+
+            def install_seeded_tc(container_name: str) -> str:
+                host_tc = shutil.which("tc")
+                if host_tc is None:
+                    raise RuntimeError(
+                        "netem seed was requested, but no host tc binary was found to copy into the container."
+                    )
+                target = "/tmp/rosotacom-host-tc"
+                commands = [
+                    ["docker", "cp", host_tc, f"{container_name}:{target}"],
+                    ["docker", "exec", "-u", "root", container_name, "chmod", "0755", target],
+                    ["docker", "exec", "-u", "root", container_name, target, "-V"],
+                ]
+                for cmd in commands:
+                    res = subprocess.run(cmd, capture_output=True, text=True, check=False)
+                    if res.returncode != 0:
+                        raise RuntimeError(
+                            f"failed to install seed-capable tc in {container_name}: "
+                            f"{' '.join(cmd)} -> {res.stderr or res.stdout}"
+                        )
+                print(f"  netem seed support in {container_name}: using host tc {host_tc} as {target}")
+                return target
+
             def make_container_runner(container_name: str) -> Callable[[Sequence[str]], None]:
                 def run(argv: Sequence[str]) -> None:
                     # Execute tc command inside container namespace as root.
-                    cmd = ["docker", "exec", "-u", "root", container_name] + list(argv)
+                    adjusted_argv = list(argv)
+                    if adjusted_argv and adjusted_argv[0] == "tc":
+                        adjusted_argv[0] = container_tc_overrides.get(container_name, "tc")
+                    cmd = ["docker", "exec", "-u", "root", container_name] + adjusted_argv
                     res = subprocess.run(cmd, capture_output=True, text=True, check=False)
                     if res.returncode != 0:
-                        print(
-                            f"Warning: Command failed in {container_name}: "
-                            f"{' '.join(cmd)} -> {res.stderr or res.stdout}",
-                            file=sys.stderr,
+                        raise RuntimeError(
+                            f"network shaping command failed in {container_name}: "
+                            f"{' '.join(cmd)} -> {res.stderr or res.stdout}"
                         )
 
                 return run
@@ -3649,6 +3811,7 @@ def _make_live_run_point(args: argparse.Namespace, session_name: str) -> RunPoin
             b_container = None
             shapers = []
             peer_steps = {}
+            measurement_window: tuple[float, float] | None = None
 
             try:
                 _ensure_smoke_network(smoke_network.name, smoke_network.subnet)
@@ -3670,6 +3833,10 @@ def _make_live_run_point(args: argparse.Namespace, session_name: str) -> RunPoin
                 )
                 if not getattr(args, "dry_run", False):
                     time.sleep(12)
+
+                if profile_obj is not None and _profile_requires_netem_seed(profile_obj):
+                    container_tc_overrides[a_container] = install_seeded_tc(a_container)
+                    container_tc_overrides[b_container] = install_seeded_tc(b_container)
 
                 # 1. Start the publishers
                 for cmd in pub_cmds:
@@ -3748,8 +3915,9 @@ def _make_live_run_point(args: argparse.Namespace, session_name: str) -> RunPoin
                 # 4. Verify shaping was applied (diagnostic)
                 if profile_obj is not None and not getattr(args, "dry_run", False):
                     for label, container in [("A (uplink)", a_container), ("B (downlink)", b_container)]:
+                        tc_binary = container_tc_overrides.get(container, "tc")
                         res = subprocess.run(
-                            ["docker", "exec", "-u", "root", container, "tc", "qdisc", "show", "dev", "eth0"],
+                            ["docker", "exec", "-u", "root", container, tc_binary, "qdisc", "show", "dev", "eth0"],
                             capture_output=True,
                             text=True,
                             check=False,
@@ -3757,6 +3925,7 @@ def _make_live_run_point(args: argparse.Namespace, session_name: str) -> RunPoin
                         print(f"  qdisc on {label} ({container}): {(res.stdout or '').strip()}")
 
                 # 5. Measure traffic under shaped conditions
+                measurement_start_s = time.time()
                 if profile_obj is not None and profile_obj.is_timeline:
                     num_steps = len(profile_obj.timeline)
                     for i in range(num_steps):
@@ -3767,6 +3936,7 @@ def _make_live_run_point(args: argparse.Namespace, session_name: str) -> RunPoin
                         time.sleep(step_duration)
                 else:
                     time.sleep(duration_s)
+                measurement_window = (measurement_start_s, time.time())
             finally:
                 for shaper in shapers:
                     shaper.teardown()
@@ -3793,7 +3963,7 @@ def _make_live_run_point(args: argparse.Namespace, session_name: str) -> RunPoin
             dest = out_dir / "probes" / probe_name
             shutil.copytree(smoke_instance.host_dir, dest, dirs_exist_ok=True)
 
-            return collect_transit_summary(smoke_instance.host_dir)
+            return collect_transit_summary(smoke_instance.host_dir, publish_window=measurement_window)
 
     return run_point
 
@@ -4187,7 +4357,7 @@ def benchmark_matrix(args: argparse.Namespace) -> int:
 def benchmark_requirements(args: argparse.Namespace) -> int:
     """Handler for ``rosotacom benchmark requirements``."""
     from .cli import _load_runtime_config
-    from .network_profiles import parse_rate_bps
+    from .network_profiles import parse_rate_bps, parse_seed
 
     if getattr(args, "interactive", False):
         return _start_interactive_benchmark(args, "requirements")
@@ -4241,8 +4411,13 @@ def benchmark_requirements(args: argparse.Namespace) -> int:
     else:
         bandwidth_low_bps = max(1.0, offered_bw * float(getattr(args, "bandwidth_low_factor", 1.0)))
     max_latency_ms = float(getattr(args, "max_latency_ms", 250.0))
+    latency_base_ms = float(getattr(args, "latency_base_ms", 0.0))
     latency_high_raw = getattr(args, "latency_high_ms", None)
     latency_high_ms = min(float(latency_high_raw), max_latency_ms) if latency_high_raw is not None else max_latency_ms
+    netem_seed_raw = getattr(args, "netem_seed", None)
+    netem_seed = parse_seed(netem_seed_raw, "netem_seed") if netem_seed_raw is not None else None
+    jitter_guard_ratio = float(getattr(args, "jitter_guard_ratio", 0.0))
+    bandwidth_guard_ratio = float(getattr(args, "bandwidth_guard_ratio", 0.0))
 
     run_point = getattr(args, "_test_run_point", None) or _make_live_run_point(args, session_name)
     with log_stdout_stderr_to_file(run_dir / "stdout.txt"):
@@ -4259,6 +4434,7 @@ def benchmark_requirements(args: argparse.Namespace) -> int:
             out_dir=run_dir,
             bandwidth_high_bps=bandwidth_high_bps,
             bandwidth_low_bps=bandwidth_low_bps,
+            latency_base_ms=latency_base_ms,
             latency_high_ms=latency_high_ms,
             jitter_high_ms=float(getattr(args, "jitter_high_ms", 120.0)),
             loss_high_pct=float(getattr(args, "loss_high", 20.0)),
@@ -4275,7 +4451,11 @@ def benchmark_requirements(args: argparse.Namespace) -> int:
             probe_repeats=int(getattr(args, "probe_repeats", 1)),
             probe_min_passes=getattr(args, "probe_min_passes", None),
             bad_lossy_count=getattr(args, "bad_lossy_count", None),
+            bandwidth_probe_repeats=getattr(args, "bandwidth_probe_repeats", None),
             search_order=str(getattr(args, "search_order", "auto")),
+            netem_seed=netem_seed,
+            jitter_guard_ratio=jitter_guard_ratio,
+            bandwidth_guard_ratio=bandwidth_guard_ratio,
             result_context=result_context,
             generated_profiles_file=generated_profiles_file,
             profile_prefix=str(getattr(args, "profile_prefix", "requirements")),
@@ -4614,6 +4794,12 @@ def _register_benchmark_driver_parsers(benchmark_subparsers: Any, *, ota_benchma
         help="Default bandwidth floor as a factor of offered stream bandwidth.",
     )
     requirements_parser.add_argument(
+        "--latency-base-ms",
+        type=float,
+        default=0.0,
+        help="Initial/fixed uplink delay before searching worse latency values.",
+    )
+    requirements_parser.add_argument(
         "--latency-high-ms",
         type=float,
         help="Worst latency ceiling to try while searching; default is --max-latency-ms.",
@@ -4712,10 +4898,41 @@ def _register_benchmark_driver_parsers(benchmark_subparsers: Any, *, ota_benchma
         help="Mark a candidate as a bad case when at least this many repeats lose messages; default is all repeats.",
     )
     requirements_parser.add_argument(
+        "--bandwidth-probe-repeats",
+        type=int,
+        help=(
+            "Override --probe-repeats for bandwidth bisection probes. "
+            "Use this when bandwidth is latency/backlog limited and jitter/final probes still need strict repeats."
+        ),
+    )
+    requirements_parser.add_argument(
         "--search-order",
         choices=["auto", "input"],
         default="auto",
         help="auto searches jitter before bandwidth/latency for exact zero-loss targets; input preserves axis order.",
+    )
+    requirements_parser.add_argument(
+        "--netem-seed",
+        type=int,
+        help="Seed for generated netem qdiscs so jitter/loss draws can be replayed on hosts whose tc supports it.",
+    )
+    requirements_parser.add_argument(
+        "--jitter-guard-ratio",
+        type=float,
+        default=0.0,
+        help=(
+            "After finding a zero-loss jitter boundary, use this fractional margin for later axes and the final "
+            "good-case profile; e.g. 0.10 uses 10%% less jitter than the boundary."
+        ),
+    )
+    requirements_parser.add_argument(
+        "--bandwidth-guard-ratio",
+        type=float,
+        default=0.0,
+        help=(
+            "After finding a bandwidth boundary, use this fractional margin for the final good-case profile; "
+            "e.g. 0.10 uses 10%% more bandwidth than the boundary."
+        ),
     )
     requirements_parser.add_argument(
         "--profile-prefix",

--- a/src/rosotacom/network_profiles.py
+++ b/src/rosotacom/network_profiles.py
@@ -115,6 +115,17 @@ def parse_pct(value: Any, what: str = "percentage") -> float:
     return pct
 
 
+def parse_seed(value: Any, what: str = "seed") -> int:
+    """``12345`` / ``"12345"`` -> a positive netem RNG seed."""
+    try:
+        seed = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{what}: expected a positive integer, got {value!r}") from exc
+    if not 1 <= seed <= 0xFFFFFFFF:
+        raise ValueError(f"{what} must be within [1, 4294967295], got {value!r}")
+    return seed
+
+
 # --------------------------------------------------------------------------- #
 # Schema
 # --------------------------------------------------------------------------- #
@@ -133,6 +144,7 @@ class DirectionShaping:
     loss_correlation_pct: float | None = None  # netem correlated loss (needs loss)
     reorder_pct: float | None = None  # netem reorder (needs delay)
     duplicate_pct: float | None = None
+    seed: int | None = None
     burst: str = _DEFAULT_TBF_BURST  # tbf buffer, only used when rate_bps is set
     tbf_latency_ms: float = _DEFAULT_TBF_LATENCY_MS
 
@@ -221,6 +233,7 @@ _DIRECTION_KEYS = frozenset(
         "loss_correlation",
         "reorder",
         "duplicate",
+        "seed",
         "burst",
         "tbf_latency",
     }
@@ -245,6 +258,7 @@ def parse_direction(spec: Mapping[str, Any] | None) -> DirectionShaping | None:
         ),
         reorder_pct=parse_pct(spec["reorder"], "reorder") if "reorder" in spec else None,
         duplicate_pct=parse_pct(spec["duplicate"], "duplicate") if "duplicate" in spec else None,
+        seed=parse_seed(spec["seed"], "seed") if "seed" in spec else None,
         burst=str(spec.get("burst", _DEFAULT_TBF_BURST)),
         tbf_latency_ms=parse_ms(spec["tbf_latency"], "tbf_latency")
         if "tbf_latency" in spec
@@ -384,6 +398,8 @@ def _netem_args(shaping: DirectionShaping) -> list[str]:
         args += ["duplicate", _pct(shaping.duplicate_pct)]
     if shaping.reorder_pct is not None:
         args += ["reorder", _pct(shaping.reorder_pct)]
+    if shaping.seed is not None:
+        args += ["seed", str(shaping.seed)]
     return args
 
 

--- a/src/rosotacom/transit.py
+++ b/src/rosotacom/transit.py
@@ -58,6 +58,64 @@ def join_transit_records(records: Iterable[dict[str, Any]]) -> list[dict[str, An
     return [joined[key] for key in sorted(joined)]
 
 
+def filter_transit_records_by_publish_window(
+    records: Iterable[dict[str, Any]],
+    *,
+    start_s: float,
+    end_s: float,
+    time_field: str = "t_wrap",
+) -> list[dict[str, Any]]:
+    """Keep records whose publish time falls inside a measurement window.
+
+    Lost records do not carry timestamps. For each source/topic/target stream,
+    keep lost sequence records only when they are bounded by delivered/reordered
+    records inside the window. This excludes startup and teardown sequence gaps
+    without hiding losses that happened during the measured interval.
+    """
+    if end_s < start_s:
+        raise ValueError("end_s must be >= start_s")
+    grouped: dict[tuple[str, str, str], list[dict[str, Any]]] = {}
+    for record in join_transit_records(records):
+        key = (
+            str(record.get("source") or ""),
+            str(record.get("target") or ""),
+            str(record.get("topic") or ""),
+        )
+        grouped.setdefault(key, []).append(record)
+
+    filtered: list[dict[str, Any]] = []
+    for key in sorted(grouped):
+        stream = grouped[key]
+        timed: list[dict[str, Any]] = []
+        for record in stream:
+            stamp = record.get(time_field)
+            if stamp is None:
+                continue
+            if start_s <= float(stamp) <= end_s:
+                timed.append(record)
+        if not timed:
+            continue
+        seq_min = min(int(record["seq"]) for record in timed)
+        seq_max = max(int(record["seq"]) for record in timed)
+        for record in stream:
+            if record.get("status") == "lost":
+                seq = int(record["seq"])
+                if seq_min <= seq <= seq_max:
+                    filtered.append(record)
+                continue
+            if record in timed:
+                filtered.append(record)
+    return sorted(
+        filtered,
+        key=lambda record: (
+            str(record.get("source") or ""),
+            str(record.get("target") or ""),
+            str(record.get("topic") or ""),
+            int(record["seq"]),
+        ),
+    )
+
+
 def summarize_transit_records(records: Iterable[dict[str, Any]]) -> dict[str, Any]:
     by_topic: dict[str, list[dict[str, Any]]] = {}
     for record in join_transit_records(records):

--- a/tests/unit/test_cli_benchmark.py
+++ b/tests/unit/test_cli_benchmark.py
@@ -34,6 +34,7 @@ from rosotacom.cli_benchmark import (
     _parse_values,
     _peer_catmux_attach_script,
     _prepare_benchmark_session_config,
+    _profile_requires_netem_seed,
     _requirements_jitter_loss_pct,
     _requirements_target_quality,
     _result_once_script,
@@ -503,6 +504,7 @@ def test_requirements_driver_finds_tight_profile_with_stubbed_probe(tmp_path: Pa
         out_dir=tmp_path,
         bandwidth_high_bps=10_000_000.0,
         bandwidth_low_bps=1_000_000.0,
+        latency_base_ms=0.0,
         latency_high_ms=300.0,
         jitter_high_ms=60.0,
         loss_high_pct=10.0,
@@ -574,6 +576,7 @@ def test_requirements_driver_can_search_coupled_jitter_loss(tmp_path: Path) -> N
         out_dir=tmp_path,
         bandwidth_high_bps=100_000_000.0,
         bandwidth_low_bps=10_000_000.0,
+        latency_base_ms=0.0,
         latency_high_ms=0.0,
         jitter_high_ms=50.0,
         loss_high_pct=10.0,
@@ -640,6 +643,7 @@ def test_requirements_zero_loss_target_clamps_network_loss(tmp_path: Path) -> No
         out_dir=tmp_path,
         bandwidth_high_bps=100_000_000.0,
         bandwidth_low_bps=10_000_000.0,
+        latency_base_ms=0.0,
         latency_high_ms=0.0,
         jitter_high_ms=40.0,
         loss_high_pct=10.0,
@@ -683,7 +687,7 @@ def test_requirements_repeat_policy_finds_good_and_bad_zero_loss_cases(tmp_path:
         jitter = parse_ms(generated["profiles"][profile]["uplink"].get("jitter", 0), "jitter")
         repeat_index = profile_counts.get(profile, 0) + 1
         profile_counts[profile] = repeat_index
-        lossy = jitter >= 10.0 or repeat_index == 10
+        lossy = jitter > 10.0 or repeat_index == 10
         return {
             "topics": {
                 "/test": {
@@ -711,7 +715,8 @@ def test_requirements_repeat_policy_finds_good_and_bad_zero_loss_cases(tmp_path:
         out_dir=tmp_path,
         bandwidth_high_bps=100_000_000.0,
         bandwidth_low_bps=10_000_000.0,
-        latency_high_ms=0.0,
+        latency_base_ms=30.0,
+        latency_high_ms=30.0,
         jitter_high_ms=20.0,
         loss_high_pct=0.0,
         axes=_parse_requirements_axes("jitter"),
@@ -725,6 +730,8 @@ def test_requirements_repeat_policy_finds_good_and_bad_zero_loss_cases(tmp_path:
         probe_repeats=10,
         probe_min_passes=9,
         bad_lossy_count=10,
+        netem_seed=12345,
+        jitter_guard_ratio=0.1,
         result_context={"test": True},
         generated_profiles_file=generated_file,
     )
@@ -737,6 +744,19 @@ def test_requirements_repeat_policy_finds_good_and_bad_zero_loss_cases(tmp_path:
     assert result["bounds"]["jitter"]["last_bad"]["repeat"]["lossy_count"] == 10
     assert result["analysis"]["bad_cases_observed"]["jitter"]["repeat"]["bad_case"] is True
     assert result["analysis"]["final_target_quality"]["repeat_pass_count"] == 9
+    assert result["analysis"]["netem_seed"] == 12345
+    assert result["analysis"]["jitter_guard_ratio"] == 0.1
+    assert result["analysis"]["guarded_axes"]["jitter"]["selected"]["jitter_ms"] == 10.0
+    assert result["analysis"]["guarded_axes"]["jitter"]["guarded"]["jitter_ms"] == 9.0
+    assert result["profile"]["candidate"]["uplink_latency_ms"] == 30.0
+    assert result["profile"]["candidate"]["jitter_ms"] == 9.0
+    generated = yaml.safe_load(generated_file.read_text(encoding="utf-8"))
+    assert generated["metadata"]["search"]["netem_seed"] == 12345
+    assert generated["metadata"]["search"]["jitter_guard_ratio"] == 0.1
+    assert generated["metadata"]["search"]["latency_base_ms"] == 30.0
+    assert generated["profiles"]["requirements_final"]["uplink"]["delay"] == "30ms"
+    assert generated["profiles"]["requirements_final"]["uplink"]["jitter"] == "9ms"
+    assert generated["profiles"]["requirements_final"]["uplink"]["seed"] == 12345
 
 
 def test_requirements_bandwidth_refine_recovers_when_previous_fail_becomes_pass(tmp_path: Path) -> None:
@@ -782,6 +802,7 @@ def test_requirements_bandwidth_refine_recovers_when_previous_fail_becomes_pass(
         out_dir=tmp_path,
         bandwidth_high_bps=16_000_000.0,
         bandwidth_low_bps=1_000_000.0,
+        latency_base_ms=0.0,
         latency_high_ms=0.0,
         jitter_high_ms=0.0,
         loss_high_pct=0.0,
@@ -793,6 +814,7 @@ def test_requirements_bandwidth_refine_recovers_when_previous_fail_becomes_pass(
         distribution="normal",
         final_refine_iterations=1,
         loss_coupling="jitter",
+        bandwidth_guard_ratio=0.1,
         result_context={"test": True},
         generated_profiles_file=generated_file,
     )
@@ -800,6 +822,77 @@ def test_requirements_bandwidth_refine_recovers_when_previous_fail_becomes_pass(
     assert result["bounds"]["bandwidth"]["status"] == "bounded_after_floor_reset"
     assert result["bounds"]["bandwidth"]["tight"] is True
     assert result["bounds"]["bandwidth"]["last_fail"]
+    selected_bw = result["bounds"]["bandwidth"]["selected"]["bandwidth_bps"]
+    assert result["profile"]["candidate"]["bandwidth_bps"] == pytest.approx(selected_bw * 1.1)
+    assert result["analysis"]["guarded_axes"]["bandwidth"]["selected"]["bandwidth_bps"] == pytest.approx(selected_bw)
+
+
+def test_requirements_bandwidth_probe_repeats_can_be_cheaper_than_final(tmp_path: Path) -> None:
+    from rosotacom.network_profiles import parse_rate_bps
+
+    generated_file = tmp_path / "generated-profiles.yaml"
+
+    def probe(*, profile: str | None, load: dict[str, Any], duration_s: float, out_dir: Path) -> dict[str, Any]:
+        assert profile is not None
+        generated = yaml.safe_load(generated_file.read_text(encoding="utf-8"))
+        rate_bps = parse_rate_bps(generated["profiles"][profile]["uplink"]["rate"])
+        passes = rate_bps >= 4_000_000.0
+        return {
+            "topics": {
+                "/test": {
+                    "expected": 100,
+                    "delivered": 100,
+                    "lost": 0,
+                    "loss_pct": 0.0,
+                    "reordered": 0,
+                    "ota_hop_ms": {"p50": 50.0, "p95": 90.0 if passes else 300.0},
+                    "jitter_ms": {"p50": 1.0, "p95": 1.0},
+                }
+            }
+        }
+
+    result = drive_requirements(
+        probe,
+        max_loss_pct=0.0,
+        max_latency_ms=250.0,
+        rate_hz=20.0,
+        size=18_000,
+        streams=1,
+        qos_reliability="best_effort",
+        qos_depth=1,
+        topic="/test",
+        out_dir=tmp_path,
+        bandwidth_high_bps=16_000_000.0,
+        bandwidth_low_bps=1_000_000.0,
+        latency_base_ms=30.0,
+        latency_high_ms=30.0,
+        jitter_high_ms=0.0,
+        loss_high_pct=0.0,
+        axes=_parse_requirements_axes("bandwidth"),
+        min_duration_s=20.0,
+        min_messages=100,
+        search_iterations=1,
+        search_rounds=1,
+        distribution="normal",
+        final_refine_iterations=0,
+        loss_coupling="jitter",
+        probe_repeats=3,
+        probe_min_passes=3,
+        bad_lossy_count=1,
+        bandwidth_probe_repeats=1,
+        result_context={"test": True},
+        generated_profiles_file=generated_file,
+    )
+
+    bandwidth_rows = [row for row in result["rows"] if row["axis"] == "bandwidth"]
+    assert bandwidth_rows
+    assert all(row["repeat"]["configured_repeats"] == 1 for row in bandwidth_rows)
+    assert result["rows"][0]["axis"] == "baseline"
+    assert result["rows"][0]["repeat"]["configured_repeats"] == 3
+    assert result["rows"][-1]["axis"] == "combined"
+    assert result["rows"][-1]["repeat"]["configured_repeats"] == 3
+    assert result["analysis"]["bandwidth_probe_repeats"] == 1
+    assert result["analysis"]["final_passes"] is True
 
 
 def test_requirements_zero_loss_target_reports_loss_as_limiter() -> None:
@@ -811,6 +904,30 @@ def test_requirements_zero_loss_target_reports_loss_as_limiter() -> None:
 
     assert quality["limiting_metric"] == "loss"
     assert quality["utilization"] == math.inf
+
+
+def test_profile_requires_netem_seed_only_when_seeded_netem_is_generated() -> None:
+    from rosotacom.network_profiles import DirectionShaping, Profile, TimelineSegment
+
+    rate_only = Profile("rate-only", "static", uplink=DirectionShaping(rate_bps=1_000_000.0, seed=123))
+    seeded_static = Profile(
+        "seeded-static",
+        "static",
+        uplink=DirectionShaping(delay_ms=30.0, jitter_ms=10.0, seed=123),
+    )
+    seeded_timeline = Profile(
+        "seeded-timeline",
+        "timeline",
+        timeline=(
+            TimelineSegment(for_s=1.0, uplink=DirectionShaping(rate_bps=1_000_000.0)),
+            TimelineSegment(for_s=1.0, downlink=DirectionShaping(delay_ms=30.0, jitter_ms=10.0, seed=123)),
+        ),
+    )
+
+    assert _profile_requires_netem_seed(None) is False
+    assert _profile_requires_netem_seed(rate_only) is False
+    assert _profile_requires_netem_seed(seeded_static) is True
+    assert _profile_requires_netem_seed(seeded_timeline) is True
 
 
 # --------------------------------------------------------------------------- #
@@ -980,7 +1097,17 @@ def test_live_lab_run_point_uses_instance_scoped_smoke_network(
     monkeypatch.setattr(cli, "_write_docker_log", lambda *args: None)
     monkeypatch.setattr(cli, "_stop_container_name", lambda name, runtime: stopped.append(name) or True)
     monkeypatch.setattr(cli, "_remove_smoke_network", lambda name: networks_removed.append(name))
-    monkeypatch.setattr(benchmark_cli, "collect_transit_summary", lambda instance_dir: {"topics": {}})
+    publish_windows: list[tuple[float, float] | None] = []
+
+    def fake_collect_transit_summary(
+        instance_dir: Path,
+        *,
+        publish_window: tuple[float, float] | None = None,
+    ) -> dict[str, Any]:
+        publish_windows.append(publish_window)
+        return {"topics": {}}
+
+    monkeypatch.setattr(benchmark_cli, "collect_transit_summary", fake_collect_transit_summary)
     monkeypatch.setattr(benchmark_cli.time, "sleep", lambda seconds: None)
     commands: list[list[str]] = []
 
@@ -1015,6 +1142,7 @@ def test_live_lab_run_point_uses_instance_scoped_smoke_network(
     assert all(args.peer_address == cli._smoke_peer_address_args(smoke_network.peer_ips) for args in started)
     assert stopped == ["container_a", "container_b"]
     assert networks_removed == [smoke_network.name]
+    assert publish_windows and publish_windows[0] is not None
     assert any(
         command[:6] == ["docker", "exec", "-u", "root", "container_a", "tc"] and "3%" in command for command in commands
     )
@@ -1159,6 +1287,7 @@ def test_benchmark_subcommand_arg_parsing() -> None:
     assert args.bandwidth_high == "auto"
     assert args.bandwidth_high_factor == 8.0
     assert args.bandwidth_low_factor == 1.0
+    assert args.latency_base_ms == 0.0
     assert args.latency_high_ms is None
     assert args.search_iterations == 6
     assert args.search_rounds == 1
@@ -1168,7 +1297,11 @@ def test_benchmark_subcommand_arg_parsing() -> None:
     assert args.probe_repeats == 1
     assert args.probe_min_passes is None
     assert args.bad_lossy_count is None
+    assert args.bandwidth_probe_repeats is None
     assert args.search_order == "auto"
+    assert args.netem_seed is None
+    assert args.jitter_guard_ratio == 0.0
+    assert args.bandwidth_guard_ratio == 0.0
 
     # Plot.
     args = parser.parse_args(["benchmark", "plot", "results.jsonl"])

--- a/tests/unit/test_cli_benchmark.py
+++ b/tests/unit/test_cli_benchmark.py
@@ -22,6 +22,7 @@ import rosotacom.cli as cli
 import rosotacom.cli_benchmark as benchmark_cli
 from rosotacom.cli_benchmark import (
     BENCHMARK_RESULT_FILE,
+    DEFAULT_BENCHMARK_DRAIN_S,
     DEFAULT_BENCHMARK_RMW,
     _benchmark_child_command,
     _benchmark_ota_target,
@@ -1108,7 +1109,8 @@ def test_live_lab_run_point_uses_instance_scoped_smoke_network(
         return {"topics": {}}
 
     monkeypatch.setattr(benchmark_cli, "collect_transit_summary", fake_collect_transit_summary)
-    monkeypatch.setattr(benchmark_cli.time, "sleep", lambda seconds: None)
+    sleep_calls: list[float] = []
+    monkeypatch.setattr(benchmark_cli.time, "sleep", lambda seconds: sleep_calls.append(float(seconds)))
     commands: list[list[str]] = []
 
     def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
@@ -1149,6 +1151,23 @@ def test_live_lab_run_point_uses_instance_scoped_smoke_network(
     assert any(
         command[:6] == ["docker", "exec", "-u", "root", "container_b", "tc"] and "1%" in command for command in commands
     )
+    assert sleep_calls[-2:] == [0.1, DEFAULT_BENCHMARK_DRAIN_S]
+    uplink_add = next(
+        i
+        for i, command in enumerate(commands)
+        if command[:8] == ["docker", "exec", "-u", "root", "container_a", "tc", "qdisc", "add"]
+    )
+    publisher_stop = next(
+        i
+        for i, command in enumerate(commands)
+        if i > uplink_add and command == ["docker", "exec", "container_a", "pkill", "-f", "sized_publisher"]
+    )
+    final_uplink_teardown = max(
+        i
+        for i, command in enumerate(commands)
+        if command[:8] == ["docker", "exec", "-u", "root", "container_a", "tc", "qdisc", "del"]
+    )
+    assert publisher_stop < final_uplink_teardown
 
 
 # --------------------------------------------------------------------------- #
@@ -1186,6 +1205,7 @@ def test_benchmark_subcommand_arg_parsing() -> None:
     assert args.benchmark_command == "capacity"
     assert args.knob == "size"
     assert args.rmw == DEFAULT_BENCHMARK_RMW
+    assert args.drain_s == DEFAULT_BENCHMARK_DRAIN_S
     assert args.ota_benchmark is False
     assert args.sudo_mode == "passwordless"
     assert _is_ota_benchmark(args) is False

--- a/tests/unit/test_network_profiles.py
+++ b/tests/unit/test_network_profiles.py
@@ -22,6 +22,7 @@ from rosotacom.network_profiles import (
     parse_profiles,
     parse_rate_bps,
     parse_seconds,
+    parse_seed,
     resolve_profile_selection,
     shaping_commands,
     teardown_command,
@@ -49,10 +50,13 @@ def test_duration_and_pct_parsing() -> None:
     assert parse_seconds("500ms") == 0.5
     assert parse_pct("2%") == 2.0
     assert parse_pct(100) == 100.0
+    assert parse_seed("12345") == 12345
     with pytest.raises(ValueError):
         parse_pct("150%")
     with pytest.raises(ValueError):
         parse_seconds("0s")
+    with pytest.raises(ValueError):
+        parse_seed(0)
 
 
 # --- direction schema + validation ----------------------------------------- #
@@ -180,6 +184,35 @@ def test_netem_arg_ordering_is_valid() -> None:
         "1%",
         "reorder",
         "5%",
+    ]
+
+
+def test_shaping_commands_emit_netem_seed() -> None:
+    commands = shaping_commands(
+        "tun0",
+        DirectionShaping(delay_ms=100.0, jitter_ms=20.0, distribution="normal", loss_pct=1.0, seed=12345),
+    )
+    assert commands == [
+        [
+            "tc",
+            "qdisc",
+            "add",
+            "dev",
+            "tun0",
+            "root",
+            "handle",
+            "10:",
+            "netem",
+            "delay",
+            "100ms",
+            "20ms",
+            "distribution",
+            "normal",
+            "loss",
+            "1%",
+            "seed",
+            "12345",
+        ]
     ]
 
 

--- a/tests/unit/test_transit.py
+++ b/tests/unit/test_transit.py
@@ -76,3 +76,22 @@ def test_filter_transit_records_by_publish_window_keeps_only_bounded_losses() ->
         (4, "lost"),
         (5, "delivered"),
     ]
+
+
+def test_filter_transit_records_by_publish_window_keeps_delayed_tail_delivery() -> None:
+    records = [
+        {**_record(1, "delivered", 10.0, 10.0), "source": "a", "target": "b"},
+        {**_record(2, "delivered", 50.0, 10.99), "source": "a", "target": "b"},
+        {**_record(3, "delivered", 10.0, 11.1), "source": "a", "target": "b"},
+    ]
+
+    filtered = filter_transit_records_by_publish_window(records, start_s=10.0, end_s=11.0)
+    summary = summarize_transit_records(filtered)["topics"]["a->b:/x"]
+
+    assert [(record["seq"], record["status"]) for record in filtered] == [
+        (1, "delivered"),
+        (2, "delivered"),
+    ]
+    assert summary["expected"] == 2
+    assert summary["lost"] == 0
+    assert summary["ota_hop_ms"]["p95"] == 50.0

--- a/tests/unit/test_transit.py
+++ b/tests/unit/test_transit.py
@@ -4,18 +4,20 @@ import json
 from pathlib import Path
 
 from rosotacom.transit import (
+    filter_transit_records_by_publish_window,
     join_transit_records,
     load_transit_records,
     summarize_transit_records,
 )
 
 
-def _record(seq: int, status: str, ota_ms: float | None = None) -> dict:
+def _record(seq: int, status: str, ota_ms: float | None = None, t_wrap: float | None = None) -> dict:
     return {
         "kind": "transit",
         "topic": "/x",
         "seq": seq,
         "status": status,
+        "t_wrap": t_wrap,
         "sections": {"ota_hop_ms": ota_ms},
         "jitter_ms": 2.0 if ota_ms is not None else None,
     }
@@ -54,3 +56,23 @@ def test_join_keeps_same_topic_sequence_from_different_sources() -> None:
     assert len(joined) == 2
     summary = summarize_transit_records([a, b])["topics"]
     assert set(summary) == {"a->b:/x", "b->a:/x"}
+
+
+def test_filter_transit_records_by_publish_window_keeps_only_bounded_losses() -> None:
+    records = [
+        {**_record(1, "delivered", 10.0, 9.9), "source": "a", "target": "b"},
+        {**_record(2, "lost"), "source": "a", "target": "b"},
+        {**_record(3, "delivered", 10.0, 10.1), "source": "a", "target": "b"},
+        {**_record(4, "lost"), "source": "a", "target": "b"},
+        {**_record(5, "delivered", 10.0, 10.5), "source": "a", "target": "b"},
+        {**_record(6, "lost"), "source": "a", "target": "b"},
+        {**_record(7, "delivered", 10.0, 11.2), "source": "a", "target": "b"},
+    ]
+
+    filtered = filter_transit_records_by_publish_window(records, start_s=10.0, end_s=11.0)
+
+    assert [(record["seq"], record["status"]) for record in filtered] == [
+        (3, "delivered"),
+        (4, "lost"),
+        (5, "delivered"),
+    ]


### PR DESCRIPTION
## Summary
- add seed-aware local benchmark shaping by copying a seed-capable host tc into containers when generated profiles use netem seed
- add requirements controls for latency base, jitter/bandwidth guard margins, and cheaper bandwidth probe repeats
- filter transit summaries to the shaped publish window so teardown/warmup messages do not pollute loss measurements
- persist seed/repeat/guard context in generated requirements artifacts

Fixes #91.

## Validation
- /home/go914/dev/rosotacom_test/ros_communication_devcontainer/.venv/bin/python -m pytest -q
- /home/go914/dev/rosotacom_test/ros_communication_devcontainer/.venv/bin/python -m ruff check .
- /home/go914/dev/rosotacom_test/ros_communication_devcontainer/.venv/bin/python -m mypy src/rosotacom
- live seeded requirements runs: artifacts/benchmarks/repro-boundary-seeded-lat30-run1, run2, run3

## Live boundary result
- command: rosotacom benchmark requirements --rate-hz 20 --size 18000 --qos-reliability best_effort --qos-depth 1 --max-loss 0 --max-latency-ms 250 --latency-base-ms 30 --downlink-mode lan --axes jitter,bandwidth --bandwidth-high-factor 8 --bandwidth-low-factor 1 --jitter-high-ms 40 --search-iterations 7 --final-refine-iterations 0 --search-rounds 1 --min-duration 20 --min-messages 100 --probe-repeats 1 --netem-seed 424242 --jitter-guard-ratio 0.20 --bandwidth-guard-ratio 0.20
- 3-run spread: final bandwidth 0.000000 Mbit/s, final jitter 0.5 ms, bad jitter threshold 0.625 ms
