### PR TITLE
Add workflow drift contract tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -559,7 +559,8 @@ issue-driven work tracking in [docs/work-items.md](docs/work-items.md).
 The test and measurement architecture is recorded in the
 [design RFCs](docs/rfcs/README.md); see [docs/testing.md](docs/testing.md) for the
 test taxonomy and [docs/quality-audit.md](docs/quality-audit.md) for the periodic
-quality audit. Quality rules live in
+quality audit. Reusable maintainer procedures live in
+[docs/playbooks/README.md](docs/playbooks/README.md). Quality rules live in
 [DEVELOPMENT_PRINCIPLES.md](DEVELOPMENT_PRINCIPLES.md).
 
 ## Choosing the Transport Layer: CycloneDDS or Zenoh

--- a/tests/contract/test_markdown_links.py
+++ b/tests/contract/test_markdown_links.py
@@ -5,8 +5,22 @@ from pathlib import Path
 from urllib.parse import unquote, urlparse
 
 PACKAGE_ROOT = Path(__file__).resolve().parents[2]
+README = (PACKAGE_ROOT / "README.md").resolve()
 IGNORED_DIRS = {".git", ".mypy_cache", ".pytest_cache", ".ruff_cache", ".venv", "build", "dist"}
 LINK_RE = re.compile(r"(?<!!)\[[^\]]+\]\((?P<target>[^)]+)\)")
+REACHABILITY_ALLOWLIST_GLOBS = (
+    # GitHub renders these through issue / PR UI flows; they are executable
+    # templates, not standalone public documentation.
+    ".github/ISSUE_TEMPLATE/*",
+    ".github/PULL_REQUEST_TEMPLATE.md",
+    # Agent loader files are discovered by tools, not by the public docs graph.
+    "AGENTS.md",
+    "CLAUDE.md",
+    # Per-release notes and copy-me templates are surfaced from releases or by
+    # explicit release work, not as normal README-starting documentation.
+    "docs/release-notes/*",
+    "*TEMPLATE*",
+)
 
 
 def _markdown_files() -> list[Path]:
@@ -27,6 +41,35 @@ def _local_link_target(raw_target: str) -> str | None:
     return unquote(target.split("#", 1)[0])
 
 
+def _internal_markdown_links(markdown_path: Path) -> list[Path]:
+    targets: list[Path] = []
+    for match in LINK_RE.finditer(markdown_path.read_text(encoding="utf-8")):
+        target = _local_link_target(match.group("target"))
+        if target is None or not target.endswith(".md"):
+            continue
+        resolved = (markdown_path.parent / target).resolve()
+        if resolved.exists() and resolved.is_relative_to(PACKAGE_ROOT):
+            targets.append(resolved)
+    return targets
+
+
+def _reachable_from_readme() -> set[Path]:
+    seen = {README}
+    stack = [README]
+    while stack:
+        current = stack.pop()
+        for target in _internal_markdown_links(current):
+            if target not in seen:
+                seen.add(target)
+                stack.append(target)
+    return seen
+
+
+def _is_reachability_allowlisted(path: Path) -> bool:
+    rel_path = path.relative_to(PACKAGE_ROOT)
+    return any(rel_path.match(glob) for glob in REACHABILITY_ALLOWLIST_GLOBS)
+
+
 def test_internal_markdown_links_resolve() -> None:
     failures: list[str] = []
 
@@ -41,3 +84,18 @@ def test_internal_markdown_links_resolve() -> None:
                 failures.append(f"{rel_path}: missing link target {target!r}")
 
     assert not failures, "\n".join(failures)
+
+
+def test_public_docs_are_reachable_from_readme() -> None:
+    reachable = _reachable_from_readme()
+    orphans = [
+        str(markdown_path.relative_to(PACKAGE_ROOT))
+        for markdown_path in _markdown_files()
+        if not _is_reachability_allowlisted(markdown_path) and markdown_path.resolve() not in reachable
+    ]
+
+    assert not orphans, (
+        "These Markdown docs are not reachable by following internal .md links "
+        "from README.md. Link them into the README-starting docs graph, or add "
+        "a narrow allowlist entry with a reason:\n" + "\n".join(orphans)
+    )

