### PR TITLE
Fix anonymize end-to-end; preserve and expose ffmpeg keyframe structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,9 @@ session/scenario definition. It:
 3. Renames the handoff topics to generic names like `/topic1`, `/topic2`, etc.
 4. Replaces message contents with mock payloads while preserving message shape,
    timestamps, payload lengths, bag QoS metadata, and playback QoS overrides.
+   For ffmpeg camera packets it additionally preserves the keyframe flag and
+   `pts`, keeping the GOP burst structure analyzable — see
+   [docs/ffmpeg-keyframes.md](docs/ffmpeg-keyframes.md).
 5. Generates a self-contained `rosotacom` project containing the anonymized bag,
    processed-topic session definition, replay scenario, QoS overrides, and an
    anonymization manifest.

--- a/docs/ffmpeg-keyframes.md
+++ b/docs/ffmpeg-keyframes.md
@@ -1,0 +1,68 @@
+# Identifying keyframes in ffmpeg camera streams
+
+An ffmpeg-transported camera topic
+(`ffmpeg_image_transport_msgs/msg/FFMPEGPacket`) is not a uniform stream: the
+encoder emits one **keyframe** (I-frame, self-contained) followed by
+`gop_size - 1` small **delta frames** (P-frames), then repeats. The two
+classes differ in size by one to two orders of magnitude — measured on the
+remote-assist processed handoff trace (gop_size 5, 10 Mbit/s cap, 10 Hz):
+keyframes 21–89 KiB (mean ~43 KiB), delta frames 0.3–15 KiB (mean ~4.5 KiB),
+with per-GOP contrast up to ~180×. For network analysis this periodic burst
+pattern *is* the stream: a link must absorb the keyframe spikes, not the
+average bitrate. Frame classification is therefore the first step of any
+GOP-aware bandwidth, loss, or latency analysis.
+
+## Primary algorithm: the `flags` field
+
+`FFMPEGPacket.flags` mirrors libav's packet flags; **bit 0 is
+`AV_PKT_FLAG_KEY` and is set exactly on keyframes**:
+
+```python
+is_keyframe = bool(msg.flags & 0x1)   # AV_PKT_FLAG_KEY
+```
+
+This works on live subscriptions, recorded handoff traces, and anonymized
+replay bags alike: `rosotacom anonymize` deliberately preserves `flags` and
+`pts` when it zeroes FFMPEGPacket payloads (see
+`src/rosotacom/resources/ws/session/creation/anonymize_bag.py`), because the
+keyframe/delta structure is stream shape — like the sizes and timing the
+anonymizer already keeps — not scene content.
+
+Offline tooling can classify frames straight from serialized CDR bytes (as
+stored in mcap files) without a ROS runtime via
+[`rosotacom.ffmpeg_packet.parse_ffmpeg_packet`](../src/rosotacom/ffmpeg_packet.py):
+
+```python
+from rosotacom.ffmpeg_packet import parse_ffmpeg_packet
+
+info = parse_ffmpeg_packet(serialized_message_bytes)
+info.is_keyframe   # flags bit 0
+info.pts           # encode order, also preserved by anonymization
+info.payload_size  # encoded frame bytes
+```
+
+Grouping a stream into GOPs is then just splitting at keyframes. Note the
+encoder may emit keyframes *early* (scene cuts), so GOPs can be shorter than
+`gop_size` — assert spacing `<= gop_size`, not `== gop_size`.
+
+## Fallback: size bimodality
+
+If `flags` is unavailable (foreign recordings, or bags anonymized before
+flag preservation existed), the size distribution still separates the two
+classes: delta frames dominate the stream (a GOP of N contributes N−1), so
+the median frame size sits on the delta mode, while keyframes are typically
+5–100× larger. `rosotacom.ffmpeg_packet.keyframes_by_size` marks frames
+above `3 × median` as keyframes. This misclassifies only when delta frames
+get unusually large (heavy motion) or keyframes unusually small (static
+scene at a very low bitrate) — prefer `flags` whenever present.
+
+## Validation
+
+- `tests/unit/test_ffmpeg_packet.py` — CDR parsing (alignment across
+  odd-length strings), flag semantics, and the size fallback on a synthetic
+  GOP pattern.
+- `tests/unit/test_anonymize.py::test_anonymize_msg_preserves_ffmpeg_keyframe_structure`
+  — anonymization keeps `flags`/`pts` while zeroing payloads.
+- `tests/e2e/test_anonymize_e2e.py` — headless end-to-end: a trace bag written
+  in the container, anonymized via the CLI, and re-read with keyframe flags
+  intact.

--- a/src/rosotacom/cli.py
+++ b/src/rosotacom/cli.py
@@ -6856,8 +6856,10 @@ def anonymize_command(args: argparse.Namespace) -> int:
                 "image_name": image_name,
                 "run_type": "command",
                 "command": " ".join(container_command),
