### PR TITLE
Fix GitHub Actions E2E jobs cascade skip

### DIFF
--- a/.github/workflows/pr-merge-gate.yml
+++ b/.github/workflows/pr-merge-gate.yml
@@ -194,6 +194,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     needs: preflight-success
+    if: needs.preflight-success.result == 'success'
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
@@ -233,6 +234,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     needs: preflight-success
+    if: needs.preflight-success.result == 'success'
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
@@ -272,6 +274,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     needs: preflight-success
+    if: needs.preflight-success.result == 'success'
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
@@ -311,6 +314,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     needs: preflight-success
+    if: needs.preflight-success.result == 'success'
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
@@ -350,6 +354,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     needs: preflight-success
+    if: needs.preflight-success.result == 'success'
     steps:
       - name: Check out repository
         uses: actions/checkout@v6


### PR DESCRIPTION
Fixes cascade skipping of parallel E2E jobs when preflight-success gating job succeeds.