--- a/tests/contract/test_readme_examples.py
+++ b/tests/contract/test_readme_examples.py
@@ -7,6 +7,7 @@ import pytest
 import yaml
 
 import rosotacom.cli as cli
+from rosotacom.deployment import load_deployment
 
 PACKAGE_ROOT = Path(__file__).resolve().parents[2]
 
@@ -29,6 +30,8 @@ def test_source_checkout_rosotacom_yaml_loads(monkeypatch: pytest.MonkeyPatch) -
     assert runtime.scenario_configs_dir == (cli.EXAMPLE_PROJECT_DIR / "scenarios",)
     assert runtime.session_instances_dir == PACKAGE_ROOT / "session-instances"
     assert runtime.deployment is None
+    assert runtime.profiles_file == cli.EXAMPLE_PROJECT_DIR / "profiles.yaml"
+    assert runtime.benchmarks_dir == (PACKAGE_ROOT.parent / "artifacts" / "benchmarks").resolve()
 
 
 def test_packaged_example_setup_paths_are_relative_to_example_root() -> None:
@@ -41,6 +44,24 @@ def test_packaged_example_setup_paths_are_relative_to_example_root() -> None:
         "session_instances_dir": "session-instances",
         "profiles": "profiles.yaml",
     }
+
+
+def test_packaged_deployment_example_loads_through_public_loader() -> None:
+    deployment = load_deployment(cli.EXAMPLE_PROJECT_DIR / "deployment.example.yaml")
+
+    assert deployment is not None
+    assert set(deployment.hosts) == {"machine-a", "machine-b"}
+    assert deployment.hosts["machine-a"].ssh is None
+    assert deployment.hosts["machine-b"].ssh == "robot-b"
+    assert deployment.values["example_router"] == "192.0.2.1"
+
+
+def test_project_setup_rejects_unknown_keys(tmp_path: Path) -> None:
+    config = tmp_path / "rosotacom.yaml"
+    config.write_text("legacy_inventory: inventory.yaml\n", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="Unsupported rosotacom.yaml keys"):
+        cli._load_runtime_config(argparse.Namespace(rosotacom_config=str(config)))
 
 
 def test_packaged_example_project_contains_documented_heartbeat_session() -> None:

