### PR TITLE
Add bundle completeness validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,6 +427,33 @@ shared:
 The MCAP is written under `logs/<peer>/metrics/`. Analyze an ordered pipeline
 with `ros2 run com_py stage_latency BAG TOPIC...`.
 
+After a recording run, validate that a session instance still contains the
+artifacts needed for later analysis:
+
+```bash
+rosotacom bundle check session-instances/.../drive_run --peer a --peer b \
+  --file config/resolved-session.yaml \
+  --bag rosbags/a/native
+```
+
+`bundle check` validates each expected peer's `status.json` and `events.jsonl`,
+requires transit rows in the event streams, and validates expected rosbag2 bags
+from their `metadata.yaml` message counts. Extra expected artifacts can be passed
+as repeated `--file`, `--optional-file`, `--bag`, and `--optional-bag` flags, or
+via a generic YAML manifest:
+
+```yaml
+schema_version: 1
+peers: [a, b]
+required_files:
+  - config/resolved-session.yaml
+required_bags:
+  - path: rosbags/a/native
+    label: native bag
+optional_files:
+  - traces/link.jsonl
+```
+
 Phase 1 samples local-domain stages directly. OTA stages are graph-only and
 their activity is inferred from adjacent local flow, so the status overview
 never creates an additional OTA payload subscription. Combine both peers' files

