### PR TITLE
Install smoke runtime dependencies

### DIFF
--- a/src/rosotacom/cli.py
+++ b/src/rosotacom/cli.py
@@ -3704,9 +3704,7 @@ def _create_scenario_tmux(
             )
         )
         if application_network:
-            application_command = (
-                f"{_wait_for_container_running_script(communication_container)}; {application_command}"
-            )
+            application_command = f"{_wait_for_container_ready_script(communication_container)}; {application_command}"
         created_window = subprocess.run(
             _tmux_command(
                 runtime,
@@ -5866,6 +5864,25 @@ def _wait_for_container_running_script(container_name: str) -> str:
     )
 
 
+def _wait_for_container_ready_script(container_name: str, timeout_s: int = 600) -> str:
+    quoted = shlex.quote(container_name)
+    marker = shlex.quote("Sourced ROS 2 workspace overlay")
+    return (
+        f"end=$(( $(date +%s) + {timeout_s} )); "
+        "while :; do "
+        f"if docker logs {quoted} 2>&1 | grep -Fq {marker}; then "
+        f"echo '[INFO] container ready: {quoted}'; break; "
+        "fi; "
+        f"state=$(docker inspect -f '{{{{.State.Running}}}}' {quoted} 2>/dev/null || true); "
+        f"if [ \"$state\" = false ]; then echo '[ERROR] container exited before ready: {quoted}' >&2; exit 1; fi; "
+        'if [ "$(date +%s)" -ge "$end" ]; then '
+        f"echo '[ERROR] timed out waiting for container readiness: {quoted}' >&2; exit 1; "
+        "fi; "
+        f"echo '[INFO] waiting for container readiness: {quoted}'; sleep 2; "
+        "done"
+    )
+
+
 def _create_interactive_smoke_tmux(
     runtime: RuntimeConfig,
     target: InteractiveSmokeTarget,
@@ -5998,7 +6015,7 @@ def _create_interactive_smoke_tmux(
                 )
                 script = (
                     f"{_wait_for_peer_spec_script(instance, peer)}; "
-                    f"{_wait_for_container_running_script(communication_container)}; "
+                    f"{_wait_for_container_ready_script(communication_container)}; "
                     f"exec {command}"
                 )
                 created_window = subprocess.run(

--- a/src/rosotacom/resources/examples/ros2docker.json
+++ b/src/rosotacom/resources/examples/ros2docker.json
@@ -22,7 +22,8 @@
   "build_args": {
     "BASE_IMAGE": "osrf/ros:kilted-desktop-full-noble",
     "DIGEST": "@sha256:29eb6f48bb06549aba004a7a4b12c00ece23b156731df12cf1f3c1ae1b0fd178",
-    "APT_PACKAGES":                  "iputils-ping psmisc net-tools snmp iw nload iftop iproute2 tshark ros-kilted-domain-bridge ros-kilted-rmw-cyclonedds-cpp",
+    "INSTALL_ZENOH":                 "1",
+    "APT_PACKAGES":                  "iputils-ping psmisc net-tools snmp iw nload iftop iproute2 tshark ros-kilted-domain-bridge ros-kilted-rmw-cyclonedds-cpp ros-kilted-ffmpeg-image-transport-msgs",
     "PIP_PACKAGES":                  "numpy>=1.26,<2 lz4 pysnmp speedtest-cli psutil zstandard opencv-python"
   }
 }

--- a/src/rosotacom/resources/examples/scripts/2_native_chatter/machine_a/external.ros2docker.json
+++ b/src/rosotacom/resources/examples/scripts/2_native_chatter/machine_a/external.ros2docker.json
@@ -15,6 +15,7 @@
 
   "build_args": {
     "BASE_IMAGE": "osrf/ros:kilted-desktop-full-noble",
-    "DIGEST": "@sha256:29eb6f48bb06549aba004a7a4b12c00ece23b156731df12cf1f3c1ae1b0fd178"
+    "DIGEST": "@sha256:29eb6f48bb06549aba004a7a4b12c00ece23b156731df12cf1f3c1ae1b0fd178",
+    "APT_PACKAGES": "ros-kilted-rmw-cyclonedds-cpp"
   }
 }

--- a/src/rosotacom/resources/examples/scripts/2_native_chatter/machine_b/external.ros2docker.json
+++ b/src/rosotacom/resources/examples/scripts/2_native_chatter/machine_b/external.ros2docker.json
@@ -13,6 +13,7 @@
 
   "build_args": {
     "BASE_IMAGE": "osrf/ros:kilted-desktop-full-noble",
-    "DIGEST": "@sha256:29eb6f48bb06549aba004a7a4b12c00ece23b156731df12cf1f3c1ae1b0fd178"
+    "DIGEST": "@sha256:29eb6f48bb06549aba004a7a4b12c00ece23b156731df12cf1f3c1ae1b0fd178",
+    "APT_PACKAGES": "ros-kilted-rmw-cyclonedds-cpp"
   }
 }

