### PR TITLE
Add singled-out anonymized remote-assist stream examples (costmap /topic5, camera /topic9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,6 +456,12 @@ The `sessions/` directory contains curated built-in session definitions:
 - `14_remote_assist_anonymized`: generic processed replay shape for the
   remote-assist OTA contract; run it with
   `rosotacom smoke 14_remote_assist_anonymized`
+- `15_remote_assist_anonymized_costmap`: single-stream cut of example 14 —
+  only `/topic5`, the anonymized compressed occupancy-grid stream; run it with
+  `rosotacom smoke 15_remote_assist_anonymized_costmap`
+- `16_remote_assist_anonymized_camera`: single-stream cut of example 14 —
+  only `/topic9`, the anonymized ffmpeg camera stream; run it with
+  `rosotacom smoke 16_remote_assist_anonymized_camera`
 
 Transport-combination coverage lives under `tests/sessions/rmw_matrix` and is
 generated from `tests/sessions/generate_rmw_matrix.py`.

--- a/src/rosotacom/resources/examples/README.md
+++ b/src/rosotacom/resources/examples/README.md
@@ -104,6 +104,21 @@ The full replay scenario with bag-play applications is generated from a
 processed handoff trace by `rosotacom anonymize`; this packaged session is the
 small deterministic smoke target for that generated shape.
 
+Two single-stream cuts isolate the heavy streams of that contract so each can
+be measured over the link (rate regularity, latency, loss) without the other
+19 topics competing for it — everything else (peers, RMW, OTA QoS,
+heartbeat/status, expects) matches example 14:
+
+```bash
+rosotacom smoke 15_remote_assist_anonymized_costmap   # /topic5: compressed occupancy grid
+rosotacom smoke 16_remote_assist_anonymized_camera    # /topic9: ffmpeg camera packets
+```
+
+Each session header documents the pre-send baseline measured on the source
+recording (message-size distribution and inter-message regularity), the
+reference point for judging how well the received stream preserves the input
+cadence.
+
 ## Two-machine runs
 
 For a real two-machine run, pass both reachable addresses on both hosts:

--- a/src/rosotacom/resources/examples/sessions/15_remote_assist_anonymized_costmap/session-definition.yaml
+++ b/src/rosotacom/resources/examples/sessions/15_remote_assist_anonymized_costmap/session-definition.yaml
@@ -1,0 +1,59 @@
+# 15_remote_assist_anonymized_costmap -- single-stream cut of
+# 14_remote_assist_anonymized: only /topic5, the anonymized handoff shape of
+# the compressed occupancy-grid stream (bz2 over the serialized grid,
+# carried as com_msgs/msg/CompressedData).
+#
+# Purpose: isolate one heavy stream so its over-the-air behavior (received
+# rate regularity, latency, loss) can be measured without the other 19
+# contract topics competing for the link, and compared 1:1 against the same
+# stream inside example 14. Peers, RMW, OTA QoS, heartbeat/status wiring, and
+# the topic's expect contract are identical to example 14.
+#
+# Pre-send baseline of the source recording (what a looped bag replay feeds
+# in): the original grid is a fixed-size message at a steady 10 Hz (median
+# interval 100 ms, stddev 9 ms, 98% of gaps within +-25% of the period);
+# the bz2 payloads are 5.5-11.0 KiB (mean 8.0 KiB, stddev 1.1 KiB). The
+# packaged smoke drives the contract with a small synthetic CompressedData
+# payload instead; use the `rosotacom anonymize` replay scenario for
+# size-faithful runs.
+
+peers:
+  a: {}
+  b: {}
+
+peer_settings:
+  a:
+    domain_id: 46
+    inbound:
+      keep_source_prefix: true
+  b:
+    domain_id: 47
+
+shared:
+  rmw: cyclone
+  ota_domain_id: 48
+  use_topic_monitor: true
+  use_heartbeat: true
+  use_status_overview: true
+  heartbeat:
+    expect:
+      hz: { min: 5, max: 20 }
+      latency_ms: { max: 1000 }
+      loss_pct: { max: 5 }
+  qos:
+    for_role:
+      ota_sub:
+        depth: 1
+        reliability: best_effort
+        lifespan: 0.7
+      ota_pub:
+        depth: 1
+        reliability: best_effort
+        lifespan: 0.7
+
+topics:
+  b_to_a:
+    - topic: "/topic5"
+      type: "com_msgs/msg/CompressedData"
+      expect:
+        hz: { min: 3, max: 15 }

--- a/src/rosotacom/resources/examples/sessions/16_remote_assist_anonymized_camera/session-definition.yaml
+++ b/src/rosotacom/resources/examples/sessions/16_remote_assist_anonymized_camera/session-definition.yaml
@@ -1,0 +1,61 @@
+# 16_remote_assist_anonymized_camera -- single-stream cut of
+# 14_remote_assist_anonymized: only /topic9, the anonymized handoff shape of
+# the ffmpeg-encoded camera stream (h264 packets, carried as
+# ffmpeg_image_transport_msgs/msg/FFMPEGPacket).
+#
+# Purpose: isolate one heavy stream so its over-the-air behavior (received
+# rate regularity, latency, loss) can be measured without the other 19
+# contract topics competing for the link, and compared 1:1 against the same
+# stream inside example 14. Peers, RMW, OTA QoS, heartbeat/status wiring, and
+# the topic's expect contract are identical to example 14.
+#
+# Pre-send baseline of the source recording (what a looped bag replay feeds
+# in): the native camera stream averages 20 Hz but is markedly irregular
+# (median interval 49 ms, min 7.6 ms, max 157 ms, stddev 17 ms; only ~27% of
+# gaps within +-10% of the median), with 130-250 KiB frames (mean 180 KiB).
+# The pipeline drops every other frame (-> ~10 Hz, inheriting that jitter)
+# and re-encodes at 10 Mbit/s, so handoff packets average ~125 KB with
+# GOP-dependent variance. The packaged smoke drives the contract with a small
+# synthetic FFMPEGPacket instead; use the `rosotacom anonymize` replay
+# scenario for size-faithful runs.
+
+peers:
+  a: {}
+  b: {}
+
+peer_settings:
+  a:
+    domain_id: 46
+    inbound:
+      keep_source_prefix: true
+  b:
+    domain_id: 47
+
+shared:
+  rmw: cyclone
+  ota_domain_id: 48
+  use_topic_monitor: true
+  use_heartbeat: true
+  use_status_overview: true
+  heartbeat:
+    expect:
+      hz: { min: 5, max: 20 }
+      latency_ms: { max: 1000 }
+      loss_pct: { max: 5 }
+  qos:
+    for_role:
+      ota_sub:
+        depth: 1
+        reliability: best_effort
+        lifespan: 0.7
+      ota_pub:
+        depth: 1
+        reliability: best_effort
+        lifespan: 0.7
+
+topics:
+  b_to_a:
+    - topic: "/topic9"
+      type: "ffmpeg_image_transport_msgs/msg/FFMPEGPacket"
+      expect:
+        hz: { min: 3, max: 15 }

--- a/tests/contract/test_packaged_resources.py
+++ b/tests/contract/test_packaged_resources.py
@@ -26,6 +26,8 @@ def test_packaged_resources_include_curated_examples_and_runtime_workspace() -> 
         "resources/examples/sessions/1_heartbeat/session-definition.yaml",
         "resources/examples/sessions/1_heartbeat_status/session-definition.yaml",
         "resources/examples/sessions/14_remote_assist_anonymized/session-definition.yaml",
+        "resources/examples/sessions/15_remote_assist_anonymized_costmap/session-definition.yaml",
+        "resources/examples/sessions/16_remote_assist_anonymized_camera/session-definition.yaml",
         "resources/examples/scenarios/2_native_chatter/scenario-definition.yaml",
         "resources/ws/session/creation/run_session.py",
         "resources/ws/session/creation/catmux_log_setup.sh",

--- a/tests/contract/test_readme_examples.py
+++ b/tests/contract/test_readme_examples.py
@@ -71,6 +71,8 @@ def test_packaged_example_project_contains_documented_heartbeat_session() -> Non
     assert "rosotacom scenario start 2_native_chatter" in readme
     assert "rosotacom smoke 2_native_chatter --interactive" in readme
     assert "rosotacom smoke 14_remote_assist_anonymized" in readme
+    assert "rosotacom smoke 15_remote_assist_anonymized_costmap" in readme
+    assert "rosotacom smoke 16_remote_assist_anonymized_camera" in readme
     assert "rosotacom ota-smoke 2_native_chatter \\" in readme
     assert "--peer-ssh b=robot-b" in readme
     assert (cli.EXAMPLE_PROJECT_DIR / "sessions" / "1_heartbeat" / "session-definition.yaml").is_file()

--- a/tests/contract/test_security_maintenance_config.py
+++ b/tests/contract/test_security_maintenance_config.py
@@ -105,6 +105,8 @@ def test_local_check_derivation_and_generated_rmw_matrix_drive_test_configs() ->
         "12_content_integrity",
         "13_link_latency",
         "14_remote_assist_anonymized",
+        "15_remote_assist_anonymized_costmap",
+        "16_remote_assist_anonymized_camera",
     }
     assert set(ota_suite_sessions(examples_dir)) == set(local_check_sessions(examples_dir))
 

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -66,6 +66,26 @@ REMOTE_ASSIST_ANON_SMOKE_SESSIONS = [
     for name in SMOKE_SESSIONS
     if name == "14_remote_assist_anonymized"
 ]
