### PR TITLE
Fix E2E merge-gate cascade skip

### DIFF
--- a/.github/workflows/pr-merge-gate.yml
+++ b/.github/workflows/pr-merge-gate.yml
@@ -194,7 +194,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     needs: preflight-success
-    if: needs.preflight-success.result == 'success'
+    if: always() && !cancelled() && needs.preflight-success.result == 'success'
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
@@ -234,7 +234,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     needs: preflight-success
-    if: needs.preflight-success.result == 'success'
+    if: always() && !cancelled() && needs.preflight-success.result == 'success'
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
@@ -274,7 +274,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     needs: preflight-success
-    if: needs.preflight-success.result == 'success'
+    if: always() && !cancelled() && needs.preflight-success.result == 'success'
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
@@ -314,7 +314,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     needs: preflight-success
-    if: needs.preflight-success.result == 'success'
+    if: always() && !cancelled() && needs.preflight-success.result == 'success'
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
@@ -354,7 +354,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     needs: preflight-success
-    if: needs.preflight-success.result == 'success'
+    if: always() && !cancelled() && needs.preflight-success.result == 'success'
     steps:
       - name: Check out repository
         uses: actions/checkout@v6

--- a/tests/contract/test_security_maintenance_config.py
+++ b/tests/contract/test_security_maintenance_config.py
@@ -74,7 +74,18 @@ def test_merge_gate_requires_new_ci_jobs_and_no_masking() -> None:
         "e2e-runtime-tools",
         "e2e-concurrency",
     }
+    e2e_jobs = {
+        "e2e-core",
+        "e2e-transforms",
+        "e2e-remote-assist",
+        "e2e-runtime-tools",
+        "e2e-concurrency",
+    }
     assert expected_jobs.issubset(set(needs))
+
+    for job in e2e_jobs:
+        assert jobs[job]["needs"] == "preflight-success"
+        assert jobs[job]["if"] == "always() && !cancelled() && needs.preflight-success.result == 'success'"
 
     # Check that required jobs are validated in the bash step of ci-success
     check_step = next(step for step in ci_success["steps"] if step.get("name") == "Check required jobs")


### PR DESCRIPTION
Closes #146.

## Summary
- add explicit status-check guards to the five merge-gate E2E jobs so they still evaluate after push-only dependency-review is intentionally skipped
- keep E2E lanes gated on a successful preflight job and avoid running them after workflow cancellation
- add a contract assertion for the E2E job guard

## Validation
- .venv/bin/python -m pytest -q tests/contract/test_security_maintenance_config.py -k merge_gate_requires_new_ci_jobs_and_no_masking
- just lint-workflows
- just test-contract
- just lint
- just check

Docker E2E was not run locally because this change only affects GitHub Actions job scheduling; the PR merge gate will exercise the E2E lanes.