-                "tty": True,
-                "stdin_open": True,
+                # Batch job: a TTY would make headless runs (CI, agents) abort
+                # with "cannot attach stdin to a TTY-enabled container".
+                "tty": False,
+                "stdin_open": False,
             },
             extra_run_args=extra_run_args,
         )

--- a/src/rosotacom/ffmpeg_packet.py
+++ b/src/rosotacom/ffmpeg_packet.py
@@ -1,0 +1,123 @@
+"""Keyframe identification for ffmpeg camera streams (FFMPEGPacket).
+
+An ffmpeg-transported camera stream is a sequence of
+``ffmpeg_image_transport_msgs/msg/FFMPEGPacket`` messages with a periodic GOP
+structure: one keyframe (I-frame, self-contained, large) followed by
+``gop_size - 1`` delta frames (P-frames, tiny). The two classes differ in size
+by one to two orders of magnitude, so distinguishing them is essential for
+network analysis -- the keyframes are the bursts a link actually has to absorb.
+
+Primary algorithm: the packet's ``flags`` field mirrors libav's packet flags;
+bit 0 is ``AV_PKT_FLAG_KEY`` -- set exactly on keyframes. ``rosotacom
+anonymize`` preserves ``flags`` (and ``pts``) when it zeroes payloads, so this
+works on live streams, recorded handoff traces, and anonymized replay bags
+alike. See docs/ffmpeg-keyframes.md.
+
+This module parses the serialized CDR bytes directly (as stored in mcap
+recordings or delivered by raw subscriptions), so offline tooling needs no ROS
+runtime. Only little-endian CDR (the ROS 2 default on all supported platforms)
+is handled.
+"""
+
+from __future__ import annotations
+
+import struct
+from dataclasses import dataclass
+from statistics import median
+
+AV_PKT_FLAG_KEY = 0x1
+
+
+@dataclass(frozen=True)
+class FFMPEGPacketInfo:
+    """Structure of one serialized FFMPEGPacket, without its payload bytes."""
+
+    stamp_sec: int
+    stamp_nanosec: int
+    frame_id: str
+    width: int
+    height: int
+    encoding: str
+    pts: int
+    flags: int
+    payload_size: int
+
+    @property
+    def is_keyframe(self) -> bool:
+        return bool(self.flags & AV_PKT_FLAG_KEY)
+
+
+def _align(offset: int, alignment: int) -> int:
+    return (offset + alignment - 1) // alignment * alignment
+
+
+def parse_ffmpeg_packet(cdr: bytes) -> FFMPEGPacketInfo:
+    """Parse a serialized ``FFMPEGPacket`` (CDR bytes as stored in a bag).
+
+    Field order per the message definition: ``std_msgs/Header header``,
+    ``int32 width``, ``int32 height``, ``string encoding``, ``uint64 pts``,
+    ``uint8 flags``, ``bool is_bigendian``, ``uint8[] data``. CDR alignment is
+    relative to the payload start, after the 4-byte encapsulation header.
+    """
+    if len(cdr) < 4 or cdr[1] != 0x01:
+        raise ValueError("expected little-endian CDR encapsulation (0x00 0x01 ...)")
+    body = cdr[4:]
+    offset = 0
+
+    stamp_sec, stamp_nanosec = struct.unpack_from("<iI", body, offset)
+    offset += 8
+
+    offset = _align(offset, 4)
+    (str_len,) = struct.unpack_from("<I", body, offset)
+    offset += 4
+    frame_id = body[offset : offset + str_len - 1].decode("utf-8", errors="replace")
+    offset += str_len
+
+    offset = _align(offset, 4)
+    width, height = struct.unpack_from("<ii", body, offset)
+    offset += 8
+
+    offset = _align(offset, 4)
+    (str_len,) = struct.unpack_from("<I", body, offset)
+    offset += 4
+    encoding = body[offset : offset + str_len - 1].decode("utf-8", errors="replace")
+    offset += str_len
+
+    offset = _align(offset, 8)
+    (pts,) = struct.unpack_from("<Q", body, offset)
+    offset += 8
+
+    flags = body[offset]
+    offset += 2  # flags + is_bigendian
+
+    offset = _align(offset, 4)
+    (payload_size,) = struct.unpack_from("<I", body, offset)
+
+    return FFMPEGPacketInfo(
+        stamp_sec=stamp_sec,
+        stamp_nanosec=stamp_nanosec,
+        frame_id=frame_id,
+        width=width,
+        height=height,
+        encoding=encoding,
+        pts=pts,
+        flags=flags,
+        payload_size=payload_size,
+    )
+
+
+def keyframes_by_size(sizes: list[int] | list[float], *, min_ratio: float = 3.0) -> list[bool]:
+    """Size-bimodality fallback when ``flags`` is unavailable or was zeroed.
+
+    Marks a frame as keyframe iff its size exceeds ``min_ratio`` times the
+    stream's median frame size. Works because delta frames dominate the stream
+    (a GOP of N has N-1 of them), pinning the median to the delta-frame mode,
+    while keyframes are typically 5-100x larger. Misclassifies only when the
+    encoder emits unusually large delta frames (heavy motion) or near-empty
+    keyframes (static scene at very low bitrate) -- prefer ``flags`` whenever
+    present.
+    """
+    if not sizes:
+        return []
+    threshold = min_ratio * median(sizes)
+    return [size > threshold for size in sizes]

