### PR TITLE
Add benchmark probe size pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,6 +477,7 @@ when the optional plotting dependency is installed:
 
 ```bash
 rosotacom benchmark probe --profile cellular-4g-typical --size 18000 --rate-hz 20 --duration 20 --repeats 1
+rosotacom benchmark probe --profile cellular-4g-typical --size-pattern 1x20KB+1x0KB --rate-hz 10 --duration 20 --repeats 1
 rosotacom benchmark plot time-bins.jsonl --type probe
 ```
 

--- a/src/rosotacom/benchmark.py
+++ b/src/rosotacom/benchmark.py
@@ -52,6 +52,99 @@ def parse_size_pattern(pattern: str) -> list[str]:
     return tokens
 
 
+def parse_payload_size_bytes(raw: str) -> int:
+    """Parse a payload byte size with optional decimal/binary units."""
+    text = raw.strip()
+    match = re.fullmatch(r"(\d+(?:\.\d+)?)\s*([A-Za-z]*)", text)
+    if not match:
+        raise ValueError(f"Invalid payload size {raw!r}. Use values like 20000, 20KB, or 20KiB.")
+
+    value = float(match.group(1))
+    unit = match.group(2).lower()
+    units = {
+        "": 1,
+        "b": 1,
+        "k": 1_000,
+        "kb": 1_000,
+        "m": 1_000_000,
+        "mb": 1_000_000,
+        "g": 1_000_000_000,
+        "gb": 1_000_000_000,
+        "ki": 1024,
+        "kib": 1024,
+        "mi": 1024 * 1024,
+        "mib": 1024 * 1024,
+        "gi": 1024 * 1024 * 1024,
+        "gib": 1024 * 1024 * 1024,
+    }
+    if unit not in units:
+        raise ValueError(f"Invalid payload size unit {match.group(2)!r}. Use B, KB, MB, KiB, or MiB.")
+    bytes_value = value * units[unit]
+    if bytes_value < 0 or not bytes_value.is_integer():
+        raise ValueError(f"Payload size {raw!r} does not resolve to a whole non-negative byte count.")
+    return int(bytes_value)
+
+
+def _compress_size_pattern(tokens: Sequence[str]) -> str:
+    compressed: list[str] = []
+    current = tokens[0]
+    count = 1
+    for token in tokens[1:]:
+        if token == current:
+            count += 1
+            continue
+        compressed.append(f"{current}*{count}")
+        current = token
+        count = 1
+    compressed.append(f"{current}*{count}")
+    return ",".join(compressed)
+
+
+def parse_size_pattern_load(pattern: str) -> dict[str, Any]:
+    """Parse ``1x20KB+1x0KB`` into ``sized_publisher`` a/b load parameters.
+
+    Pattern terms are ``COUNTxSIZE`` or just ``SIZE``, separated by ``+`` or
+    ``,``. Decimal units (KB/MB/GB) use powers of 1000; binary units
+    (KiB/MiB/GiB) use powers of 1024. The current ROS publisher supports up to
+    two distinct payload sizes, mapped to ``size_a`` and ``size_b``.
+    """
+    if not pattern.strip():
+        raise ValueError("size pattern must not be empty.")
+
+    label_by_size: dict[int, str] = {}
+    size_by_label: dict[str, int] = {}
+    tokens: list[str] = []
+
+    for raw_term in re.split(r"[+,]", pattern):
+        term = raw_term.strip()
+        if not term:
+            raise ValueError(f"Invalid size pattern {pattern!r}: empty term.")
+        match = re.fullmatch(r"(?:(\d+)\s*[x*]\s*)?(.+)", term)
+        if not match:
+            raise ValueError(f"Invalid size pattern term {raw_term!r}. Use terms like 1x20KB or 0KB.")
+        count = int(match.group(1) or "1")
+        if count < 1:
+            raise ValueError(f"Size pattern term {raw_term!r} must repeat at least once.")
+        size = parse_payload_size_bytes(match.group(2))
+        label = label_by_size.get(size)
+        if label is None:
+            if len(label_by_size) >= 2:
+                raise ValueError("size pattern supports at most two distinct payload sizes.")
+            label = "a" if not label_by_size else "b"
+            label_by_size[size] = label
+            size_by_label[label] = size
+        tokens.extend([label] * count)
+
+    load: dict[str, Any] = {
+        "size_a": size_by_label["a"],
+        "pattern": _compress_size_pattern(tokens),
+        "size_pattern": pattern,
+    }
+    if "b" in size_by_label:
+        load["size_b"] = size_by_label["b"]
+    return load
+
+
 def expand_size_pattern(pattern: str, size_a: int, size_b: int | None = None) -> list[int]:
     """Expand a pattern into the concrete cyclic byte-size sequence it publishes."""
     if size_a < 0:

--- a/src/rosotacom/cli_benchmark.py
+++ b/src/rosotacom/cli_benchmark.py
@@ -516,6 +516,57 @@ def _load_context(load: dict[str, Any]) -> dict[str, Any]:
     )
 
 
+def _probe_load(
+    *,
+    size: int,
+    size_pattern: str | None,
+    rate_hz: float,
+    streams: int,
+) -> dict[str, Any]:
+    if size_pattern is not None:
+        from .benchmark import parse_size_pattern_load
+
+        load = parse_size_pattern_load(size_pattern)
+    else:
+        if size < 0:
+            raise ValueError("size must be >= 0.")
+        load = {"size_a": size}
+
+    load["rate"] = rate_hz
+    if streams != 1:
+        load["streams"] = streams
+    return load
+
+
+def _sized_publisher_param_args(topic_name: str, load: dict[str, Any]) -> list[str]:
+    rate = load.get("rate", 20.0)
+    streams = load.get("streams", 1)
+    params = [
+        "-p",
+        f"topic:={topic_name}",
+        "-p",
+        f"rate:={rate}",
+        "-p",
+        f"streams:={streams}",
+    ]
+
+    pattern = load.get("pattern")
+    if pattern:
+        size_a = load.get("size_a", load.get("size", 66000))
+        params.extend(["-p", f"size_a:={size_a}", "-p", f"pattern:={pattern}"])
+        if load.get("size_b") is not None:
+            params.extend(["-p", f"size_b:={load['size_b']}"])
+        return params
+
+    size = load.get("size")
+    if size is None:
+        size = load.get("size_a")
+    if size is None:
+        size = 66000
+    params.extend(["-p", f"size:={size}"])
+    return params
+
+
 def _benchmark_ota_target(args: argparse.Namespace, session_name: str) -> tuple[str, str]:
     target = getattr(args, "target", None)
     target_type = getattr(args, "target_type", None)
