### PR TITLE
Fix benchmark multi-stream probe wiring

### DIFF
--- a/src/rosotacom/cli_benchmark.py
+++ b/src/rosotacom/cli_benchmark.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import argparse
 import contextlib
+import copy
 import json
 import math
 import shlex
@@ -337,6 +338,12 @@ def _prepare_benchmark_session_config(args: argparse.Namespace, session_name: st
         reliability=getattr(args, "qos_reliability", None),
         depth=getattr(args, "qos_depth", None),
     )
+    stream_options = None
+    if session_name == "bench_1_1_capacity":
+        stream_options = _expand_benchmark_capacity_stream_topics(
+            cfg,
+            int(getattr(args, "streams", 1) or 1),
+        )
     config_path.write_text(yaml.safe_dump(cfg, sort_keys=False), encoding="utf-8")
 
     existing_raw = getattr(args, "session_configs_dir", None)
@@ -359,6 +366,7 @@ def _prepare_benchmark_session_config(args: argparse.Namespace, session_name: st
         "rmw": rmw,
         "runtime_implementation": _rmw_runtime_implementation(rmw),
         "qos": qos_options,
+        "streams": stream_options,
     }
 
 
@@ -538,16 +546,64 @@ def _probe_load(
     return load
 
 
-def _sized_publisher_param_args(topic_name: str, load: dict[str, Any]) -> list[str]:
+def _benchmark_stream_topic_name(topic_name: str, index: int) -> str:
+    return f"{topic_name}_{index}"
+
+
+def _expand_benchmark_capacity_stream_topics(cfg: dict[str, Any], streams: int) -> dict[str, Any] | None:
+    if streams < 1:
+        raise ValueError("streams must be >= 1.")
+    if streams == 1:
+        return None
+
+    topics = cfg.setdefault("topics", {})
+    if not isinstance(topics, dict):
+        raise RuntimeError("Benchmark session config 'topics' must be a mapping.")
+    a_to_b = topics.get("a_to_b")
+    if not isinstance(a_to_b, list) or len(a_to_b) != 1:
+        raise RuntimeError("Multi-stream capacity benchmark sessions must define exactly one a_to_b topic template.")
+
+    template = a_to_b[0]
+    if not isinstance(template, dict):
+        raise RuntimeError("Benchmark session topic template must be a mapping.")
+    topic_name = template.get("topic")
+    if not isinstance(topic_name, str) or not topic_name:
+        raise RuntimeError("Benchmark session topic template must define a non-empty topic.")
+
+    expanded_topics: list[str] = []
+    expanded_specs: list[dict[str, Any]] = []
+    for index in range(streams):
+        spec = copy.deepcopy(template)
+        stream_topic = _benchmark_stream_topic_name(topic_name, index)
+        spec["topic"] = stream_topic
+        expanded_specs.append(spec)
+        expanded_topics.append(stream_topic)
+    topics["a_to_b"] = expanded_specs
+    return {"count": streams, "base_topic": topic_name, "topics": expanded_topics}
+
+
+def _publisher_streams_for_topic_specs(topic_specs: Sequence[Any], load: dict[str, Any]) -> int:
+    streams = int(load.get("streams", 1) or 1)
+    if streams > 1 and len(topic_specs) >= streams:
+        return 1
+    return streams
+
+
+def _sized_publisher_param_args(
+    topic_name: str,
+    load: dict[str, Any],
+    *,
+    streams: int | None = None,
+) -> list[str]:
     rate = load.get("rate", 20.0)
-    streams = load.get("streams", 1)
+    publisher_streams = int(streams if streams is not None else load.get("streams", 1) or 1)
     params = [
         "-p",
         f"topic:={topic_name}",
         "-p",
         f"rate:={rate}",
         "-p",
-        f"streams:={streams}",
+        f"streams:={publisher_streams}",
     ]
 
     pattern = load.get("pattern")
@@ -4679,16 +4735,23 @@ def _make_live_run_point(args: argparse.Namespace, session_name: str) -> RunPoin
 
             ros_setup_a = _smoke_ros_setup(smoke_instance.config_container_dir, cfg, "a")
             topics_a = cfg.get("topics", {}).get("a_to_b", [])
+            publisher_streams = _publisher_streams_for_topic_specs(topics_a, load)
             pub_cmds = []
-            for topic_spec in topics_a:
+            for topic_index, topic_spec in enumerate(topics_a):
                 topic_name = topic_spec.get("topic")
                 publisher_args = " ".join(
-                    shlex.quote(str(part)) for part in _sized_publisher_param_args(topic_name, load)
+                    shlex.quote(str(part))
+                    for part in _sized_publisher_param_args(topic_name, load, streams=publisher_streams)
+                )
+                log_path = (
+                    "${ROSOTACOM_LOGS_DIR}/a/sized_publisher.log"
+                    if len(topics_a) == 1
+                    else f"${{ROSOTACOM_LOGS_DIR}}/a/sized_publisher_{topic_index}.log"
                 )
                 cmd = (
                     f"{ros_setup_a} && timeout 300 ros2 run com_py sized_publisher --ros-args "
                     f"{publisher_args} "
-                    f'> "${{ROSOTACOM_LOGS_DIR}}/a/sized_publisher.log" 2>&1'
+                    f'> "{log_path}" 2>&1'
                 )
                 pub_cmds.append(cmd)
 

--- a/tests/unit/test_cli_benchmark.py
+++ b/tests/unit/test_cli_benchmark.py
@@ -268,6 +268,27 @@ def test_sized_publisher_args_include_size_pattern_and_zero_payload() -> None:
         "-p",
         "size:=0",
     ]