--- a/src/rosotacom/resources/ws/session/creation/anonymize_bag.py
+++ b/src/rosotacom/resources/ws/session/creation/anonymize_bag.py
@@ -9,9 +9,18 @@ import sys
 from pathlib import Path
 
 import rosbag2_py
-import yaml
 from rclpy.serialization import deserialize_message, serialize_message
 from rosidl_runtime_py.utilities import get_message
+
+# Fields that anonymization must keep per message type (ROS 2 Python message
+# __slots__ carry a leading underscore). Anonymization deliberately preserves
+# structure, sizes, and timing; these fields are equally non-sensitive stream
+# structure. FFMPEGPacket.flags bit 0 (libav AV_PKT_FLAG_KEY) marks keyframes
+# and pts keeps the encode order -- both are essential for GOP-aware network
+# analysis of the replayed stream and reveal nothing about scene content.
+PRESERVED_SLOTS: dict[str, frozenset[str]] = {
+    "FFMPEGPacket": frozenset({"_flags", "_pts"}),
+}
 
 
 def anonymize_msg(msg) -> None:
@@ -19,7 +28,10 @@ def anonymize_msg(msg) -> None:
     if not hasattr(msg, "__slots__"):
         return
 
+    preserved = PRESERVED_SLOTS.get(type(msg).__name__, frozenset())
     for slot in msg.__slots__:
+        if slot in preserved:
+            continue
         val = getattr(msg, slot)
         if val is None:
             continue
@@ -66,25 +78,6 @@ def anonymize_msg(msg) -> None:
             setattr(msg, slot, type(val)(0))
 
 
-def get_topics_info(metadata_path: Path) -> dict[str, dict]:
-    if metadata_path.is_dir():
-        metadata_path = metadata_path / "metadata.yaml"
-    with open(metadata_path, encoding="utf-8") as f:
-        doc = yaml.safe_load(f) or {}
-    info = doc.get("rosbag2_bagfile_information", {})
-    topics_info = {}
-    for entry in info.get("topics_with_message_count", []):
-        meta = entry.get("topic_metadata", {})
-        name = meta.get("name")
-        if name:
-            topics_info[name] = {
-                "type": meta.get("type"),
-                "serialization_format": meta.get("serialization_format", "cdr"),
-                "offered_qos_profiles": meta.get("offered_qos_profiles", []),
-            }
-    return topics_info
-
-
 def main() -> int:
     parser = argparse.ArgumentParser(description="Anonymize a rosbag's messages and topics.")
     parser.add_argument("--input-bag", required=True, help="Path to input bag directory")
@@ -101,22 +94,25 @@ def main() -> int:
         print(f"Error: input bag '{input_path}' does not exist", file=sys.stderr)
         return 1
 
-    topics_info = get_topics_info(input_path)
-
-    missing_topics = [orig for orig in topics_map if orig not in topics_info]
-    if missing_topics:
-        print("Error: mapped topic(s) missing from the input bag:", file=sys.stderr)
-        for topic in missing_topics:
-            print(f"  {topic}", file=sys.stderr)
-        return 1
-    active_topics_map = dict(topics_map)
-
     # Initialize sequential reader
     reader = rosbag2_py.SequentialReader()
     reader.open(
         rosbag2_py.StorageOptions(uri=str(input_path), storage_id=args.storage_id),
         rosbag2_py.ConverterOptions("", ""),
     )
+
+    # The reader's typed TopicMetadata (with rosbag2_py.QoS offered profiles) is
+    # the only construction the writer accepts; re-parsing metadata.yaml into
+    # dicts breaks on current rosbag2.
+    input_topics = {tm.name: tm for tm in reader.get_all_topics_and_types()}
+
+    missing_topics = [orig for orig in topics_map if orig not in input_topics]
+    if missing_topics:
+        print("Error: mapped topic(s) missing from the input bag:", file=sys.stderr)
+        for topic in missing_topics:
+            print(f"  {topic}", file=sys.stderr)
+        return 1
+    active_topics_map = dict(topics_map)
 
     # Initialize sequential writer
     writer = rosbag2_py.SequentialWriter()
@@ -127,15 +123,16 @@ def main() -> int:
 
     # Register output topics with the writer
     for orig, anonymized in active_topics_map.items():