@@ -1101,6 +1152,7 @@ def drive_probe(
     *,
     profile: str | None,
     size: int = 18_000,
+    size_pattern: str | None = None,
     rate_hz: float = 20.0,
     streams: int = 1,
     topic: str = "",
@@ -1114,8 +1166,6 @@ def drive_probe(
     """Run a fixed probe and characterize time-dependent latency/loss behavior."""
     if repeats < 1:
         raise ValueError("repeats must be >= 1.")
-    if size < 0:
-        raise ValueError("size must be >= 0.")
     if rate_hz <= 0.0:
         raise ValueError("rate_hz must be > 0.")
     if streams < 1:
@@ -1123,9 +1173,7 @@ def drive_probe(
 
     profile = _normalize_benchmark_profile(profile)
     profile_label = _benchmark_profile_label(profile)
-    load: dict[str, Any] = {"size_a": size, "rate": rate_hz}
-    if streams != 1:
-        load["streams"] = streams
+    load = _probe_load(size=size, size_pattern=size_pattern, rate_hz=rate_hz, streams=streams)
     load_info = _load_context(load)
     out_dir.mkdir(parents=True, exist_ok=True)
 
@@ -4630,17 +4678,16 @@ def _make_live_run_point(args: argparse.Namespace, session_name: str) -> RunPoin
                 return run
 
             ros_setup_a = _smoke_ros_setup(smoke_instance.config_container_dir, cfg, "a")
-            rate = load.get("rate", 20.0)
-            size = load.get("size") or load.get("size_a") or 66000
-            streams = load.get("streams", 1)
-
             topics_a = cfg.get("topics", {}).get("a_to_b", [])
             pub_cmds = []
             for topic_spec in topics_a:
                 topic_name = topic_spec.get("topic")
+                publisher_args = " ".join(
+                    shlex.quote(str(part)) for part in _sized_publisher_param_args(topic_name, load)
+                )
                 cmd = (
                     f"{ros_setup_a} && timeout 300 ros2 run com_py sized_publisher --ros-args "
-                    f"-p topic:={shlex.quote(topic_name)} -p size:={size} -p rate:={rate} -p streams:={streams} "
+                    f"{publisher_args} "
                     f'> "${{ROSOTACOM_LOGS_DIR}}/a/sized_publisher.log" 2>&1'
                 )
                 pub_cmds.append(cmd)
@@ -4846,6 +4893,7 @@ def benchmark_probe(args: argparse.Namespace) -> int:
             run_point,
             profile=args.profile,
             size=getattr(args, "size", 18_000),
+            size_pattern=getattr(args, "size_pattern", None),
             rate_hz=getattr(args, "rate_hz", 20.0),
             streams=getattr(args, "streams", 1),
             topic=getattr(args, "topic", ""),
@@ -5653,6 +5701,11 @@ def _register_benchmark_driver_parsers(benchmark_subparsers: Any, *, ota_benchma
     _add_benchmark_common_args(probe_parser, ota_benchmark=ota_benchmark)
     probe_parser.add_argument("--profile", required=True, help="Network profile name.")
     probe_parser.add_argument("--size", type=int, default=18_000, help="Payload size (bytes).")
+    probe_parser.add_argument(
+        "--size-pattern",
+        default=None,
+        help="Cyclic payload sizes such as 1x20KB+1x0KB; overrides --size when set.",
+    )
     probe_parser.add_argument("--rate-hz", type=float, default=20.0, help="Publish rate (Hz).")
     probe_parser.add_argument("--streams", type=int, default=1, help="Parallel stream count.")
     probe_parser.add_argument("--topic", default="", help="Topic to characterize (default: all).")

--- a/tests/unit/test_benchmark.py
+++ b/tests/unit/test_benchmark.py
@@ -32,7 +32,9 @@ from rosotacom.benchmark import (
     offered_bandwidth_bps,
     oracle_passes,
     oracle_passes_topic,
+    parse_payload_size_bytes,
     parse_size_pattern,
+    parse_size_pattern_load,
     pattern_mean_bytes,
     recovery_metrics,
     save_budget,
@@ -52,6 +54,20 @@ def test_size_pattern_generation_matches_a_b_sequence() -> None:
     assert pattern_mean_bytes("a*4,b*1", size_a=0, size_b=70_000) == 14_000
 
 
+def test_human_size_pattern_load_maps_to_a_b_publisher_params() -> None:
+    assert parse_payload_size_bytes("20KB") == 20_000
+    assert parse_payload_size_bytes("20KiB") == 20 * 1024
+
+    load = parse_size_pattern_load("1x20KB+1x0KB")
+    assert load == {
+        "size_a": 20_000,
+        "size_b": 0,
+        "pattern": "a*1,b*1",
+        "size_pattern": "1x20KB+1x0KB",
+    }
+    assert pattern_mean_bytes(load["pattern"], load["size_a"], load["size_b"]) == 10_000
+
+
 def test_size_pattern_rejects_unset_b_and_bad_tokens() -> None:
     with pytest.raises(ValueError):
         expand_size_pattern("a,b", size_a=10)  # size_b missing
@@ -59,6 +75,8 @@ def test_size_pattern_rejects_unset_b_and_bad_tokens() -> None:
         parse_size_pattern("c*2")
     with pytest.raises(ValueError):
         parse_size_pattern("a*0")
+    with pytest.raises(ValueError):
+        parse_size_pattern_load("1x20KB+1x10KB+1x0KB")
 
 
 # --- capacity binary-search driver + oracle -------------------------------- #

--- a/tests/unit/test_cli_benchmark.py
+++ b/tests/unit/test_cli_benchmark.py
@@ -194,6 +194,82 @@ def test_probe_driver_writes_time_bins_from_transit_records(tmp_path: Path) -> N
     assert result_doc["artifacts"]["time_bins"] == "time-bins.jsonl"
 
 
+def test_probe_driver_accepts_size_pattern_load(tmp_path: Path) -> None:
+    seen_loads: list[dict[str, Any]] = []
+
+    def stub(*, profile: str | None, load: dict[str, Any], duration_s: float, out_dir: Path) -> dict[str, Any]:
+        seen_loads.append(dict(load))
+        return {
+            "topics": {
+                "/test": {
+                    "expected": 2,
+                    "delivered": 2,
+                    "lost": 0,
+                    "loss_pct": 0.0,
+                    "reordered": 0,
+                    "ota_hop_ms": {"p50": 10.0, "p95": 10.0},
+                    "jitter_ms": {"p50": 1.0, "p95": 1.0},
+                }
+            }
+        }
+
+    result = drive_probe(
+        stub,
+        profile="lossless-typical",
+        size_pattern="1x20KB+1x0KB",
+        rate_hz=10.0,
+        repeats=1,
+        duration_s=1.0,
+        bin_s=1.0,
+        render_plot=False,
+        out_dir=tmp_path,
+    )
+
+    assert seen_loads == [
+        {
+            "size_a": 20_000,
+            "size_b": 0,
+            "pattern": "a*1,b*1",
+            "size_pattern": "1x20KB+1x0KB",
+            "rate": 10.0,
+        }
+    ]
+    assert result["load"]["mean_payload_bytes"] == 10_000.0
+    assert result["load"]["offered_bandwidth_bps"] == 800_000.0
+    result_doc = json.loads((tmp_path / BENCHMARK_RESULT_FILE).read_text(encoding="utf-8"))
+    assert result_doc["configuration"]["load"]["parameters"]["size_pattern"] == "1x20KB+1x0KB"
+
+
+def test_sized_publisher_args_include_size_pattern_and_zero_payload() -> None:
+    assert benchmark_cli._sized_publisher_param_args(
+        "/bench_capacity",
+        {
+            "size_a": 20_000,
+            "size_b": 0,
+            "pattern": "a*1,b*1",
+            "rate": 10.0,
+            "streams": 1,
+        },
+    ) == [
+        "-p",
+        "topic:=/bench_capacity",
+        "-p",
+        "rate:=10.0",
+        "-p",
+        "streams:=1",
+        "-p",
+        "size_a:=20000",
+        "-p",
+        "pattern:=a*1,b*1",
+        "-p",
+        "size_b:=0",
+    ]
+    assert benchmark_cli._sized_publisher_param_args("/bench_capacity", {"size_a": 0})[-2:] == [
+        "-p",
+        "size:=0",
+    ]
+
+
 # --------------------------------------------------------------------------- #
 # Capacity driver
 # --------------------------------------------------------------------------- #
@@ -1374,9 +1450,25 @@ def test_benchmark_subcommand_arg_parsing() -> None:
     assert args.rate_hz == 20.0
     assert args.bin_s == 1.0
     assert args.plot is True
+    assert args.size_pattern is None
 
     args = parser.parse_args(["benchmark", "probe", "--profile", "losssless-typical", "--no-plot"])
     assert args.plot is False
+
+    args = parser.parse_args(
+        [
+            "benchmark",
+            "probe",
+            "--profile",
+            "lossless-typical",
+            "--size-pattern",
+            "1x20KB+1x0KB",
+            "--rate-hz",
+            "10",
+        ]
+    )
+    assert args.size_pattern == "1x20KB+1x0KB"
+    assert args.rate_hz == 10.0
 
     # Capacity.
     args = parser.parse_args(


### PR DESCRIPTION
## Summary
- add `benchmark probe --size-pattern` for cyclic payload loads such as `1x20KB+1x0KB`
- translate human size patterns into the existing `sized_publisher` `size_a`/`size_b`/`pattern` parameters
- record mean payload/offered bandwidth for patterned probes and document the example

Fixes #118

## Validation
- `pytest tests/unit/test_benchmark.py tests/unit/test_cli_benchmark.py -q` — 67 passed
- `python3 -m ruff check src/rosotacom/benchmark.py src/rosotacom/cli_benchmark.py tests/unit/test_benchmark.py tests/unit/test_cli_benchmark.py` — passed
- `PYTHONPATH=src python3 -m rosotacom.cli benchmark probe --help | rg -n "size-pattern|rate-hz"` — passed
- parser smoke for `benchmark probe --profile lossless-typical --size-pattern 1x20KB+1x0KB --rate-hz 10 --duration 20 --repeats 1` — passed
- `git diff --check` — passed
- `pytest tests/contract/test_readme_examples.py -q` — fails in this environment before the changed README example is exercised because `ros2docker` is not installed and `cli.py` leaves `load_config` undefined