--- a/src/rosotacom/resources/ros2docker.json.example
+++ b/src/rosotacom/resources/ros2docker.json.example
@@ -22,7 +22,8 @@
   "build_args": {
     "BASE_IMAGE":                    "osrf/ros:kilted-desktop-full-noble",
     "DIGEST":                        "@sha256:29eb6f48bb06549aba004a7a4b12c00ece23b156731df12cf1f3c1ae1b0fd178",
-    "APT_PACKAGES":                  "iputils-ping psmisc net-tools snmp iw nload iftop iproute2 tshark ros-kilted-domain-bridge ros-kilted-rmw-cyclonedds-cpp",
+    "INSTALL_ZENOH":                 "1",
+    "APT_PACKAGES":                  "iputils-ping psmisc net-tools snmp iw nload iftop iproute2 tshark ros-kilted-domain-bridge ros-kilted-rmw-cyclonedds-cpp ros-kilted-ffmpeg-image-transport-msgs",
     "PIP_PACKAGES":                  "numpy>=1.26,<2 lz4 pysnmp speedtest-cli psutil zstandard opencv-python"
   }
 }

--- a/tests/contract/test_packaged_resources.py
+++ b/tests/contract/test_packaged_resources.py
@@ -74,9 +74,31 @@ def test_default_ros2docker_config_pins_supported_kilted_noble_image() -> None:
     assert default_build_args["BASE_IMAGE"] == example_build_args["BASE_IMAGE"]
     assert default_build_args["DIGEST"] == example_build_args["DIGEST"]
     for build_args in (default_build_args, example_build_args):
+        assert build_args["INSTALL_ZENOH"] == "1"
         apt_packages = set(str(build_args["APT_PACKAGES"]).split())
         assert "ros-kilted-domain-bridge" in apt_packages
         assert "ros-kilted-rmw-cyclonedds-cpp" in apt_packages