--- a/src/rosotacom/bundle_check.py
+++ b/src/rosotacom/bundle_check.py
@@ -1,0 +1,517 @@
+"""Completeness checks for rosotacom session-instance artifact bundles."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+import yaml
+
+CheckStatus = Literal["present", "missing", "empty", "invalid"]
+
+
+@dataclass(frozen=True)
+class ExpectedPath:
+    path: str
+    label: str | None = None
+    required: bool = True
+
+    @property
+    def display_label(self) -> str:
+        return self.label or self.path
+
+
+@dataclass(frozen=True)
+class BundleCheckConfig:
+    peers: tuple[str, ...] = ()
+    files: tuple[ExpectedPath, ...] = ()
+    bags: tuple[ExpectedPath, ...] = ()
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    status: CheckStatus
+    kind: str
+    label: str
+    path: str
+    required: bool
+    detail: str = ""
+
+    @property
+    def failed(self) -> bool:
+        if self.status == "present":
+            return False
+        if not self.required and self.status == "missing":
+            return False
+        return True
+
+
+@dataclass(frozen=True)
+class BundleCheckReport:
+    root: Path
+    results: tuple[CheckResult, ...]
+
+    @property
+    def failures(self) -> tuple[CheckResult, ...]:
+        return tuple(result for result in self.results if result.failed)
+
+    @property
+    def complete(self) -> bool:
+        return not self.failures
+
+
+_MANIFEST_KEYS = {
+    "schema_version",
+    "peers",
+    "files",
+    "bags",
+    "required_files",
+    "optional_files",
+    "required_bags",
+    "optional_bags",
+}
+_ENTRY_KEYS = {"path", "label", "required"}
+
+
+def load_bundle_manifest(path: str | Path) -> BundleCheckConfig:
+    manifest_path = Path(path)
+    loaded = yaml.safe_load(manifest_path.read_text(encoding="utf-8")) or {}
+    if not isinstance(loaded, Mapping):
+        raise RuntimeError(f"Bundle manifest must contain a mapping: {manifest_path}")
+    unknown = sorted(set(loaded) - _MANIFEST_KEYS)
+    if unknown:
+        raise RuntimeError(f"Unsupported bundle manifest keys in {manifest_path}: {unknown}")
+    schema_version = loaded.get("schema_version", 1)
+    if schema_version != 1:
+        raise RuntimeError(f"Unsupported bundle manifest schema_version {schema_version!r}; expected 1.")
+
+    files = (
+        *_parse_expected_path_entries(loaded.get("files", ()), default_required=True, allow_required_override=True),
+        *_parse_expected_path_entries(
+            loaded.get("required_files", ()), default_required=True, allow_required_override=False
+        ),
+        *_parse_expected_path_entries(
+            loaded.get("optional_files", ()), default_required=False, allow_required_override=False
+        ),
+    )
+    bags = (
+        *_parse_expected_path_entries(loaded.get("bags", ()), default_required=True, allow_required_override=True),
+        *_parse_expected_path_entries(
+            loaded.get("required_bags", ()), default_required=True, allow_required_override=False
+        ),
+        *_parse_expected_path_entries(
+            loaded.get("optional_bags", ()), default_required=False, allow_required_override=False
+        ),
+    )
+    return BundleCheckConfig(peers=_parse_peer_names(loaded.get("peers", ())), files=files, bags=bags)
+
+
+def merge_bundle_configs(*configs: BundleCheckConfig) -> BundleCheckConfig:
+    peers: list[str] = []
+    files: list[ExpectedPath] = []
+    bags: list[ExpectedPath] = []
+    for config in configs:
+        for peer in config.peers:
+            if peer not in peers:
+                peers.append(peer)
+        files.extend(config.files)
+        bags.extend(config.bags)
+    return BundleCheckConfig(peers=tuple(peers), files=tuple(files), bags=tuple(bags))
+
+
+def check_bundle(root_path: str | Path, config: BundleCheckConfig | None = None) -> BundleCheckReport:
+    root = Path(root_path)
+    effective_config = config or BundleCheckConfig()
+    results: list[CheckResult] = []
+
+    if not root.exists():
+        return BundleCheckReport(root, (CheckResult("missing", "directory", "bundle root", ".", True),))
+    if not root.is_dir():
+        return BundleCheckReport(root, (CheckResult("invalid", "directory", "bundle root", ".", True),))
+
+    results.append(CheckResult("present", "directory", "bundle root", ".", True))
+    peers = effective_config.peers or _discover_peer_names(root)
+    if not peers:
+        results.append(
+            CheckResult(
+                "missing",
+                "peer",
+                "peer status directories",
+                "logs/*/status",
+                True,
+                "no peers discovered; pass --peer or manifest peers when discovery is insufficient",
+            )
+        )
+    for peer in peers:
+        _validate_peer_name(peer)
+        results.append(_check_status_json(root, peer))
+        results.append(_check_events_jsonl(root, peer))
+
+    for expected_file in effective_config.files:
+        results.append(_check_required_file(root, expected_file))
+    for expected_bag in effective_config.bags:
+        results.append(_check_bag(root, expected_bag))
+
+    return BundleCheckReport(root, tuple(results))
+
+
+def format_bundle_report(report: BundleCheckReport) -> str:
+    lines = [f"Bundle check: {report.root}"]
+    for result in report.results:
+        required = "required" if result.required else "optional"
+        detail = f" ({result.detail})" if result.detail else ""
+        lines.append(f"{result.status:7} {required} {result.kind} {result.label}: {result.path}{detail}")
+    if report.complete:
+        lines.append("Bundle complete.")
+    else:
+        lines.append(f"Bundle incomplete: {len(report.failures)} failure(s).")
+    return "\n".join(lines)
+
+
+def _parse_peer_names(raw: Any) -> tuple[str, ...]:
+    if raw is None:
+        return ()
+    if isinstance(raw, str):
+        peers = [raw]
+    elif isinstance(raw, Sequence):
+        peers = list(raw)
+    else:
+        raise RuntimeError("Bundle manifest peers must be a string or list of strings.")
+    parsed: list[str] = []
+    for peer in peers:
+        if not isinstance(peer, str):
+            raise RuntimeError("Bundle manifest peers must be strings.")
+        _validate_peer_name(peer)
+        if peer not in parsed:
+            parsed.append(peer)
+    return tuple(parsed)
+
+
+def _parse_expected_path_entries(
+    raw: Any, *, default_required: bool, allow_required_override: bool
+) -> tuple[ExpectedPath, ...]:
+    if raw is None:
+        return ()
+    if isinstance(raw, (str, Mapping)):
+        entries: Iterable[Any] = (raw,)
+    elif isinstance(raw, Sequence):
+        entries = raw
+    else:
+        raise RuntimeError("Bundle manifest path entries must be strings or mappings.")
+
+    parsed: list[ExpectedPath] = []
+    for entry in entries:
+        if isinstance(entry, str):
+            parsed.append(ExpectedPath(path=entry, required=default_required))
+            continue
+        if not isinstance(entry, Mapping):
+            raise RuntimeError("Bundle manifest path entries must be strings or mappings.")
+        unknown = sorted(set(entry) - _ENTRY_KEYS)
+        if unknown:
+            raise RuntimeError(f"Unsupported bundle manifest path entry keys: {unknown}")
+        path = entry.get("path")
+        if not isinstance(path, str) or not path:
+            raise RuntimeError("Bundle manifest path entries need a non-empty string path.")
+        label = entry.get("label")
+        if label is not None and not isinstance(label, str):
+            raise RuntimeError("Bundle manifest path entry label must be a string when provided.")
+        required = default_required
+        if allow_required_override and "required" in entry:
+            required_raw = entry["required"]
+            if not isinstance(required_raw, bool):
+                raise RuntimeError("Bundle manifest path entry required must be true or false.")
+            required = required_raw
+        parsed.append(ExpectedPath(path=path, label=label, required=required))
+    return tuple(parsed)
+
+
+def _validate_peer_name(peer: str) -> None:
+    if not peer or peer in {".", ".."} or Path(peer).name != peer:
+        raise RuntimeError(f"Peer names must be single path tokens, got {peer!r}.")
+
+
+def _discover_peer_names(root: Path) -> tuple[str, ...]:
+    logs_dir = root / "logs"
+    if not logs_dir.is_dir():
+        return ()
+    return tuple(sorted(child.name for child in logs_dir.iterdir() if child.is_dir() and (child / "status").is_dir()))
+
+
+def _relative_path(path: Path, root: Path) -> str:
+    try:
+        return path.relative_to(root).as_posix()
+    except ValueError:
+        return str(path)
+
+
+def _resolve_path(root: Path, raw_path: str) -> Path:
+    path = Path(raw_path)
+    return path if path.is_absolute() else root / path
+
+
+def _check_existing_file(
+    root: Path,
+    path: Path,
+    *,
+    kind: str,
+    label: str,
+    required: bool,
+    detail: str = "non-empty",
+) -> CheckResult:
+    display_path = _relative_path(path, root)
+    if not path.exists():
+        return CheckResult("missing", kind, label, display_path, required)
+    if not path.is_file():
+        return CheckResult("invalid", kind, label, display_path, required, "not a file")
+    if path.stat().st_size == 0:
+        return CheckResult("empty", kind, label, display_path, required)
+    return CheckResult("present", kind, label, display_path, required, detail)
+
+
+def _check_status_json(root: Path, peer: str) -> CheckResult:
+    rel = Path("logs") / peer / "status" / "status.json"
+    path = root / rel
+    base = _check_existing_file(root, path, kind="status", label=f"{peer} status.json", required=True)
+    if base.status != "present":
+        return base
+    text = path.read_text(encoding="utf-8")
+    if not text.strip():
+        return CheckResult("empty", "status", f"{peer} status.json", rel.as_posix(), True)
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError as exc:
+        return CheckResult("invalid", "status", f"{peer} status.json", rel.as_posix(), True, str(exc))
+    if not isinstance(payload, Mapping):
+        return CheckResult(
+            "invalid",
+            "status",
+            f"{peer} status.json",
+            rel.as_posix(),
+            True,
+            "JSON root is not an object",
+        )
+    return CheckResult("present", "status", f"{peer} status.json", rel.as_posix(), True, "valid JSON")
+
+
+def _check_events_jsonl(root: Path, peer: str) -> CheckResult:
+    rel = Path("logs") / peer / "status" / "events.jsonl"
+    path = root / rel
+    base = _check_existing_file(root, path, kind="events", label=f"{peer} events.jsonl", required=True)
+    if base.status != "present":
+        return base
+    text = path.read_text(encoding="utf-8")
+    if not text.strip():
+        return CheckResult("empty", "events", f"{peer} events.jsonl", rel.as_posix(), True, "file is empty")
+
+    transit_rows = 0
+    parsed_rows = 0
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        if not line.strip():
+            continue
+        parsed_rows += 1
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError as exc:
+            return CheckResult(
+                "invalid",
+                "events",
+                f"{peer} events.jsonl",
+                rel.as_posix(),
+                True,
+                f"line {lineno}: {exc}",
+            )
+        if not isinstance(payload, Mapping):
+            return CheckResult(
+                "invalid",
+                "events",
+                f"{peer} events.jsonl",
+                rel.as_posix(),
+                True,
+                f"line {lineno}: JSON root is not an object",
+            )
+        if payload.get("kind") == "transit":
+            transit_rows += 1
+
+    if parsed_rows == 0:
+        return CheckResult("empty", "events", f"{peer} events.jsonl", rel.as_posix(), True, "file is empty")
+    if transit_rows == 0:
+        return CheckResult("empty", "events", f"{peer} events.jsonl", rel.as_posix(), True, "no transit rows")
+    row_label = "row" if transit_rows == 1 else "rows"
+    return CheckResult(
+        "present",
+        "events",
+        f"{peer} events.jsonl",
+        rel.as_posix(),
+        True,
+        f"{transit_rows} transit {row_label}",
+    )
+
+
+def _check_required_file(root: Path, expected: ExpectedPath) -> CheckResult:
+    path = _resolve_path(root, expected.path)
+    return _check_existing_file(root, path, kind="file", label=expected.display_label, required=expected.required)
+
+
+def _check_bag(root: Path, expected: ExpectedPath) -> CheckResult:
+    raw_path = _resolve_path(root, expected.path)
+    metadata_path = raw_path if raw_path.name == "metadata.yaml" else raw_path / "metadata.yaml"
+    bag_dir = metadata_path.parent
+    display_path = _relative_path(raw_path, root)
+    if not raw_path.exists():
+        return CheckResult("missing", "bag", expected.display_label, display_path, expected.required)
+    if metadata_path != raw_path and not raw_path.is_dir():
+        return CheckResult(
+            "invalid", "bag", expected.display_label, display_path, expected.required, "not a bag directory"
+        )
+    if not metadata_path.exists():
+        return CheckResult(
+            "missing", "bag", expected.display_label, _relative_path(metadata_path, root), expected.required
+        )
+    if not metadata_path.is_file():
+        return CheckResult(
+            "invalid",
+            "bag",
+            expected.display_label,
+            _relative_path(metadata_path, root),
+            expected.required,
+            "not a file",
+        )
+    if metadata_path.stat().st_size == 0:
+        return CheckResult(
+            "empty", "bag", expected.display_label, _relative_path(metadata_path, root), expected.required
+        )
+
+    try:
+        loaded = yaml.safe_load(metadata_path.read_text(encoding="utf-8")) or {}
+    except yaml.YAMLError as exc:
+        return CheckResult(
+            "invalid",
+            "bag",
+            expected.display_label,
+            _relative_path(metadata_path, root),
+            expected.required,
+            str(exc),
+        )
+    if not isinstance(loaded, Mapping):
+        return CheckResult(
+            "invalid",
+            "bag",
+            expected.display_label,
+            _relative_path(metadata_path, root),
+            expected.required,
+            "metadata root is not a mapping",
+        )
+    info = loaded.get("rosbag2_bagfile_information")
+    if not isinstance(info, Mapping):
+        return CheckResult(
+            "invalid",
+            "bag",
+            expected.display_label,
+            _relative_path(metadata_path, root),
+            expected.required,
+            "missing rosbag2_bagfile_information",
+        )
+
+    topics = info.get("topics_with_message_count") or ()
+    if not isinstance(topics, Sequence) or isinstance(topics, (str, bytes)):
+        return CheckResult(
+            "invalid",
+            "bag",
+            expected.display_label,
+            _relative_path(metadata_path, root),
+            expected.required,
+            "topics_with_message_count is not a list",
+        )
+    total_messages = 0
+    topics_with_messages = 0
+    for index, entry in enumerate(topics):
+        if not isinstance(entry, Mapping):
+            return CheckResult(
+                "invalid",
+                "bag",
+                expected.display_label,
+                _relative_path(metadata_path, root),
+                expected.required,
+                f"topic entry {index} is not a mapping",
+            )
+        try:
+            count = int(entry.get("message_count") or 0)
+        except (TypeError, ValueError):
+            return CheckResult(
+                "invalid",
+                "bag",
+                expected.display_label,
+                _relative_path(metadata_path, root),
+                expected.required,
+                f"topic entry {index} has non-integer message_count",
+            )
+        if count > 0:
+            topics_with_messages += 1
+            total_messages += count
+    if total_messages <= 0:
+        return CheckResult(
+            "empty", "bag", expected.display_label, display_path, expected.required, "metadata has no messages"
+        )
+
+    data_files = info.get("relative_file_paths") or ()
+    if not isinstance(data_files, Sequence) or isinstance(data_files, (str, bytes)):
+        return CheckResult(
+            "invalid",
+            "bag",
+            expected.display_label,
+            _relative_path(metadata_path, root),
+            expected.required,
+            "relative_file_paths is not a list",
+        )
+    for data_file in data_files:
+        if not isinstance(data_file, str) or not data_file:
+            return CheckResult(
+                "invalid",
+                "bag",
+                expected.display_label,
+                _relative_path(metadata_path, root),
+                expected.required,
+                "relative_file_paths entries must be non-empty strings",
+            )
+        data_path = bag_dir / data_file
+        if not data_path.exists():
+            return CheckResult(
+                "missing",
+                "bag",
+                expected.display_label,
+                _relative_path(data_path, root),
+                expected.required,
+                "metadata references missing data file",
+            )
+        if not data_path.is_file():
+            return CheckResult(
+                "invalid",
+                "bag",
+                expected.display_label,
+                _relative_path(data_path, root),
+                expected.required,
+                "metadata references a non-file path",
+            )
+        if data_path.stat().st_size == 0:
+            return CheckResult(
+                "empty",
+                "bag",
+                expected.display_label,
+                _relative_path(data_path, root),
+                expected.required,
+                "metadata references an empty data file",
+            )
+
+    topic_label = "topic" if topics_with_messages == 1 else "topics"
+    message_label = "message" if total_messages == 1 else "messages"
+    return CheckResult(
+        "present",
+        "bag",
+        expected.display_label,
+        display_path,
+        expected.required,
+        f"{topics_with_messages} {topic_label}, {total_messages} {message_label}",
+    )

--- a/src/rosotacom/cli.py
+++ b/src/rosotacom/cli.py
@@ -40,6 +40,14 @@ import yaml
 from argcomplete.completers import DirectoriesCompleter
 
 from . import __version__
+from .bundle_check import (
+    BundleCheckConfig,
+    ExpectedPath,
+    check_bundle,
+    format_bundle_report,
+    load_bundle_manifest,
+    merge_bundle_configs,
+)
 from .deployment import (
     DeploymentConfig,
     PeerBinding,
@@ -7380,6 +7388,22 @@ def anonymize_command(args: argparse.Namespace) -> int:
     return 0
 
 
+def bundle_check_command(args: argparse.Namespace) -> int:
+    configs: list[BundleCheckConfig] = []
+    if args.manifest:
+        configs.append(load_bundle_manifest(args.manifest))
+
+    files = tuple(ExpectedPath(path=path, required=True) for path in args.required_file or ())
+    files += tuple(ExpectedPath(path=path, required=False) for path in args.optional_file or ())
+    bags = tuple(ExpectedPath(path=path, required=True) for path in args.required_bag or ())
+    bags += tuple(ExpectedPath(path=path, required=False) for path in args.optional_bag or ())
+    configs.append(BundleCheckConfig(peers=tuple(args.peer or ()), files=files, bags=bags))
+
+    report = check_bundle(args.directory, merge_bundle_configs(*configs))
+    print(format_bundle_report(report))
+    return 0 if report.complete else 1
+
+
 def main(argv: list[str] | None = None) -> int:
     argv = list(sys.argv[1:] if argv is None else argv)
     commands = {
@@ -7402,6 +7426,7 @@ def main(argv: list[str] | None = None) -> int:
         "scenario",
         "examples",
         "config",
+        "bundle",
         "completion",
         "benchmark",
         "ota-benchmark",
@@ -7751,6 +7776,51 @@ def main(argv: list[str] | None = None) -> int:
         help="Clear the machine-wide default (the only persisted scope).",
     )
     config_unset_parser.set_defaults(func=config_command)
+
+    bundle_parser = subparsers.add_parser("bundle", help="Inspect session-instance artifact bundles.")
+    bundle_subparsers = bundle_parser.add_subparsers(dest="bundle_command", required=True)
+    bundle_check_parser = bundle_subparsers.add_parser(
+        "check",
+        help="Validate a session-instance artifact bundle.",
+    )
+    bundle_check_parser.add_argument("directory", help="Session-instance directory to validate.")
+    bundle_check_parser.add_argument(
+        "--manifest",
+        help="YAML manifest listing expected peers, files, and bags relative to the session instance.",
+    )
+    bundle_check_parser.add_argument(
+        "--peer",
+        action="append",
+        default=[],
+        help="Expected peer key with logs/<peer>/status/status.json and events.jsonl. Repeat as needed.",
+    )
+    bundle_check_parser.add_argument(
+        "--file",
+        dest="required_file",
+        action="append",
+        default=[],
+        help="Required non-empty file relative to the session instance. Repeat as needed.",
+    )
+    bundle_check_parser.add_argument(
+        "--optional-file",
+        action="append",
+        default=[],
+        help="Optional file to validate when present. Repeat as needed.",
+    )
+    bundle_check_parser.add_argument(
+        "--bag",
+        dest="required_bag",
+        action="append",
+        default=[],
+        help="Required rosbag2 bag directory or metadata.yaml path. Repeat as needed.",
+    )
+    bundle_check_parser.add_argument(
+        "--optional-bag",
+        action="append",
+        default=[],
+        help="Optional rosbag2 bag directory or metadata.yaml path to validate when present. Repeat as needed.",
+    )
+    bundle_check_parser.set_defaults(func=bundle_check_command)
 
     from .cli_benchmark import register_benchmark_parser
 

--- a/tests/unit/test_bundle_check.py
+++ b/tests/unit/test_bundle_check.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+import rosotacom.cli as rosotacom_cli
+from rosotacom.bundle_check import BundleCheckConfig, check_bundle
+
+
+def _write_status_artifacts(instance: Path, peer: str, *, events: str | None = None) -> None:
+    status_dir = instance / "logs" / peer / "status"
+    status_dir.mkdir(parents=True, exist_ok=True)
+    (status_dir / "status.json").write_text(
+        json.dumps({"schema_version": 1, "peer": peer, "summary": {"OK": 1}}) + "\n",
+        encoding="utf-8",
+    )
+    events_payload = events
+    if events_payload is None:
+        events_payload = "\n".join(
+            [
+                json.dumps({"kind": "state_transition", "topic": "/heartbeat"}),
+                json.dumps({"kind": "transit", "topic": "/heartbeat", "seq": 1, "status": "delivered"}),
+                "",
+            ]
+        )
+    (status_dir / "events.jsonl").write_text(events_payload, encoding="utf-8")
+
+
+def _write_bag(bag_dir: Path) -> None:
+    bag_dir.mkdir(parents=True)
+    (bag_dir / "native_0.mcap").write_bytes(b"mcap")
+    metadata = {
+        "rosbag2_bagfile_information": {
+            "storage_identifier": "mcap",
+            "relative_file_paths": ["native_0.mcap"],
+            "duration": {"nanoseconds": 1_000_000_000},
+            "topics_with_message_count": [
+                {
+                    "topic_metadata": {
+                        "name": "/heartbeat",
+                        "type": "std_msgs/msg/String",
+                        "serialization_format": "cdr",
+                    },
+                    "message_count": 3,
+                }
+            ],
+        }
+    }
+    (bag_dir / "metadata.yaml").write_text(yaml.safe_dump(metadata), encoding="utf-8")
+
+
+def _write_complete_bundle(instance: Path) -> Path:
+    _write_status_artifacts(instance, "a")
+    _write_status_artifacts(instance, "b")
+    config_dir = instance / "config"
+    config_dir.mkdir(parents=True)
+    (config_dir / "resolved-session.yaml").write_text("schema_version: 1\n", encoding="utf-8")
+    (instance / "operator-notes.md").write_text("checked before departure\n", encoding="utf-8")
+    _write_bag(instance / "rosbags" / "a" / "native")
+    manifest = instance / "bundle.yaml"
+    manifest.write_text(
+        yaml.safe_dump(
+            {
+                "schema_version": 1,
+                "peers": ["a", "b"],
+                "required_files": [
+                    {"path": "config/resolved-session.yaml", "label": "resolved session config"},
+                    "operator-notes.md",
+                ],
+                "required_bags": [{"path": "rosbags/a/native", "label": "native bag"}],
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    return manifest
+
+
+def test_bundle_check_accepts_complete_fixture_directory(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    instance = tmp_path / "session-instances" / "2026-07-01" / "drive_001"
+    manifest = _write_complete_bundle(instance)
+
+    rc = rosotacom_cli.main(["bundle", "check", str(instance), "--manifest", str(manifest)])
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Bundle complete." in out
+    assert "present required status a status.json: logs/a/status/status.json (valid JSON)" in out
+    assert "present required bag native bag: rosbags/a/native (1 topic, 3 messages)" in out
+
+
+def test_bundle_check_reports_missing_peer_status_file(tmp_path: Path) -> None:
+    instance = tmp_path / "instance"
+    _write_status_artifacts(instance, "a")
+    _write_status_artifacts(instance, "b")
+    (instance / "logs" / "b" / "status" / "status.json").unlink()
+
+    report = check_bundle(instance, BundleCheckConfig(peers=("a", "b")))
+
+    assert not report.complete
+    assert any(
+        result.status == "missing" and result.kind == "status" and result.path == "logs/b/status/status.json"
+        for result in report.failures
+    )
+
+
+def test_bundle_check_reports_empty_events_file(tmp_path: Path) -> None:
+    instance = tmp_path / "instance"
+    _write_status_artifacts(instance, "a", events="")
+    _write_status_artifacts(instance, "b")
+
+    report = check_bundle(instance, BundleCheckConfig(peers=("a", "b")))
+
+    assert not report.complete
+    assert any(
+        result.status == "empty" and result.kind == "events" and result.path == "logs/a/status/events.jsonl"
+        for result in report.failures
+    )


### PR DESCRIPTION
## Summary

- adds `rosotacom bundle check <session-instance-dir>` with manifest and CLI flag support for expected peers, files, optional files, bags, and optional bags
- validates per-peer `status.json`, `events.jsonl` transit rows, non-empty extra files, and rosbag2 `metadata.yaml` message counts plus referenced data files
- documents the public command in the README and covers complete, missing status, and empty events fixture directories with unit tests

Closes #151.

## Validation

- `/home/go914/dev/rosotacom_test/ros_communication_devcontainer/.venv/bin/python -m pytest tests/unit/test_cli.py tests/unit/test_bundle_check.py` -> 103 passed
- `/home/go914/dev/rosotacom_test/ros_communication_devcontainer/.venv/bin/python -m pytest tests/contract/test_readme_examples.py tests/contract/test_markdown_links.py` -> 10 passed
- `/home/go914/dev/rosotacom_test/ros_communication_devcontainer/.venv/bin/python -m ruff check src/rosotacom/bundle_check.py src/rosotacom/cli.py tests/unit/test_bundle_check.py` -> passed
- `/home/go914/dev/rosotacom_test/ros_communication_devcontainer/.venv/bin/python -m mypy src/rosotacom/bundle_check.py src/rosotacom/cli.py` -> passed

## Local demonstration

Passing existing benchmark instance scoped to the peer with transit records:

```text
Bundle check: fzi_projects/remote_assist/session-instances/2026-07-02/bench_1_1_capacity_2026-07-02_11-52-13_2d56cfa9
present required directory bundle root: .
present required status b status.json: logs/b/status/status.json (valid JSON)
present required events b events.jsonl: logs/b/status/events.jsonl (497 transit rows)
present required file manifest.yaml: manifest.yaml (non-empty)
present required file config/session-definition.yaml: config/session-definition.yaml (non-empty)
present required file config/b/session_specification.yaml: config/b/session_specification.yaml (non-empty)
Bundle complete.
```

Stricter existing trace instance showing a historical gap the new check catches:

```text
Bundle check: fzi_projects/remote_assist/session-instances/2026-07-02/remote_assist_2026-07-02_17-14-31_anon-trace-1
present required directory bundle root: .
present required status a status.json: logs/a/status/status.json (valid JSON)
empty   required events a events.jsonl: logs/a/status/events.jsonl (no transit rows)
present required status b status.json: logs/b/status/status.json (valid JSON)
empty   required events b events.jsonl: logs/b/status/events.jsonl (no transit rows)
present required file manifest.yaml: manifest.yaml (non-empty)
present required file config/session-definition.yaml: config/session-definition.yaml (non-empty)
present required file config/a/session_specification.yaml: config/a/session_specification.yaml (non-empty)
present required file config/b/session_specification.yaml: config/b/session_specification.yaml (non-empty)
present required bag traces/full_a: traces/full_a (2 topics, 280 messages)
present required bag traces/full_b: traces/full_b (18 topics, 19949 messages)
Bundle incomplete: 2 failure(s).
```