--- a/tests/contract/test_workflow_contracts.py
+++ b/tests/contract/test_workflow_contracts.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import re
+from collections.abc import Iterator
+from pathlib import Path
+
+import yaml
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[2]
+JUSTFILE_PATH = PACKAGE_ROOT / "justfile"
+PRE_COMMIT_PATH = PACKAGE_ROOT / ".pre-commit-config.yaml"
+PYPROJECT_PATH = PACKAGE_ROOT / "pyproject.toml"
+WORKFLOWS_DIR = PACKAGE_ROOT / ".github" / "workflows"
+IGNORED_MARKDOWN_DIRS = {".git", ".mypy_cache", ".pytest_cache", ".ruff_cache", ".venv", "build", "dist"}
+
+RECIPE_RE = re.compile(r"^(?P<name>[A-Za-z_][A-Za-z0-9_-]*)[^:\n]*:(?!=)", re.MULTILINE)
+COMMAND_INVOCATION_RE = re.compile(
+    r"^\s*(?:[A-Za-z_][A-Za-z0-9_]*=\S+[ \t]+)*just[ \t]+(?P<name>[A-Za-z_][A-Za-z0-9_-]*)",
+    re.MULTILINE,
+)
+INLINE_INVOCATION_RE = re.compile(r"^just[ \t]+(?P<name>[A-Za-z_][A-Za-z0-9_-]*)")
+FENCED_CODE_RE = re.compile(r"```[^\n]*\n(.*?)```", re.DOTALL)
+INLINE_CODE_RE = re.compile(r"`([^`\n]+)`")
+
+
+def _recipe_names() -> set[str]:
+    return set(RECIPE_RE.findall(JUSTFILE_PATH.read_text(encoding="utf-8")))
+
+
+def _just_command_invocations(text: str) -> set[str]:
+    return set(COMMAND_INVOCATION_RE.findall(text))
+
+
+def _markdown_files() -> list[Path]:
+    return sorted(
+        path
+        for path in PACKAGE_ROOT.rglob("*.md")
+        if not any(
+            part in IGNORED_MARKDOWN_DIRS or part.endswith(".egg-info") for part in path.relative_to(PACKAGE_ROOT).parts
+        )
+    )
+
+
+def _just_invocations_in_markdown(text: str) -> set[str]:
+    names: set[str] = set()
+    for context in FENCED_CODE_RE.findall(text):
+        names |= _just_command_invocations(context)
+    for context in INLINE_CODE_RE.findall(text):
+        match = INLINE_INVOCATION_RE.match(context.strip())
+        if match:
+            names.add(match.group("name"))
+    return names
+
+
+def _workflow_run_blocks(value: object) -> Iterator[str]:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            if key == "run" and isinstance(child, str):
+                yield child
+            else:
+                yield from _workflow_run_blocks(child)
+    elif isinstance(value, list):
+        for item in value:
+            yield from _workflow_run_blocks(item)
+
+
+def _hook_rev(pre_commit: str, repo_url: str) -> str:
+    match = re.search(
+        rf"^\s*-\s*repo:\s*{re.escape(repo_url)}\s*\n\s*rev:\s*(\S+)",
+        pre_commit,
+        re.MULTILINE,
+    )
+    assert match, f"no pre-commit repo entry found for {repo_url}"
+    return match.group(1).strip()
+
+
+def test_just_recipe_names_are_discovered() -> None:
+    recipes = _recipe_names()
+
+    assert {"setup", "lint", "typecheck", "test-contract", "docs", "check"} <= recipes
+
+
+def test_referenced_just_recipes_exist() -> None:
+    recipes = _recipe_names()
+    failures: list[str] = []
+
+    for workflow in sorted(WORKFLOWS_DIR.glob("*.yml")):
+        workflow_doc = yaml.safe_load(workflow.read_text(encoding="utf-8"))
+        for run_block in _workflow_run_blocks(workflow_doc):
+            for name in sorted(_just_command_invocations(run_block)):
+                if name not in recipes:
+                    failures.append(f"{workflow.relative_to(PACKAGE_ROOT)}: just {name}")
+
+    for markdown in _markdown_files():
+        for name in sorted(_just_invocations_in_markdown(markdown.read_text(encoding="utf-8"))):
+            if name not in recipes:
+                failures.append(f"{markdown.relative_to(PACKAGE_ROOT)}: just {name}")
+
+    assert not failures, (
+        "These `just <recipe>` references point at recipes that do not exist in the justfile:\n" + "\n".join(failures)
+    )
+
+
+def test_precommit_ruff_matches_pyproject_pin() -> None:
+    pyproject = PYPROJECT_PATH.read_text(encoding="utf-8")
+    pin = re.search(r'"ruff==([^"]+)"', pyproject)
+    assert pin, "no `ruff==` pin found in pyproject.toml [dev] dependencies"
+    pyproject_version = pin.group(1)
+
+    rev = _hook_rev(
+        PRE_COMMIT_PATH.read_text(encoding="utf-8"),
+        "https://github.com/astral-sh/ruff-pre-commit",
+    )
+
+    assert rev == f"v{pyproject_version}", (
+        f"ruff pre-commit rev {rev!r} does not match pyproject pin "
+        f"ruff=={pyproject_version}; keep local hooks and just/CI checks aligned"
+    )


### PR DESCRIPTION
Fixes #128

## Summary

- Adds README-starting Markdown reachability coverage with explicit allowlist reasons.
- Adds workflow contract checks for referenced `just` recipes and ruff pre-commit / `pyproject.toml` pin parity.
- Extends public config/example contracts for checkout benchmark output, packaged deployment examples, and unknown `rosotacom.yaml` keys.
- Links the maintainer playbooks index into the README docs graph.

## Public Behavior

- Does not change public CLI/config/API/Docker behavior.

## Checks

- [x] `just setup`
- [x] `just lint`
- [x] `just docs`
- [x] `just test-contract`
- [x] `just check`
- [ ] `just test-e2e-smoke`, not needed because Docker/runtime behavior did not change

## Test Integrity

- Tests/CI were not skipped, weakened, or removed to make this pass.

## Merge Mode

- Ready autonomous PR, auto-merge requested.
