### PR TITLE
Seamless timeline stepping: replace the qdisc tree in place instead of del+add

### DIFF
--- a/docs/rfcs/0004-network-profiles.md
+++ b/docs/rfcs/0004-network-profiles.md
@@ -119,6 +119,15 @@ the OTA interface, so the transport sees a realistic pipe and is unaware of it
   arm with an automatic revert on stop, on error, *and* a safety max-duration, so
   a crashed run cannot leave a `qdisc` shaping every later result. `tc qdisc del
   dev <if> root` is idempotent and always runs on teardown.
+- **Seamless timeline stepping (issue #124).** Timeline steps `tc qdisc replace`
+  the *same* qdisc tree in place — never del+add, which drops everything queued
+  inside `netem` and leaves a brief unshaped window at every boundary (observed
+  as lost plus under-delayed messages, even between identical segments). The tree
+  shape is fixed per timeline (tbf `1:` + netem `10:` when any segment
+  rate-limits, else netem `10:` root); an unused stage is armed as a pass-through
+  (effectively-unlimited tbf / bare netem) instead of being removed. `catchup`
+  outages fold in as an in-place `netem loss 100%`; `reconnect` stays link-down
+  (disruptive by design), restored by the following step.
 - **Bench-only, privileged.** `tc`/`netem` needs `CAP_NET_ADMIN` and applies on
   the controllable bench. The real fleet is never shaped — there the link *is* the
   condition and is measured. Selecting a profile on a real-deployment run is an
@@ -221,6 +230,10 @@ risk — a stuck `qdisc` silently corrupts every later result on the machine.
 - [x] Add timeline profiles (ordered segments + `outage`) — the substrate for the
   recovery genre in RFC 0005 (`network_profiles.TimelineSegment` / `expand_timeline`;
   both `outage` kinds — see Open questions).
+- [x] Make timeline stepping seamless (issue #124): steps `tc qdisc replace` one
+  constant tree in place instead of del+add, so a boundary drops no queued packets
+  and never runs unshaped (`expand_timeline`, `_tbf_stage_command` /
+  `_netem_stage_command`; outages folded into the same tree).
 - [x] Add per-profile calibration — realized as `rosotacom test --suggest --profile
   P`, which emits `P`'s conditional band nested under `per_profile`
   (`status_eval.suggest_profile_band`), reusing the RFC 0002 `--suggest` machinery.
@@ -265,6 +278,16 @@ off during implementation). Notes whether automation is feasible; privileged
 - [x] **Timeline profiles** (ordered segments + `outage`) — host unit test on the
   schedule expansion (`test_expand_timeline_*`, both outage kinds); live stepping is
   a **bench check** (and the substrate for the RFC 0005 recovery genre).
+- [x] **Seamless timeline stepping** (in-place `replace` of one constant tree — no
+  queue drop, no unshaped window at step boundaries) — host unit tests on the argv
+  (`test_expand_timeline_replaces_one_constant_tree_no_teardown`,
+  `test_timeline_catchup_is_in_place_full_loss_interface_up`,
+  `test_timeline_reconnect_downs_link_and_next_step_restores_it_first`) plus the
+  Docker e2e test proving the kernel changes the tree in place — stats/queue
+  persist across a boundary, the netem child survives a tbf-root replace, a bare
+  netem step resets stale parameters (`tests/e2e/test_timeline_stepping.py`, in the
+  fast-e2e lane). Bench confirmation: a probe run under a stepping profile shows no
+  boundary loss/under-delay.
 - [x] **Per-profile calibration** (`rosotacom test --suggest --profile P`) — host
   unit test that a reference status fixture yields `P`'s conditional band nested
   under `per_profile` (`test_suggest_profile_band_*`), reusing the RFC 0002
@@ -289,7 +312,7 @@ off during implementation). Notes whether automation is feasible; privileged
   survive → recovery is "catch up"); `outage: reconnect` is link-down (forces RMW
   re-discovery → the harsher reconnect with the multi-second backlog/simultaneous
   arrival the baseline describes). A bare `outage: true` defaults to the milder
-  `catchup`. Implemented in `network_profiles.outage_commands` / `OUTAGE_KINDS`.
+  `catchup`. Implemented in `network_profiles.expand_timeline` / `OUTAGE_KINDS`.
 - **Where the metric backbone reads the link during emulation.** The same
   `/proc/net/dev` link sampler (RFC 0003 / `link_bytes.py`) measures the shaped
   interface — confirm `tbf`/`netem` byte counts reflect post-shaping wire bytes so

--- a/src/rosotacom/network_profiles.py
+++ b/src/rosotacom/network_profiles.py
@@ -42,6 +42,12 @@ OUTAGE_KINDS = (OUTAGE_CATCHUP, OUTAGE_RECONNECT)
 _DEFAULT_TBF_BURST = "32kbit"
 _DEFAULT_TBF_LATENCY_MS = 100.0
 
