### PR TITLE
benchmark: consistent probe onset — binary include/exclude, loss-aware start-up

### DIFF
--- a/src/rosotacom/benchmark.py
+++ b/src/rosotacom/benchmark.py
@@ -499,75 +499,57 @@ def _mad(values: Sequence[float]) -> float:
     return _median([abs(v - center) for v in values])
 
 
-# Per-sample settling labels. Only ``SETTLED`` samples reflect the profile under
-# test; the others are start-up artefacts and are excluded from summaries.
-SETTLED = "settled"
-WARMUP = "warmup"
-TRANSITION = "transition"
+# A fixed-probe sample is either INCLUDED (the impaired regime under test) or
+# EXCLUDED (the start-up: warm-up floor, the partial packet, and any startup drop).
+INCLUDED = "included"
+EXCLUDED = "excluded"
 
 
-@dataclass(frozen=True)
-class ProbeSettling:
-    """Result of :func:`classify_probe_settling` for one time-ordered stream."""
-
-    labels: list[str]  # one of SETTLED / WARMUP / TRANSITION per input sample
-    onset_index: int | None  # first index of the settled regime, or None if all settled
-
-    @property
-    def excluded_count(self) -> int:
-        return sum(1 for label in self.labels if label != SETTLED)
-
-
-def classify_probe_settling(
-    latencies_ms: Sequence[float],
+def find_probe_onset(
+    samples: Sequence[float | None],
     *,
     min_points: int = 12,
     step_window: int = 6,
     min_step_ratio: float = 3.0,
     min_step_ms: float = 15.0,
-    settle_fraction: float = 0.5,
-    warmup_mad_k: float = 5.0,
-) -> ProbeSettling:
-    """Split a time-ordered fixed-probe latency series into warm-up and impaired.
+    settle_fraction: float = 0.6,
+    settle_window: int = 6,
+) -> int | None:
+    """Index in ``samples`` where the clean impaired regime begins, or ``None``.
 
-    A fixed probe starts before the tc/netem shaping is applied, so the leading
-    packets sit at the un-impaired transport floor (a few ms). When shaping
-    engages the latency jumps sharply to the impaired regime — which may be a
-    stable plateau *or* a rising ramp (a shaped rate below the offered load builds
-    an ever-growing queue, i.e. bufferbloat). The detector therefore anchors on
-    the **sharp upward step from the low floor**, not on any plateau, so a ramping
-    profile is kept whole instead of being mistaken for a long transition.
+    ``samples`` is one stream ordered by send time; each entry is a delivered
+    packet's latency in ms, or ``None`` for a lost packet.
 
-    Around the step three regimes are labelled:
+    A fixed probe records packets before the tc/netem shaping is applied (the low
+    transport floor), then a brief transition where the in-flight packet sees a
+    partial delay and/or is dropped as the qdisc changes, then the impaired regime
+    under test (a plateau *or* a rising bufferbloat ramp). This returns the first
+    index from which the stream is *cleanly* in the impaired regime — a sustained
+    window whose latencies are at/above a threshold set between the floor and the
+    impaired level, with no loss dragging the window down. Everything before it
+    (warm-up, the immature partial packet, and any startup drop) is start-up and
+    should be excluded, so plot and summary agree on a clean measurement window.
 
-    * ``WARMUP`` — leading packets still at the floor (network delay ≈ 0);
-    * ``TRANSITION`` — the packet(s) in flight as shaping engages, seeing only a
-      partial delay (floor < latency < impaired regime);
-    * ``SETTLED`` — the impaired regime under test, kept for characterisation.
-
-    Detection is conservative: without a clear low-floor→high step (``impaired``
-    at least ``min_step_ratio``× **or** ``min_step_ms`` above the floor) every
-    sample is ``SETTLED`` and nothing is excluded — e.g. impairment live from the
-    first packet, a no-op profile, or a smooth ramp with no warm-up.
-
-    ``latencies_ms`` must already be ordered by send time.
+    Detection is conservative: without a clear low-floor→high step (``impaired`` at
+    least ``min_step_ratio``× **or** ``min_step_ms`` above the floor) it returns
+    ``None`` and nothing is excluded — e.g. impairment live from the first packet,
+    a no-op profile, or a smooth ramp with no warm-up.
     """
-    n = len(latencies_ms)
-    if n < min_points:
-        return ProbeSettling([SETTLED] * n, None)
+    n = len(samples)
+    delivered = [s for s in samples if s is not None]
+    if len(delivered) < min_points:
+        return None
 
-    latencies = list(latencies_ms)
-    window = max(1, min(step_window, n // 2))
-
-    # Locate the sharpest upward step: the largest ratio between the windowed
-    # median just after an index and just before it. The un-impaired floor is the
-    # lowest level in the run, so the warm-up→impaired jump dominates, and windowed
-    # medians keep a single ramp spike from masquerading as the step.
+    window = max(1, min(step_window, len(delivered) // 2))
+    # Sharpest upward step on the delivered latencies: the largest ratio between
+    # the windowed median just after and just before an index. The un-impaired
+    # floor is the lowest level, so the warm-up→impaired jump dominates, and
+    # windowed medians stop a single ramp spike from masquerading as the step.
     step_index: int | None = None
     best_ratio = 1.0
-    for i in range(window, n - window):
-        pre = _median(latencies[i - window : i])
-        post = _median(latencies[i : i + window])
+    for i in range(window, len(delivered) - window):
+        pre = _median(delivered[i - window : i])
+        post = _median(delivered[i : i + window])
         if pre <= 0.0:
             continue
         ratio = post / pre
@@ -575,56 +557,53 @@ def classify_probe_settling(
             best_ratio = ratio
             step_index = i
     if step_index is None:
-        return ProbeSettling([SETTLED] * n, None)
+        return None
 
-    floor = _median(latencies[max(0, step_index - window) : step_index])
-    impaired = _median(latencies[step_index : step_index + window])
+    floor = _median(delivered[max(0, step_index - window) : step_index])
+    impaired = _median(delivered[step_index : step_index + window])
     step_is_real = impaired >= floor * min_step_ratio or impaired - floor >= min_step_ms
     if best_ratio < min_step_ratio or not step_is_real:
-        return ProbeSettling([SETTLED] * n, None)
+        return None
 
-    warmup_hi = floor + max(warmup_mad_k * _mad(latencies[:step_index]), 0.02 * (impaired - floor))
+    # Threshold between floor and impaired level; ``settle_fraction`` sits it above
+    # the partial packet so the immature transition sample is excluded.
     impaired_lo = floor + settle_fraction * (impaired - floor)
+    hold = max(1, min(settle_window, len(delivered) // 2))
 
-    # Onset = first packet that reaches *and holds* the impaired regime, so the
-    # partial transition packet(s) below ``impaired_lo`` stay out of it.
-    onset: int | None = None
+    # Onset = first delivered sample at/above the regime that *starts* a sustained
+    # window mostly at/above it. A startup drop (``None``) or the partial packet
+    # keeps its window from qualifying, so onset lands on the first mature packet
+    # after them — the point from which the measurement is clean.
     for i in range(n):
-        if latencies[i] >= impaired_lo:
-            ahead = latencies[i : i + window]
-            if sum(1 for v in ahead if v >= impaired_lo) >= 0.7 * len(ahead):
-                onset = i
-                break
-    if not onset:  # None or 0 → nothing clean to exclude
-        return ProbeSettling([SETTLED] * n, None)
+        value = samples[i]
+        if value is None or value < impaired_lo:
+            continue
+        ahead = samples[i : i + hold]
+        if len(ahead) < hold:
+            break
+        good = sum(1 for s in ahead if s is not None and s >= impaired_lo)
+        if good >= 0.7 * hold:
+            return i
+    return None
 
-    labels = [SETTLED if i >= onset else (TRANSITION if v > warmup_hi else WARMUP) for i, v in enumerate(latencies)]
-    return ProbeSettling(labels, onset)
 
-
-def _probe_onset_send_time(
+def _stream_samples(
     stream: Sequence[dict[str, Any]],
     *,
     seq0: int,
     t0: float,
     period_s: float,
     time_field: str,
-) -> float | None:
-    """Send-time at which one stream's impairment settles, or None if no warm-up step."""
-    delivered: list[tuple[float, float]] = []
+) -> list[tuple[float, float | None]]:
+    """One seq-ordered stream as ``(send_time, latency_or_None)`` — ``None`` = lost."""
+    samples: list[tuple[float, float | None]] = []
     for record in stream:
-        if record.get("status") == "lost":
-            continue
-        latency_ms = _section_ms(record, "ota_hop_ms", "ota_hop_uncorrected_ms")
-        if latency_ms is None:
-            continue
         send_t = _send_time(record, seq0=seq0, t0=t0, period_s=period_s, time_field=time_field)
-        delivered.append((send_t, latency_ms))
-    delivered.sort(key=lambda point: point[0])
-    settling = classify_probe_settling([latency for _, latency in delivered])
-    if settling.onset_index is None:
-        return None
-    return delivered[settling.onset_index][0]
+        latency = (
+            None if record.get("status") == "lost" else _section_ms(record, "ota_hop_ms", "ota_hop_uncorrected_ms")
+        )
+        samples.append((send_t, latency))
+    return samples
 
 
 def exclude_probe_warmup(
@@ -633,12 +612,14 @@ def exclude_probe_warmup(
     nominal_period_s: float | None = None,
     time_field: str = "t_wrap",
 ) -> tuple[list[dict[str, Any]], float | None]:
-    """Drop the warm-up/transition prefix from already-joined transit records.
+    """Drop the start-up prefix from already-joined transit records.
 
-    Returns ``(settled_records, onset_send_time)`` where ``onset_send_time`` is the
-    earliest per-stream impairment onset on the publish timeline — the origin that
-    re-anchors "time since first publish" so ``t=0`` is where shaping is fully
-    applied. Streams with no clear warm-up step are kept whole; when no stream
+    Returns ``(included_records, onset_send_time)`` where ``onset_send_time`` is
+    the earliest per-stream impairment onset on the publish timeline — the origin
+    that re-anchors "time since first publish" so ``t=0`` is the clean measurement
+    start. Every record before its stream's onset (warm-up, the partial packet,
+    and any startup drop) is dropped, so the summary and the raw plot agree on the
+    same window. Streams with no clear warm-up step are kept whole; when no stream
     shows a step, nothing is dropped and ``onset_send_time`` is ``None``.
     """
     joined = list(joined_records)
@@ -665,16 +646,14 @@ def exclude_probe_warmup(
         anchor = min(stamped or stream, key=lambda record: int(record["seq"]))
         seq0 = int(anchor["seq"])
         t0 = float(anchor.get(time_field) or 0.0)
-        onset = _probe_onset_send_time(stream, seq0=seq0, t0=t0, period_s=period_s, time_field=time_field)
-        if onset is None:
+        samples = _stream_samples(stream, seq0=seq0, t0=t0, period_s=period_s, time_field=time_field)
+        onset_index = find_probe_onset([latency for _, latency in samples])
+        if onset_index is None:
             kept.extend(stream)
             continue
-        onsets.append(onset)
-        kept.extend(
-            record
-            for record in stream
-            if _send_time(record, seq0=seq0, t0=t0, period_s=period_s, time_field=time_field) >= onset
-        )
+        onset_send = samples[onset_index][0]
+        onsets.append(onset_send)
+        kept.extend(record for record, (send_t, _lat) in zip(stream, samples, strict=True) if send_t >= onset_send)
     return kept, (min(onsets) if onsets else None)
 
 

--- a/src/rosotacom/plots.py
+++ b/src/rosotacom/plots.py
@@ -352,15 +352,7 @@ def plot_probe_raw(
     _, plt = _require_matplotlib()
     out = Path(out)
 
-    from .benchmark import (
-        SETTLED,
-        TRANSITION,
-        WARMUP,
-        _infer_nominal_period_s,
-        _section_ms,
-        _send_time,
-        classify_probe_settling,
-    )
+    from .benchmark import _infer_nominal_period_s, _section_ms, _send_time, find_probe_onset
 
     grouped: dict[tuple[str, int], list[dict[str, Any]]] = {}
     for row in records:
@@ -374,7 +366,8 @@ def plot_probe_raw(
     fig, ax = plt.subplots(figsize=(10, 6))
     cmap = plt.colormaps["tab10"].resampled(max(len(grouped), 1))
 
-    all_lost_xs: list[float] = []
+    setup_lost_xs: list[float] = []
+    real_lost_xs: list[float] = []
     reanchored = False
 
     for index, ((label, attempt), stream) in enumerate(sorted(grouped.items())):
@@ -391,107 +384,62 @@ def plot_probe_raw(
         seq0 = int(anchor["seq"])
         t0 = float(anchor.get(time_field) or 0.0)
 
-        expanded = []
+        # One seq-ordered sample per packet: (x, latency) or (x, None) for a loss.
+        first_send_s = min(_send_time(r, seq0=seq0, t0=t0, period_s=period_s, time_field=time_field) for r in stream)
+        ordered: list[tuple[float, float | None]] = []
         for record in stream:
             send_t = _send_time(record, seq0=seq0, t0=t0, period_s=period_s, time_field=time_field)
-            expanded.append((record, send_t))
-
-        if not expanded:
+            x = max(0.0, send_t - first_send_s)
+            latency = (
+                None if record.get("status") == "lost" else _section_ms(record, "ota_hop_ms", "ota_hop_uncorrected_ms")
+            )
+            ordered.append((x, latency))
+        if not ordered:
             continue
 
-        first_send_s = min(send_t for _, send_t in expanded)
+        # Onset splits start-up (excluded) from the impaired regime (included).
+        onset_index = find_probe_onset([latency for _, latency in ordered])
+        onset_x = ordered[onset_index][0] if onset_index is not None else 0.0
+        reanchored = reanchored or onset_index is not None
 
-        # Delivered samples in send-time order, so the settling detector sees the
-        # warm-up → settled step in the order it happened.
-        delivered: list[tuple[float, float]] = []
-        stream_lost_xs: list[float] = []
-        for record, send_t in expanded:
-            x = max(0.0, send_t - first_send_s)
-            if record.get("status") == "lost":
-                stream_lost_xs.append(x)
-                continue
-            latency_ms = _section_ms(record, "ota_hop_ms", "ota_hop_uncorrected_ms")
-            if latency_ms is not None:
-                delivered.append((x, latency_ms))
-        delivered.sort(key=lambda point: point[0])
-
-        settling = classify_probe_settling([lat for _, lat in delivered])
-        # Re-anchor time so t=0 is the impairment onset: the settled regime starts
-        # at 0 and the excluded setup (warm-up/transition) falls at negative time.
-        onset_x = (
-            delivered[settling.onset_index][0]
-            if settling.onset_index is not None and settling.onset_index < len(delivered)
-            else 0.0
-        )
-        reanchored = reanchored or bool(onset_x)
-
-        regimes: dict[str, tuple[list[float], list[float]]] = {
-            SETTLED: ([], []),
-            WARMUP: ([], []),
-            TRANSITION: ([], []),
-        }
-        for (x, lat), sample_label in zip(delivered, settling.labels, strict=True):
-            xs, ys = regimes[sample_label]
-            xs.append(x - onset_x)
-            ys.append(lat)
-        all_lost_xs.extend(x - onset_x for x in stream_lost_xs)
+        inc_xs: list[float] = []
+        inc_ys: list[float] = []
+        exc_xs: list[float] = []
+        exc_ys: list[float] = []
+        for i, (x, latency) in enumerate(ordered):
+            included = onset_index is None or i >= onset_index
+            shifted = x - onset_x
+            if latency is None:
+                (real_lost_xs if included else setup_lost_xs).append(shifted)
+            elif included:
+                inc_xs.append(shifted)
+                inc_ys.append(latency)
+            else:
+                exc_xs.append(shifted)
+                exc_ys.append(latency)
 
         color = cmap(index)
         stream_label = label
         if len({key[1] for key in grouped}) > 1:
             stream_label = f"{stream_label} #{attempt}"
 
-        s_xs, s_ys = regimes[SETTLED]
-        if s_xs:
-            ax.scatter(s_xs, s_ys, color=color, s=12, alpha=0.6, label=f"{stream_label} latency")
-
-        w_xs, w_ys = regimes[WARMUP]
-        if w_xs:
-            ax.scatter(
-                w_xs,
-                w_ys,
-                facecolors="none",
-                edgecolors="0.6",
-                s=14,
-                alpha=0.7,
-                label="excluded: warm-up (pre-impairment)",
-            )
-
-        t_xs, t_ys = regimes[TRANSITION]
-        if t_xs:
-            ax.scatter(
-                t_xs,
-                t_ys,
-                color="crimson",
-                marker="x",
-                s=55,
-                linewidths=1.6,
-                label="excluded: transition (partial)",
-            )
-
-        # Dashed line at the onset (t=0 once re-anchored), so the split is obvious.
-        if onset_x:
-            ax.axvline(
-                0.0,
-                color="0.5",
-                linestyle="--",
-                linewidth=1.0,
-                alpha=0.8,
-                label="impairment onset (t=0)",
-            )
+        if inc_xs:
+            ax.scatter(inc_xs, inc_ys, color=color, s=12, alpha=0.6, label=f"{stream_label} latency")
+        if exc_xs:
+            ax.scatter(exc_xs, exc_ys, facecolors="none", edgecolors="0.6", s=14, alpha=0.7, label="excluded: start-up")
+        if onset_index is not None:
+            ax.axvline(0.0, color="0.5", linestyle="--", linewidth=1.0, alpha=0.8, label="impairment onset (t=0)")
 
     ax.set_ylim(bottom=0.0)
     ymin, ymax = ax.get_ylim()
 
-    # After re-anchoring, losses at t<0 happened during setup (e.g. the packet
-    # dropped as the qdisc changed); they are excluded like the warm-up, so the
-    # settled-window summary correctly reports them as no loss.
-    setup_lost = [x for x in all_lost_xs if x < 0.0]
-    real_lost = [x for x in all_lost_xs if x >= 0.0]
-    if real_lost:
-        ax.vlines(real_lost, ymin, ymax, colors="crimson", alpha=0.3, linewidth=1.0, label="lost packet")
-    if setup_lost:
-        ax.vlines(setup_lost, ymin, ymax, colors="0.6", alpha=0.4, linewidth=1.0, label="excluded: setup loss")
+    # A loss inside the included window is real; one at t<0 was dropped during
+    # start-up (e.g. as the qdisc changed) and is excluded like the warm-up, so
+    # the summary and the plot agree on the same clean window.
+    if real_lost_xs:
+        ax.vlines(real_lost_xs, ymin, ymax, colors="crimson", alpha=0.3, linewidth=1.0, label="lost packet")
+    if setup_lost_xs:
+        ax.vlines(setup_lost_xs, ymin, ymax, colors="0.6", alpha=0.4, linewidth=1.0, label="excluded: start-up loss")
 
     ax.set_ylabel("Latency (ms)")
     ax.set_xlabel(

--- a/tests/unit/test_benchmark.py
+++ b/tests/unit/test_benchmark.py
@@ -7,9 +7,6 @@ from pathlib import Path
 import pytest
 
 from rosotacom.benchmark import (
-    SETTLED,
-    TRANSITION,
-    WARMUP,
     BudgetEntry,
     BudgetKey,
     CapacitySlice,
@@ -20,12 +17,12 @@ from rosotacom.benchmark import (
     SweepBounds,
     capacity_binary_search,
     characterize_probe_records,
-    classify_probe_settling,
     compare_to_budget,
     exclude_probe_warmup,
     expand_size_pattern,
     find_baseline,
     find_capacity,
+    find_probe_onset,
     guard_shared_link,
     linear_ramp,
     load_budget,
@@ -270,98 +267,82 @@ def test_characterize_probe_records_bins_loss_latency_hz_and_bandwidth() -> None
 # --- fixed-probe settling / warm-up exclusion ------------------------------ #
 
 
-def test_classify_probe_settling_splits_warmup_transition_and_settled() -> None:
-    # 20 un-impaired warm-up samples, one partial packet as shaping engages,
-    # then the settled operating regime.
+def test_find_probe_onset_excludes_warmup_and_partial() -> None:
+    # 20 un-impaired warm-up samples, one partial packet as shaping engages, then
+    # the impaired plateau. Onset is the first mature packet; the partial drops.
     warmup = [5.0, 4.5, 5.5, 4.8, 5.2, 6.0, 4.9, 5.1, 5.3, 4.7] * 2
     settled = [80.0, 78.0, 84.0, 77.0, 88.0, 81.0, 79.0, 86.0, 74.0, 83.0] * 3
-    latencies = [*warmup, 21.0, *settled]
+    samples = [*warmup, 21.0, *settled]
 
-    result = classify_probe_settling(latencies)
-
-    assert result.onset_index == len(warmup) + 1
-    assert result.labels[: len(warmup)] == [WARMUP] * len(warmup)
-    assert result.labels[len(warmup)] == TRANSITION
-    assert all(label == SETTLED for label in result.labels[len(warmup) + 1 :])
-    assert result.excluded_count == len(warmup) + 1
+    assert find_probe_onset(samples) == len(warmup) + 1
 
 
-def test_classify_probe_settling_keeps_ramping_impaired_regime_whole() -> None:
-    # Bufferbloat: warm-up floor, one partial transition packet, then a latency
-    # ramp with no plateau (a shaped rate below the offered load). The whole ramp
-    # is the profile under test and must be kept — only warm-up + transition drop.
+def test_find_probe_onset_skips_a_startup_drop() -> None:
+    # The packet in flight as the qdisc changes is partial (46) and the next is
+    # dropped (None). Onset lands on the first mature packet after both, so the
+    # startup drop is excluded and never counts as loss.
     warmup = [5.0, 4.5, 5.5, 4.8, 5.2, 6.0, 4.9, 5.1, 5.3, 4.7] * 2
-    ramp = [96.0 + 6.0 * i for i in range(60)]  # 96 → ~450 ms, monotonically rising
-    latencies = [*warmup, 48.0, *ramp]
+    settled = [88.0, 86.0, 85.0, 91.0, 85.0, 90.0, 87.0, 84.0, 89.0, 86.0] * 3
+    samples = [*warmup, 46.0, None, *settled]
 
-    result = classify_probe_settling(latencies)
-
-    assert result.onset_index == len(warmup) + 1
-    assert result.labels[: len(warmup)] == [WARMUP] * len(warmup)
-    assert result.labels[len(warmup)] == TRANSITION  # the 48 ms partial packet
-    assert all(label == SETTLED for label in result.labels[len(warmup) + 1 :])
+    assert find_probe_onset(samples) == len(warmup) + 2  # past the partial and the drop
 
 
-def test_classify_probe_settling_keeps_everything_without_a_clear_step() -> None:
-    # Impairment live from the first packet: no warm-up floor, no step.
-    latencies = [80.0, 78.0, 84.0, 77.0, 88.0, 81.0, 79.0, 86.0, 74.0, 83.0] * 3
+def test_find_probe_onset_keeps_ramping_regime_whole() -> None:
+    # Bufferbloat: warm-up floor, one partial packet, then a rising ramp with no
+    # plateau. Onset is the first ramp packet; the whole ramp is kept.
+    warmup = [5.0, 4.5, 5.5, 4.8, 5.2, 6.0, 4.9, 5.1, 5.3, 4.7] * 2
+    ramp = [96.0 + 6.0 * i for i in range(60)]
+    samples = [*warmup, 48.0, *ramp]
 
-    result = classify_probe_settling(latencies)
-
-    assert result.onset_index is None
-    assert result.excluded_count == 0
-    assert set(result.labels) == {SETTLED}
-
-
-def test_classify_probe_settling_keeps_a_smooth_ramp_without_warmup() -> None:
-    # A pure ramp with no low warm-up floor has no sharp step — keep everything.
-    latencies = [96.0 + 4.0 * i for i in range(80)]  # 96 → ~412 ms, smooth
-
-    result = classify_probe_settling(latencies)
-
-    assert result.onset_index is None
-    assert set(result.labels) == {SETTLED}
+    assert find_probe_onset(samples) == len(warmup) + 1
 
 
-def test_classify_probe_settling_ignores_short_series() -> None:
-    latencies = [5.0, 5.0, 80.0, 80.0]
-
-    result = classify_probe_settling(latencies)
-
-    assert result.labels == [SETTLED] * 4
-    assert result.onset_index is None
+def test_find_probe_onset_none_without_a_clear_step() -> None:
+    # Impairment live from the first packet, and a smooth ramp with no warm-up:
+    # no sharp low→high step, so nothing is excluded.
+    assert find_probe_onset([80.0, 78.0, 84.0, 77.0, 88.0, 81.0, 79.0, 86.0, 74.0, 83.0] * 3) is None
+    assert find_probe_onset([96.0 + 4.0 * i for i in range(80)]) is None
 
 
-def _probe_stream(latencies: list[float], *, period_s: float = 0.05, t0: float = 100.0) -> list[dict]:
-    """Build joined transit records at a fixed rate — one delivered packet per latency."""
-    return [
-        {
+def test_find_probe_onset_ignores_short_series() -> None:
+    assert find_probe_onset([5.0, 5.0, 80.0, 80.0]) is None
+
+
+def _probe_stream(latencies: list[float | None], *, period_s: float = 0.05, t0: float = 100.0) -> list[dict]:
+    """Build joined transit records at a fixed rate; ``None`` latency means a lost packet."""
+    records: list[dict] = []
+    for seq, latency in enumerate(latencies):
+        record = {
             "kind": "transit",
             "source": "a",
             "target": "b",
             "topic": "/x",
             "seq": seq,
-            "status": "delivered",
             "t_wrap": t0 + seq * period_s,
-            "sections": {"ota_hop_ms": latency},
-            "size_bytes": 100,
         }
-        for seq, latency in enumerate(latencies)
-    ]
+        if latency is None:
+            record["status"] = "lost"
+        else:
+            record.update(status="delivered", sections={"ota_hop_ms": latency}, size_bytes=100)
+        records.append(record)
+    return records
 
 
-def test_exclude_probe_warmup_drops_prefix_and_reports_onset() -> None:
+def test_exclude_probe_warmup_drops_startup_incl_drop_and_reports_onset() -> None:
     warmup = [5.0] * 20
     settled = [80.0] * 40
-    records = _probe_stream([*warmup, 21.0, *settled])
+    # A partial packet (21) and a startup drop (None) sit between warm-up and the
+    # impaired plateau; both must be excluded so the kept window carries no loss.
+    records = _probe_stream([*warmup, 21.0, None, *settled])
 
     kept, onset = exclude_probe_warmup(records, nominal_period_s=0.05)
 
-    # The 20 warm-up samples and the one transition packet are dropped.
     assert len(kept) == len(settled)
     assert {record["sections"]["ota_hop_ms"] for record in kept} == {80.0}
-    # Onset is the send time of the first settled packet (seq 21).
-    assert onset == pytest.approx(100.0 + 21 * 0.05)
+    assert not any(record["status"] == "lost" for record in kept)  # startup drop excluded
+    # Onset is the send time of the first mature packet (seq 22).
+    assert onset == pytest.approx(100.0 + 22 * 0.05)
 
 
 def test_exclude_probe_warmup_keeps_all_without_a_step() -> None:
@@ -381,7 +362,7 @@ def test_characterize_probe_records_excludes_warmup_and_reanchors_to_onset() -> 
     excluded = characterize_probe_records(records, bin_s=1.0, nominal_period_s=0.05)
     included = characterize_probe_records(records, bin_s=1.0, nominal_period_s=0.05, exclude_warmup=False)
 
-    # Re-anchored: the settled regime starts at bin 0, and no bin carries the
+    # Re-anchored: the impaired regime starts at bin 0, and no bin carries the
     # warm-up latency floor.
     assert excluded[0]["bin_start_s"] == 0.0
     assert all(row["latency_p50_ms"] > 50.0 for row in excluded)


### PR DESCRIPTION
Closes #122. Follow-up to #114.

## Problem
On a rate-shaped (bufferbloat) probe run the raw plot and the summary disagreed, and the start-up boundary was imprecise: the qdisc-change drop was drawn as a real loss while the summary reported none; the onset could land on the immature partial packet; and the warm-up/transition split mislabelled warm-up jitter as "transition".

## Change
- **`find_probe_onset`** replaces `classify_probe_settling`. It operates on the seq-ordered stream (`latency`, or `None` for a lost packet) and returns the first index of the *clean* impaired regime: the first mature packet that starts a sustained window at/above a threshold between the floor and the impaired level, with no loss dragging it down. So the immature partial packet **and** any start-up drop fall before onset and are excluded. A rising bufferbloat ramp is still kept whole; no clear step ⇒ keep everything.
- **`exclude_probe_warmup`** builds per-stream samples including losses and filters on the onset send-time, so a start-up drop never counts toward loss in the summary — plot and summary use the same window.
- **`plot_probe_raw`**: binary **included** (blue) vs **excluded: start-up** (grey); losses split into real (crimson, inside the window) vs excluded start-up loss (grey, `t<0`). Dropped the transition (red ✗) class.

## Validation
- `tests/unit/test_benchmark.py`: onset excludes warm-up + partial; **skips a start-up drop**; keeps a ramping regime whole; returns `None` without a clear step / for a smooth ramp / short series; `exclude_probe_warmup` drops start-up incl. the drop and reports onset; characterize re-anchors to onset. Full unit suite: 323 passed; ruff clean.
- Verified against the recorded static / bufferbloat / conservative-rate runs: the included window carries **0 loss** in all three (the single raw loss in two runs is the excluded start-up drop), matching the plot.