### PR TITLE
Install Zenoh RMW in smoke image

### DIFF
--- a/src/rosotacom/resources/examples/ros2docker.json
+++ b/src/rosotacom/resources/examples/ros2docker.json
@@ -23,7 +23,7 @@
     "BASE_IMAGE": "osrf/ros:kilted-desktop-full-noble",
     "DIGEST": "@sha256:29eb6f48bb06549aba004a7a4b12c00ece23b156731df12cf1f3c1ae1b0fd178",
     "INSTALL_ZENOH":                 "1",
-    "APT_PACKAGES":                  "iputils-ping psmisc net-tools snmp iw nload iftop iproute2 tshark ros-kilted-domain-bridge ros-kilted-rmw-cyclonedds-cpp ros-kilted-ffmpeg-image-transport-msgs",
+    "APT_PACKAGES":                  "iputils-ping psmisc net-tools snmp iw nload iftop iproute2 tshark ros-kilted-domain-bridge ros-kilted-rmw-cyclonedds-cpp ros-kilted-rmw-zenoh-cpp ros-kilted-ffmpeg-image-transport-msgs",
     "PIP_PACKAGES":                  "numpy>=1.26,<2 lz4 pysnmp speedtest-cli psutil zstandard opencv-python"
   }
 }

--- a/src/rosotacom/resources/ros2docker.json.example
+++ b/src/rosotacom/resources/ros2docker.json.example
@@ -23,7 +23,7 @@
     "BASE_IMAGE":                    "osrf/ros:kilted-desktop-full-noble",
     "DIGEST":                        "@sha256:29eb6f48bb06549aba004a7a4b12c00ece23b156731df12cf1f3c1ae1b0fd178",
     "INSTALL_ZENOH":                 "1",
-    "APT_PACKAGES":                  "iputils-ping psmisc net-tools snmp iw nload iftop iproute2 tshark ros-kilted-domain-bridge ros-kilted-rmw-cyclonedds-cpp ros-kilted-ffmpeg-image-transport-msgs",
+    "APT_PACKAGES":                  "iputils-ping psmisc net-tools snmp iw nload iftop iproute2 tshark ros-kilted-domain-bridge ros-kilted-rmw-cyclonedds-cpp ros-kilted-rmw-zenoh-cpp ros-kilted-ffmpeg-image-transport-msgs",
     "PIP_PACKAGES":                  "numpy>=1.26,<2 lz4 pysnmp speedtest-cli psutil zstandard opencv-python"
   }
 }

--- a/tests/contract/test_packaged_resources.py
+++ b/tests/contract/test_packaged_resources.py
@@ -78,6 +78,7 @@ def test_default_ros2docker_config_pins_supported_kilted_noble_image() -> None:
         apt_packages = set(str(build_args["APT_PACKAGES"]).split())
         assert "ros-kilted-domain-bridge" in apt_packages
         assert "ros-kilted-rmw-cyclonedds-cpp" in apt_packages
+        assert "ros-kilted-rmw-zenoh-cpp" in apt_packages
         assert "ros-kilted-ffmpeg-image-transport-msgs" in apt_packages
 
 


### PR DESCRIPTION
Closes #112

## Summary

- install `ros-kilted-rmw-zenoh-cpp` in the default packaged `ros2docker.json` configs
- extend the packaged-resource contract so the native Zenoh RMW dependency stays present

## Context

Nightly E2E failed on `develop` at 9b4b66da8d7bc9a15857abf730cd832bbba1a07d:
https://github.com/develNor/ros_communication_devcontainer/actions/runs/28499318785

The reproduced failure was `test_full_rmw_heartbeat_smoke_matrix[zen-endpoints]`. The smoke logs showed ROS commands failing to load `librmw_zenoh_cpp.so`, so the generated native Zenoh matrix could not publish heartbeats or write status reports.

## Validation

- `.venv/bin/python -m pytest -q tests/contract/test_packaged_resources.py::test_default_ros2docker_config_pins_supported_kilted_noble_image`
- `ROSOTACOM_RUN_E2E=1 ROSOTACOM_RUN_FULL_E2E=1 .venv/bin/python -m pytest -q 'tests/e2e/test_smoke.py::test_full_rmw_heartbeat_smoke_matrix[zen-endpoints]'`
- `.venv/bin/python -m pytest -q tests/contract/test_packaged_resources.py`
- `git diff --check`
- `.venv/bin/python -m ruff check tests/contract/test_packaged_resources.py`
