### PR TITLE
Fix mixed RMW heartbeat smoke discovery

### DIFF
--- a/src/rosotacom/resources/ws/session/content/base/session_plugin_base.yaml
+++ b/src/rosotacom/resources/ws/session/content/base/session_plugin_base.yaml
@@ -283,7 +283,7 @@ windows:
         # For zenoh_ros2dds the OTA domain is loopback-only (zenoh is the inter-host
         # transport), so confine discovery to localhost instead of statically peering
         # the remote host — otherwise the OTA-domain DDS double-delivers alongside zenoh.
-        - if [ '${use_zenoh_ros2dds}' = "True" ] || [ '${use_zenoh_ros2dds}' = "true" ]; then export ROS_AUTOMATIC_DISCOVERY_RANGE=LOCALHOST; else export ROS_STATIC_PEERS="${ip_remote}"; fi
+        - if [ '${use_zenoh_ros2dds}' = "True" ] || [ '${use_zenoh_ros2dds}' = "true" ]; then export ROS_AUTOMATIC_DISCOVERY_RANGE=LOCALHOST; else export ROS_STATIC_PEERS="${ip_local};${ip_remote}"; fi
         - ros2 run com_py bridge_in --ros-args
             -p base_topic_files:=[${topic_list_paths_inbound}]
             -p local_name:=${local_name}
@@ -308,7 +308,7 @@ windows:
         # For zenoh_ros2dds the OTA domain is loopback-only (zenoh is the inter-host
         # transport), so confine discovery to localhost instead of statically peering
         # the remote host — otherwise the OTA-domain DDS double-delivers alongside zenoh.
-        - if [ '${use_zenoh_ros2dds}' = "True" ] || [ '${use_zenoh_ros2dds}' = "true" ]; then export ROS_AUTOMATIC_DISCOVERY_RANGE=LOCALHOST; else export ROS_STATIC_PEERS="${ip_remote}"; fi
+        - if [ '${use_zenoh_ros2dds}' = "True" ] || [ '${use_zenoh_ros2dds}' = "true" ]; then export ROS_AUTOMATIC_DISCOVERY_RANGE=LOCALHOST; else export ROS_STATIC_PEERS="${ip_local};${ip_remote}"; fi
         - ros2 run com_py bridge_out --ros-args
             -p base_topic_files:=[${topic_list_paths_outbound}]
             -p local_name:=${local_name}

--- a/tests/contract/test_packaged_resources.py
+++ b/tests/contract/test_packaged_resources.py
@@ -116,6 +116,18 @@ def test_domain_bridge_generates_ota_dds_config_before_launch() -> None:
     assert commands[1].startswith("ros2 run domain_bridge domain_bridge")
 
 
+def test_ota_bridge_static_peers_include_same_host_domain_bridge() -> None:
+    plugin = yaml.safe_load(
+        (cli.WS_DIR / "session" / "content" / "base" / "session_plugin_base.yaml").read_text(encoding="utf-8")
+    )
+
+    for window_name in ("IN", "OUT"):
+        window = next(window for window in plugin["windows"] if window["name"] == window_name)
+        bridge_commands = window["splits"][0]["commands"]
+
+        assert 'export ROS_STATIC_PEERS="${ip_local};${ip_remote}"' in bridge_commands[3]
+
+
 def test_native_chatter_waiter_reads_topic_info_without_broken_pipe(tmp_path: Path) -> None:
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()


### PR DESCRIPTION
## Summary

- Seed non-zenoh OTA bridge discovery with both the same-host container IP and the remote peer IP.
- Add a contract assertion for the IN/OUT bridge launch template so mixed-RMW heartbeat smoke cannot regress to remote-only static peers.

## Linked Issue

- Fixes #94

## Release Notes

- [ ] Release PR: includes `docs/release-notes/vX.Y.Z.md`
- [ ] Release PR: summarizes user-facing changes since the previous release
- [ ] Release PR: documents compatibility, migration, and validation notes
- [ ] Release PR: records the intended `main` commit and previous release tag
- [x] Not a release PR

## Public Behavior

- [x] Changes public CLI/config/API/Docker behavior
- [ ] Does not change public behavior

The generated communication container now exports `ROS_STATIC_PEERS="${ip_local};${ip_remote}"` for non-zenoh OTA bridge splits, so mixed-RMW runs can discover the same-host domain bridge participant as well as the remote peer.

## Checks

- [x] `just lint`
- [x] `just typecheck`
- [x] `just test-unit`
- [x] `just test-contract`
- [x] `just docs`
- [x] `just package`
- [x] `just check`
- [ ] `just test-e2e-smoke`, if Docker/runtime behavior changed

Additional Docker/runtime validation:

- [x] `ROSOTACOM_RUN_E2E=1 ROSOTACOM_RUN_FULL_E2E=1 .venv/bin/python -m pytest -q 'tests/e2e/test_smoke.py::test_full_rmw_heartbeat_smoke_matrix[fastdds-local-cyclone-ota]' -m e2e`

## Test Integrity

- [x] Tests/CI were not skipped, weakened, or removed to make this pass

## Maintainer Evidence

- Required CI links: pending on this PR
- Failing nightly source: https://github.com/develNor/ros_communication_devcontainer/actions/runs/28355082294
- Manual/runtime evidence: exact failed generated RMW case passed locally in 130.54s on commit `ba35ee6`
- External OTA evidence, if this PR is part of a `main` promotion: not applicable
