### PR TITLE
Fix benchmark probe lint formatting

### DIFF
--- a/src/rosotacom/benchmark.py
+++ b/src/rosotacom/benchmark.py
@@ -417,8 +417,10 @@ def characterize_probe_records(
     joined_records = join_transit_records(records)
     if not joined_records:
         return []
-    period_s = nominal_period_s if nominal_period_s is not None else _infer_nominal_period_s(
-        joined_records, time_field=time_field
+    period_s = (
+        nominal_period_s
+        if nominal_period_s is not None
+        else _infer_nominal_period_s(joined_records, time_field=time_field)
     )
     period_s = float(period_s or 0.0)
 

--- a/src/rosotacom/cli_benchmark.py
+++ b/src/rosotacom/cli_benchmark.py
@@ -581,8 +581,8 @@ def _initialize_interactive_log(full_log: Path, command: Sequence[str]) -> None:
 
 def _benchmark_run_script(command: Sequence[str], full_log: Path, session_name: str) -> str:
     pattern = (
-        r"probe\(|Probe time bins saved|Benchmark result saved|Capacity result|Capacity:|Ramp curve copied|Recovery metrics copied|"
-        r"Sweep frontier copied|ERROR|Error|Warning|benchmark exited"
+        r"probe\(|Probe time bins saved|Benchmark result saved|Capacity result|Capacity:|Ramp curve copied|"
+        r"Recovery metrics copied|Sweep frontier copied|ERROR|Error|Warning|benchmark exited"
     )
     script = f"""
 import pathlib


### PR DESCRIPTION
## Summary
- split the benchmark operator log regex line under the configured line length
- apply ruff formatting to the probe characterization period selection

Closes #104

## Validation
- `/home/go914/dev/rosotacom_issue_102_benchmark_probe/.venv/bin/python -m ruff check .`
- `/home/go914/dev/rosotacom_issue_102_benchmark_probe/.venv/bin/python -m ruff format --check .`
- `/home/go914/dev/rosotacom_issue_102_benchmark_probe/.venv/bin/python -m mypy`
- `/home/go914/dev/rosotacom_issue_102_benchmark_probe/.venv/bin/python -m pytest tests/unit/test_benchmark.py tests/unit/test_cli_benchmark.py tests/unit/test_plots.py`
- `/home/go914/dev/rosotacom_issue_102_benchmark_probe/.venv/bin/python -m pytest -q tests/contract/test_markdown_links.py tests/contract/test_readme_examples.py tests/contract/test_pytest_policy.py`