+# Single-stream cuts of the anonymized remote-assist contract: one heavy
+# stream per session so its delivery can be measured in isolation.
+SINGLE_STREAM_ANON_SMOKE_SESSIONS = [
+    pytest.param(name, topic, msg_type, id=f"remote-assist-anonymized-{label}")
+    for name, topic, msg_type, label in (
+        (
+            "15_remote_assist_anonymized_costmap",
+            "/topic5",
+            "com_msgs/msg/CompressedData",
+            "costmap",
+        ),
+        (
+            "16_remote_assist_anonymized_camera",
+            "/topic9",
+            "ffmpeg_image_transport_msgs/msg/FFMPEGPacket",
+            "camera",
+        ),
+    )
+    if name in SMOKE_SESSIONS
+]
 
 EXPECTED_HEARTBEAT_CHECKS = (
     "OK: generated plugin.yaml files use literal CLI addresses",
@@ -584,6 +604,36 @@ def test_local_remote_assist_anonymized_smoke_from_copied_example_project(
     _assert_heartbeat_rate_and_latency_within_bounds(session_name, result.stdout)
     _assert_metric_present(session_name, result.stdout, topic="/topic1", label="a->b final topic")
     _assert_metric_present(session_name, result.stdout, topic="/b/topic3", label="b->a final topic")
+
+
+@pytest.mark.parametrize(("session_name", "topic", "msg_type"), SINGLE_STREAM_ANON_SMOKE_SESSIONS)
+def test_local_single_stream_anonymized_smoke_from_copied_example_project(
+    copied_example_project: Path,
+    session_name: str,
+    topic: str,
+    msg_type: str,
+) -> None:
+    result = _run(_smoke_command(copied_example_project, session_name), timeout=900)
+
+    assert f"OK: smoke publisher b->a {topic} ({msg_type}) is advertising" in result.stdout
+    assert f"OK: b->a inbound bridge topic (/com/in/b{topic})" in result.stdout
+    assert f"OK: b->a final topic (/b{topic})" in result.stdout
+
+    artifact_dir = _artifact_dir(result.stdout)
+    config_dir = artifact_dir / "config"
+    # The session is a true single-stream cut: nothing but the heartbeat and the
+    # singled-out topic crosses the link.
+    assert (config_dir / "a_to_b_topics.txt").read_text(encoding="utf-8").splitlines() == [
+        "/heartbeat_a",
+    ]
+    assert (config_dir / "b_to_a_topics.txt").read_text(encoding="utf-8").splitlines() == [
+        "/heartbeat_b",
+        topic,
+    ]
+
+    _assert_no_ros_or_catmux_errors(session_name, artifact_dir)
+    _assert_heartbeat_rate_and_latency_within_bounds(session_name, result.stdout)
+    _assert_metric_present(session_name, result.stdout, topic=f"/b{topic}", label="b->a final topic")
 
 
 def test_native_chatter_scenario_starts_apps_and_communication_together(


### PR DESCRIPTION
Closes #134.

## What

Two packaged example sessions that each carry exactly one heavy stream of the anonymized remote-assist contract, keeping peers, RMW, OTA QoS, heartbeat/status wiring, and the topic's expect identical to `14_remote_assist_anonymized`:

- `15_remote_assist_anonymized_costmap`: only `/topic5` (`com_msgs/msg/CompressedData`) — the bz2-compressed occupancy-grid stream.
- `16_remote_assist_anonymized_camera`: only `/topic9` (`ffmpeg_image_transport_msgs/msg/FFMPEGPacket`) — the ffmpeg-encoded camera stream.

Purpose: measure one stream's over-the-air behavior (received rate regularity, latency, loss) without the other 19 contract topics competing for the link, and compare 1:1 against the same stream inside example 14. Each session header documents the pre-send baseline measured on the source recording (message-size distribution and inter-message regularity) as the reference point for received-side regularity analysis:

- costmap: fixed-size grid at a steady 10 Hz (100 ms ± 9 ms), bz2 payloads 5.5–11.0 KiB (mean 8.0 KiB);
- camera: 20 Hz average but irregular (median gap 49 ms, spread 7.6–157 ms), 130–250 KiB frames; drop-half + 10 Mbit/s h264 → ~10 Hz, ~125 KB packets.

## Validation

- `tests/contract/test_packaged_resources.py`: both session files asserted in the packaged wheel resources.
- `tests/contract/test_readme_examples.py`: README documents both smoke commands.
- `tests/contract/test_security_maintenance_config.py`: both sessions in the local-check/OTA derivation set.
- `tests/e2e/test_smoke.py`: dedicated Docker-backed smoke lanes (`remote-assist-anonymized-costmap`, `remote-assist-anonymized-camera`) asserting the singled-out topic lists (`a_to_b` = heartbeat only, `b_to_a` = heartbeat + the one topic), publisher/bridge/final-topic checks, and heartbeat bounds.

Local runs: 367 unit+contract tests pass; both new e2e smoke lanes pass (`2 passed in 259.97s`).