+# The "unimpaired" tbf stage for rate-less steps of a rated timeline. Seamless
+# stepping needs the qdisc tree shape to stay constant, so the stage stays
+# present but never binds: faster than any link we emulate, with a token bucket
+# big enough (~10 ms of tokens at 10 Gbit/s) that no packet ever waits on it.
+_UNSHAPED_TBF_ARGS = ("rate", "10gbit", "burst", "12500kb", "latency", "100ms")
+
 
 # --------------------------------------------------------------------------- #
 # Value parsing (human strings → normalized numbers)
@@ -403,56 +409,50 @@ def _netem_args(shaping: DirectionShaping) -> list[str]:
     return args
 
 
+def _tbf_stage_command(interface: str, shaping: DirectionShaping | None) -> list[str]:
+    """``tc qdisc replace`` for the tbf root stage (``1:``) — in place when it
+    already exists. A step without a rate keeps the stage present but effectively
+    unlimited (:data:`_UNSHAPED_TBF_ARGS`), so the tree shape never changes."""
+    if shaping is not None and shaping.rate_bps is not None:
+        args = [
+            "rate",
+            f"{int(round(shaping.rate_bps))}bit",
+            "burst",
+            shaping.burst,
+            "latency",
+            _ms(shaping.tbf_latency_ms),
+        ]
+    else:
+        args = list(_UNSHAPED_TBF_ARGS)
+    return ["tc", "qdisc", "replace", "dev", interface, "root", "handle", "1:", "tbf", *args]
+
+
+def _netem_stage_command(interface: str, netem_args: Sequence[str], *, child_of_tbf: bool) -> list[str]:
+    """``tc qdisc replace`` for the netem stage (``10:``) — in place when it
+    already exists. Empty ``netem_args`` is a pass-through netem; a netem change
+    replaces the whole parameter set, so anything omitted is reset, not inherited."""
+    location = ["parent", "1:"] if child_of_tbf else ["root"]
+    return ["tc", "qdisc", "replace", "dev", interface, *location, "handle", "10:", "netem", *netem_args]
+
+
 def shaping_commands(interface: str, shaping: DirectionShaping) -> list[list[str]]:
     """The ordered ``tc`` argv list that arms ``shaping`` on ``interface`` egress.
 
     Layout mirrors the calibrated baseline: a ``tbf`` root for rate limiting with a
     child ``netem`` for delay/jitter/loss. When only one of the two is requested it
-    becomes the root qdisc; an empty shaping arms nothing.
+    becomes the root qdisc; an empty shaping arms nothing. Emitted as ``tc qdisc
+    replace`` (add-or-change), so re-arming over an existing tree of the same
+    shape updates it in place instead of failing.
     """
     if shaping.is_empty:
         return []
     commands: list[list[str]] = []
     if shaping.rate_bps is not None:
-        commands.append(
-            [
-                "tc",
-                "qdisc",
-                "add",
-                "dev",
-                interface,
-                "root",
-                "handle",
-                "1:",
-                "tbf",
-                "rate",
-                f"{int(round(shaping.rate_bps))}bit",
-                "burst",
-                shaping.burst,
-                "latency",
-                _ms(shaping.tbf_latency_ms),
-            ]
-        )
+        commands.append(_tbf_stage_command(interface, shaping))
         if shaping.has_netem:
-            commands.append(
-                [
-                    "tc",
-                    "qdisc",
-                    "add",
-                    "dev",
-                    interface,
-                    "parent",
-                    "1:",
-                    "handle",
-                    "10:",
-                    "netem",
-                    *_netem_args(shaping),
-                ]
-            )
+            commands.append(_netem_stage_command(interface, _netem_args(shaping), child_of_tbf=True))
     elif shaping.has_netem:
-        commands.append(
-            ["tc", "qdisc", "add", "dev", interface, "root", "handle", "10:", "netem", *_netem_args(shaping)]
-        )
+        commands.append(_netem_stage_command(interface, _netem_args(shaping), child_of_tbf=False))
     return commands
 
 
@@ -481,34 +481,6 @@ def safety_teardown_command(interface: str, max_duration_s: float) -> list[str]:
     return ["sh", "-c", f"sleep {seconds}; tc qdisc del dev {iface} root; ip link set dev {iface} up"]
 
 
