### PR TITLE
Install Cyclone RMW in default Docker image

### DIFF
--- a/src/rosotacom/resources/examples/ros2docker.json
+++ b/src/rosotacom/resources/examples/ros2docker.json
@@ -22,7 +22,7 @@
   "build_args": {
     "BASE_IMAGE": "osrf/ros:kilted-desktop-full-noble",
     "DIGEST": "@sha256:29eb6f48bb06549aba004a7a4b12c00ece23b156731df12cf1f3c1ae1b0fd178",
-    "APT_PACKAGES":                  "iputils-ping psmisc net-tools snmp iw nload iftop iproute2 tshark ros-kilted-domain-bridge",
+    "APT_PACKAGES":                  "iputils-ping psmisc net-tools snmp iw nload iftop iproute2 tshark ros-kilted-domain-bridge ros-kilted-rmw-cyclonedds-cpp",
     "PIP_PACKAGES":                  "numpy>=1.26,<2 lz4 pysnmp speedtest-cli psutil zstandard opencv-python"
   }
 }

--- a/src/rosotacom/resources/ros2docker.json.example
+++ b/src/rosotacom/resources/ros2docker.json.example
@@ -22,7 +22,7 @@
   "build_args": {
     "BASE_IMAGE":                    "osrf/ros:kilted-desktop-full-noble",
     "DIGEST":                        "@sha256:29eb6f48bb06549aba004a7a4b12c00ece23b156731df12cf1f3c1ae1b0fd178",
-    "APT_PACKAGES":                  "iputils-ping psmisc net-tools snmp iw nload iftop iproute2 tshark ros-kilted-domain-bridge",
+    "APT_PACKAGES":                  "iputils-ping psmisc net-tools snmp iw nload iftop iproute2 tshark ros-kilted-domain-bridge ros-kilted-rmw-cyclonedds-cpp",
     "PIP_PACKAGES":                  "numpy>=1.26,<2 lz4 pysnmp speedtest-cli psutil zstandard opencv-python"
   }
 }

--- a/tests/contract/test_packaged_resources.py
+++ b/tests/contract/test_packaged_resources.py
@@ -73,6 +73,10 @@ def test_default_ros2docker_config_pins_supported_kilted_noble_image() -> None:
     assert default_build_args["DIGEST"].startswith("@sha256:")
     assert default_build_args["BASE_IMAGE"] == example_build_args["BASE_IMAGE"]
     assert default_build_args["DIGEST"] == example_build_args["DIGEST"]
+    for build_args in (default_build_args, example_build_args):
+        apt_packages = set(str(build_args["APT_PACKAGES"]).split())
+        assert "ros-kilted-domain-bridge" in apt_packages
+        assert "ros-kilted-rmw-cyclonedds-cpp" in apt_packages
 
 
 def test_shell_entrypoints_pass_syntax_check() -> None:


### PR DESCRIPTION
## Summary
- install ros-kilted-rmw-cyclonedds-cpp in the packaged default and example Docker build configs
- assert the packaged configs keep the Cyclone RMW package alongside domain_bridge

## Validation
- docker apt-cache confirms ros-kilted-rmw-cyclonedds-cpp is available for the pinned Kilted image
- PYTHONPATH=src /home/go914/dev/rosotacom_issue_102_benchmark_probe/.venv/bin/python -m pytest tests/contract/test_packaged_resources.py::test_default_ros2docker_config_pins_supported_kilted_noble_image
- ROSOTACOM_RUN_E2E=1 PYTHONPATH=src /home/go914/dev/rosotacom_issue_102_benchmark_probe/.venv/bin/python -m pytest -q tests/e2e/test_benchmark_capacity.py::test_benchmark_capacity_good_case
- ROSOTACOM_RUN_E2E=1 PYTHONPATH=src /home/go914/dev/rosotacom_issue_102_benchmark_probe/.venv/bin/python -m pytest -q 'tests/e2e/test_smoke.py::test_local_heartbeat_smoke_matrix_from_copied_example_project[status]'
- PYTHONPATH=src /home/go914/dev/rosotacom_issue_102_benchmark_probe/.venv/bin/python -m pytest tests/contract/test_packaged_resources.py tests/unit/test_cli_benchmark.py::test_probe_driver_writes_time_bins_from_transit_records tests/unit/test_benchmark.py::test_characterize_probe_records_bins_loss_latency_hz_and_bandwidth tests/unit/test_plots.py::test_probe_timeseries_writes_figure
- /home/go914/dev/rosotacom_issue_102_benchmark_probe/.venv/bin/pre-commit run --files src/rosotacom/resources/examples/ros2docker.json src/rosotacom/resources/ros2docker.json.example tests/contract/test_packaged_resources.py

Fixes #106