### PR TITLE
fix: resolve shellcheck SC2035 in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Generate checksums
         run: |
           cd dist
-          sha256sum * > SHA256SUMS
+          sha256sum -- * > SHA256SUMS
 
       - name: Upload distributions
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
Resolves actionlint shellcheck warning SC2035 in the release workflow.