-def outage_commands(interface: str, kind: str) -> list[list[str]]:
-    """Arm an outage of the given kind on ``interface``.
-
-    ``catchup`` drops every packet but keeps the interface up (DDS endpoints
-    survive → recovery is "catch up"); ``reconnect`` brings the interface down
-    (forces RMW re-discovery → the harsher reconnect). The matching restore is
-    :func:`outage_restore_commands`.
-    """
-    if kind == OUTAGE_CATCHUP:
-        return [
-            teardown_command(interface),
-            ["tc", "qdisc", "add", "dev", interface, "root", "handle", "10:", "netem", "loss", "100%"],
-        ]
-    if kind == OUTAGE_RECONNECT:
-        return [["ip", "link", "set", "dev", interface, "down"]]
-    raise ValueError(f"outage must be one of {OUTAGE_KINDS}, got {kind!r}")
-
-
-def outage_restore_commands(interface: str, kind: str) -> list[list[str]]:
-    """Undo an outage. ``catchup`` clears the 100%-loss qdisc; ``reconnect`` brings
-    the interface back up. The caller re-arms the following segment's shaping after."""
-    if kind == OUTAGE_CATCHUP:
-        return [teardown_command(interface)]
-    if kind == OUTAGE_RECONNECT:
-        return [["ip", "link", "set", "dev", interface, "up"]]
-    raise ValueError(f"outage must be one of {OUTAGE_KINDS}, got {kind!r}")
-
-
 # --------------------------------------------------------------------------- #
 # Timeline expansion (segments → a stepping schedule)
 # --------------------------------------------------------------------------- #
@@ -534,28 +506,58 @@ def expand_timeline(
 ) -> list[TimelineStep]:
     """Expand a timeline profile into absolute-clock steps for the given direction.
 
-    Each step first tears the previous shaping down (the idempotent root delete),
-    then arms its own — shaping segments arm ``shaping_commands``; outage segments
-    arm ``outage_commands``. The stepping driver runs ``commands`` at ``start_s``;
-    the recovery genre (RFC 0005) reads ``outage`` to know which restore semantics
-    a given ``end_s`` represents.
+    Steps transition **seamlessly**: every step ``tc qdisc replace``\\ s the *same*
+    qdisc tree in place instead of tearing it down and re-adding it — a del+add
+    drops everything queued inside netem and leaves a brief unshaped window, which
+    shows up as lost and under-delayed messages at every boundary (even between
+    identical segments). The tree shape is therefore fixed for the whole timeline,
+    decided up front: a tbf root (``1:``) with a netem child (``10:``) when any
+    segment rate-limits, else a netem root (``10:``). A step that does not use a
+    stage arms it as a pass-through (unlimited tbf / bare netem) rather than
+    removing it; a direction that never shapes (and no outages) arms nothing.
+
+    Outage segments fold into the same tree: ``catchup`` is an in-place
+    ``netem loss 100%`` (interface stays up — seamless entry and exit, DDS
+    endpoints survive → recovery is "catch up"); ``reconnect`` downs the link
+    (disruptive by design — forces RMW re-discovery) and the following step
+    restores it first. The stepping driver runs ``commands`` at ``start_s``; the
+    recovery genre (RFC 0005) reads ``outage`` to know which restore semantics a
+    given ``end_s`` represents.
     """
     if not profile.is_timeline:
         raise ValueError(f"profile {profile.name!r} is not a timeline profile")
     if direction not in ("uplink", "downlink"):
         raise ValueError(f"direction must be 'uplink' or 'downlink', got {direction!r}")
 
+    shapings = [segment.uplink if direction == "uplink" else segment.downlink for segment in profile.timeline]
+    rated = any(shaping is not None and shaping.rate_bps is not None for shaping in shapings)
+    shaped = (
+        rated
+        or any(shaping is not None and shaping.has_netem for shaping in shapings)
+        or any(segment.outage is not None for segment in profile.timeline)
+    )
+
     steps: list[TimelineStep] = []
     clock = 0.0
+    previous_outage: str | None = None
     for index, segment in enumerate(profile.timeline):
         start_s, end_s = clock, clock + segment.for_s
-        if segment.outage is not None:
-            commands = outage_commands(interface, segment.outage)
-        else:
-            shaping = segment.uplink if direction == "uplink" else segment.downlink
-            commands = [teardown_command(interface)]
-            if shaping is not None:
-                commands += shaping_commands(interface, shaping)
+        commands: list[list[str]] = []
+        if previous_outage == OUTAGE_RECONNECT and segment.outage != OUTAGE_RECONNECT:
+            commands.append(restore_link_command(interface))
+        if segment.outage == OUTAGE_RECONNECT:
+            commands.append(["ip", "link", "set", "dev", interface, "down"])
+        elif shaped:
+            if segment.outage == OUTAGE_CATCHUP:
+                shaping: DirectionShaping | None = None
+                netem_args: list[str] = ["loss", "100%"]
+            else:
+                shaping = shapings[index]
+                netem_args = _netem_args(shaping) if shaping is not None else []
+            if rated:
+                commands.append(_tbf_stage_command(interface, shaping))
+            commands.append(_netem_stage_command(interface, netem_args, child_of_tbf=rated))
         steps.append(TimelineStep(index=index, start_s=start_s, end_s=end_s, outage=segment.outage, commands=commands))
         clock = end_s
+        previous_outage = segment.outage
     return steps