+        assert "ros-kilted-ffmpeg-image-transport-msgs" in apt_packages
+
+
+def test_external_ros2docker_configs_install_selected_rmw_implementations() -> None:
+    configs = sorted(cli.EXAMPLE_PROJECT_DIR.glob("scripts/**/external.ros2docker.json"))
+    assert configs
+
+    offenders: list[str] = []
+    for config_path in configs:
+        config = cli.load_config(config_path, resolve_run_args=False)
+        run_args = [str(value) for value in config.get("run_args", []) or []]
+        if "RMW_IMPLEMENTATION=rmw_cyclonedds_cpp" not in run_args:
+            continue
+
+        build_args = config.get("build_args", {}) or {}
+        apt_packages = set(str(build_args.get("APT_PACKAGES", "")).split())
+        if "ros-kilted-rmw-cyclonedds-cpp" not in apt_packages:
+            rel = config_path.relative_to(cli.EXAMPLE_PROJECT_DIR)
+            offenders.append(f"{rel} selects rmw_cyclonedds_cpp but does not install its package")
+
+    assert not offenders
 
 
 def test_shell_entrypoints_pass_syntax_check() -> None:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -588,7 +588,7 @@ def test_scenario_tmux_commands_keep_ctrl_b_and_use_full_windows(
     assert "--network-name scenario-net --network-ip 10.139.0.2" in joined
     assert "scenario _run-application demo" in joined
     assert "--network-name container:rosotacom_test_com_to_b" in joined
-    assert "waiting for container: rosotacom_test_com_to_b" in joined
+    assert "waiting for container readiness: rosotacom_test_com_to_b" in joined
     assert sum("new-window" in command for command in calls) == 1
     assert not any("split-window" in command for command in calls)
     assert any(
@@ -667,7 +667,7 @@ def test_interactive_smoke_tmux_uses_full_windows_and_metadata(
     assert "scenario _run-application demo --identity a --application local_app" in joined
     assert "--network-name container:rosotacom_test_com_to_b" in joined
     assert "waiting for generated config" in joined
-    assert "waiting for container" in joined
+    assert "waiting for container readiness" in joined
     assert any(command[-1] == "smoke-scenario-demo:verification" for command in calls if "select-window" in command)
 
 


### PR DESCRIPTION
## Summary
- install zenoh and the FFMPEG image transport message package in the packaged default ros2docker configs
- install Cyclone RMW in native chatter external app images that select `rmw_cyclonedds_cpp`
- add contract coverage for default smoke dependencies and external configs selecting Cyclone RMW

## Validation
- `PYTHONPATH=src /home/go914/dev/rosotacom_issue_102_benchmark_probe/.venv/bin/python -m pytest tests/contract/test_packaged_resources.py tests/unit/test_cli.py::test_smoke_publish_message_supports_remote_assist_anonymized_types tests/unit/test_cli.py::test_smoke_crossed_topics_include_zenoh_compressed_occupancy_grid_pipeline tests/unit/test_cli.py::test_smoke_crossed_topics_include_sized_payload_pipelines`
- `/home/go914/dev/rosotacom_issue_102_benchmark_probe/.venv/bin/ros2docker build -f src/rosotacom/resources/ros2docker.json.example -o '{"image_name":"rosotacom-ci-fix-deps-108"}' --dry-run`\n- `/home/go914/dev/rosotacom_issue_102_benchmark_probe/.venv/bin/ros2docker build -f src/rosotacom/resources/examples/scripts/2_native_chatter/machine_b/external.ros2docker.json -o '{"image_name":"rosotacom-native-chatter-ci-fix-108"}'`\n- `docker run --rm rosotacom-native-chatter-ci-fix-108 bash -lc 'set -e; source /opt/ros/kilted/setup.bash; RMW_IMPLEMENTATION=rmw_cyclonedds_cpp ros2 topic list >/tmp/topics.txt; echo cyclonedds-runtime-ok'`\n- `docker run --rm rosotacom-ci-fix-deps-108 bash -lc 'set -e; command -v zenohd; zenohd --version; source /opt/ros/kilted/setup.bash; ros2 interface show ffmpeg_image_transport_msgs/msg/FFMPEGPacket >/tmp/ffmpeg_packet.txt; echo ffmpeg-packet-msg-ok'`\n- `ROSOTACOM_RUN_E2E=1 PYTHONPATH=src /home/go914/dev/rosotacom_issue_102_benchmark_probe/.venv/bin/python -m pytest -q tests/e2e/test_smoke.py::test_local_remote_assist_anonymized_smoke_from_copied_example_project tests/e2e/test_smoke.py::test_native_chatter_scenario_starts_apps_and_communication_together tests/e2e/test_smoke.py::test_interactive_native_chatter_smoke_starts_full_local_debug_rig tests/e2e/test_smoke.py::test_local_zenoh_compressed_occupancy_grid_smoke_from_copied_example_project tests/e2e/test_smoke.py::test_local_zenoh_sized_payload_smoke_from_copied_example_project`\n- `/home/go914/dev/rosotacom_issue_102_benchmark_probe/.venv/bin/pre-commit run --files src/rosotacom/resources/examples/ros2docker.json src/rosotacom/resources/ros2docker.json.example src/rosotacom/resources/examples/scripts/2_native_chatter/machine_a/external.ros2docker.json src/rosotacom/resources/examples/scripts/2_native_chatter/machine_b/external.ros2docker.json tests/contract/test_packaged_resources.py`\n\nFixes #108