-        info = topics_info[orig]
-        topic_metadata = rosbag2_py.TopicMetadata(
-            id=0,
-            name=anonymized,
-            type=info["type"],
-            serialization_format=info["serialization_format"],
-            offered_qos_profiles=info["offered_qos_profiles"],
+        tm = input_topics[orig]
+        writer.create_topic(
+            rosbag2_py.TopicMetadata(
+                id=0,
+                name=anonymized,
+                type=tm.type,
+                serialization_format=tm.serialization_format,
+                offered_qos_profiles=tm.offered_qos_profiles,
+            )
         )
-        writer.create_topic(topic_metadata)
 
     # Read and anonymize messages
     print(f"Anonymizing bag: {input_path} -> {output_path}")
@@ -144,8 +141,7 @@ def main() -> int:
         topic, serialized_bytes, timestamp = reader.read_next()
         if topic in active_topics_map:
             anonymized_topic = active_topics_map[topic]
-            msg_type = topics_info[topic]["type"]
-            msg_cls = get_message(msg_type)
+            msg_cls = get_message(input_topics[topic].type)
             msg = deserialize_message(serialized_bytes, msg_cls)
             anonymize_msg(msg)
             anonymized_bytes = serialize_message(msg)

--- a/tests/e2e/test_anonymize_e2e.py
+++ b/tests/e2e/test_anonymize_e2e.py
@@ -1,0 +1,200 @@
+"""Headless end-to-end check of `rosotacom anonymize`.
+
+Guards the three ways this flow has actually broken on a real trace:
+a TTY-enabled anonymizer container aborting without a terminal, writer topic
+registration failing against current rosbag2_py, and FFMPEGPacket keyframe
+flags being zeroed away. A trace bag is written inside the project container,
+anonymized through the real CLI (headless subprocess), and re-read inside the
+container; the anonymized bag must keep sizes, timestamps, `flags`, and `pts`
+while zeroing payloads and strings.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[2]
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.skipif(
+        os.environ.get("ROSOTACOM_RUN_E2E") != "1",
+        reason="Docker-backed E2E tests require ROSOTACOM_RUN_E2E=1.",
+    ),
+]
+
+TRACE_TOPIC = "/topic9"  # the camera stream's handoff name in packaged example 16
+FLAG_PATTERN = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0]
+PAYLOAD_SIZES = [40000, 3000, 3500, 3200, 3100, 42000, 2900, 3300, 3600, 3400, 41000, 3000]
+
+MAKE_TRACE_SCRIPT = f"""
+import rosbag2_py
+from rclpy.serialization import serialize_message
+from rosidl_runtime_py.utilities import get_message
+
+FFMPEGPacket = get_message("ffmpeg_image_transport_msgs/msg/FFMPEGPacket")
+writer = rosbag2_py.SequentialWriter()
+writer.open(
+    rosbag2_py.StorageOptions(uri="/work/trace", storage_id="mcap"),
+    rosbag2_py.ConverterOptions("", ""),
+)
+writer.create_topic(
+    rosbag2_py.TopicMetadata(
+        id=0,
+        name={TRACE_TOPIC!r},
+        type="ffmpeg_image_transport_msgs/msg/FFMPEGPacket",
+        serialization_format="cdr",
+    )
+)
+for i, (flags, size) in enumerate(zip({FLAG_PATTERN!r}, {PAYLOAD_SIZES!r})):
+    msg = FFMPEGPacket()
+    msg.header.stamp.sec = 100 + i
+    msg.header.frame_id = "front_medium"
+    msg.width = 640
+    msg.height = 480
+    msg.encoding = "h264"
+    msg.pts = i
+    msg.flags = flags
+    msg.data = bytes((j % 251) + 1 for j in range(size))  # nonzero payload
+    writer.write({TRACE_TOPIC!r}, serialize_message(msg), (100 + i) * 100_000_000)
+del writer
+print("TRACE_WRITTEN")
+"""
+
+READ_BAG_SCRIPT = """
+import json
+import rosbag2_py
+from rclpy.serialization import deserialize_message
+from rosidl_runtime_py.utilities import get_message
+
+FFMPEGPacket = get_message("ffmpeg_image_transport_msgs/msg/FFMPEGPacket")
+reader = rosbag2_py.SequentialReader()
+bag_uri = "/work/anon/scenarios/anonymized_16_remote_assist_anonymized_camera/anonymized_bag"
+reader.open(
+    rosbag2_py.StorageOptions(uri=bag_uri, storage_id="mcap"),
+    rosbag2_py.ConverterOptions("", ""),
+)
+rows = []
+while reader.has_next():
+    topic, data, stamp = reader.read_next()
+    msg = deserialize_message(data, FFMPEGPacket)
+    rows.append({
+        "topic": topic,
+        "stamp": stamp,
+        "flags": msg.flags,
+        "pts": msg.pts,
+        "size": len(msg.data),
+        "payload_zeroed": not any(msg.data),
+        "frame_id": msg.header.frame_id,
+        "encoding": msg.encoding,
+    })
+with open("/work/result.json", "w") as f:
+    json.dump(rows, f)
+print("BAG_READ")
+"""
+
+
+@pytest.fixture(scope="session")
+def copied_example_project(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    project = tmp_path_factory.mktemp("rosotacom") / "examples"
+    subprocess.run(
+        [sys.executable, "-m", "rosotacom", "examples", "create", str(project)],
+        cwd=PACKAGE_ROOT,
+        text=True,
+        capture_output=True,
+        timeout=60,
+        check=True,
+    )
+    return project
+
+
+def _run_in_container(project: Path, work_dir: Path, name: str, script: str) -> None:
+    """Run a python script inside the project image; raises on non-zero exit."""
+    from ros2docker.api import run as ros2docker_run
+    from ros2docker.config import load_config
+
+    script_path = work_dir / f"{name}.py"
+    script_path.write_text(script, encoding="utf-8")
+    image_name = load_config(project / "ros2docker.json").get("image_name", "ros2docker")
+    ros2docker_run(
+        config_file=project / "ros2docker.json",
+        override={
+            "container_name": f"rosotacom_anonymize_e2e_{name}",
+            "image_name": image_name,
+            "run_type": "command",
+            "command": f"python3 /work/{name}.py",
+            "tty": False,
+            "stdin_open": False,
+        },
+        extra_run_args=["-v", f"{work_dir}:/work"],
+    )
+
+
+def test_anonymize_headless_end_to_end_preserves_keyframe_structure(
+    copied_example_project: Path,
+    tmp_path: Path,
+) -> None:
+    from ros2docker.api import build as ros2docker_build
+
+    work_dir = tmp_path
+    work_dir.chmod(0o777)  # container user must write the bag and result.json
+
+    ros2docker_build(config_file=copied_example_project / "ros2docker.json")
+    _run_in_container(copied_example_project, work_dir, "make_trace", MAKE_TRACE_SCRIPT)
+
+    # The real CLI, headless: no TTY on stdin — this is exactly the environment
+    # in which a tty-enabled anonymizer container refuses to start.
+    anonymize = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "rosotacom",
+            "anonymize",
+            str(work_dir / "trace"),
+            "-s",
+            "16_remote_assist_anonymized_camera",
+            "--rosotacom-config",
+            str(copied_example_project / "rosotacom.yaml"),
+            "-o",
+            str(work_dir / "anon"),
+        ],
+        cwd=PACKAGE_ROOT,
+        text=True,
+        capture_output=True,
+        timeout=600,
+        stdin=subprocess.DEVNULL,
+    )
+    assert anonymize.returncode == 0, f"anonymize failed:\nSTDOUT:\n{anonymize.stdout}\nSTDERR:\n{anonymize.stderr}"
+
+    out_name = "anonymized_16_remote_assist_anonymized_camera"
+    session_def = yaml.safe_load(
+        (work_dir / "anon" / "sessions" / out_name / "session-definition.yaml").read_text(encoding="utf-8")
+    )
+    assert session_def["topics"]["b_to_a"][0]["topic"] == "/topic1"
+    assert session_def["topics"]["b_to_a"][0]["type"] == "ffmpeg_image_transport_msgs/msg/FFMPEGPacket"
+    scenario_dir = work_dir / "anon" / "scenarios" / out_name
+    assert (scenario_dir / "anonymized_bag" / "metadata.yaml").is_file()
+    assert (scenario_dir / "scenario-definition.yaml").is_file()
+    play_cfg = json.loads((scenario_dir / "play_bag_b.ros2docker.json").read_text(encoding="utf-8"))
+    assert "ros2 bag play --loop /bag/anonymized_bag" in play_cfg["command"]
+
+    _run_in_container(copied_example_project, work_dir, "read_bag", READ_BAG_SCRIPT)
+    rows = json.loads((work_dir / "result.json").read_text(encoding="utf-8"))
+    rows.sort(key=lambda row: row["stamp"])
+
+    assert [row["topic"] for row in rows] == ["/topic1"] * len(FLAG_PATTERN)
+    # Keyframe structure survives anonymization ...
+    assert [row["flags"] for row in rows] == FLAG_PATTERN
+    assert [row["pts"] for row in rows] == list(range(len(FLAG_PATTERN)))
+    assert [row["size"] for row in rows] == PAYLOAD_SIZES
+    assert [row["stamp"] for row in rows] == [(100 + i) * 100_000_000 for i in range(len(FLAG_PATTERN))]
+    # ... while content does not.
+    assert all(row["payload_zeroed"] for row in rows)
+    assert all(row["frame_id"] == "x" * len("front_medium") for row in rows)
+    assert all(row["encoding"] == "xxxx" for row in rows)

--- a/tests/unit/test_anonymize.py
+++ b/tests/unit/test_anonymize.py
@@ -74,6 +74,26 @@ class MockMessage:
         self.nested_list = [MockInner("subsecret", 8)]
 
 
+class MockFFMPEGPacket:
+    """Mimics ffmpeg_image_transport_msgs FFMPEGPacket (ROS 2 slots carry a
+    leading underscore); only the class NAME drives the preserve rules."""
+
+    __slots__ = ["_header", "_width", "_height", "_encoding", "_pts", "_flags", "_is_bigendian", "_data"]
+
+    def __init__(self):
+        self._header = Time(1, 2)
+        self._width = 640
+        self._height = 480
+        self._encoding = "h264"
+        self._pts = 987
+        self._flags = 1
+        self._is_bigendian = False
+        self._data = b"\x01\x02\x03"
+
+
+MockFFMPEGPacket.__name__ = "FFMPEGPacket"
+
+
 def test_anonymize_msg_recursive_replacement() -> None:
     msg = MockMessage()
     anonymize_bag.anonymize_msg(msg)
@@ -95,42 +115,57 @@ def test_anonymize_msg_recursive_replacement() -> None:
     assert msg.nested_list[0].inner_int == 0
 
 
-def test_anonymize_bag_writer_preserves_offered_qos_profiles(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    bag_dir = tmp_path / "processed_bag"
-    bag_dir.mkdir()
-    offered_qos = [{"reliability": "reliable", "durability": "transient_local", "depth": 1}]
-    metadata = {
-        "rosbag2_bagfile_information": {
-            "storage_identifier": "mcap",
-            "topics_with_message_count": [
-                {
-                    "message_count": 1,
-                    "topic_metadata": {
-                        "name": "/processed",
-                        "type": "std_msgs/msg/String",
-                        "serialization_format": "cdr",
-                        "offered_qos_profiles": offered_qos,
-                    },
-                }
-            ],
-        }
-    }
-    with open(bag_dir / "metadata.yaml", "w", encoding="utf-8") as f:
-        yaml.safe_dump(metadata, f)
+def test_anonymize_msg_preserves_ffmpeg_keyframe_structure() -> None:
+    """flags (bit 0 = AV_PKT_FLAG_KEY) and pts survive anonymization so GOP
+    analysis works on anonymized replay bags; everything else is still zeroed."""
+    msg = MockFFMPEGPacket()
+    anonymize_bag.anonymize_msg(msg)
 
+    assert msg._flags == 1
+    assert msg._pts == 987
+    assert msg._data == b"\x00\x00\x00"
+    assert msg._encoding == "xxxx"
+    assert msg._width == 0
+    assert msg._height == 0
+
+
+class FakeTopicMetadata:
+    def __init__(self, id, name, type, serialization_format, offered_qos_profiles):
+        self.id = id
+        self.name = name
+        self.type = type
+        self.serialization_format = serialization_format
+        self.offered_qos_profiles = offered_qos_profiles
+
+
+def _fake_reader_cls(topics: list[FakeTopicMetadata], messages: list[tuple[str, bytes, int]]):
     class FakeReader:
         def __init__(self) -> None:
-            self.done = False
+            self._remaining = list(messages)
 
         def open(self, *args, **kwargs) -> None:
             pass
 
+        def get_all_topics_and_types(self):
+            return topics
+
         def has_next(self) -> bool:
-            return not self.done
+            return bool(self._remaining)
 
         def read_next(self):
-            self.done = True
-            return "/processed", b"serialized", 123
+            return self._remaining.pop(0)
+
+    return FakeReader
+
+
+def test_anonymize_bag_writer_reuses_reader_topic_metadata(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Output topics must be registered from the reader's own typed
+    TopicMetadata (incl. its QoS objects) — re-parsing metadata.yaml into dicts
+    breaks the rosbag2_py TopicMetadata constructor."""
+    bag_dir = tmp_path / "processed_bag"
+    bag_dir.mkdir()
+    offered_qos = ["<opaque rosbag2 QoS object>"]
+    input_metadata = FakeTopicMetadata(1, "/processed", "std_msgs/msg/String", "cdr", offered_qos)
 
     created_topics = []
     writes = []
@@ -145,15 +180,11 @@ def test_anonymize_bag_writer_preserves_offered_qos_profiles(tmp_path: Path, mon
         def write(self, *args) -> None:
             writes.append(args)
 
-    class FakeTopicMetadata:
-        def __init__(self, id, name, type, serialization_format, offered_qos_profiles):
-            self.id = id
-            self.name = name
-            self.type = type
-            self.serialization_format = serialization_format
-            self.offered_qos_profiles = offered_qos_profiles
-
-    monkeypatch.setattr(anonymize_bag.rosbag2_py, "SequentialReader", FakeReader)
+    monkeypatch.setattr(
+        anonymize_bag.rosbag2_py,
+        "SequentialReader",
+        _fake_reader_cls([input_metadata], [("/processed", b"serialized", 123)]),
+    )
     monkeypatch.setattr(anonymize_bag.rosbag2_py, "SequentialWriter", FakeWriter)
     monkeypatch.setattr(anonymize_bag.rosbag2_py, "TopicMetadata", FakeTopicMetadata)
     monkeypatch.setattr(anonymize_bag.rosbag2_py, "StorageOptions", lambda **kwargs: kwargs)
@@ -177,30 +208,19 @@ def test_anonymize_bag_writer_preserves_offered_qos_profiles(tmp_path: Path, mon
 
     assert anonymize_bag.main() == 0
     assert created_topics[0].name == "/topic1"
-    assert created_topics[0].offered_qos_profiles == offered_qos
+    assert created_topics[0].type == "std_msgs/msg/String"
+    assert created_topics[0].serialization_format == "cdr"
+    assert created_topics[0].offered_qos_profiles is offered_qos
     assert writes == [("/topic1", b"anonymized", 123)]
 
 
 def test_anonymize_bag_fails_when_mapped_topic_is_missing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     bag_dir = tmp_path / "processed_bag"
     bag_dir.mkdir()
-    metadata = {
-        "rosbag2_bagfile_information": {
-            "storage_identifier": "mcap",
-            "topics_with_message_count": [
-                {
-                    "message_count": 1,
-                    "topic_metadata": {
-                        "name": "/present",
-                        "type": "std_msgs/msg/String",
-                        "serialization_format": "cdr",
-                    },
-                }
-            ],
-        }
-    }
-    with open(bag_dir / "metadata.yaml", "w", encoding="utf-8") as f:
-        yaml.safe_dump(metadata, f)
+    present = FakeTopicMetadata(1, "/present", "std_msgs/msg/String", "cdr", [])
+    monkeypatch.setattr(anonymize_bag.rosbag2_py, "SequentialReader", _fake_reader_cls([present], []))
+    monkeypatch.setattr(anonymize_bag.rosbag2_py, "StorageOptions", lambda **kwargs: kwargs)
+    monkeypatch.setattr(anonymize_bag.rosbag2_py, "ConverterOptions", lambda *args: args)
     monkeypatch.setattr(
         sys,
         "argv",
@@ -349,6 +369,9 @@ def test_anonymize_cli_subcommand(tmp_path: Path, monkeypatch: pytest.MonkeyPatc
     assert len(container_runs) == 1
     override, extra_args = container_runs[0]
     assert override["container_name"] == "rosotacom_anonymizer"
+    # Batch job must stay headless-safe: a TTY aborts without a terminal.
+    assert override["tty"] is False
+    assert override["stdin_open"] is False
     assert "anonymize_bag.py" in override["command"]
     assert f"/input_parent_dir/{bag_dir.name}" in override["command"]
 

--- a/tests/unit/test_ffmpeg_packet.py
+++ b/tests/unit/test_ffmpeg_packet.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import struct
+
+import pytest
+
+from rosotacom.ffmpeg_packet import (
+    AV_PKT_FLAG_KEY,
+    keyframes_by_size,
+    parse_ffmpeg_packet,
+)
+
+
+def _cdr_string(offset: int, value: str) -> tuple[bytes, int]:
+    pad = (-offset) % 4
+    raw = value.encode() + b"\x00"
+    chunk = b"\x00" * pad + struct.pack("<I", len(raw)) + raw
+    return chunk, offset + len(chunk)
+
+
+def make_packet(
+    *,
+    frame_id: str = "camera",
+    width: int = 640,
+    height: int = 480,
+    encoding: str = "h264",
+    pts: int = 42,
+    flags: int = AV_PKT_FLAG_KEY,
+    payload: bytes = b"\x01\x02\x03",
+) -> bytes:
+    """Serialize an FFMPEGPacket by hand, following XCDR1 little-endian rules."""
+    body = b""
+    offset = 0
+    body += struct.pack("<iI", 7, 9)  # header.stamp
+    offset += 8
+    chunk, offset = _cdr_string(offset, frame_id)
+    body += chunk
+    pad = (-offset) % 4
+    body += b"\x00" * pad + struct.pack("<ii", width, height)
+    offset += pad + 8
+    chunk, offset = _cdr_string(offset, encoding)
+    body += chunk
+    pad = (-offset) % 8
+    body += b"\x00" * pad + struct.pack("<Q", pts)
+    offset += pad + 8
+    body += struct.pack("<BB", flags, 0)  # flags + is_bigendian
+    offset += 2
+    pad = (-offset) % 4
+    body += b"\x00" * pad + struct.pack("<I", len(payload)) + payload
+    return b"\x00\x01\x00\x00" + body
+
+
+# Odd-length strings shift subsequent fields across alignment boundaries; a
+# parser with a wrong alignment origin fails exactly there.
+@pytest.mark.parametrize("frame_id", ["camera", "c", "front_medium_x"])
+@pytest.mark.parametrize("encoding", ["h264", "hevc_nvenc"])
+def test_parse_round_trips_hand_built_packets(frame_id: str, encoding: str) -> None:
+    cdr = make_packet(frame_id=frame_id, encoding=encoding, pts=123456789, flags=1, payload=b"\xaa" * 501)
+
+    info = parse_ffmpeg_packet(cdr)
+
+    assert info.stamp_sec == 7
+    assert info.stamp_nanosec == 9
+    assert info.frame_id == frame_id
+    assert info.width == 640
+    assert info.height == 480
+    assert info.encoding == encoding
+    assert info.pts == 123456789
+    assert info.flags == 1
+    assert info.is_keyframe
+    assert info.payload_size == 501
+
+
+def test_delta_frame_is_not_keyframe() -> None:
+    info = parse_ffmpeg_packet(make_packet(flags=0))
+
+    assert info.flags == 0
+    assert not info.is_keyframe
+
+
+def test_non_key_flag_bits_do_not_mark_keyframes() -> None:
+    # e.g. AV_PKT_FLAG_CORRUPT (0x2) alone is not a keyframe marker.
+    assert not parse_ffmpeg_packet(make_packet(flags=0x2)).is_keyframe
+    assert parse_ffmpeg_packet(make_packet(flags=0x3)).is_keyframe
+
+
+def test_big_endian_encapsulation_is_rejected() -> None:
+    cdr = bytearray(make_packet())
+    cdr[1] = 0x00
+
+    with pytest.raises(ValueError, match="little-endian"):
+        parse_ffmpeg_packet(bytes(cdr))
+
+
+def test_keyframes_by_size_marks_the_bimodal_upper_mode() -> None:
+    # A GOP-of-5 stream: the median sits on the delta frames, keyframes are
+    # far above 3x that median.
+    sizes = [44000, 3000, 4000, 4200, 3900] * 4
+
+    mask = keyframes_by_size(sizes)
+
+    assert mask == [True, False, False, False, False] * 4
+
+
+def test_keyframes_by_size_empty_input() -> None:
+    assert keyframes_by_size([]) == []


### PR DESCRIPTION
Closes #141, closes #142.

## What

Running `rosotacom anonymize` on a real processed handoff trace (recorded from the live remote-assist pipeline while producing the singled-out replay scenarios from #134) showed the flow had never worked end-to-end. This PR fixes it and adds the keyframe-identification capability the traces are analyzed with:

1. **Headless anonymizer**: the container was started with `tty: True, stdin_open: True` and aborted without a terminal (`cannot attach stdin to a TTY-enabled container`). It is a batch job; both are now off.
2. **Kilted rosbag2_py compatibility**: `anonymize_bag.py` re-parsed `metadata.yaml` and passed QoS dicts to `rosbag2_py.TopicMetadata`, which current rosbag2 rejects (`TypeError: incompatible constructor arguments`). Writer topics are now registered from the reader's own typed `TopicMetadata` objects; the YAML re-parse path is gone.
3. **Keyframe structure preserved**: anonymization zeroed every int, including `FFMPEGPacket.flags` (bit 0 = libav `AV_PKT_FLAG_KEY`) and `pts`. Sizes and timing are deliberately preserved; the keyframe/delta structure is equally non-sensitive stream shape and is essential for GOP-aware network analysis (measured on the remote-assist trace: keyframes ≈43 KiB mean vs delta frames ≈4.5 KiB, per-GOP contrast up to 179×). Both fields are now preserved.
4. **`rosotacom.ffmpeg_packet`**: stdlib-only CDR parser for serialized FFMPEGPacket (flags/pts/payload size + `is_keyframe`), plus a documented size-bimodality fallback (`keyframes_by_size`) for streams without flags. Algorithm documented in `docs/ffmpeg-keyframes.md`, linked from the README's anonymize section.

## Validation

- `tests/unit/test_ffmpeg_packet.py` — CDR parsing across alignment-shifting string lengths, flag semantics (bit 0 only), size fallback on a synthetic GOP.
- `tests/unit/test_anonymize.py` — preserve rules (`flags`/`pts` kept, payload/encoding/width/height still zeroed), writer registration from reader metadata, headless container override.
- `tests/e2e/test_anonymize_e2e.py` (new Docker lane) — writes an FFMPEGPacket trace bag inside the project container, runs the real CLI headless, re-reads the anonymized bag: sizes, stamps, `flags`, `pts` preserved; payloads and strings zeroed. This exact test fails on `develop` (TTY abort, then TypeError).
- Real-data check: the three anonymized remote-assist replay scenarios (costmap `/topic5` cut, camera `/topic9` cut, full 20-topic contract) were generated with this code and verified — 1396/1396 message sizes within CDR trailing padding (≤3 B), timestamps identical, 285 keyframes at identical positions, payloads zeroed, and the generated bag replays at 10 Hz via the generated `ros2 bag play` scenario.

Local runs: 384 unit+contract tests pass; the new e2e passes (`1 passed in 14.49s`).