+    assert benchmark_cli._sized_publisher_param_args(
+        "/bench_capacity_0",
+        {"size_a": 9000, "rate": 20.0, "streams": 2},
+        streams=1,
+    ) == [
+        "-p",
+        "topic:=/bench_capacity_0",
+        "-p",
+        "rate:=20.0",
+        "-p",
+        "streams:=1",
+        "-p",
+        "size:=9000",
+    ]
+
+
+def test_publisher_streams_collapse_for_expanded_stream_topics() -> None:
+    topics = [{"topic": "/bench_capacity_0"}, {"topic": "/bench_capacity_1"}]
+
+    assert benchmark_cli._publisher_streams_for_topic_specs(topics, {"streams": 2}) == 1
+    assert benchmark_cli._publisher_streams_for_topic_specs([{"topic": "/bench_capacity"}], {"streams": 2}) == 2
 
 
 # --------------------------------------------------------------------------- #
@@ -1824,6 +1845,72 @@ def test_benchmark_session_copy_pins_requested_rmw(tmp_path: Path) -> None:
     assert args.session_configs_dir[0] == str(run_dir / "session-configs")
     assert context["runtime_implementation"] == "rmw_cyclonedds_cpp"
     assert context["qos"] == {"reliability": "reliable", "depth": 10}
+
+
+def test_benchmark_session_copy_expands_capacity_stream_topics(tmp_path: Path) -> None:
+    import argparse
+
+    import yaml
+
+    project = tmp_path / "project"
+    session_dir = project / "sessions" / "bench_1_1_capacity"
+    session_dir.mkdir(parents=True)
+    (session_dir / "session-definition.yaml").write_text(
+        "peers:\n"
+        "  a: {}\n"
+        "  b: {}\n"
+        "shared:\n"
+        "  rmw: cyclone\n"
+        "topics:\n"
+        "  a_to_b:\n"
+        "    - topic: /bench_capacity\n"
+        "      type: com_msgs/msg/SizedPayload\n"
+        "      processing:\n"
+        "        use_ota_wrapper: true\n",
+        encoding="utf-8",
+    )
+    ros2docker = project / "ros2docker.json"
+    ros2docker.write_text("{}", encoding="utf-8")
+    config_file = project / "rosotacom.yaml"
+    config_file.write_text(
+        yaml.safe_dump(
+            {
+                "ros2docker_config": str(ros2docker),
+                "session_configs_dir": ["sessions"],
+                "session_instances_dir": "session-instances",
+            }
+        ),
+        encoding="utf-8",
+    )
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    args = argparse.Namespace(
+        rosotacom_config=str(config_file),
+        ros2docker_config=None,
+        session_configs_dir=None,
+        scenario_configs_dir=None,
+        session_instances_dir=None,
+        deployment=None,
+        profiles_file=None,
+        artifacts_dir=None,
+        rmw="cyclone",
+        qos_reliability=None,
+        qos_depth=None,
+        streams=2,
+    )
+
+    context = _prepare_benchmark_session_config(args, "bench_1_1_capacity", run_dir)
+
+    copied = yaml.safe_load(Path(context["config_path"]).read_text(encoding="utf-8"))
+    topics = copied["topics"]["a_to_b"]
+    assert [topic["topic"] for topic in topics] == ["/bench_capacity_0", "/bench_capacity_1"]
+    assert all(topic["type"] == "com_msgs/msg/SizedPayload" for topic in topics)
+    assert all(topic["processing"] == {"use_ota_wrapper": True} for topic in topics)
+    assert context["streams"] == {
+        "count": 2,
+        "base_topic": "/bench_capacity",
+        "topics": ["/bench_capacity_0", "/bench_capacity_1"],
+    }
 
 
 def test_benchmark_ota_target_defaults_to_benchmark_session() -> None:


### PR DESCRIPTION
## Summary

Fixes #120.

- Expand `bench_1_1_capacity` benchmark session copies into one configured topic per requested stream, e.g. `/bench_capacity_0` and `/bench_capacity_1` for `--streams 2`.
- Launch one `sized_publisher` stream per expanded topic so each configured ROS 2 topic publishes at the requested `--rate-hz` and `--size`.
- Add unit coverage for stream topic expansion and publisher parameter generation.

## Validation

- `pytest -q tests/unit/test_benchmark.py tests/unit/test_cli_benchmark.py -q`
- `python3 -m ruff check src/rosotacom/cli_benchmark.py tests/unit/test_cli_benchmark.py`
- `git diff --check`
- pre-commit hooks during `git commit`
