### PR TITLE
Support remote assist smoke publisher synthesis

### DIFF
--- a/src/rosotacom/cli.py
+++ b/src/rosotacom/cli.py
@@ -215,6 +215,7 @@ class SmokeTopicSpec:
     label: str
     enforce_bounds: bool
     use_default_bounds: bool = False
+    delivery_mode: str = "stream"
     publish_topic: str | None = None
     publish_type: str | None = None
     publish_rate: float = 5.0
@@ -4832,7 +4833,20 @@ def _smoke_postprocessed_topic(entry: Any, pipe: dict[str, Any]) -> str:
         return str(pipe["comp_in"])
     if pipe.get("ota_wrap"):
         return str(pipe["ota_in"])
+    if pipe.get("framebridge") == "global_to_local":
+        return str(pipe["fb_g2l_base"])
     return str(pipe["final"])
+
+
+def _smoke_source_publish_topic(
+    cfg: dict[str, Any],
+    source_peer_key: str,
+    receiver_peer_key: str,
+    entry: Any,
+    pipe: dict[str, Any],
+) -> str:
+    source_topic = str(pipe["final"]) if pipe.get("framebridge") == "global_to_local" else entry.base
+    return _smoke_forward_topic_for_inbound(cfg, source_peer_key, receiver_peer_key, source_topic)
 
 
 def _smoke_expect_bounds(expect: Any) -> tuple[float | None, float | None, float | None]:
@@ -4848,6 +4862,13 @@ def _smoke_expect_bounds(expect: Any) -> tuple[float | None, float | None, float
         else None
     )
     return hz_min, hz_max, max_delay_s
+
+
+def _smoke_expect_mode(expect: Any) -> str:
+    if not isinstance(expect, dict):
+        return "stream"
+    mode = str(expect.get("mode", "stream")).strip().lower() or "stream"
+    return mode if mode in {"stream", "latched", "existence"} else "stream"
 
 
 def _smoke_publish_qos(qos: Any) -> dict[str, Any] | None:
@@ -4883,6 +4904,20 @@ def _smoke_native_publish_rate(expect: Any) -> float:
     return _smoke_publish_rate(expect)
 
 
+def _smoke_source_publish_rate(expect: Any, pipe: dict[str, Any]) -> float:
+    native_rate = _smoke_native_publish_rate(expect)
+    if isinstance(expect, dict) and expect.get("smoke_native_hz") is not None:
+        return native_rate
+    drop_count = pipe.get("drop_count")
+    window_size = pipe.get("window_size")
+    if drop_count is None or window_size is None:
+        return native_rate
+    delivered_per_window = int(window_size) - int(drop_count)
+    if delivered_per_window <= 0:
+        return native_rate
+    return native_rate * (int(window_size) / delivered_per_window)
+
+
 def _smoke_rmw_spec(cfg: dict[str, Any]) -> Any:
     peers = cfg.get("peers", {}) or {}
     if not isinstance(peers, dict):
@@ -4899,6 +4934,17 @@ def _smoke_rmw_env_value(cfg: dict[str, Any]) -> str | None:
     if local_impl is None:
         return None
     return str(session_gen.RMW_ALIASES.get(local_impl, local_impl))
+
+
+SMOKE_CYCLONEDDS_MAX_AUTO_PARTICIPANT_INDEX = 99
+
+
+def _smoke_default_cyclonedds_uri() -> str:
+    return (
+        "<CycloneDDS><Domain><Discovery><ParticipantIndex>auto</ParticipantIndex>"
+        f"<MaxAutoParticipantIndex>{SMOKE_CYCLONEDDS_MAX_AUTO_PARTICIPANT_INDEX}</MaxAutoParticipantIndex>"
+        "</Discovery></Domain></CycloneDDS>"
+    )
 
 
 def _smoke_local_domain_id(cfg: dict[str, Any], receiver_peer_key: str) -> str | None:
@@ -4947,7 +4993,11 @@ def _smoke_ros_setup(config_container_dir: str, cfg: dict[str, Any], receiver_pe
     local_domain_id = _smoke_local_domain_id(cfg, receiver_peer_key)
     if local_domain_id:
         commands.append(f"export ROS_DOMAIN_ID={shlex.quote(local_domain_id)}")
-    commands.extend(_smoke_local_config_commands(config_container_dir, cfg, receiver_peer_key))
+    local_config_commands = _smoke_local_config_commands(config_container_dir, cfg, receiver_peer_key)
+    if local_config_commands:
+        commands.extend(local_config_commands)
+    elif rmw_env == "rmw_cyclonedds_cpp":
+        commands.append(f"export CYCLONEDDS_URI={shlex.quote(_smoke_default_cyclonedds_uri())}")
     return " && ".join(commands)
 
 
@@ -4957,7 +5007,7 @@ def _smoke_ros_setup(config_container_dir: str, cfg: dict[str, Any], receiver_pe
 SMOKE_HZ_MIN = 5.0
 SMOKE_HZ_MAX = 20.0
 SMOKE_MAX_DELAY_S = 1.0
-SMOKE_PUBLISHER_DURATION_S = 900.0
+SMOKE_PUBLISHER_DURATION_S = 3600.0
 ISOLATION_PROBE_TOPIC = "/local_only"
 
 
@@ -5021,6 +5071,7 @@ def _received_crossed_topics(cfg: dict[str, Any], receiver_peer_key: str) -> lis
             received_topic = _smoke_receiver_final_topic(cfg, src, dst, postprocessed_topic)
             inbound_topic = _smoke_inbound_forward_topic(cfg, src, dst, final_topic)
             expect_hz_min, expect_hz_max, expect_max_delay_s = _smoke_expect_bounds(entry.expect)
+            expect_mode = _smoke_expect_mode(entry.expect)
             specs.extend(
                 [
                     SmokeTopicSpec(
@@ -5029,18 +5080,19 @@ def _received_crossed_topics(cfg: dict[str, Any], receiver_peer_key: str) -> lis
                         topic=inbound_topic,
                         label=f"{src}->{dst} inbound bridge topic",
                         enforce_bounds=False,
+                        delivery_mode=expect_mode,
                     ),
                     SmokeTopicSpec(
                         source_peer_key=src,
                         receiver_peer_key=dst,
                         topic=received_topic,
                         label=f"{src}->{dst} final topic",
-                        enforce_bounds=any(
-                            value is not None for value in (expect_hz_min, expect_hz_max, expect_max_delay_s)
-                        ),
-                        publish_topic=_smoke_forward_topic_for_inbound(cfg, src, dst, entry.base),
+                        enforce_bounds=expect_mode == "stream"
+                        and any(value is not None for value in (expect_hz_min, expect_hz_max, expect_max_delay_s)),
+                        delivery_mode=expect_mode,
+                        publish_topic=_smoke_source_publish_topic(cfg, src, dst, entry, pipe),
                         publish_type=entry.msg_type,
-                        publish_rate=_smoke_native_publish_rate(entry.expect),
+                        publish_rate=_smoke_source_publish_rate(entry.expect, pipe),
                         hz_min=expect_hz_min,
                         hz_max=expect_hz_max,
                         max_delay_s=expect_max_delay_s,
@@ -5073,6 +5125,19 @@ def _verify_received_topics(
         topic = spec.topic
         label = spec.label
         log_line(f"Waiting for {label} ({topic}) in {container_name}")
+        if spec.delivery_mode in {"latched", "existence"}:
+            present = False
+            for _ in range(10):
+                if _topic_present(container_name, ros_setup, topic):
+                    present = True
+                    break
+                time.sleep(1)
+            if not present:
+                errors.append(f"{label} ({topic}) not present in {container_name}")
+                continue
+            log_line(f"OK: {label} ({topic}) is present in {container_name} ({spec.delivery_mode})")
+            log_line(_smoke_metric_line(label=label, topic=topic, container_name=container_name, hz=None, delay_s=None))
+            continue
         output = _wait_for_topic_hz(container_name, ros_setup, topic)
         if detail_log:
             detail_log(f"\n--- {label} ({topic}) in {container_name} ---\n{output}")
@@ -5125,6 +5190,12 @@ def _smoke_publish_message(msg_type: str) -> str:
         return "{header: {frame_id: base_link}, twist: {linear: {x: 1.0}, angular: {z: 0.1}}}"
     if normalized in {"tf2_msgs/msg/TFMessage", "tf2_msgs/TFMessage"}:
         return "{transforms: [{header: {frame_id: map}, child_frame_id: base_link, transform: {rotation: {w: 1.0}}}]}"
+    if normalized in {"visualization_msgs/msg/MarkerArray", "visualization_msgs/MarkerArray"}:
+        return (
+            "{markers: [{header: {frame_id: map}, ns: smoke, id: 1, type: 1, action: 0, "
+            "pose: {orientation: {w: 1.0}}, scale: {x: 1.0, y: 1.0, z: 1.0}, "
+            "color: {r: 0.0, g: 0.7, b: 1.0, a: 1.0}}]}"
+        )
     if normalized == "nav_msgs/msg/OccupancyGrid":
         return (
             "{header: {frame_id: map}, "
@@ -5133,6 +5204,21 @@ def _smoke_publish_message(msg_type: str) -> str:
         )
     if normalized in {"sensor_msgs/msg/CameraInfo", "sensor_msgs/CameraInfo"}:
         return "{header: {frame_id: camera}, height: 1, width: 1}"
+    if normalized in {"sensor_msgs/msg/CompressedImage", "sensor_msgs/CompressedImage"}:
+        return (
+            "{header: {frame_id: camera}, format: png, data: ["
+            "137, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 13, 73, 72, 68, 82, "
+            "0, 0, 0, 32, 0, 0, 0, 32, 8, 2, 0, 0, 0, 252, 24, 237, 163, "
+            "0, 0, 0, 93, 73, 68, 65, 84, 72, 13, 181, 193, 1, 1, 0, 0, "
+            "0, 130, 160, 124, 238, 243, 90, 17, 80, 115, 69, 205, 21, 53, "
+            "87, 212, 92, 81, 115, 69, 205, 21, 53, 87, 212, 92, 81, 115, "
+            "69, 205, 21, 53, 87, 212, 92, 81, 115, 69, 205, 21, 53, 87, "
+            "212, 92, 81, 115, 69, 205, 21, 53, 87, 212, 92, 81, 115, 69, "
+            "205, 21, 53, 87, 212, 92, 81, 115, 69, 205, 21, 53, 87, 212, "
+            "92, 81, 115, 69, 205, 21, 53, 87, 212, 92, 13, 245, 197, 48, "
+            "1, 194, 66, 132, 57, "
+            "0, 0, 0, 0, 73, 69, 78, 68, 174, 66, 96, 130]}"
+        )
     if normalized in {"sensor_msgs/msg/NavSatFix", "sensor_msgs/NavSatFix"}:
         return (
             "{header: {frame_id: gps}, status: {status: 0, service: 1}, "

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -392,12 +392,20 @@ def _assert_heartbeat_rate_and_latency_within_bounds(session_name: str, stdout: 
     )
 
 
-def _assert_metric_present(session_name: str, stdout: str, *, topic: str, label: str) -> None:
+def _assert_metric_present(
+    session_name: str,
+    stdout: str,
+    *,
+    topic: str,
+    label: str,
+    require_hz: bool = True,
+) -> None:
     matches = [m for m in _parse_metrics(stdout) if m["topic"] == topic and m["label"] == label]
     assert matches, f"no metric for {label} ({topic}) in smoke output for {session_name}:\n{stdout}"
-    assert any(isinstance(m["hz"], float) for m in matches), (
-        f"no publishing rate for {label} ({topic}) in smoke output for {session_name}:\n{stdout}"
-    )
+    if require_hz:
+        assert any(isinstance(m["hz"], float) for m in matches), (
+            f"no publishing rate for {label} ({topic}) in smoke output for {session_name}:\n{stdout}"
+        )
 
 
 def _assert_metric_within_bounds(
@@ -602,7 +610,7 @@ def test_local_remote_assist_anonymized_smoke_from_copied_example_project(
 
     _assert_no_ros_or_catmux_errors(session_name, artifact_dir)
     _assert_heartbeat_rate_and_latency_within_bounds(session_name, result.stdout)
-    _assert_metric_present(session_name, result.stdout, topic="/topic1", label="a->b final topic")
+    _assert_metric_present(session_name, result.stdout, topic="/topic1", label="a->b final topic", require_hz=False)
     _assert_metric_present(session_name, result.stdout, topic="/b/topic3", label="b->a final topic")
 
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -4,9 +4,12 @@ import argparse
 import base64
 import io
 import os
+import re
+import struct
 import subprocess
 import sys
 import tarfile
+import zlib
 from collections.abc import Callable
 from pathlib import Path
 
@@ -1887,7 +1890,7 @@ def test_stop_list_doctor_and_smoke_host_flows(
         == 0
     )
     assert publisher_durations == [rosotacom.SMOKE_PUBLISHER_DURATION_S]
-    assert rosotacom.SMOKE_PUBLISHER_DURATION_S == 900.0
+    assert rosotacom.SMOKE_PUBLISHER_DURATION_S == 3600.0
     assert networks_created == [(smoke_network.name, smoke_network.subnet)]
     assert [(args.identity, args.network_name, args.network_ip) for args in started] == [
         ("a", smoke_network.name, smoke_network.peer_ips["a"]),
@@ -1983,8 +1986,25 @@ def test_smoke_crossed_topics_include_native_chatter_direction() -> None:
         for s in rosotacom._smoke_publish_specs(cfg, source_peer_key="b")
     ] == [("b", "a", "/chatter")]
     assert rosotacom._smoke_publish_specs(cfg, source_peer_key="a") == []
-    assert "export ROS_DOMAIN_ID=46" in rosotacom._smoke_ros_setup("/config", cfg, "a")
-    assert "export ROS_DOMAIN_ID=47" in rosotacom._smoke_ros_setup("/config", cfg, "b")
+    setup_a = rosotacom._smoke_ros_setup("/config", cfg, "a")
+    setup_b = rosotacom._smoke_ros_setup("/config", cfg, "b")
+    assert "export ROS_DOMAIN_ID=46" in setup_a
+    assert "export ROS_DOMAIN_ID=47" in setup_b
+    assert "export CYCLONEDDS_URI=" in setup_a
+    assert "MaxAutoParticipantIndex>99<" in setup_a
+
+
+def test_smoke_ros_setup_keeps_explicit_cyclonedds_config() -> None:
+    cfg = yaml.safe_load(
+        (rosotacom.EXAMPLE_PROJECT_DIR / "sessions" / "1_heartbeat_status" / "session-definition.yaml").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    setup = rosotacom._smoke_ros_setup("/config", cfg, "a")
+
+    assert "export CYCLONEDDS_URI=file:///config/a/local_dds.xml" in setup
+    assert "MaxAutoParticipantIndex" not in setup
 
 
 def test_smoke_publish_specs_use_source_target_prefix_and_qos() -> None:
@@ -2025,6 +2045,74 @@ def test_smoke_publish_specs_use_source_target_prefix_and_qos() -> None:
     assert "--qos-durability transient_local" in command
 
 
+def test_smoke_global_to_local_publishes_and_asserts_generated_pipeline_topics() -> None:
+    cfg = {
+        "peers": {"a": {}, "b": {}},
+        "peer_settings": {
+            "a": {"domain_id": 46, "outbound": {"target_prefix": {"use_target_prefix": True}}},
+            "b": {"domain_id": 47},
+        },
+        "shared": {"processing_suffixes": {"framebridge_global": "/globalframe"}},
+        "topics": {
+            "a_to_b": [
+                {
+                    "topic": "/move_base_free/goal",
+                    "type": "geometry_msgs/msg/PoseStamped",
+                    "processing": {"framebridge": "global_to_local"},
+                    "expect": {"mode": "latched", "presence": "required"},
+                }
+            ]
+        },
+    }
+
+    specs = rosotacom._received_crossed_topics(cfg, "b")
+
+    assert [(s.topic, s.label, s.publish_topic) for s in specs] == [
+        ("/com/in/a/to_b/move_base_free/goal/globalframe", "a->b inbound bridge topic", None),
+        ("/move_base_free/goal", "a->b final topic", "/to_b/move_base_free/goal/globalframe"),
+    ]
+    assert [s.delivery_mode for s in specs] == ["latched", "latched"]
+    assert not specs[-1].enforce_bounds
+
+
+def test_verify_received_topics_checks_latched_presence_not_rate(monkeypatch: pytest.MonkeyPatch) -> None:
+    spec = rosotacom.SmokeTopicSpec(
+        source_peer_key="b",
+        receiver_peer_key="a",
+        topic="/b/site/latched",
+        label="b->a final topic",
+        enforce_bounds=False,
+        delivery_mode="latched",
+    )
+    log_lines: list[str] = []
+    present_checks: list[str] = []
+
+    monkeypatch.setattr(rosotacom, "_received_crossed_topics", lambda cfg, receiver: [spec])
+
+    def fake_present(container: str, ros_setup: str, topic: str) -> bool:
+        present_checks.append(topic)
+        return True
+
+    monkeypatch.setattr(rosotacom, "_topic_present", fake_present)
+    monkeypatch.setattr(
+        rosotacom,
+        "_wait_for_topic_hz",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("latched topics must not use topic hz")),
+    )
+
+    errors = rosotacom._verify_received_topics(
+        "container_a",
+        "source ros",
+        {},
+        "a",
+        log_line=log_lines.append,
+    )
+
+    assert errors == []
+    assert present_checks == ["/b/site/latched"]
+    assert any("is present" in line and "latched" in line for line in log_lines)
+
+
 def test_smoke_probe_false_keeps_topic_out_of_synthetic_runner() -> None:
     cfg = {
         "peers": {"a": {}, "b": {}},
@@ -2047,6 +2135,13 @@ def test_smoke_native_publish_rate_override() -> None:
     assert rosotacom._smoke_native_publish_rate({"smoke_native_hz": 10, "hz": {"min": 3, "max": 7}}) == 10.0
     # Without the override it falls back to the derived rate (midpoint of bounds).
     assert rosotacom._smoke_native_publish_rate({"hz": {"min": 4, "max": 6}}) == 5.0
+
+
+def test_smoke_source_publish_rate_compensates_derived_drop_rate() -> None:
+    pipe = {"drop_count": 1, "window_size": 2}
+
+    assert rosotacom._smoke_source_publish_rate({"hz": {"min": 2}}, pipe) == 6.0
+    assert rosotacom._smoke_source_publish_rate({"smoke_native_hz": 10, "hz": {"min": 2}}, pipe) == 10.0
 
 
 def test_drop_example_source_publishes_at_native_rate() -> None:
@@ -2086,7 +2181,9 @@ def test_restamp_example_uses_stale_stamped_header_source() -> None:
         "geometry_msgs/msg/PoseStamped",
         "geometry_msgs/msg/TwistStamped",
         "tf2_msgs/msg/TFMessage",
+        "visualization_msgs/msg/MarkerArray",
         "sensor_msgs/msg/CameraInfo",
+        "sensor_msgs/msg/CompressedImage",
         "sensor_msgs/msg/NavSatFix",
         "gps_msgs/msg/GPSFix",
         "com_msgs/msg/CompressedData",
@@ -2095,6 +2192,32 @@ def test_restamp_example_uses_stale_stamped_header_source() -> None:
 )
 def test_smoke_publish_message_supports_remote_assist_anonymized_types(msg_type: str) -> None:
     assert rosotacom._smoke_publish_message(msg_type)
+
+
+def test_smoke_compressed_image_payload_is_valid_png_for_ffmpeg_path() -> None:
+    msg = rosotacom._smoke_publish_message("sensor_msgs/msg/CompressedImage")
+    match = re.search(r"data: \[([^\]]+)\]", msg)
+    assert match is not None
+    png = bytes(int(item.strip()) for item in match.group(1).split(","))
+
+    assert png.startswith(b"\x89PNG\r\n\x1a\n")
+    chunks: list[tuple[bytes, bytes]] = []
+    offset = 8
+    while offset < len(png):
+        length = struct.unpack(">I", png[offset : offset + 4])[0]
+        chunk_type = png[offset + 4 : offset + 8]
+        chunk_data = png[offset + 8 : offset + 8 + length]
+        expected_crc = struct.unpack(">I", png[offset + 8 + length : offset + 12 + length])[0]
+        actual_crc = zlib.crc32(chunk_type + chunk_data) & 0xFFFFFFFF
+        assert actual_crc == expected_crc
+        chunks.append((chunk_type, chunk_data))
+        offset += 12 + length
+
+    assert offset == len(png)
+    assert chunks[0][0] == b"IHDR"
+    assert struct.unpack(">II", chunks[0][1][:8]) == (32, 32)
+    assert any(chunk_type == b"IDAT" for chunk_type, _ in chunks)
+    assert chunks[-1][0] == b"IEND"
 
 
 def test_named_stage_latency_is_left_to_status_oracle() -> None:


### PR DESCRIPTION
## Summary
- add synthetic smoke publishers for MarkerArray and valid CompressedImage payloads
- make smoke verification handle latched/existence topics with presence checks instead of rate probes
- correct global_to_local publish/final topic derivation, compensate source rates before drop stages, and avoid CycloneDDS participant exhaustion for synthetic publishers

Closes #131

## Validation
- `PYTHONPATH=/home/go914/dev/rosotacom-issue-131-markerarray-smoke/src /home/go914/dev/rosotacom_test/ros_communication_devcontainer/.venv/bin/python -m pytest tests/unit/test_cli.py` -> 100 passed
- `git diff --check`
- `rosotacom smoke 14_remote_assist_anonymized ...` -> TEST OK: 2 peer(s), 44 topic(s) meet status + expectations; artifacts `/home/go914/dev/rosotacom-issue-131-markerarray-smoke/session-instances/2026-07-02/14_remote_assist_anonymized_2026-07-02_16-00-14_224b0dd0`
- `rosotacom smoke remote_assist --rosotacom-config /home/go914/dev/rosotacom_test/fzi_projects/remote_assist/rosotacom.yaml --local-ip 127.0.0.1` -> TEST OK: 2 peer(s), 44 topic(s) meet status + expectations; artifacts `/home/go914/dev/rosotacom_test/fzi_projects/remote_assist/session-instances/2026-07-02/remote_assist_2026-07-02_16-05-03_6a4f984b`