### PR TITLE
benchmark: exclude probe warm-up/transition, re-anchor to impairment onset

### DIFF
--- a/src/rosotacom/benchmark.py
+++ b/src/rosotacom/benchmark.py
@@ -393,6 +393,198 @@ def _infer_nominal_period_s(records: Sequence[dict[str, Any]], *, time_field: st
     return ordered[len(ordered) // 2]
 
 
+def _median(values: Sequence[float]) -> float:
+    ordered = sorted(values)
+    n = len(ordered)
+    mid = n // 2
+    return ordered[mid] if n % 2 else 0.5 * (ordered[mid - 1] + ordered[mid])
+
+
+def _mad(values: Sequence[float]) -> float:
+    """Median absolute deviation — a spread estimate that ignores outliers."""
+    center = _median(values)
+    return _median([abs(v - center) for v in values])
+
+
+# Per-sample settling labels. Only ``SETTLED`` samples reflect the profile under
+# test; the others are start-up artefacts and are excluded from summaries.
+SETTLED = "settled"
+WARMUP = "warmup"
+TRANSITION = "transition"
+
+
+@dataclass(frozen=True)
+class ProbeSettling:
+    """Result of :func:`classify_probe_settling` for one time-ordered stream."""
+
+    labels: list[str]  # one of SETTLED / WARMUP / TRANSITION per input sample
+    onset_index: int | None  # first index of the settled regime, or None if all settled
+
+    @property
+    def excluded_count(self) -> int:
+        return sum(1 for label in self.labels if label != SETTLED)
+
+
+def classify_probe_settling(
+    latencies_ms: Sequence[float],
+    *,
+    min_points: int = 12,
+    step_window: int = 6,
+    min_step_ratio: float = 3.0,
+    min_step_ms: float = 15.0,
+    settle_fraction: float = 0.5,
+    warmup_mad_k: float = 5.0,
+) -> ProbeSettling:
+    """Split a time-ordered fixed-probe latency series into warm-up and impaired.
+
+    A fixed probe starts before the tc/netem shaping is applied, so the leading
+    packets sit at the un-impaired transport floor (a few ms). When shaping
+    engages the latency jumps sharply to the impaired regime — which may be a
+    stable plateau *or* a rising ramp (a shaped rate below the offered load builds
+    an ever-growing queue, i.e. bufferbloat). The detector therefore anchors on
+    the **sharp upward step from the low floor**, not on any plateau, so a ramping
+    profile is kept whole instead of being mistaken for a long transition.
+
+    Around the step three regimes are labelled:
+
+    * ``WARMUP`` — leading packets still at the floor (network delay ≈ 0);
+    * ``TRANSITION`` — the packet(s) in flight as shaping engages, seeing only a
+      partial delay (floor < latency < impaired regime);
+    * ``SETTLED`` — the impaired regime under test, kept for characterisation.
+
+    Detection is conservative: without a clear low-floor→high step (``impaired``
+    at least ``min_step_ratio``× **or** ``min_step_ms`` above the floor) every
+    sample is ``SETTLED`` and nothing is excluded — e.g. impairment live from the
+    first packet, a no-op profile, or a smooth ramp with no warm-up.
+
+    ``latencies_ms`` must already be ordered by send time.
+    """
+    n = len(latencies_ms)
+    if n < min_points:
+        return ProbeSettling([SETTLED] * n, None)
+
+    latencies = list(latencies_ms)
+    window = max(1, min(step_window, n // 2))
+
+    # Locate the sharpest upward step: the largest ratio between the windowed
+    # median just after an index and just before it. The un-impaired floor is the
+    # lowest level in the run, so the warm-up→impaired jump dominates, and windowed
+    # medians keep a single ramp spike from masquerading as the step.
+    step_index: int | None = None
+    best_ratio = 1.0
+    for i in range(window, n - window):
+        pre = _median(latencies[i - window : i])
+        post = _median(latencies[i : i + window])
+        if pre <= 0.0:
+            continue
+        ratio = post / pre
+        if ratio > best_ratio:
+            best_ratio = ratio
+            step_index = i
+    if step_index is None:
+        return ProbeSettling([SETTLED] * n, None)
+
+    floor = _median(latencies[max(0, step_index - window) : step_index])
+    impaired = _median(latencies[step_index : step_index + window])
+    step_is_real = impaired >= floor * min_step_ratio or impaired - floor >= min_step_ms
+    if best_ratio < min_step_ratio or not step_is_real:
+        return ProbeSettling([SETTLED] * n, None)
+
+    warmup_hi = floor + max(warmup_mad_k * _mad(latencies[:step_index]), 0.02 * (impaired - floor))
+    impaired_lo = floor + settle_fraction * (impaired - floor)
+
+    # Onset = first packet that reaches *and holds* the impaired regime, so the
+    # partial transition packet(s) below ``impaired_lo`` stay out of it.
+    onset: int | None = None
+    for i in range(n):
+        if latencies[i] >= impaired_lo:
+            ahead = latencies[i : i + window]
+            if sum(1 for v in ahead if v >= impaired_lo) >= 0.7 * len(ahead):
+                onset = i
+                break
+    if not onset:  # None or 0 → nothing clean to exclude
+        return ProbeSettling([SETTLED] * n, None)
+
+    labels = [SETTLED if i >= onset else (TRANSITION if v > warmup_hi else WARMUP) for i, v in enumerate(latencies)]
+    return ProbeSettling(labels, onset)
+
+
+def _probe_onset_send_time(
+    stream: Sequence[dict[str, Any]],
+    *,
+    seq0: int,
+    t0: float,
+    period_s: float,
+    time_field: str,
+) -> float | None:
+    """Send-time at which one stream's impairment settles, or None if no warm-up step."""
+    delivered: list[tuple[float, float]] = []
+    for record in stream:
+        if record.get("status") == "lost":
+            continue
+        latency_ms = _section_ms(record, "ota_hop_ms", "ota_hop_uncorrected_ms")
+        if latency_ms is None:
+            continue
+        send_t = _send_time(record, seq0=seq0, t0=t0, period_s=period_s, time_field=time_field)
+        delivered.append((send_t, latency_ms))
+    delivered.sort(key=lambda point: point[0])
+    settling = classify_probe_settling([latency for _, latency in delivered])
+    if settling.onset_index is None:
+        return None
+    return delivered[settling.onset_index][0]
+
+
+def exclude_probe_warmup(
+    joined_records: Sequence[dict[str, Any]],
+    *,
+    nominal_period_s: float | None = None,
+    time_field: str = "t_wrap",
+) -> tuple[list[dict[str, Any]], float | None]:
+    """Drop the warm-up/transition prefix from already-joined transit records.
+
+    Returns ``(settled_records, onset_send_time)`` where ``onset_send_time`` is the
+    earliest per-stream impairment onset on the publish timeline — the origin that
+    re-anchors "time since first publish" so ``t=0`` is where shaping is fully
+    applied. Streams with no clear warm-up step are kept whole; when no stream
+    shows a step, nothing is dropped and ``onset_send_time`` is ``None``.
+    """
+    joined = list(joined_records)
+    if not joined:
+        return [], None
+    period_s = (
+        nominal_period_s if nominal_period_s is not None else _infer_nominal_period_s(joined, time_field=time_field)
+    ) or 0.0
+
+    grouped: dict[tuple[str, str, str], list[dict[str, Any]]] = {}
+    for record in joined:
+        key = (
+            str(record.get("source") or ""),
+            str(record.get("target") or ""),
+            str(record.get("topic") or ""),
+        )
+        grouped.setdefault(key, []).append(record)
+
+    kept: list[dict[str, Any]] = []
+    onsets: list[float] = []
+    for _key, stream in grouped.items():
+        stream = sorted(stream, key=lambda record: int(record["seq"]))
+        stamped = [record for record in stream if record.get(time_field) is not None]
+        anchor = min(stamped or stream, key=lambda record: int(record["seq"]))
+        seq0 = int(anchor["seq"])
+        t0 = float(anchor.get(time_field) or 0.0)
+        onset = _probe_onset_send_time(stream, seq0=seq0, t0=t0, period_s=period_s, time_field=time_field)
+        if onset is None:
+            kept.extend(stream)
+            continue
+        onsets.append(onset)
+        kept.extend(
+            record
+            for record in stream
+            if _send_time(record, seq0=seq0, t0=t0, period_s=period_s, time_field=time_field) >= onset
+        )
+    return kept, (min(onsets) if onsets else None)
+
+
 def characterize_probe_records(
     records: Iterable[dict[str, Any]],
     *,
@@ -400,14 +592,20 @@ def characterize_probe_records(
     nominal_period_s: float | None = None,
     topic: str = "",
     time_field: str = "t_wrap",
+    exclude_warmup: bool = True,
 ) -> list[dict[str, Any]]:
     """Summarize one fixed probe as per-topic time bins.
 
-    Bins are aligned to the first observed publish timestamp and use publish
-    time, not arrival time, so latency/loss spikes line up with the traffic that
-    caused them. Lost records often lack timestamps; when a nominal period is
-    supplied (usually ``1 / rate_hz``), their send time is reconstructed from
-    sequence number just like the recovery metrics do.
+    Bins use publish time, not arrival time, so latency/loss spikes line up with
+    the traffic that caused them. Lost records often lack timestamps; when a
+    nominal period is supplied (usually ``1 / rate_hz``), their send time is
+    reconstructed from sequence number just like the recovery metrics do.
+
+    With ``exclude_warmup`` (the default) the un-impaired warm-up plateau and the
+    partial-impairment transition packet are dropped via
+    :func:`exclude_probe_warmup`, and the bins are aligned to the impairment
+    onset so ``bin_start_s == 0`` is where shaping is fully applied. Set it False
+    to bin the raw timeline from the first publish.
     """
     if bin_s <= 0.0:
         raise ValueError("bin_s must be > 0.")
@@ -423,6 +621,11 @@ def characterize_probe_records(
         else _infer_nominal_period_s(joined_records, time_field=time_field)
     )
     period_s = float(period_s or 0.0)
+
+    if exclude_warmup:
+        joined_records, _onset = exclude_probe_warmup(joined_records, nominal_period_s=period_s, time_field=time_field)
+        if not joined_records:
+            return []
 
     grouped: dict[tuple[str, str, str], list[dict[str, Any]]] = {}
     for record in joined_records:

--- a/src/rosotacom/cli_benchmark.py
+++ b/src/rosotacom/cli_benchmark.py
@@ -1063,16 +1063,35 @@ def _run_probe_attempt(
         "load": load_info,
     }
     if bin_s is not None:
-        from .benchmark import characterize_probe_records
+        from .benchmark import characterize_probe_records, exclude_probe_warmup
 
         records = _load_raw_records_from_out(out_dir)
         rate_hz = float(load.get("rate", load.get("rate_hz", 0.0)) or 0.0)
+        nominal_period_s = (1.0 / rate_hz) if rate_hz > 0.0 else None
         result["raw_record_count"] = len(records)
+
+        # Drop the un-impaired warm-up plateau and the partial-impairment
+        # transition packet so neither the time bins nor the per-topic p95/loss
+        # summary reflect start-up artefacts (RFC 0005, "characterise the profile
+        # under test, not the setup"). Detection is conservative: without a clear
+        # step nothing is dropped and the full-run summary stands.
+        settled, onset = exclude_probe_warmup(records, nominal_period_s=nominal_period_s)
+        if onset is not None:
+            from .transit import summarize_transit_records
+
+            summary = summarize_transit_records(settled)
+            rows = _topic_rows(summary, topic)
+            result["summary"] = summary
+            result["topics"] = rows
+            result["warmup_excluded"] = len(records) - len(settled)
+            result["settled_onset_s"] = round(onset, 6)
+
         result["time_bins"] = characterize_probe_records(
-            records,
+            settled,
             bin_s=bin_s,
-            nominal_period_s=(1.0 / rate_hz) if rate_hz > 0.0 else None,
+            nominal_period_s=nominal_period_s,
             topic=topic,
+            exclude_warmup=False,
         )
     return result
 
@@ -1133,20 +1152,24 @@ def drive_probe(
             for bin_row in attempt_result.get("time_bins", [])
         ]
         time_bins.extend(attempt_bins)
+        warmup_excluded = int(attempt_result.get("warmup_excluded", 0) or 0)
         attempts.append(
             {
                 "attempt": attempt,
                 "artifact_dir": str(attempt_dir.relative_to(out_dir)),
                 "raw_record_count": attempt_result.get("raw_record_count", 0),
+                "warmup_excluded": warmup_excluded,
+                "settled_onset_s": attempt_result.get("settled_onset_s"),
                 "time_bin_count": len(attempt_bins),
                 "topics": attempt_result["topics"],
                 "summary": attempt_result["summary"],
             }
         )
+        warmup_note = f" warmup_excluded={warmup_excluded}" if warmup_excluded else ""
         print(
             f"  probe(attempt={attempt}/{repeats}): "
             f"offered_bw={_format_bps(load_info.get('offered_bandwidth_bps'))} "
-            f"bins={len(attempt_bins)} {_format_topic_rows(attempt_result['topics'])}"
+            f"bins={len(attempt_bins)}{warmup_note} {_format_topic_rows(attempt_result['topics'])}"
         )
 
     bins_path = out_dir / "time-bins.jsonl"

--- a/src/rosotacom/plots.py
+++ b/src/rosotacom/plots.py
@@ -352,7 +352,15 @@ def plot_probe_raw(
     _, plt = _require_matplotlib()
     out = Path(out)
 
-    from .benchmark import _infer_nominal_period_s, _section_ms, _send_time
+    from .benchmark import (
+        SETTLED,
+        TRANSITION,
+        WARMUP,
+        _infer_nominal_period_s,
+        _section_ms,
+        _send_time,
+        classify_probe_settling,
+    )
 
     grouped: dict[tuple[str, int], list[dict[str, Any]]] = {}
     for row in records:
@@ -367,7 +375,7 @@ def plot_probe_raw(
     cmap = plt.colormaps["tab10"].resampled(max(len(grouped), 1))
 
     all_lost_xs: list[float] = []
-    max_latency = 0.0
+    reanchored = False
 
     for index, ((label, attempt), stream) in enumerate(sorted(grouped.items())):
         stream = sorted(stream, key=lambda record: int(record.get("seq", 0)))
@@ -393,41 +401,102 @@ def plot_probe_raw(
 
         first_send_s = min(send_t for _, send_t in expanded)
 
-        xs_delivered = []
-        ys_latency = []
-        xs_lost = []
-
+        # Delivered samples in send-time order, so the settling detector sees the
+        # warm-up → settled step in the order it happened.
+        delivered: list[tuple[float, float]] = []
+        stream_lost_xs: list[float] = []
         for record, send_t in expanded:
             x = max(0.0, send_t - first_send_s)
             if record.get("status") == "lost":
-                xs_lost.append(x)
-            else:
-                latency_ms = _section_ms(record, "ota_hop_ms", "ota_hop_uncorrected_ms")
-                if latency_ms is not None:
-                    xs_delivered.append(x)
-                    ys_latency.append(latency_ms)
-                    if latency_ms > max_latency:
-                        max_latency = latency_ms
+                stream_lost_xs.append(x)
+                continue
+            latency_ms = _section_ms(record, "ota_hop_ms", "ota_hop_uncorrected_ms")
+            if latency_ms is not None:
+                delivered.append((x, latency_ms))
+        delivered.sort(key=lambda point: point[0])
+
+        settling = classify_probe_settling([lat for _, lat in delivered])
+        # Re-anchor time so t=0 is the impairment onset: the settled regime starts
+        # at 0 and the excluded setup (warm-up/transition) falls at negative time.
+        onset_x = (
+            delivered[settling.onset_index][0]
+            if settling.onset_index is not None and settling.onset_index < len(delivered)
+            else 0.0
+        )
+        reanchored = reanchored or bool(onset_x)
+
+        regimes: dict[str, tuple[list[float], list[float]]] = {
+            SETTLED: ([], []),
+            WARMUP: ([], []),
+            TRANSITION: ([], []),
+        }
+        for (x, lat), sample_label in zip(delivered, settling.labels, strict=True):
+            xs, ys = regimes[sample_label]
+            xs.append(x - onset_x)
+            ys.append(lat)
+        all_lost_xs.extend(x - onset_x for x in stream_lost_xs)
 
         color = cmap(index)
         stream_label = label
         if len({key[1] for key in grouped}) > 1:
             stream_label = f"{stream_label} #{attempt}"
 
-        if xs_delivered:
-            ax.scatter(xs_delivered, ys_latency, color=color, s=12, alpha=0.6, label=f"{stream_label} latency")
+        s_xs, s_ys = regimes[SETTLED]
+        if s_xs:
+            ax.scatter(s_xs, s_ys, color=color, s=12, alpha=0.6, label=f"{stream_label} latency")
 
-        if xs_lost:
-            all_lost_xs.extend(xs_lost)
+        w_xs, w_ys = regimes[WARMUP]
+        if w_xs:
+            ax.scatter(
+                w_xs,
+                w_ys,
+                facecolors="none",
+                edgecolors="0.6",
+                s=14,
+                alpha=0.7,
+                label="excluded: warm-up (pre-impairment)",
+            )
+
+        t_xs, t_ys = regimes[TRANSITION]
+        if t_xs:
+            ax.scatter(
+                t_xs,
+                t_ys,
+                color="crimson",
+                marker="x",
+                s=55,
+                linewidths=1.6,
+                label="excluded: transition (partial)",
+            )
+
+        # Dashed line at the onset (t=0 once re-anchored), so the split is obvious.
+        if onset_x:
+            ax.axvline(
+                0.0,
+                color="0.5",
+                linestyle="--",
+                linewidth=1.0,
+                alpha=0.8,
+                label="impairment onset (t=0)",
+            )
 
     ax.set_ylim(bottom=0.0)
     ymin, ymax = ax.get_ylim()
 
-    if all_lost_xs:
-        ax.vlines(all_lost_xs, ymin, ymax, colors="crimson", alpha=0.3, linewidth=1.0, label="lost packet")
+    # After re-anchoring, losses at t<0 happened during setup (e.g. the packet
+    # dropped as the qdisc changed); they are excluded like the warm-up, so the
+    # settled-window summary correctly reports them as no loss.
+    setup_lost = [x for x in all_lost_xs if x < 0.0]
+    real_lost = [x for x in all_lost_xs if x >= 0.0]
+    if real_lost:
+        ax.vlines(real_lost, ymin, ymax, colors="crimson", alpha=0.3, linewidth=1.0, label="lost packet")
+    if setup_lost:
+        ax.vlines(setup_lost, ymin, ymax, colors="0.6", alpha=0.4, linewidth=1.0, label="excluded: setup loss")
 
     ax.set_ylabel("Latency (ms)")
-    ax.set_xlabel("Time since first publish (s)")
+    ax.set_xlabel(
+        "Time relative to impairment onset (s); setup at t<0" if reanchored else "Time since first publish (s)"
+    )
     ax.set_title(title)
 
     handles, labels = ax.get_legend_handles_labels()

--- a/tests/unit/test_benchmark.py
+++ b/tests/unit/test_benchmark.py
@@ -7,6 +7,9 @@ from pathlib import Path
 import pytest
 
 from rosotacom.benchmark import (
+    SETTLED,
+    TRANSITION,
+    WARMUP,
     BudgetEntry,
     BudgetKey,
     CapacitySlice,
@@ -17,7 +20,9 @@ from rosotacom.benchmark import (
     SweepBounds,
     capacity_binary_search,
     characterize_probe_records,
+    classify_probe_settling,
     compare_to_budget,
+    exclude_probe_warmup,
     expand_size_pattern,
     find_baseline,
     find_capacity,
@@ -242,6 +247,130 @@ def test_characterize_probe_records_bins_loss_latency_hz_and_bandwidth() -> None
             "inter_arrival_p95_ms": 500.0,
         },
     ]
+
+
+# --- fixed-probe settling / warm-up exclusion ------------------------------ #
+
+
+def test_classify_probe_settling_splits_warmup_transition_and_settled() -> None:
+    # 20 un-impaired warm-up samples, one partial packet as shaping engages,
+    # then the settled operating regime.
+    warmup = [5.0, 4.5, 5.5, 4.8, 5.2, 6.0, 4.9, 5.1, 5.3, 4.7] * 2
+    settled = [80.0, 78.0, 84.0, 77.0, 88.0, 81.0, 79.0, 86.0, 74.0, 83.0] * 3
+    latencies = [*warmup, 21.0, *settled]
+
+    result = classify_probe_settling(latencies)
+
+    assert result.onset_index == len(warmup) + 1
+    assert result.labels[: len(warmup)] == [WARMUP] * len(warmup)
+    assert result.labels[len(warmup)] == TRANSITION
+    assert all(label == SETTLED for label in result.labels[len(warmup) + 1 :])
+    assert result.excluded_count == len(warmup) + 1
+
+
+def test_classify_probe_settling_keeps_ramping_impaired_regime_whole() -> None:
+    # Bufferbloat: warm-up floor, one partial transition packet, then a latency
+    # ramp with no plateau (a shaped rate below the offered load). The whole ramp
+    # is the profile under test and must be kept — only warm-up + transition drop.
+    warmup = [5.0, 4.5, 5.5, 4.8, 5.2, 6.0, 4.9, 5.1, 5.3, 4.7] * 2
+    ramp = [96.0 + 6.0 * i for i in range(60)]  # 96 → ~450 ms, monotonically rising
+    latencies = [*warmup, 48.0, *ramp]
+
+    result = classify_probe_settling(latencies)
+
+    assert result.onset_index == len(warmup) + 1
+    assert result.labels[: len(warmup)] == [WARMUP] * len(warmup)
+    assert result.labels[len(warmup)] == TRANSITION  # the 48 ms partial packet
+    assert all(label == SETTLED for label in result.labels[len(warmup) + 1 :])
+
+
+def test_classify_probe_settling_keeps_everything_without_a_clear_step() -> None:
+    # Impairment live from the first packet: no warm-up floor, no step.
+    latencies = [80.0, 78.0, 84.0, 77.0, 88.0, 81.0, 79.0, 86.0, 74.0, 83.0] * 3
+
+    result = classify_probe_settling(latencies)
+
+    assert result.onset_index is None
+    assert result.excluded_count == 0
+    assert set(result.labels) == {SETTLED}
+
+
+def test_classify_probe_settling_keeps_a_smooth_ramp_without_warmup() -> None:
+    # A pure ramp with no low warm-up floor has no sharp step — keep everything.
+    latencies = [96.0 + 4.0 * i for i in range(80)]  # 96 → ~412 ms, smooth
+
+    result = classify_probe_settling(latencies)
+
+    assert result.onset_index is None
+    assert set(result.labels) == {SETTLED}
+
+
+def test_classify_probe_settling_ignores_short_series() -> None:
+    latencies = [5.0, 5.0, 80.0, 80.0]
+
+    result = classify_probe_settling(latencies)
+
+    assert result.labels == [SETTLED] * 4
+    assert result.onset_index is None
+
+
+def _probe_stream(latencies: list[float], *, period_s: float = 0.05, t0: float = 100.0) -> list[dict]:
+    """Build joined transit records at a fixed rate — one delivered packet per latency."""
+    return [
+        {
+            "kind": "transit",
+            "source": "a",
+            "target": "b",
+            "topic": "/x",
+            "seq": seq,
+            "status": "delivered",
+            "t_wrap": t0 + seq * period_s,
+            "sections": {"ota_hop_ms": latency},
+            "size_bytes": 100,
+        }
+        for seq, latency in enumerate(latencies)
+    ]
+
+
+def test_exclude_probe_warmup_drops_prefix_and_reports_onset() -> None:
+    warmup = [5.0] * 20
+    settled = [80.0] * 40
+    records = _probe_stream([*warmup, 21.0, *settled])
+
+    kept, onset = exclude_probe_warmup(records, nominal_period_s=0.05)
+
+    # The 20 warm-up samples and the one transition packet are dropped.
+    assert len(kept) == len(settled)
+    assert {record["sections"]["ota_hop_ms"] for record in kept} == {80.0}
+    # Onset is the send time of the first settled packet (seq 21).
+    assert onset == pytest.approx(100.0 + 21 * 0.05)
+
+
+def test_exclude_probe_warmup_keeps_all_without_a_step() -> None:
+    records = _probe_stream([80.0] * 40)
+
+    kept, onset = exclude_probe_warmup(records, nominal_period_s=0.05)
+
+    assert len(kept) == len(records)
+    assert onset is None
+
+
+def test_characterize_probe_records_excludes_warmup_and_reanchors_to_onset() -> None:
+    warmup = [5.0] * 20
+    settled = [80.0] * 60  # 3 s of settled traffic at 20 Hz
+    records = _probe_stream([*warmup, 21.0, *settled])
+
+    excluded = characterize_probe_records(records, bin_s=1.0, nominal_period_s=0.05)
+    included = characterize_probe_records(records, bin_s=1.0, nominal_period_s=0.05, exclude_warmup=False)
+
+    # Re-anchored: the settled regime starts at bin 0, and no bin carries the
+    # warm-up latency floor.
+    assert excluded[0]["bin_start_s"] == 0.0
+    assert all(row["latency_p50_ms"] > 50.0 for row in excluded)
+    # Without exclusion the warm-up is binned from the first publish and shows up
+    # as an extra low-latency bin at the front.
+    assert len(included) > len(excluded)
+    assert included[0]["latency_p50_ms"] < 10.0
 
 
 # --- budget store + regression compare ------------------------------------- #


### PR DESCRIPTION
## Problem
The fixed-probe raw plot and the derived results included the pre-impairment **warm-up** (packets sent before tc/netem shaping is applied — a few ms floor) and the single **transition** packet that straddles the qdisc change. These start-up artefacts polluted the per-topic p95/median and the time bins, and the raw plot drew a setup-dropped packet as a "lost packet" even though the measurement-window summary reports no loss.

A second failure mode: for a **bufferbloat** profile (shaped rate below offered load) the latency ramps continuously with no plateau. The first detector assumed a stable settled plateau and mislabelled the whole ramp as one long "transition".

## Change
- **`classify_probe_settling`** now anchors on the *sharp upward step from the low floor* (windowed-median jump ratio), not on a plateau. It labels each sample `warmup` / `transition` / `settled`, so a rising ramp is kept whole. Conservative: no clear low→high step ⇒ everything is `settled` (nothing excluded).
- **`exclude_probe_warmup`** drops the warm-up/transition prefix from joined transit records and returns the impairment-onset send-time.
- **`characterize_probe_records`** excludes warm-up by default and re-anchors bins so `bin_start_s == 0` is the onset.
- The probe attempt **summary (p95/loss)** is recomputed over the settled regime; `warmup_excluded` / `settled_onset_s` are surfaced.
- **`plot_probe_raw`** marks warm-up (hollow grey), transition (red ✗), and distinguishes *setup loss* (pre-onset, excluded) from *real loss*; the x-axis is re-anchored so `t=0` is the onset and setup samples fall at `t<0`.

## Validation
- New unit tests in `test_benchmark.py`: warm-up/transition/settled split, **ramping regime kept whole**, smooth-ramp-without-warmup kept, no-step kept, short series, `exclude_probe_warmup` prefix drop + onset, and characterize re-anchoring.
- Full unit suite: 316 passed; ruff clean.
- Verified against two real runs — a static plateau (`losssless-typical`) and a bufferbloat ramp (`typical-conservative-rate-3`): warm-up + the single transition packet excluded, the ramp kept whole, and the settled-window summary reports 0 loss consistent with the setup-dropped packet being excluded.