### PR TITLE
feat: add raw latency and loss plot for probe benchmarks

### DIFF
--- a/src/rosotacom/cli_benchmark.py
+++ b/src/rosotacom/cli_benchmark.py
@@ -1159,11 +1159,20 @@ def drive_probe(
     plot_error: str | None = None
     if render_plot and time_bins:
         try:
-            from .plots import plot_probe_timeseries
+            from .plots import plot_probe_raw, plot_probe_timeseries
 
             plot_path = plot_probe_timeseries(time_bins, out=out_dir / "probe-timeseries.png")
             artifacts["plot"] = plot_path.name
             print(f"Probe plot saved to {plot_path}")
+
+            try:
+                raw_records = _load_raw_records_from_out(out_dir)
+                if raw_records:
+                    raw_plot_path = plot_probe_raw(raw_records, out=out_dir / "probe-raw.png")
+                    artifacts["plot_raw"] = raw_plot_path.name
+                    print(f"Probe raw plot saved to {raw_plot_path}")
+            except Exception as raw_exc:
+                print(f"Probe raw plot skipped: {raw_exc}", file=sys.stderr)
         except Exception as exc:
             plot_error = str(exc)
             artifacts["plot_error"] = plot_error
@@ -1531,12 +1540,35 @@ def _load_raw_records_from_out(out_dir: Path) -> list[dict[str, Any]]:
     """Load raw transit records from the most recent run's events files."""
     from .transit import join_transit_records, load_transit_records
 
+    # Check if there are attempt subdirectories
+    attempts_dirs = sorted(out_dir.glob("attempts/attempt_*"))
+    if attempts_dirs:
+        records: list[dict[str, Any]] = []
+        for attempt_dir in attempts_dirs:
+            try:
+                attempt = int(attempt_dir.name.split("_")[-1])
+            except ValueError:
+                attempt = 1
+            events = sorted(attempt_dir.rglob("status/events.jsonl"))
+            if not events:
+                events = sorted(attempt_dir.rglob("events.jsonl"))
+            if events:
+                joined = join_transit_records(load_transit_records(events))
+                for r in joined:
+                    r["attempt"] = attempt
+                records.extend(joined)
+        return records
+
     events = sorted(out_dir.rglob("status/events.jsonl"))
     if not events:
         events = sorted(out_dir.rglob("events.jsonl"))
     if not events:
         return []
-    return join_transit_records(load_transit_records(events))
+    joined = join_transit_records(load_transit_records(events))
+    for r in joined:
+        if "attempt" not in r:
+            r["attempt"] = 1
+    return joined
 
 
 # --------------------------------------------------------------------------- #
@@ -5448,6 +5480,7 @@ def benchmark_plot(args: argparse.Namespace) -> int:
     from .plots import (
         plot_capacity_frontier,
         plot_offered_bw,
+        plot_probe_raw,
         plot_probe_timeseries,
         plot_ramp,
         plot_recovery_timeline,
@@ -5493,6 +5526,26 @@ def benchmark_plot(args: argparse.Namespace) -> int:
                 plot_capacity_frontier(data, out=out)
             elif plot_type == "probe":
                 plot_probe_timeseries(data, out=out)
+                try:
+                    raw_records = _load_raw_records_from_out(input_path.parent)
+                    if raw_records:
+                        raw_out = (
+                            Path(args.out).parent / "probe-raw.png"
+                            if getattr(args, "out", None)
+                            else input_path.parent / "probe-raw.png"
+                        )
+                        if getattr(args, "out", None) and Path(args.out) == raw_out:
+                            raw_out = Path(args.out).parent / "probe-raw.png"
+                        plot_probe_raw(raw_records, out=raw_out)
+                        print(f"Probe raw plot saved to {raw_out}")
+                except Exception:
+                    pass
+            elif plot_type == "probe-raw":
+                raw_out = Path(args.out) if getattr(args, "out", None) else input_path.parent / "probe-raw.png"
+                raw_records = _load_raw_records_from_out(input_path.parent)
+                plot_probe_raw(raw_records, out=raw_out)
+                print(f"Probe raw plot saved to {raw_out}")
+
             elif plot_type == "offered_bw":
                 plot_offered_bw(data, out=out)
             elif plot_type == "ramp":
@@ -5507,7 +5560,8 @@ def benchmark_plot(args: argparse.Namespace) -> int:
                 plot_topic_heatmap(per_topic, out=out)
             else:
                 print(
-                    f"Unknown plot type: {plot_type!r}. Use: frontier, probe, offered_bw, ramp, recovery, heatmap.",
+                    f"Unknown plot type: {plot_type!r}. Use: frontier, probe, "
+                    "probe-raw, offered_bw, ramp, recovery, heatmap.",
                     file=sys.stderr,
                 )
                 return 1
@@ -6079,7 +6133,7 @@ def _register_benchmark_plot_parser(benchmark_subparsers: Any) -> None:
     plot_parser.add_argument("--artifacts-dir", help="Output directory for all benchmark artifacts.")
     plot_parser.add_argument(
         "--type",
-        choices=["auto", "frontier", "probe", "offered_bw", "ramp", "recovery", "heatmap"],
+        choices=["auto", "frontier", "probe", "probe-raw", "offered_bw", "ramp", "recovery", "heatmap"],
         default="auto",
         help="Plot type (default: auto-detect from data).",
     )

--- a/src/rosotacom/plots.py
+++ b/src/rosotacom/plots.py
@@ -335,3 +335,107 @@ def plot_topic_heatmap(
     fig.savefig(out, dpi=150, bbox_inches="tight")
     plt.close(fig)
     return out
+
+
+# --------------------------------------------------------------------------- #
+# Raw fixed probe — individual packet latencies and packet losses
+# --------------------------------------------------------------------------- #
+
+
+def plot_probe_raw(
+    records: Sequence[dict[str, Any]],
+    *,
+    out: str | Path,
+    title: str = "Probe raw latency and loss",
+) -> Path:
+    """Render raw probe transit records: individual packet latencies and losses."""
+    _, plt = _require_matplotlib()
+    out = Path(out)
+
+    from .benchmark import _infer_nominal_period_s, _section_ms, _send_time
+
+    grouped: dict[tuple[str, int], list[dict[str, Any]]] = {}
+    for row in records:
+        source = str(row.get("source") or "")
+        target = str(row.get("target") or "")
+        topic = str(row.get("topic") or "")
+        topic_label = f"{source}->{target}:{topic}" if source or target else topic
+        attempt = int(row.get("attempt", 1) or 1)
+        grouped.setdefault((topic_label, attempt), []).append(row)
+
+    fig, ax = plt.subplots(figsize=(10, 6))
+    cmap = plt.colormaps["tab10"].resampled(max(len(grouped), 1))
+
+    all_lost_xs: list[float] = []
+    max_latency = 0.0
+
+    for index, ((label, attempt), stream) in enumerate(sorted(grouped.items())):
+        stream = sorted(stream, key=lambda record: int(record.get("seq", 0)))
+
+        time_field = "t_wrap"
+        period_s = _infer_nominal_period_s(stream, time_field=time_field)
+        period_s = float(period_s or 0.0)
+
+        stamped = [record for record in stream if record.get(time_field) is not None]
+        if not stamped:
+            continue
+        anchor = min(stamped, key=lambda record: int(record.get("seq", 0)))
+        seq0 = int(anchor["seq"])
+        t0 = float(anchor.get(time_field) or 0.0)
+
+        expanded = []
+        for record in stream:
+            send_t = _send_time(record, seq0=seq0, t0=t0, period_s=period_s, time_field=time_field)
+            expanded.append((record, send_t))
+
+        if not expanded:
+            continue
+
+        first_send_s = min(send_t for _, send_t in expanded)
+
+        xs_delivered = []
+        ys_latency = []
+        xs_lost = []
+
+        for record, send_t in expanded:
+            x = max(0.0, send_t - first_send_s)
+            if record.get("status") == "lost":
+                xs_lost.append(x)
+            else:
+                latency_ms = _section_ms(record, "ota_hop_ms", "ota_hop_uncorrected_ms")
+                if latency_ms is not None:
+                    xs_delivered.append(x)
+                    ys_latency.append(latency_ms)
+                    if latency_ms > max_latency:
+                        max_latency = latency_ms
+
+        color = cmap(index)
+        stream_label = label
+        if len({key[1] for key in grouped}) > 1:
+            stream_label = f"{stream_label} #{attempt}"
+
+        if xs_delivered:
+            ax.scatter(xs_delivered, ys_latency, color=color, s=12, alpha=0.6, label=f"{stream_label} latency")
+
+        if xs_lost:
+            all_lost_xs.extend(xs_lost)
+
+    ax.set_ylim(bottom=0.0)
+    ymin, ymax = ax.get_ylim()
+
+    if all_lost_xs:
+        ax.vlines(all_lost_xs, ymin, ymax, colors="crimson", alpha=0.3, linewidth=1.0, label="lost packet")
+
+    ax.set_ylabel("Latency (ms)")
+    ax.set_xlabel("Time since first publish (s)")
+    ax.set_title(title)
+
+    handles, labels = ax.get_legend_handles_labels()
+    by_label = dict(zip(labels, handles, strict=False))
+    if by_label:
+        ax.legend(by_label.values(), by_label.keys(), loc="upper right", fontsize="small")
+
+    fig.tight_layout()
+    fig.savefig(out, dpi=150, bbox_inches="tight")
+    plt.close(fig)
+    return out

--- a/tests/unit/test_plots.py
+++ b/tests/unit/test_plots.py
@@ -21,6 +21,7 @@ from rosotacom.plots import (  # noqa: E402, I001
     plot_capacity_frontier,
     plot_offered_bw,
     plot_probe_timeseries,
+    plot_probe_raw,
     plot_ramp,
     plot_recovery_timeline,
     plot_topic_heatmap,
@@ -86,6 +87,42 @@ PROBE_BINS: list[dict] = [
     },
 ]
 
+RAW_RECORDS: list[dict] = [
+    {
+        "kind": "transit",
+        "peer": "b",
+        "source": "a",
+        "target": "b",
+        "topic": "/bench_capacity",
+        "seq": 0,
+        "status": "delivered",
+        "t_wrap": 10.0,
+        "sections": {"ota_hop_ms": 10.0},
+        "size_bytes": 100,
+    },
+    {
+        "kind": "transit",
+        "peer": "b",
+        "source": "a",
+        "target": "b",
+        "topic": "/bench_capacity",
+        "seq": 1,
+        "status": "lost",
+    },
+    {
+        "kind": "transit",
+        "peer": "b",
+        "source": "a",
+        "target": "b",
+        "topic": "/bench_capacity",
+        "seq": 2,
+        "status": "delivered",
+        "t_wrap": 11.0,
+        "sections": {"ota_hop_ms": 20.0},
+        "size_bytes": 200,
+    },
+]
+
 
 # -- smoke tests ------------------------------------------------------------ #
 
@@ -107,6 +144,13 @@ def test_offered_bw_writes_figure(tmp_path: Path) -> None:
 def test_probe_timeseries_writes_figure(tmp_path: Path) -> None:
     out = tmp_path / "probe.png"
     result = plot_probe_timeseries(PROBE_BINS, out=out)
+    assert result == out
+    assert out.stat().st_size > 0
+
+
+def test_probe_raw_writes_figure(tmp_path: Path) -> None:
+    out = tmp_path / "probe_raw.png"
+    result = plot_probe_raw(RAW_RECORDS, out=out)
     assert result == out
     assert out.stat().st_size > 0
 


### PR DESCRIPTION
This PR adds a raw packet-level plot (probe-raw) showing individual message latencies and losses over time for fixed probe benchmarks.