--- a/src/rosotacom/network_shaper.py
+++ b/src/rosotacom/network_shaper.py
@@ -77,17 +77,6 @@ class ProfileShaper:
     def _run(self, argv: Sequence[str]) -> None:
         self._runner(list(argv))
 
-    def _is_idempotent_cleanup(self, argv: Sequence[str]) -> bool:
-        command = list(argv)
-        return command in (teardown_command(self.interface), restore_link_command(self.interface))
-
-    def _run_tolerating_idempotent_cleanup(self, argv: Sequence[str]) -> None:
-        try:
-            self._run(argv)
-        except Exception:
-            if not self._is_idempotent_cleanup(argv):
-                raise
-
     def teardown(self) -> None:
         """Always-safe revert: clear any root qdisc and bring the link back up.
 
@@ -115,11 +104,14 @@ class ProfileShaper:
     def apply(self, commands: Iterable[Sequence[str]]) -> None:
         """Run ``commands`` as-is, without a fresh clean-slate or watchdog.
 
-        Used to step a timeline (each :func:`~rosotacom.network_profiles.expand_timeline`
-        step already begins with its own teardown); the watchdog is launched once via
-        :meth:`arm` at the start of the run, not per step."""
+        Used to step a timeline: each :func:`~rosotacom.network_profiles.expand_timeline`
+        step updates the qdisc tree **in place** (``tc qdisc replace``), so there is
+        no teardown between steps — a del+add would drop netem's queue and leave a
+        brief unshaped window at every boundary. The watchdog is launched once via
+        :meth:`arm` at the start of the run, not per step; a failing step command
+        raises (the context manager still reverts)."""
         for argv in commands:
-            self._run_tolerating_idempotent_cleanup(argv)
+            self._run(argv)
         self.armed = True
 
     def __enter__(self) -> ProfileShaper:

--- a/tests/e2e/test_timeline_stepping.py
+++ b/tests/e2e/test_timeline_stepping.py
@@ -1,0 +1,159 @@
+"""RFC 0004 validation — live seamless timeline stepping (issue #124).
+
+The host unit tests assert the generated argv; this proves the kernel semantics
+that argv relies on, live in a container: ``tc qdisc replace`` on an unchanged
+tree changes it **in place** — the qdisc stats (and with them the queue) persist
+across a step boundary and the netem child survives a tbf-root replace — so
+stepping drops no queued packets and never leaves an unshaped window. It also
+proves that a bare ``netem`` step resets previous delay/loss instead of
+inheriting it, and that a reconnect outage's link-down is restored by the
+following step.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import uuid
+from collections.abc import Iterator, Sequence
+
+import pytest
+
+from rosotacom.network_profiles import expand_timeline, parse_profile
+from rosotacom.network_shaper import ProfileShaper
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.skipif(
+        os.environ.get("ROSOTACOM_RUN_E2E") != "1",
+        reason="Docker-backed E2E tests require ROSOTACOM_RUN_E2E=1.",
+    ),
+]
+
+# Any small image with a shell works; iproute2 is installed into it. The shaping
+# itself runs against the container's eth0 with CAP_NET_ADMIN, exactly like the
+# lab benchmark path.
+IMAGE = "debian:stable-slim"
+
+
+def _exec(container: str, argv: Sequence[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["docker", "exec", "-u", "root", container, *argv],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _runner(container: str):
+    def run(argv: Sequence[str]) -> None:
+        result = _exec(container, argv)
+        if result.returncode != 0:
+            raise RuntimeError(f"{' '.join(argv)} -> {result.stderr or result.stdout}")
+
+    return run
+
+
+def _qdisc_show(container: str) -> str:
+    result = _exec(container, ["tc", "-s", "qdisc", "show", "dev", "eth0"])
+    assert result.returncode == 0, result.stderr
+    return result.stdout
+
+
+def _netem_sent_packets(container: str) -> int:
+    match = re.search(r"qdisc netem 10:.*?Sent \d+ bytes (\d+) pkt", _qdisc_show(container), re.DOTALL)
+    assert match, "netem 10: stage not found in qdisc show"
+    return int(match.group(1))
+
+
+def _operstate(container: str) -> str:
+    return _exec(container, ["cat", "/sys/class/net/eth0/operstate"]).stdout.strip()
+
+
+def _send_udp_burst(container: str) -> None:
+    # Fire-and-forget datagrams towards TEST-NET-3 egress eth0 via the default
+    # route; no reply is needed, only egress traffic through the qdisc tree.
+    result = _exec(
+        container,
+        ["bash", "-c", "for i in $(seq 40); do echo probe > /dev/udp/203.0.113.1/9; done"],
+    )
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.fixture()
+def shaping_container() -> Iterator[str]:
+    name = f"rosotacom-stepping-{uuid.uuid4().hex[:8]}"
+    subprocess.run(
+        ["docker", "run", "-d", "--rm", "--name", name, "--cap-add", "NET_ADMIN", IMAGE, "sleep", "600"],
+        check=True,
+        capture_output=True,
+    )
+    try:
+        install = _exec(name, ["sh", "-c", "apt-get update -qq && apt-get install -y -qq iproute2 >/dev/null"])
+        if install.returncode != 0:
+            pytest.fail(f"could not install iproute2 in {IMAGE}: {install.stderr}")
+        netem_probe = _exec(name, ["tc", "qdisc", "replace", "dev", "eth0", "root", "handle", "10:", "netem"])
+        if netem_probe.returncode != 0:
+            pytest.skip(f"host kernel lacks sch_netem: {netem_probe.stderr.strip()}")
+        _exec(name, ["tc", "qdisc", "del", "dev", "eth0", "root"])
+        yield name
+    finally:
+        subprocess.run(["docker", "rm", "-f", name], capture_output=True, check=False)
+
+
+def test_timeline_steps_change_the_qdisc_tree_in_place(shaping_container: str) -> None:
+    profile = parse_profile(
+        "stepping",
+        {
+            "timeline": [
+                {"for": "1s", "uplink": {"rate": "8mbit", "delay": "50ms", "jitter": "15ms", "distribution": "normal"}},
+                {"for": "1s", "uplink": {"rate": "3mbit", "delay": "80ms"}},
+                {"for": "1s", "outage": "catchup"},
+                {"for": "1s", "uplink": {"delay": "20ms"}},
+                {"for": "1s", "outage": "reconnect"},
+                {"for": "1s", "uplink": {"rate": "8mbit"}},
+            ]
+        },
+    )
+    steps = expand_timeline(profile, "eth0", direction="uplink")
+
+    with ProfileShaper("eth0", _runner(shaping_container)) as shaper:
+        shaper.arm([])
+
+        shaper.apply(steps[0].commands)
+        show = _qdisc_show(shaping_container)
+        assert "8Mbit" in show and "delay 50ms" in show
+        _send_udp_burst(shaping_container)
+        sent_before = _netem_sent_packets(shaping_container)
+        assert sent_before > 0
+
+        # The step boundary must change the tree in place: a recreated qdisc
+        # would reset its stats (and drop its queue) — they must persist.
+        shaper.apply(steps[1].commands)
+        show = _qdisc_show(shaping_container)
+        assert "3Mbit" in show and "delay 80ms" in show
+        assert _netem_sent_packets(shaping_container) >= sent_before
+
+        # Catchup outage: in-place full loss, interface stays up.
+        shaper.apply(steps[2].commands)
+        assert "loss 100%" in _qdisc_show(shaping_container)
+        assert _operstate(shaping_container) == "up"
+
+        # Rate-less step: tbf stage stays as effectively-unlimited, loss is gone.
+        shaper.apply(steps[3].commands)
+        show = _qdisc_show(shaping_container)
+        assert "10Gbit" in show and "delay 20ms" in show and "loss" not in show
+
+        # Reconnect outage downs the link; the following step restores it first
+        # and a netem-less segment leaves a bare pass-through netem stage.
+        shaper.apply(steps[4].commands)
+        assert _operstate(shaping_container) == "down"
+        shaper.apply(steps[5].commands)
+        assert _operstate(shaping_container) == "up"
+        show = _qdisc_show(shaping_container)
+        assert "8Mbit" in show and "delay" not in show
+
+    # Context exit reverts: no shaping stages remain on the interface.
+    show = _qdisc_show(shaping_container)
+    assert "tbf" not in show and "netem" not in show

--- a/tests/unit/test_cli_benchmark.py
+++ b/tests/unit/test_cli_benchmark.py
@@ -1433,15 +1433,15 @@ def test_live_lab_run_point_uses_instance_scoped_smoke_network(
         command[:6] == ["docker", "exec", "-u", "root", "container_b", "tc"] and "1%" in command for command in commands
     )
     assert sleep_calls[-2:] == [0.1, DEFAULT_BENCHMARK_DRAIN_S]
-    uplink_add = next(
+    uplink_arm = next(
         i
         for i, command in enumerate(commands)
-        if command[:8] == ["docker", "exec", "-u", "root", "container_a", "tc", "qdisc", "add"]
+        if command[:8] == ["docker", "exec", "-u", "root", "container_a", "tc", "qdisc", "replace"]
     )
     publisher_stop = next(
         i
         for i, command in enumerate(commands)
-        if i > uplink_add and command == ["docker", "exec", "container_a", "pkill", "-f", "sized_publisher"]
+        if i > uplink_arm and command == ["docker", "exec", "container_a", "pkill", "-f", "sized_publisher"]
     )
     final_uplink_teardown = max(
         i

--- a/tests/unit/test_network_profiles.py
+++ b/tests/unit/test_network_profiles.py
@@ -13,8 +13,6 @@ from rosotacom.network_profiles import (
     TimelineSegment,
     expand_timeline,
     load_profiles_file,
-    outage_commands,
-    outage_restore_commands,
     parse_direction,
     parse_ms,
     parse_pct,
@@ -92,14 +90,15 @@ def test_parse_direction_rejects_unknown_keys_and_invalid_combos() -> None:
 
 
 def test_shaping_commands_tbf_root_with_netem_child() -> None:
-    # The canonical static cellular profile from the calibrated baseline.
+    # The canonical static cellular profile from the calibrated baseline. Emitted
+    # as `replace` (add-or-change): creates from a clean slate, updates in place.
     shaping = DirectionShaping(rate_bps=4_000_000, delay_ms=120.0, jitter_ms=30.0, distribution="normal", loss_pct=2.0)
     commands = shaping_commands("tun0", shaping)
     assert commands == [
         [
             "tc",
             "qdisc",
-            "add",
+            "replace",
             "dev",
             "tun0",
             "root",
@@ -116,7 +115,7 @@ def test_shaping_commands_tbf_root_with_netem_child() -> None:
         [
             "tc",
             "qdisc",
-            "add",
+            "replace",
             "dev",
             "tun0",
             "parent",
@@ -138,7 +137,7 @@ def test_shaping_commands_tbf_root_with_netem_child() -> None:
 def test_shaping_commands_netem_only_becomes_root() -> None:
     commands = shaping_commands("tun0", DirectionShaping(delay_ms=60.0, loss_pct=1.0))
     assert commands == [
-        ["tc", "qdisc", "add", "dev", "tun0", "root", "handle", "10:", "netem", "delay", "60ms", "loss", "1%"]
+        ["tc", "qdisc", "replace", "dev", "tun0", "root", "handle", "10:", "netem", "delay", "60ms", "loss", "1%"]
     ]
 
 
@@ -148,7 +147,7 @@ def test_shaping_commands_rate_only_and_empty() -> None:
         [
             "tc",
             "qdisc",
-            "add",
+            "replace",
             "dev",
             "eth0",
             "root",
@@ -196,7 +195,7 @@ def test_shaping_commands_emit_netem_seed() -> None:
         [
             "tc",
             "qdisc",
-            "add",
+            "replace",
             "dev",
             "tun0",
             "root",
@@ -220,20 +219,44 @@ def test_teardown_is_root_delete() -> None:
     assert teardown_command("tun0") == ["tc", "qdisc", "del", "dev", "tun0", "root"]
 
 
-# --- outage kinds (both named variants) ------------------------------------ #
+# --- outage kinds (both named variants, in the timeline tree) --------------- #
 
 
-def test_outage_catchup_is_full_loss_interface_up() -> None:
-    assert outage_commands("tun0", OUTAGE_CATCHUP) == [
-        ["tc", "qdisc", "del", "dev", "tun0", "root"],
-        ["tc", "qdisc", "add", "dev", "tun0", "root", "handle", "10:", "netem", "loss", "100%"],
+def test_timeline_catchup_is_in_place_full_loss_interface_up() -> None:
+    profile = parse_profile(
+        "o",
+        {
+            "timeline": [
+                {"for": "5s", "uplink": {"delay": "50ms"}},
+                {"for": "5s", "outage": "catchup"},
+                {"for": "5s", "uplink": {"delay": "50ms"}},
+            ]
+        },
+    )
+    steps = expand_timeline(profile, "tun0")
+    assert steps[1].commands == [
+        ["tc", "qdisc", "replace", "dev", "tun0", "root", "handle", "10:", "netem", "loss", "100%"]
     ]
-    assert outage_restore_commands("tun0", OUTAGE_CATCHUP) == [["tc", "qdisc", "del", "dev", "tun0", "root"]]
+    # The interface never goes down, and the exit is the same in-place change back.
+    assert all(cmd[0] == "tc" for step in steps for cmd in step.commands)
+    assert steps[2].commands == steps[0].commands
 
 
-def test_outage_reconnect_is_link_down() -> None:
-    assert outage_commands("tun0", OUTAGE_RECONNECT) == [["ip", "link", "set", "dev", "tun0", "down"]]
-    assert outage_restore_commands("tun0", OUTAGE_RECONNECT) == [["ip", "link", "set", "dev", "tun0", "up"]]
+def test_timeline_reconnect_downs_link_and_next_step_restores_it_first() -> None:
+    profile = parse_profile(
+        "o",
+        {
+            "timeline": [
+                {"for": "5s", "uplink": {"rate": "4mbit"}},
+                {"for": "5s", "outage": "reconnect"},
+                {"for": "5s", "uplink": {"rate": "4mbit"}},
+            ]
+        },
+    )
+    steps = expand_timeline(profile, "tun0")
+    assert steps[1].commands == [["ip", "link", "set", "dev", "tun0", "down"]]
+    assert steps[2].commands[0] == ["ip", "link", "set", "dev", "tun0", "up"]
+    assert steps[2].commands[1:] == steps[0].commands
 
 
 # --- profile parsing (static + timeline) ----------------------------------- #
@@ -304,10 +327,52 @@ def test_expand_timeline_places_steps_on_absolute_clock() -> None:
         (30.0, 35.0, OUTAGE_CATCHUP),
         (35.0, 75.0, None),
     ]
-    # Every shaping step first tears the previous qdisc down (idempotent), then arms its own.
-    assert steps[0].commands[0] == teardown_command("tun0")
-    assert steps[0].commands[1][:9] == ["tc", "qdisc", "add", "dev", "tun0", "root", "handle", "1:", "tbf"]
-    assert steps[1].commands == outage_commands("tun0", OUTAGE_CATCHUP)
+    # Every step replaces the same tbf(1:)+netem(10:) tree in place — including the
+    # catchup outage, which is a full-loss netem on an unlimited tbf stage.
+    assert steps[0].commands[0][:9] == ["tc", "qdisc", "replace", "dev", "tun0", "root", "handle", "1:", "tbf"]
+    netem_prefix = ["tc", "qdisc", "replace", "dev", "tun0", "parent", "1:", "handle", "10:", "netem"]
+    assert steps[0].commands[1][:10] == netem_prefix
+    assert steps[1].commands[0][8:10] == ["tbf", "rate"] and "10gbit" in steps[1].commands[0]
+    assert steps[1].commands[1][-3:] == ["netem", "loss", "100%"]
+
+
+def test_expand_timeline_replaces_one_constant_tree_no_teardown() -> None:
+    # The seamlessness contract: a del+add between steps drops netem's queue and
+    # opens an unshaped window, so steps may only `replace` an unchanging tree.
+    profile = parse_profile(
+        "stepping",
+        {
+            "timeline": [
+                {"for": "5s", "uplink": {"rate": "8mbit", "delay": "50ms", "jitter": "15ms", "distribution": "normal"}},
+                {"for": "5s", "uplink": {"rate": "8mbit", "delay": "50ms", "jitter": "15ms", "distribution": "normal"}},
+                {"for": "5s", "uplink": {"delay": "50ms"}},
+                {"for": "5s", "uplink": {"rate": "3mbit"}},
+            ]
+        },
+    )
+    steps = expand_timeline(profile, "tun0", direction="uplink")
+    assert {cmd[2] for step in steps for cmd in step.commands} == {"replace"}
+    # Identical consecutive segments produce identical (idempotent) commands.
+    assert steps[1].commands == steps[0].commands
+    # The tree shape is constant: every step arms both stages. A rate-less step
+    # keeps the tbf stage as effectively-unlimited; a netem-less step keeps the
+    # netem stage as a bare pass-through (netem change resets omitted params).
+    assert [len(step.commands) for step in steps] == [2, 2, 2, 2]
+    assert "10gbit" in steps[2].commands[0]
+    assert steps[3].commands[1][-1] == "netem"
+
+
+def test_expand_timeline_unshaped_direction_arms_nothing() -> None:
+    profile = parse_profile(
+        "uplink-only",
+        {
+            "timeline": [
+                {"for": "5s", "uplink": {"rate": "4mbit"}},
+                {"for": "5s", "uplink": {"rate": "2mbit"}},
+            ]
+        },
+    )
+    assert all(step.commands == [] for step in expand_timeline(profile, "tun0", direction="downlink"))
 
 
 def test_expand_timeline_uses_the_requested_direction() -> None:
@@ -324,8 +389,8 @@ def test_expand_timeline_uses_the_requested_direction() -> None:
     )
     up = expand_timeline(profile, "tun0", direction="uplink")[0]
     down = expand_timeline(profile, "tun0", direction="downlink")[0]
-    assert "1000000bit" in up.commands[1]
-    assert "25000000bit" in down.commands[1]
+    assert "1000000bit" in up.commands[0]
+    assert "25000000bit" in down.commands[0]
     with pytest.raises(ValueError):
         expand_timeline(profile, "tun0", direction="sideways")
 

--- a/tests/unit/test_network_shaper.py
+++ b/tests/unit/test_network_shaper.py
@@ -81,26 +81,28 @@ def test_teardown_tolerates_a_missing_qdisc() -> None:
     assert not shaper.armed
 
 
-def test_apply_tolerates_timeline_cleanup_with_no_qdisc() -> None:
-    runner = FakeRunner(fail_on="del")
+def test_apply_runs_step_commands_as_is() -> None:
+    # Timeline steps update the qdisc tree in place (`replace`) — apply must run
+    # them verbatim, with no clean-slate of its own between steps.
+    runner = FakeRunner()
     shaper = ProfileShaper("tun0", runner)
-    shaping = ["tc", "qdisc", "add", "dev", "tun0", "root", "handle", "10:", "netem", "delay", "50ms"]
+    shaping = ["tc", "qdisc", "replace", "dev", "tun0", "root", "handle", "10:", "netem", "delay", "50ms"]
 
-    shaper.apply([teardown_command("tun0"), shaping])
+    shaper.apply([shaping])
 
-    assert runner.calls == [teardown_command("tun0"), shaping]
+    assert runner.calls == [shaping]
     assert shaper.armed
 
 
 def test_apply_reraises_timeline_shaping_failures() -> None:
-    runner = FakeRunner(fail_on="add")
+    runner = FakeRunner(fail_on="replace")
     shaper = ProfileShaper("tun0", runner)
-    shaping = ["tc", "qdisc", "add", "dev", "tun0", "root", "handle", "10:", "netem", "delay", "50ms"]
+    shaping = ["tc", "qdisc", "replace", "dev", "tun0", "root", "handle", "10:", "netem", "delay", "50ms"]
 
-    with pytest.raises(RuntimeError, match="boom on 'add'"):
-        shaper.apply([teardown_command("tun0"), shaping])
+    with pytest.raises(RuntimeError, match="boom on 'replace'"):
+        shaper.apply([shaping])
 
-    assert runner.calls == [teardown_command("tun0"), shaping]
+    assert runner.calls == [shaping]
 
 
 # --- revert on stop and on error (the context manager) --------------------- #
@@ -109,7 +111,7 @@ def test_apply_reraises_timeline_shaping_failures() -> None:
 def test_context_manager_reverts_on_normal_exit() -> None:
     runner = FakeRunner()
     with ProfileShaper("tun0", runner) as shaper:
-        shaper.apply([["tc", "qdisc", "add", "dev", "tun0", "root", "handle", "10:", "netem", "loss", "1%"]])
+        shaper.apply([["tc", "qdisc", "replace", "dev", "tun0", "root", "handle", "10:", "netem", "loss", "1%"]])
         assert shaper.armed
     assert runner.calls[-2:] == [teardown_command("tun0"), restore_link_command("tun0")]
     assert not shaper.armed
@@ -119,7 +121,7 @@ def test_context_manager_reverts_on_error_and_reraises() -> None:
     runner = FakeRunner()
     with pytest.raises(ValueError, match="run blew up"):
         with ProfileShaper("tun0", runner) as shaper:
-            shaper.apply([["tc", "qdisc", "add", "dev", "tun0", "root", "handle", "10:", "netem", "loss", "1%"]])
+            shaper.apply([["tc", "qdisc", "replace", "dev", "tun0", "root", "handle", "10:", "netem", "loss", "1%"]])
             raise ValueError("run blew up")
     # The error propagates, but the interface is still reverted.
     assert runner.calls[-2:] == [teardown_command("tun0"), restore_link_command("tun0")]


### PR DESCRIPTION
Closes #124.

## Problem

Every timeline step began with `tc qdisc del … root` and re-added the tbf+netem tree. The del discards everything queued inside netem (~1–2 messages at 50 ms / 20 Hz) and the del→add gap runs on the default qdisc with no delay and no rate limit. Probe runs showed both artifacts — lost plus under-delayed messages — at **every** step boundary, even between identical segments.

## Change

Timeline steps now `tc qdisc replace` one constant tree in place:

- tree shape fixed per timeline+direction: tbf root (`1:`) + netem child (`10:`) when any segment rate-limits, else a netem root (`10:`);
- a rate-less step keeps the tbf stage effectively unlimited (10gbit, ~10 ms token bucket); a netem-less step keeps a bare pass-through netem (netem change replaces the whole parameter set, so stale delay/loss cannot linger);
- `catchup` outage folds into the same tree as an in-place `netem loss 100%` (seamless entry/exit, interface stays up); `reconnect` stays link-down by design, and the following step restores the link first;
- a direction that never shapes (and no outages) arms nothing;
- static profiles emit `replace` too (add-or-change), same layout as before;
- `ProfileShaper.apply` drops the idempotent-cleanup tolerance (steps carry no teardown); arm/exit keep the clean slate, safety watchdog, and fail-safe revert;
- `outage_commands` / `outage_restore_commands` are folded into `expand_timeline` (no other callers).

## Validation

- Host unit tests on the generated argv: replace-only steps, constant tree, identical segments → identical commands, in-place catchup, link restore after reconnect, unshaped direction arms nothing (`test_network_profiles.py`, `test_network_shaper.py`).
- New Docker e2e test (fast-e2e lane) proving the kernel semantics live: qdisc stats — and with them the queue — persist across a step boundary (in-place change, not recreate), the netem child survives a tbf-root replace, a bare netem step resets stale parameters, reconnect restore brings the link back up (`tests/e2e/test_timeline_stepping.py`; passes locally in ~18 s).
- `just check` green (lint, typecheck, 355 unit + 9 contract tests, docs, package).
- RFC 0004 updated: lifecycle section, implementation + validation checklists.
- Bench follow-up: rerun `rosotacom benchmark probe --profile temporary-test --size 9000 --rate-hz 20 --duration 20` — boundaries should show no lost packets and no under-delayed messages.