### PR TITLE
Fix timeline qdisc cleanup tolerance

### DIFF
--- a/src/rosotacom/network_shaper.py
+++ b/src/rosotacom/network_shaper.py
@@ -77,6 +77,17 @@ class ProfileShaper:
     def _run(self, argv: Sequence[str]) -> None:
         self._runner(list(argv))
 
+    def _is_idempotent_cleanup(self, argv: Sequence[str]) -> bool:
+        command = list(argv)
+        return command in (teardown_command(self.interface), restore_link_command(self.interface))
+
+    def _run_tolerating_idempotent_cleanup(self, argv: Sequence[str]) -> None:
+        try:
+            self._run(argv)
+        except Exception:
+            if not self._is_idempotent_cleanup(argv):
+                raise
+
     def teardown(self) -> None:
         """Always-safe revert: clear any root qdisc and bring the link back up.
 
@@ -108,7 +119,7 @@ class ProfileShaper:
         step already begins with its own teardown); the watchdog is launched once via
         :meth:`arm` at the start of the run, not per step."""
         for argv in commands:
-            self._run(argv)
+            self._run_tolerating_idempotent_cleanup(argv)
         self.armed = True
 
     def __enter__(self) -> ProfileShaper:

--- a/tests/unit/test_network_shaper.py
+++ b/tests/unit/test_network_shaper.py
@@ -81,6 +81,28 @@ def test_teardown_tolerates_a_missing_qdisc() -> None:
     assert not shaper.armed
 
 
+def test_apply_tolerates_timeline_cleanup_with_no_qdisc() -> None:
+    runner = FakeRunner(fail_on="del")
+    shaper = ProfileShaper("tun0", runner)
+    shaping = ["tc", "qdisc", "add", "dev", "tun0", "root", "handle", "10:", "netem", "delay", "50ms"]
+
+    shaper.apply([teardown_command("tun0"), shaping])
+
+    assert runner.calls == [teardown_command("tun0"), shaping]
+    assert shaper.armed
+
+
+def test_apply_reraises_timeline_shaping_failures() -> None:
+    runner = FakeRunner(fail_on="add")
+    shaper = ProfileShaper("tun0", runner)
+    shaping = ["tc", "qdisc", "add", "dev", "tun0", "root", "handle", "10:", "netem", "delay", "50ms"]
+
+    with pytest.raises(RuntimeError, match="boom on 'add'"):
+        shaper.apply([teardown_command("tun0"), shaping])
+
+    assert runner.calls == [teardown_command("tun0"), shaping]
+
+
 # --- revert on stop and on error (the context manager) --------------------- #
 
 


### PR DESCRIPTION
Fixes #116.

## Summary
- Treat exact idempotent profile cleanup commands as best-effort during timeline `ProfileShaper.apply()` calls.
- Keep actual shaping command failures fatal.
- Add regression coverage for missing-qdisc cleanup during timeline stepping and for propagated shaping failures.

## Validation
- `python3 -m pytest tests/unit/test_network_shaper.py`
- `python3 -m pytest tests/unit/test_network_profiles.py`
- `python3 -m pytest tests/unit/test_cli_benchmark.py`
- `python3 -m pytest tests/unit` currently fails on `origin/develop`-scoped scenario/anonymize tests with `NameError: name 'load_config' is not defined`; targeted tests for this change pass.