### PR TITLE
Add link trace recorder

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,6 +394,11 @@ The running session writes, under
   wrapped topics (delivered/lost/reordered, section latency, size, inter-arrival,
   and jitter).
 
+For fixed-interval network-condition samples alongside the same session, enable
+the [link trace recorder](docs/link-trace.md). It writes
+`link_trace.jsonl` under the same status directory with `/proc/net/dev` counter
+deltas, echo-heartbeat RTT/loss provenance, and an optional modem-metrics hook.
+
 Read it from the host with the `status` command:
 
 ```bash

--- a/docs/link-trace.md
+++ b/docs/link-trace.md
@@ -1,0 +1,83 @@
+# Link Trace Recorder
+
+The link trace recorder writes an append-only JSONL stream next to the live
+status overview artifacts:
+
+```text
+session-instances/.../logs/<peer>/status/link_trace.jsonl
+```
+
+Enable it in a session definition:
+
+```yaml
+shared:
+  use_status_overview: true
+  link_trace:
+    enabled: true
+    interval_s: 1.0
+    modem_metrics_command: "cat /run/modem-metrics.json"
+    modem_metrics_timeout_s: 2.0
+```
+
+Or enable it for a single run:
+
+```bash
+rosotacom start 13_link_latency --identity a --link-trace
+rosotacom smoke 13_link_latency --link-trace --link-trace-interval 0.5
+rosotacom ota-smoke 13_link_latency --link-trace
+```
+
+`--link-trace-interval` and `--link-trace-modem-command` also enable the
+recorder and force `shared.use_status_overview: true` for the generated instance.
+
+## Row Schema
+
+Each line is one JSON object:
+
+```json
+{
+  "schema_version": 1,
+  "kind": "link_trace",
+  "generated_at": "2026-07-07T10:00:00.000",
+  "monotonic_s": 123.456,
+  "peer": "a",
+  "remote": "b",
+  "passive_counter_delta": {
+    "available": true,
+    "provenance": "proc_net_dev_counter_delta",
+    "interface": "eth0",
+    "window_s": 1.0,
+    "observed_not_available_bandwidth": true,
+    "rx": {"bytes_delta": 1234, "packets_delta": 10, "observed_kbps": 9.872},
+    "tx": {"bytes_delta": 5678, "packets_delta": 20, "observed_kbps": 45.424}
+  },
+  "peer_probe": {
+    "available": true,
+    "provenance": "echo_heartbeat_status_snapshot",
+    "rtt_ms": 12.5,
+    "peer_offset_ms": -1.2,
+    "loss_pct": 0.0,
+    "assumption": "symmetric_path"
+  },
+  "modem": {
+    "available": true,
+    "provenance": "modem_metrics_command",
+    "command": "cat /run/modem-metrics.json",
+    "metrics": {"rsrp_dbm": -88}
+  }
+}
+```
+
+`passive_counter_delta` uses `/proc/net/dev` counters for the resolved OTA
+interface. Its `observed_kbps` fields are observed traffic during the sampling
+window. They are not available-bandwidth estimates and cannot reveal unused link
+capacity.
+
+`peer_probe` reuses the status overview's echo heartbeat snapshot. RTT and clock
+offset require `shared.use_heartbeat: true`; loss is copied from the first status
+stage that has sequence-loss provenance.
+
+`modem_metrics_command` is optional. It runs inside the communication container
+at each sample interval, must print a JSON object on stdout, and is recorded under
+`modem.metrics`. Non-zero exits, timeouts, invalid JSON, or non-object JSON are
+captured as unavailable modem blocks instead of failing the session.

--- a/src/rosotacom/cli.py
+++ b/src/rosotacom/cli.py
@@ -1669,6 +1669,7 @@ def _ota_start_parts(
     *,
     mode: str,
     force: bool = True,
+    link_trace_parts: list[str] | None = None,
 ) -> list[str]:
     if target.target_type == "scenario":
         parts = ["scenario", "start", target.name, "--identity", identity, "--mode", mode, "--instance-id", instance_id]
@@ -1684,6 +1685,7 @@ def _ota_start_parts(
             instance_id,
         ]
     parts.append("--force" if force else "--no-force")
+    parts.extend(link_trace_parts or [])
     for override in peer_args:
         parts.extend(["--peer-address", override])
     return parts
@@ -1697,6 +1699,7 @@ def _ota_communication_start_parts(
     *,
     mode: str,
     force: bool = True,
+    link_trace_parts: list[str] | None = None,
 ) -> list[str]:
     parts = [
         "start",
@@ -1710,8 +1713,20 @@ def _ota_communication_start_parts(
         "--smoke-managed",
     ]
     parts.append("--force" if force else "--no-force")
+    parts.extend(link_trace_parts or [])
     for override in peer_args:
         parts.extend(["--peer-address", override])
+    return parts
+
+
+def _link_trace_parts_from_args(args: argparse.Namespace) -> list[str]:
+    parts: list[str] = []
+    if getattr(args, "link_trace", None):
+        parts.append("--link-trace")
+    if getattr(args, "link_trace_interval_s", None) is not None:
+        parts.extend(["--link-trace-interval", str(args.link_trace_interval_s)])
+    if getattr(args, "link_trace_modem_command", None):
+        parts.extend(["--link-trace-modem-command", args.link_trace_modem_command])
     return parts
 
 
@@ -2619,13 +2634,14 @@ def _ota_start_peers(
     *,
     dry_run: bool,
     mode: str = "detached",
+    link_trace_parts: list[str] | None = None,
 ) -> None:
     peer_args = _ota_peer_address_args(plan)
     for peer_name in sorted(plan.peers):
         peer = plan.peers[peer_name]
         command = _ota_rosotacom_command(
             plan,
-            _ota_start_parts(target, peer_name, instance_id, peer_args, mode=mode),
+            _ota_start_parts(target, peer_name, instance_id, peer_args, mode=mode, link_trace_parts=link_trace_parts),
         )
         _ota_run(peer, command, label=f"{peer_name}: start {target.name}", dry_run=dry_run)
 
@@ -2904,6 +2920,7 @@ def _ota_create_tmux(
     target: InteractiveSmokeTarget,
     plan: OtaSmokePlan,
     instance: SessionInstance,
+    link_trace_parts: list[str] | None = None,
 ) -> str:
     _require_tmux()
     session_name = _ota_smoke_tmux_session(target.target_type, target.name)
@@ -2912,7 +2929,14 @@ def _ota_create_tmux(
     first_peer = peers[0]
     first_start = _ota_rosotacom_command(
         plan,
-        _ota_communication_start_parts(target, first_peer.name, instance.instance_id, peer_args, mode="attach"),
+        _ota_communication_start_parts(
+            target,
+            first_peer.name,
+            instance.instance_id,
+            peer_args,
+            mode="attach",
+            link_trace_parts=link_trace_parts,
+        ),
     )
     first_script = (
         "set -e; "
@@ -2984,7 +3008,14 @@ def _ota_create_tmux(
     for peer in peers[1:]:
         start = _ota_rosotacom_command(
             plan,
-            _ota_communication_start_parts(target, peer.name, instance.instance_id, peer_args, mode="attach"),
+            _ota_communication_start_parts(
+                target,
+                peer.name,
+                instance.instance_id,
+                peer_args,
+                mode="attach",
+                link_trace_parts=link_trace_parts,
+            ),
         )
         script = (
             "set -e; "
@@ -3178,7 +3209,7 @@ def _start_interactive_ota_smoke(args: argparse.Namespace) -> int:
         print(f"Would create OTA smoke tmux session: {tmux_session}")
         print(f"OTA smoke artifacts: {instance.host_dir}")
         return 0
-    created = _ota_create_tmux(runtime, target, plan, instance)
+    created = _ota_create_tmux(runtime, target, plan, instance, link_trace_parts=_link_trace_parts_from_args(args))
     print(f"rosotacom OTA smoke instance: {instance.host_dir}")
     print(f"rosotacom OTA smoke started: {target.name} ({target.target_type})")
     print("Local control tmux prefix: Ctrl-b. Send the peer tmux/catmux prefix with Ctrl-b Ctrl-b.")
@@ -3232,7 +3263,13 @@ def _start_noninteractive_ota_smoke(args: argparse.Namespace) -> int:
     try:
         if profile is not None:
             shapers = _ota_arm_profile(plan, profile, directions, dry_run=dry_run)
-        _ota_start_peers(target, plan, instance.instance_id, dry_run=dry_run)
+        _ota_start_peers(
+            target,
+            plan,
+            instance.instance_id,
+            dry_run=dry_run,
+            link_trace_parts=_link_trace_parts_from_args(args),
+        )
         if not dry_run:
             time.sleep(12)
         _ota_start_session_publishers(target, plan, dry_run=dry_run)
@@ -3705,6 +3742,12 @@ def _scenario_communication_command(
     command.append("--force" if getattr(args, "force", True) else "--no-force")
     if getattr(args, "rewrite_formatting", False):
         command.append("--rewrite-formatting")
+    if getattr(args, "link_trace", None):
+        command.append("--link-trace")
+    if getattr(args, "link_trace_interval_s", None) is not None:
+        command.extend(["--link-trace-interval", str(args.link_trace_interval_s)])
+    if getattr(args, "link_trace_modem_command", None):
+        command.extend(["--link-trace-modem-command", args.link_trace_modem_command])
     for assignment in getattr(args, "peer", []) or []:
         command.extend(["--peer", assignment])
     for override in getattr(args, "peer_address", []) or []:
@@ -3981,6 +4024,9 @@ def _session_command(
     rewrite_formatting: bool,
     peer_address_overrides: dict[str, str],
     attach_mode: str,
+    link_trace: bool | None = None,
+    link_trace_interval_s: float | None = None,
+    link_trace_modem_command: str | None = None,
 ) -> list[str]:
     parts = [
         RUN_SESSION_CONTAINER_PATH,
@@ -4001,6 +4047,12 @@ def _session_command(
         parts.append("--force")
     if rewrite_formatting:
         parts.append("--rewrite-formatting")
+    if link_trace:
+        parts.append("--link-trace")
+    if link_trace_interval_s is not None:
+        parts.extend(["--link-trace-interval", str(link_trace_interval_s)])
+    if link_trace_modem_command:
+        parts.extend(["--link-trace-modem-command", link_trace_modem_command])
     for peer_key, address_value in peer_address_overrides.items():
         parts.extend(["--peer-address", f"{peer_key}={address_value}"])
     if attach_mode == "attach":
@@ -4110,6 +4162,9 @@ def start_session(args: argparse.Namespace) -> str:
         rewrite_formatting=args.rewrite_formatting,
         peer_address_overrides=_binding_addresses(bindings),
         attach_mode=mode,
+        link_trace=getattr(args, "link_trace", None),
+        link_trace_interval_s=getattr(args, "link_trace_interval_s", None),
+        link_trace_modem_command=getattr(args, "link_trace_modem_command", None),
     )
 
     print("Command which will be run in container: " + shlex.join(command))
@@ -6160,6 +6215,7 @@ def _interactive_smoke_communication_command(
     network_name: str,
     *,
     force: bool,
+    link_trace_parts: list[str] | None = None,
 ) -> list[str]:
     command = [
         sys.executable,
@@ -6181,6 +6237,7 @@ def _interactive_smoke_communication_command(
         *_runtime_cli_args(runtime),
     ]
     command.append("--force" if force else "--no-force")
+    command.extend(link_trace_parts or [])
     for override in _interactive_smoke_peer_address_args(peer_ips):
         command.extend(["--peer-address", override])
     return command
@@ -6292,6 +6349,7 @@ def _create_interactive_smoke_tmux(
     instance: SessionInstance,
     peer_ips: dict[str, str],
     network_name: str,
+    link_trace_parts: list[str] | None = None,
 ) -> str:
     session_name = _interactive_smoke_tmux_session(target.target_type, target.name)
     peers = sorted(peer_ips)
@@ -6305,6 +6363,7 @@ def _create_interactive_smoke_tmux(
             peer_ips,
             network_name,
             force=True,
+            link_trace_parts=link_trace_parts,
         )
     )
     created = subprocess.run(
@@ -6383,6 +6442,7 @@ def _create_interactive_smoke_tmux(
                 peer_ips,
                 network_name,
                 force=False,
+                link_trace_parts=link_trace_parts,
             )
         )
         script = f"{_wait_for_peer_spec_script(instance, peer)}; exec {command}"
@@ -6653,7 +6713,14 @@ def _start_interactive_smoke(args: argparse.Namespace) -> int:
         network_subnet=network_subnet,
         tmux_session=tmux_session,
     )
-    created_session = _create_interactive_smoke_tmux(runtime, target, instance, peer_ips, network_name)
+    created_session = _create_interactive_smoke_tmux(
+        runtime,
+        target,
+        instance,
+        peer_ips,
+        network_name,
+        link_trace_parts=_link_trace_parts_from_args(args),
+    )
     print(f"rosotacom interactive smoke instance: {instance.host_dir}")
     print(f"rosotacom interactive smoke started: {target.name} ({target.target_type})")
     print(f"Smoke peers isolated on docker network {network_name} ({network_subnet})")
@@ -6784,6 +6851,9 @@ def smoke(args: argparse.Namespace) -> int:
         "peer_address": peer_address_args,
         "instance_id": smoke_instance.instance_id,
         "network_name": smoke_network.name,
+        "link_trace": getattr(args, "link_trace", None),
+        "link_trace_interval_s": getattr(args, "link_trace_interval_s", None),
+        "link_trace_modem_command": getattr(args, "link_trace_modem_command", None),
     }
 
     log_line(f"Starting local smoke test with PEER_ADDRESSES={', '.join(peer_address_args)}")
@@ -7031,6 +7101,26 @@ def _add_profile_arg(parser: argparse.ArgumentParser) -> None:
     )
 
 
+def _add_link_trace_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--link-trace",
+        action="store_true",
+        default=None,
+        help="Record logs/<peer>/status/link_trace.jsonl for this run.",
+    )
+    parser.add_argument(
+        "--link-trace-interval",
+        dest="link_trace_interval_s",
+        type=float,
+        help="Link trace sample interval in seconds; enables link tracing.",
+    )
+    parser.add_argument(
+        "--link-trace-modem-command",
+        dest="link_trace_modem_command",
+        help="Shell command returning a JSON object to merge under each link trace sample.",
+    )
+
+
 def _add_session_arg(parser: argparse.ArgumentParser, *args: str, **kwargs: Any) -> argparse.Action:
     action = parser.add_argument(*args, **kwargs)
     cast(Any, action).completer = _session_name_completer
@@ -7090,6 +7180,7 @@ def _add_scenario_identity_args(parser: argparse.ArgumentParser) -> None:
 
 def _add_start_args(parser: argparse.ArgumentParser) -> None:
     _add_common_config_args(parser)
+    _add_link_trace_args(parser)
     _add_session_arg(parser, "session_dir_positional", nargs="?")
     _add_session_arg(parser, "-s", "--session-dir", dest="session_dir")
     _add_identity_arg(parser)
@@ -7469,6 +7560,7 @@ def main(argv: list[str] | None = None) -> int:
     smoke_parser = subparsers.add_parser("smoke", help="Run a local smoke test.")
     _add_common_config_args(smoke_parser)
     _add_profile_arg(smoke_parser)
+    _add_link_trace_args(smoke_parser)
     smoke_target = smoke_parser.add_argument("session_dir", nargs="?")
     cast(Any, smoke_target).completer = _smoke_target_completer
     smoke_parser.add_argument("--local", action="store_true", default=True)
@@ -7506,6 +7598,7 @@ def main(argv: list[str] | None = None) -> int:
     ota_smoke_parser = subparsers.add_parser("ota-smoke", help="Run a generic multi-machine OTA smoke test.")
     _add_common_config_args(ota_smoke_parser)
     _add_profile_arg(ota_smoke_parser)
+    _add_link_trace_args(ota_smoke_parser)
     ota_target = ota_smoke_parser.add_argument("target", nargs="?")
     cast(Any, ota_target).completer = _smoke_target_completer
     _add_peer_arg(ota_smoke_parser)
@@ -7678,6 +7771,7 @@ def main(argv: list[str] | None = None) -> int:
         help="Start a scenario in an isolated outer tmux session.",
     )
     _add_common_config_args(scenario_start_parser)
+    _add_link_trace_args(scenario_start_parser)
     _add_scenario_arg(scenario_start_parser, "scenario")
     _add_scenario_identity_args(scenario_start_parser)
     scenario_start_parser.add_argument("--mode", choices=["auto", "attach", "detached"], default="auto")

--- a/src/rosotacom/resources/examples/sessions/13_link_latency/session-definition.yaml
+++ b/src/rosotacom/resources/examples/sessions/13_link_latency/session-definition.yaml
@@ -23,6 +23,9 @@ peer_settings:
 shared:
   use_heartbeat: true
   use_status_overview: true
+  link_trace:
+    enabled: true
+    interval_s: 1.0
   rmw: cyclone
   ota_domain_id: 48
 

--- a/src/rosotacom/resources/ws/ros2src/com_py/com_py/link_bytes.py
+++ b/src/rosotacom/resources/ws/ros2src/com_py/com_py/link_bytes.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 import subprocess
 import time
-from typing import Dict, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple
 
 PROC_NET_DEV = "/proc/net/dev"
 
@@ -28,7 +28,9 @@ PROC_NET_DEV = "/proc/net/dev"
 # Receive: bytes packets errs drop fifo frame compressed multicast
 # Transmit: bytes packets errs drop fifo colls carrier compressed
 _RX_BYTES_IDX = 0
+_RX_PACKETS_IDX = 1
 _TX_BYTES_IDX = 8
+_TX_PACKETS_IDX = 9
 
 
 def parse_proc_net_dev(text: str) -> Dict[str, Dict[str, int]]:
@@ -45,7 +47,9 @@ def parse_proc_net_dev(text: str) -> Dict[str, Dict[str, int]]:
         try:
             out[iface] = {
                 "rx_bytes": int(fields[_RX_BYTES_IDX]),
+                "rx_packets": int(fields[_RX_PACKETS_IDX]),
                 "tx_bytes": int(fields[_TX_BYTES_IDX]),
+                "tx_packets": int(fields[_TX_PACKETS_IDX]),
             }
         except ValueError:
             continue
@@ -89,15 +93,20 @@ def find_interface_for_ip(ip: str) -> Optional[str]:
 
 def read_iface_counters(iface: str, proc_path: str = PROC_NET_DEV) -> Optional[Tuple[int, int]]:
     """Return (rx_bytes, tx_bytes) for ``iface`` now, or None if unavailable."""
+    row = read_iface_counter_row(iface, proc_path)
+    if row is None:
+        return None
+    return row["rx_bytes"], row["tx_bytes"]
+
+
+def read_iface_counter_row(iface: str, proc_path: str = PROC_NET_DEV) -> Optional[Dict[str, int]]:
+    """Return parsed /proc/net/dev counters for ``iface``, or None if unavailable."""
     try:
         with open(proc_path, encoding="utf-8") as fp:
             stats = parse_proc_net_dev(fp.read())
     except OSError:
         return None
-    row = stats.get(iface)
-    if row is None:
-        return None
-    return row["rx_bytes"], row["tx_bytes"]
+    return stats.get(iface)
 
 
 def kbps(delta_bytes: int, elapsed_s: float) -> float:
@@ -122,24 +131,47 @@ class LinkByteSampler:
         self._last_t: Optional[float] = None
         self._last_rx: Optional[int] = None
         self._last_tx: Optional[int] = None
+        self._last_rx_packets: Optional[int] = None
+        self._last_tx_packets: Optional[int] = None
 
-    def sample(self) -> Optional[Dict[str, float]]:
-        counters = read_iface_counters(self.iface, self._proc_path)
+    def sample(self) -> Optional[Dict[str, Any]]:
+        counters = read_iface_counter_row(self.iface, self._proc_path)
         if counters is None:
             return None
-        rx, tx = counters
+        rx = counters["rx_bytes"]
+        tx = counters["tx_bytes"]
+        rx_packets = counters.get("rx_packets")
+        tx_packets = counters.get("tx_packets")
         now = self._clock()
-        prev_t, prev_rx, prev_tx = self._last_t, self._last_rx, self._last_tx
-        self._last_t, self._last_rx, self._last_tx = now, rx, tx
+        prev_t = self._last_t
+        prev_rx = self._last_rx
+        prev_tx = self._last_tx
+        prev_rx_packets = self._last_rx_packets
+        prev_tx_packets = self._last_tx_packets
+        self._last_t = now
+        self._last_rx = rx
+        self._last_tx = tx
+        self._last_rx_packets = rx_packets
+        self._last_tx_packets = tx_packets
         if prev_t is None or prev_rx is None or prev_tx is None:
             return None
         elapsed = now - prev_t
         d_rx, d_tx = rx - prev_rx, tx - prev_tx
         if d_rx < 0 or d_tx < 0 or elapsed <= 0:
             return None  # counter reset/wrap -- skip this window
+        d_rx_packets = rx_packets - prev_rx_packets if rx_packets is not None and prev_rx_packets is not None else None
+        d_tx_packets = tx_packets - prev_tx_packets if tx_packets is not None and prev_tx_packets is not None else None
+        if d_rx_packets is not None and d_rx_packets < 0:
+            d_rx_packets = None
+        if d_tx_packets is not None and d_tx_packets < 0:
+            d_tx_packets = None
         return {
             "interface": self.iface,
             "rx_kbps": kbps(d_rx, elapsed),
             "tx_kbps": kbps(d_tx, elapsed),
+            "rx_bytes_delta": d_rx,
+            "tx_bytes_delta": d_tx,
+            "rx_packets_delta": d_rx_packets,
+            "tx_packets_delta": d_tx_packets,
             "window_s": elapsed,
         }

--- a/src/rosotacom/resources/ws/ros2src/com_py/com_py/link_trace.py
+++ b/src/rosotacom/resources/ws/ros2src/com_py/com_py/link_trace.py
@@ -1,0 +1,186 @@
+"""Append-only link trace samples for rosotacom session artifacts."""
+
+from __future__ import annotations
+
+import datetime
+import json
+import os
+import subprocess
+import time
+from typing import Any, Callable, Dict, Optional
+
+
+def passive_counter_delta_block(link_sample: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    """Schema block for passive /proc/net/dev counter deltas.
+
+    The rates are observed traffic over the sampling window. They are not a
+    capacity estimate and cannot reveal unused bandwidth.
+    """
+    if not link_sample:
+        return {
+            "available": False,
+            "provenance": "proc_net_dev_counter_delta",
+            "reason": "no counter delta sample",
+            "observed_not_available_bandwidth": True,
+        }
+    return {
+        "available": True,
+        "provenance": "proc_net_dev_counter_delta",
+        "interface": link_sample.get("interface"),
+        "window_s": round(float(link_sample.get("window_s") or 0.0), 6),
+        "observed_not_available_bandwidth": True,
+        "rx": {
+            "bytes_delta": int(link_sample.get("rx_bytes_delta") or 0),
+            "packets_delta": link_sample.get("rx_packets_delta"),
+            "observed_kbps": round(float(link_sample.get("rx_kbps") or 0.0), 3),
+        },
+        "tx": {
+            "bytes_delta": int(link_sample.get("tx_bytes_delta") or 0),
+            "packets_delta": link_sample.get("tx_packets_delta"),
+            "observed_kbps": round(float(link_sample.get("tx_kbps") or 0.0), 3),
+        },
+    }
+
+
+def echo_probe_block(snapshot: Dict[str, Any]) -> Dict[str, Any]:
+    """Extract RTT/offset/loss as observed by the status snapshot."""
+    clock_sync = snapshot.get("clock_sync") if isinstance(snapshot.get("clock_sync"), dict) else None
+    rtt_ms = clock_sync.get("rtt_ms") if clock_sync else None
+    peer_offset_ms = clock_sync.get("peer_offset_ms") if clock_sync else None
+    loss_pct = None
+    for topic in snapshot.get("topics") or []:
+        if not isinstance(topic, dict):
+            continue
+        for stage in topic.get("stages") or []:
+            if not isinstance(stage, dict):
+                continue
+            if rtt_ms is None and stage.get("rtt_ms") is not None:
+                rtt_ms = stage.get("rtt_ms")
+            if loss_pct is None and stage.get("loss_pct") is not None:
+                loss_pct = stage.get("loss_pct")
+            if rtt_ms is not None and loss_pct is not None:
+                break
+        if rtt_ms is not None and loss_pct is not None:
+            break
+    return {
+        "available": rtt_ms is not None or peer_offset_ms is not None or loss_pct is not None,
+        "provenance": "echo_heartbeat_status_snapshot",
+        "rtt_ms": rtt_ms,
+        "peer_offset_ms": peer_offset_ms,
+        "loss_pct": loss_pct,
+        "assumption": clock_sync.get("assumption") if clock_sync else None,
+    }
+
+
+def run_modem_metrics_hook(
+    command: str,
+    *,
+    timeout_s: float = 2.0,
+    runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+) -> Dict[str, Any]:
+    """Run a configured modem metrics command and parse its JSON object output."""
+    command = (command or "").strip()
+    if not command:
+        return {"available": False, "provenance": "modem_metrics_command", "reason": "not configured"}
+    try:
+        result = runner(command, shell=True, text=True, capture_output=True, timeout=timeout_s, check=False)
+    except Exception as exc:  # noqa: BLE001 - surfaced as trace provenance, not fatal.
+        return {
+            "available": False,
+            "provenance": "modem_metrics_command",
+            "command": command,
+            "reason": f"command failed to run: {exc}",
+        }
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout or "").strip()
+        return {
+            "available": False,
+            "provenance": "modem_metrics_command",
+            "command": command,
+            "reason": f"exit {result.returncode}" + (f": {detail}" if detail else ""),
+        }
+    try:
+        metrics = json.loads((result.stdout or "").strip() or "{}")
+    except json.JSONDecodeError as exc:
+        return {
+            "available": False,
+            "provenance": "modem_metrics_command",
+            "command": command,
+            "reason": f"invalid JSON: {exc}",
+        }
+    if not isinstance(metrics, dict):
+        return {
+            "available": False,
+            "provenance": "modem_metrics_command",
+            "command": command,
+            "reason": "JSON output is not an object",
+        }
+    return {
+        "available": True,
+        "provenance": "modem_metrics_command",
+        "command": command,
+        "metrics": metrics,
+    }
+
+
+def build_link_trace_sample(
+    snapshot: Dict[str, Any],
+    link_sample: Optional[Dict[str, Any]],
+    *,
+    modem_metrics: Optional[Dict[str, Any]] = None,
+    monotonic_s: Optional[float] = None,
+) -> Dict[str, Any]:
+    """Build one JSON-serializable link trace row."""
+    return {
+        "schema_version": 1,
+        "kind": "link_trace",
+        "generated_at": snapshot.get("generated_at")
+        or datetime.datetime.now().isoformat(timespec="milliseconds"),
+        "monotonic_s": round(float(monotonic_s if monotonic_s is not None else time.monotonic()), 6),
+        "peer": snapshot.get("peer"),
+        "remote": snapshot.get("remote"),
+        "passive_counter_delta": passive_counter_delta_block(link_sample),
+        "peer_probe": echo_probe_block(snapshot),
+        "modem": modem_metrics or {
+            "available": False,
+            "provenance": "modem_metrics_command",
+            "reason": "not configured",
+        },
+    }
+
+
+class LinkTraceRecorder:
+    """Write link trace rows as append-only JSONL."""
+
+    def __init__(
+        self,
+        path: str,
+        *,
+        interval_s: float = 1.0,
+        modem_metrics_command: str = "",
+        modem_metrics_timeout_s: float = 2.0,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self.path = path
+        self.interval_s = max(0.1, float(interval_s))
+        self.modem_metrics_command = modem_metrics_command
+        self.modem_metrics_timeout_s = modem_metrics_timeout_s
+        self._clock = clock
+        self._last_write: Optional[float] = None
+
+    def maybe_write(self, snapshot: Dict[str, Any], link_sample: Optional[Dict[str, Any]]) -> bool:
+        now = self._clock()
+        if self._last_write is not None and now - self._last_write < self.interval_s:
+            return False
+        self._last_write = now
+        modem = run_modem_metrics_hook(
+            self.modem_metrics_command,
+            timeout_s=self.modem_metrics_timeout_s,
+        )
+        row = build_link_trace_sample(snapshot, link_sample, modem_metrics=modem, monotonic_s=now)
+        parent = os.path.dirname(self.path)
+        if parent:
+            os.makedirs(parent, exist_ok=True)
+        with open(self.path, "a", encoding="utf-8") as fp:
+            fp.write(json.dumps(row, sort_keys=True) + "\n")
+        return True

--- a/src/rosotacom/resources/ws/ros2src/com_py/com_py/status_overview.py
+++ b/src/rosotacom/resources/ws/ros2src/com_py/com_py/status_overview.py
@@ -68,6 +68,7 @@ from rclpy.serialization import serialize_message
 from rosidl_runtime_py.utilities import get_message
 
 from com_py.link_bytes import LinkByteSampler, find_interface_for_ip
+from com_py.link_trace import LinkTraceRecorder
 from com_py.status_overview_core import (
     ClockOffsetEstimator,
     StageObservation,
@@ -302,6 +303,10 @@ class StatusOverview(Node):
         # (the snapshot's `link` block is null).
         self.declare_parameter("ota_interface", "")
         self.declare_parameter("ota_local_ip", "")
+        self.declare_parameter("link_trace", False)
+        self.declare_parameter("link_trace_interval_s", 1.0)
+        self.declare_parameter("link_trace_modem_command", "")
+        self.declare_parameter("link_trace_modem_timeout_s", 2.0)
 
         spec_file = str(self.get_parameter("status_spec_file").value or "").strip()
         output_dir = str(self.get_parameter("output_dir").value or "").strip()
@@ -393,6 +398,19 @@ class StatusOverview(Node):
                 + (f" (resolved from {ota_local_ip})" if ota_local_ip else "")
             )
 
+        link_trace_recorder = None
+        if bool(self.get_parameter("link_trace").value):
+            link_trace_path = os.path.join(output_dir, "link_trace.jsonl")
+            link_trace_recorder = LinkTraceRecorder(
+                link_trace_path,
+                interval_s=float(self.get_parameter("link_trace_interval_s").value),
+                modem_metrics_command=str(self.get_parameter("link_trace_modem_command").value or ""),
+                modem_metrics_timeout_s=float(self.get_parameter("link_trace_modem_timeout_s").value),
+            )
+            self.get_logger().info(
+                f"status_overview: link trace enabled; writing {link_trace_path}"
+            )
+
         self.aggregator = StatusAggregator(
             self.get_logger(),
             self.spec,
@@ -404,6 +422,7 @@ class StatusOverview(Node):
             delay_bad_ms=float(self.get_parameter("delay_bad_ms").value),
             link_sampler=link_sampler,
             clock_estimator=clock_estimator,
+            link_trace_recorder=link_trace_recorder,
         )
 
         self.create_timer(self.write_interval_s, self._on_write)

--- a/src/rosotacom/resources/ws/ros2src/com_py/com_py/status_overview_core.py
+++ b/src/rosotacom/resources/ws/ros2src/com_py/com_py/status_overview_core.py
@@ -50,7 +50,6 @@ from collections import deque
 from dataclasses import dataclass, field
 from typing import Any, Deque, Dict, Hashable, List, Optional, Tuple
 
-
 # --- State vocabulary shared with heartbeat health ---
 ABSENT = "ABSENT"        # no publisher and never received a message
 IDLE = "IDLE"            # publisher present but no message observed yet
@@ -437,7 +436,8 @@ class StatusAggregator:
                  observers_by_domain: Dict[str, Any],
                  *, liveness_window_s: float = 3.0, stale_after_s: float = 3.0,
                  delay_good_ms: float = 100.0, delay_bad_ms: float = 200.0,
-                 link_sampler: Any = None, clock_estimator: Any = None):
+                 link_sampler: Any = None, clock_estimator: Any = None,
+                 link_trace_recorder: Any = None):
         self._log = logger
         self._spec = spec
         self._output_dir = output_dir
@@ -451,6 +451,7 @@ class StatusAggregator:
         # stays free of any I/O and is unit-testable.
         self._link_sampler = link_sampler
         self._clock_estimator = clock_estimator
+        self._link_trace_recorder = link_trace_recorder
         self._prev_states: Dict[str, Dict[str, Any]] = {}
         os.makedirs(self._output_dir, exist_ok=True)
         self._json_path = os.path.join(self._output_dir, "status.json")
@@ -933,6 +934,12 @@ class StatusAggregator:
                 if self._log is not None:
                     self._log.warning(f"status_overview: link sampling failed: {exc}")
         snapshot = self.build_snapshot(now_mono, link_sample=link_sample)
+        if self._link_trace_recorder is not None:
+            try:
+                self._link_trace_recorder.maybe_write(snapshot, link_sample)
+            except Exception as exc:  # pragma: no cover - defensive
+                if self._log is not None:
+                    self._log.warning(f"status_overview: failed to write link trace: {exc}")
         events = self.detect_transitions(snapshot)
         transit_records = self.collect_transit_records()
         try:

--- a/src/rosotacom/resources/ws/session/content/base/session_plugin_base.yaml
+++ b/src/rosotacom/resources/ws/session/content/base/session_plugin_base.yaml
@@ -60,6 +60,10 @@ parameters:
   status_write_interval_s: 2.0
   status_liveness_window_s: 3.0
   status_stale_after_s: 3.0
+  link_trace: false
+  link_trace_interval_s: 1.0
+  link_trace_modem_command: ""
+  link_trace_modem_timeout_s: 2.0
   metric_stage_bag: false
   metric_stage_topics:
 
@@ -347,6 +351,10 @@ windows:
             -p liveness_window_s:=${status_liveness_window_s}
             -p stale_after_s:=${status_stale_after_s}
             -p ota_local_ip:=${ip_local}
+            -p link_trace:=${link_trace}
+            -p link_trace_interval_s:=${link_trace_interval_s}
+            -p link_trace_modem_command:='${link_trace_modem_command}'
+            -p link_trace_modem_timeout_s:=${link_trace_modem_timeout_s}
       - commands:
         - status_out_dir="$(dirname "${ROSOTACOM_CATMUX_LOG_DIR:-/tmp/rosotacom_logs/catmux}")/status"
         - status_txt="$status_out_dir/status.txt"

--- a/src/rosotacom/resources/ws/session/creation/generate_session_files.py
+++ b/src/rosotacom/resources/ws/session/creation/generate_session_files.py
@@ -949,6 +949,7 @@ def _validate_session_template_cfg(cfg: Dict[str, Any]) -> None:
                 "use_heartbeat",
                 "heartbeat",
                 "metric_backbone",
+                "link_trace",
                 "use_in",
                 "use_out",
                 "rmw",
@@ -997,6 +998,29 @@ def _validate_session_template_cfg(cfg: Dict[str, Any]) -> None:
             _assert_allowed_keys("shared.heartbeat", hb, {"expect"})
             if "expect" in hb and hb["expect"] is not None and not isinstance(hb["expect"], dict):
                 raise RuntimeError("shared.heartbeat.expect must be a mapping.")
+        if "link_trace" in shared and shared["link_trace"] is not None:
+            link_trace = _assert_mapping(shared.get("link_trace"), "shared.link_trace")
+            _assert_allowed_keys(
+                "shared.link_trace",
+                link_trace,
+                {"enabled", "interval_s", "modem_metrics_command", "modem_metrics_timeout_s"},
+            )
+            if "enabled" in link_trace and not isinstance(link_trace["enabled"], bool):
+                raise RuntimeError("shared.link_trace.enabled must be boolean if provided.")
+            if "interval_s" in link_trace and link_trace["interval_s"] is not None:
+                if not isinstance(link_trace["interval_s"], (int, float)) or float(link_trace["interval_s"]) <= 0:
+                    raise RuntimeError("shared.link_trace.interval_s must be a positive number if provided.")
+            if "modem_metrics_command" in link_trace and link_trace["modem_metrics_command"] is not None:
+                if not isinstance(link_trace["modem_metrics_command"], str):
+                    raise RuntimeError("shared.link_trace.modem_metrics_command must be a string if provided.")
+            if "modem_metrics_timeout_s" in link_trace and link_trace["modem_metrics_timeout_s"] is not None:
+                if (
+                    not isinstance(link_trace["modem_metrics_timeout_s"], (int, float))
+                    or float(link_trace["modem_metrics_timeout_s"]) <= 0
+                ):
+                    raise RuntimeError(
+                        "shared.link_trace.modem_metrics_timeout_s must be a positive number if provided."
+                    )
 
     # peer_settings is optional
     if "peer_settings" in cfg and cfg["peer_settings"] is not None:
@@ -1841,6 +1865,15 @@ def func(
             "shared.metric_backbone.record_stages requires shared.use_status_overview=true "
             "so the generated pipeline defines the stage topics."
         )
+    link_trace = shared.get("link_trace", {}) or {}
+    if not isinstance(link_trace, dict):
+        raise RuntimeError("shared.link_trace must be a mapping if provided.")
+    link_trace_enabled = bool(link_trace.get("enabled", False))
+    link_trace_interval_s = float(link_trace.get("interval_s", 1.0))
+    link_trace_modem_command = str(link_trace.get("modem_metrics_command") or "")
+    link_trace_modem_timeout_s = float(link_trace.get("modem_metrics_timeout_s", 2.0))
+    if link_trace_enabled and not use_status_overview:
+        raise RuntimeError("shared.link_trace.enabled requires shared.use_status_overview=true.")
     shared_use_in = shared.get("use_in", None)
     shared_use_out = shared.get("use_out", None)
 
@@ -2135,6 +2168,54 @@ def func(
                             ("heartbeat_remote_topic", hb_topic[remote]),
                             *_heartbeat_monitor_overrides((shared.get("heartbeat") or {}).get("expect")),
                         ],
+                    )
+                )
+            if use_status_overview:
+                generated.append(
+                    (
+                        os.path.join(param_dir, local, "pipeline_spec.yaml"),
+                        _build_status_pipeline_spec(
+                            local=local,
+                            remote=remote,
+                            peer_name=peer_name,
+                            out_entries=[],
+                            out_pipes=[],
+                            in_entries=[],
+                            in_pipes=[],
+                            use_target_prefix=False,
+                            remote_uses_target_prefix=False,
+                            native_have_source_prefix=False,
+                            inbound_keep_source_prefix=False,
+                            local_domain_id=peer_local_domain_id[local],
+                            ota_domain_id=ota_domain_id,
+                            uses_domain_bridge=_use_domain_bridge(local),
+                            hb_topic=hb_topic,
+                            use_heartbeat=use_heartbeat,
+                            heartbeat_expect=(shared.get("heartbeat") or {}).get("expect"),
+                            out_enabled=False,
+                            in_enabled=False,
+                            final_topic_type=_final_topic_type,
+                        ),
+                    )
+                )
+                blocks.append(
+                    PluginBlock(
+                        "status_overview",
+                        [
+                            ("status_overview", True),
+                            ("status_spec_file", "${peer_dir}/pipeline_spec.yaml"),
+                        ]
+                        + (
+                            [
+                                ("status_write_interval_s", link_trace_interval_s),
+                                ("link_trace", True),
+                                ("link_trace_interval_s", link_trace_interval_s),
+                                ("link_trace_modem_command", link_trace_modem_command),
+                                ("link_trace_modem_timeout_s", link_trace_modem_timeout_s),
+                            ]
+                            if link_trace_enabled
+                            else []
+                        ),
                     )
                 )
             generated.append((os.path.join(param_dir, local, "plugin.yaml"), _render_plugin_yaml(blocks)))
@@ -2759,7 +2840,18 @@ def func(
                     [
                         ("status_overview", True),
                         ("status_spec_file", "${peer_dir}/pipeline_spec.yaml"),
-                    ],
+                    ]
+                    + (
+                        [
+                            ("status_write_interval_s", link_trace_interval_s),
+                            ("link_trace", True),
+                            ("link_trace_interval_s", link_trace_interval_s),
+                            ("link_trace_modem_command", link_trace_modem_command),
+                            ("link_trace_modem_timeout_s", link_trace_modem_timeout_s),
+                        ]
+                        if link_trace_enabled
+                        else []
+                    ),
                 )
             )
             if record_metric_stages:

--- a/src/rosotacom/resources/ws/session/creation/run_session.py
+++ b/src/rosotacom/resources/ws/session/creation/run_session.py
@@ -38,6 +38,7 @@
 # ---------------------------------------------------------------------
 
 import argparse
+import copy
 import os
 import re
 import subprocess
@@ -156,6 +157,32 @@ def _load_session_config_input(session_config_yaml: str) -> Dict:
     return cfg
 
 
+def _apply_link_trace_overrides(
+    cfg: Dict,
+    *,
+    link_trace: Optional[bool] = None,
+    link_trace_interval_s: Optional[float] = None,
+    link_trace_modem_command: Optional[str] = None,
+) -> Dict:
+    if link_trace is None and link_trace_interval_s is None and link_trace_modem_command is None:
+        return cfg
+    updated = copy.deepcopy(cfg)
+    shared = updated.setdefault("shared", {})
+    if not isinstance(shared, dict):
+        raise RuntimeError("shared must be a mapping before applying link trace overrides.")
+    trace_cfg = shared.setdefault("link_trace", {})
+    if not isinstance(trace_cfg, dict):
+        raise RuntimeError("shared.link_trace must be a mapping before applying link trace overrides.")
+    shared["use_status_overview"] = True
+    trace_cfg["enabled"] = True if link_trace is None else bool(link_trace)
+    if link_trace_interval_s is not None:
+        trace_cfg["interval_s"] = float(link_trace_interval_s)
+    if link_trace_modem_command is not None:
+        trace_cfg["modem_metrics_command"] = link_trace_modem_command
+    session_gen._validate_session_template_cfg(updated)
+    return updated
+
+
 def _resolve_peer_dir(
     session_dir: str,
     output_dir: Optional[str],
@@ -163,6 +190,9 @@ def _resolve_peer_dir(
     force: bool,
     rewrite_formatting: bool,
     peer_address=None,
+    link_trace: Optional[bool] = None,
+    link_trace_interval_s: Optional[float] = None,
+    link_trace_modem_command: Optional[str] = None,
 ) -> str:
     """
     Resolve a runnable session directory (the directory containing session_specification.yaml).
@@ -215,7 +245,12 @@ def _resolve_peer_dir(
             f"{candidates}. Got dir: {p}"
         )
 
-    cfg_for_generation = _load_session_config_input(param_yaml)
+    cfg_for_generation = _apply_link_trace_overrides(
+        _load_session_config_input(param_yaml),
+        link_trace=link_trace,
+        link_trace_interval_s=link_trace_interval_s,
+        link_trace_modem_command=link_trace_modem_command,
+    )
     peer_addresses = _parse_peer_address_overrides(peer_address)
     known_peers = set((cfg_for_generation.get("peers") or {}).keys())
     unknown = sorted(set(peer_addresses) - known_peers)
@@ -255,6 +290,9 @@ def main(
     force: bool = False,
     rewrite_formatting: bool = False,
     peer_address=None,
+    link_trace: Optional[bool] = None,
+    link_trace_interval_s: Optional[float] = None,
+    link_trace_modem_command: Optional[str] = None,
     attach: Optional[bool] = None,
 ):
 
@@ -265,6 +303,9 @@ def main(
         force,
         rewrite_formatting,
         peer_address=peer_address,
+        link_trace=link_trace,
+        link_trace_interval_s=link_trace_interval_s,
+        link_trace_modem_command=link_trace_modem_command,
     )
 
     # Ensure merged .session_readonly.yaml exists for catmux
@@ -368,6 +409,23 @@ if __name__ == "__main__":
         default=[],
         metavar="PEER=ADDRESS",
         help="Resolved peer address. Pass once for every logical peer.",
+    )
+    parser.add_argument(
+        "--link-trace",
+        action="store_true",
+        default=None,
+        help="Enable link_trace.jsonl recording for this generated session instance.",
+    )
+    parser.add_argument(
+        "--link-trace-interval",
+        dest="link_trace_interval_s",
+        type=float,
+        help="Link trace sample interval in seconds; enables link tracing.",
+    )
+    parser.add_argument(
+        "--link-trace-modem-command",
+        dest="link_trace_modem_command",
+        help="Shell command returning a JSON object to merge under each trace row's modem block.",
     )
     attach_group = parser.add_mutually_exclusive_group()
     attach_group.add_argument(

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -459,6 +459,12 @@ def _read_transit_records(artifact_dir: Path, peer: str) -> list[dict[str, objec
     return rows
 
 
+def _read_link_trace_rows(artifact_dir: Path, peer: str) -> list[dict[str, object]]:
+    path = artifact_dir / "logs" / peer / "status" / "link_trace.jsonl"
+    assert path.is_file(), f"no link_trace.jsonl for peer {peer} under {artifact_dir}"
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
 @pytest.mark.parametrize("session_name", LINK_LATENCY_SMOKE_SESSIONS)
 def test_local_link_latency_smoke_exposes_metric_backbone(
     copied_example_project: Path,
@@ -500,6 +506,19 @@ def test_local_link_latency_smoke_exposes_metric_backbone(
     assert any(row.get("status") == "delivered" for row in transit_rows), (
         f"no delivered transit record for {session_name}: {transit_rows[:3]}"
     )
+
+    link_trace_rows = _read_link_trace_rows(artifact_dir, "a")
+    assert link_trace_rows, f"no link trace rows for {session_name}"
+    assert any(
+        row.get("kind") == "link_trace"
+        and row.get("schema_version") == 1
+        and isinstance(row.get("passive_counter_delta"), dict)
+        and row["passive_counter_delta"].get("provenance") == "proc_net_dev_counter_delta"
+        and row["passive_counter_delta"].get("observed_not_available_bandwidth") is True
+        and isinstance(row.get("peer_probe"), dict)
+        and row["peer_probe"].get("provenance") == "echo_heartbeat_status_snapshot"
+        for row in link_trace_rows
+    ), f"link_trace.jsonl rows do not expose expected provenance for {session_name}: {link_trace_rows[:3]}"
 
     # The `rosotacom metrics` digest joins those rows into a non-empty summary.
     events_path = artifact_dir / "logs" / "a" / "status" / "events.jsonl"

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -644,6 +644,7 @@ def test_interactive_smoke_tmux_uses_full_windows_and_metadata(
         instance,
         {"a": "10.137.42.2", "b": "10.137.42.3"},
         "smoke-net",
+        link_trace_parts=["--link-trace", "--link-trace-interval", "0.5"],
     )
 
     assert tmux_session == "smoke-scenario-demo"
@@ -665,6 +666,7 @@ def test_interactive_smoke_tmux_uses_full_windows_and_metadata(
     assert any("inner catmux: C-b C-b" in part for command in calls for part in command)
     joined = "\n".join(" ".join(command) for command in calls)
     assert "--smoke-managed" in joined
+    assert "--link-trace --link-trace-interval 0.5" in joined
     assert "--network-name smoke-net --network-ip 10.137.42.2" in joined
     assert "--peer-address a=10.137.42.2 --peer-address b=10.137.42.3" in joined
     assert "scenario _run-application demo --identity a --application local_app --instance-id interactive" in joined
@@ -1668,6 +1670,22 @@ def test_peer_binding_identity_and_command_helpers(tmp_path: Path, monkeypatch: 
         "--attach",
     ]
 
+    traced_command = rosotacom._session_command(
+        session,
+        instance,
+        "a",
+        force=False,
+        rewrite_formatting=False,
+        peer_address_overrides={},
+        attach_mode="detached",
+        link_trace=True,
+        link_trace_interval_s=0.5,
+        link_trace_modem_command="cat /tmp/modem.json",
+    )
+    assert "--link-trace" in traced_command
+    assert traced_command[traced_command.index("--link-trace-interval") + 1] == "0.5"
+    assert traced_command[traced_command.index("--link-trace-modem-command") + 1] == "cat /tmp/modem.json"
+
     with pytest.raises(RuntimeError, match="Duplicate"):
         rosotacom._parse_peer_address_overrides(["a=1.1.1.1", "a=2.2.2.2"])
 
@@ -2436,11 +2454,20 @@ def test_run_session_generates_into_instance_config_without_touching_static_sour
         force=True,
         rewrite_formatting=False,
         peer_address=["a=127.0.0.1", "b=127.0.0.2"],
+        link_trace=True,
+        link_trace_interval_s=0.5,
+        link_trace_modem_command="cat /tmp/modem.json",
     )
 
     assert Path(peer_dir) == output / "a"
     assert (output / "session-definition.yaml").is_file()
     assert (output / "a" / "plugin.yaml").is_file()
+    plugin = yaml.safe_load((output / "a" / "plugin.yaml").read_text(encoding="utf-8"))
+    assert plugin["parameters"]["status_overview"] is True
+    assert plugin["parameters"]["link_trace"] is True
+    assert plugin["parameters"]["link_trace_interval_s"] == 0.5
+    assert plugin["parameters"]["link_trace_modem_command"] == "cat /tmp/modem.json"
+    assert (output / "a" / "pipeline_spec.yaml").is_file()
     assert not (source / "a").exists()
 
 

--- a/tests/unit/test_link_trace.py
+++ b/tests/unit/test_link_trace.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WS_PY = REPO_ROOT / "src" / "rosotacom" / "resources" / "ws" / "ros2src" / "com_py"
+sys.path.insert(0, str(WS_PY))
+
+from com_py.link_bytes import LinkByteSampler, parse_proc_net_dev  # noqa: E402
+from com_py.link_trace import (  # noqa: E402
+    LinkTraceRecorder,
+    build_link_trace_sample,
+    run_modem_metrics_hook,
+)
+
+
+def _proc_net_dev(rx_bytes: int, rx_packets: int, tx_bytes: int, tx_packets: int) -> str:
+    return "\n".join(
+        [
+            "Inter-|   Receive                                                |  Transmit",
+            " face |bytes    packets errs drop fifo frame compressed multicast|"
+            "bytes    packets errs drop fifo colls carrier compressed",
+            f"  eth0:{rx_bytes:8d} {rx_packets:7d}    0    0    0     0          0         0 "
+            f"{tx_bytes:8d} {tx_packets:7d}    0    0    0     0       0          0",
+            "",
+        ]
+    )
+
+
+def test_link_byte_sampler_reports_packet_and_byte_deltas(tmp_path: Path) -> None:
+    proc_path = tmp_path / "dev"
+    clock_values = iter([10.0, 12.0])
+    sampler = LinkByteSampler("eth0", proc_path=str(proc_path), clock=lambda: next(clock_values))
+
+    proc_path.write_text(_proc_net_dev(1_000, 10, 2_000, 20), encoding="utf-8")
+    assert sampler.sample() is None
+
+    proc_path.write_text(_proc_net_dev(2_000, 15, 3_500, 27), encoding="utf-8")
+    sample = sampler.sample()
+
+    assert sample is not None
+    assert sample["interface"] == "eth0"
+    assert sample["rx_bytes_delta"] == 1_000
+    assert sample["tx_bytes_delta"] == 1_500
+    assert sample["rx_packets_delta"] == 5
+    assert sample["tx_packets_delta"] == 7
+    assert sample["rx_kbps"] == pytest.approx(3.90625)
+    assert sample["tx_kbps"] == pytest.approx(5.859375)
+
+
+def test_parse_proc_net_dev_exposes_packet_counters() -> None:
+    stats = parse_proc_net_dev(_proc_net_dev(123, 4, 567, 8))
+    assert stats["eth0"] == {
+        "rx_bytes": 123,
+        "rx_packets": 4,
+        "tx_bytes": 567,
+        "tx_packets": 8,
+    }
+
+
+def test_build_link_trace_sample_marks_passive_rates_as_observed() -> None:
+    row = build_link_trace_sample(
+        {
+            "generated_at": "2026-07-07T10:00:00.000",
+            "peer": "a",
+            "remote": "b",
+            "clock_sync": {"rtt_ms": 12.5, "peer_offset_ms": -1.25, "assumption": "symmetric_path"},
+            "topics": [
+                {
+                    "stages": [
+                        {"stage": "com_in", "loss_pct": 2.5},
+                    ],
+                }
+            ],
+        },
+        {
+            "interface": "eth0",
+            "window_s": 1.2345678,
+            "rx_bytes_delta": 100,
+            "tx_bytes_delta": 200,
+            "rx_packets_delta": 3,
+            "tx_packets_delta": 4,
+            "rx_kbps": 0.8,
+            "tx_kbps": 1.6,
+        },
+        modem_metrics={"available": True, "provenance": "modem_metrics_command", "metrics": {"rsrp_dbm": -88}},
+        monotonic_s=42.1234567,
+    )
+
+    assert row["schema_version"] == 1
+    assert row["kind"] == "link_trace"
+    assert row["peer"] == "a"
+    assert row["passive_counter_delta"]["provenance"] == "proc_net_dev_counter_delta"
+    assert row["passive_counter_delta"]["observed_not_available_bandwidth"] is True
+    assert row["passive_counter_delta"]["rx"]["bytes_delta"] == 100
+    assert row["peer_probe"]["provenance"] == "echo_heartbeat_status_snapshot"
+    assert row["peer_probe"]["rtt_ms"] == 12.5
+    assert row["peer_probe"]["loss_pct"] == 2.5
+    assert row["modem"]["metrics"]["rsrp_dbm"] == -88
+
+
+def test_modem_metrics_hook_requires_json_object() -> None:
+    def good_runner(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(args[0], 0, '{"rsrp_dbm": -90}', "")
+
+    def bad_runner(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(args[0], 0, "[1, 2]", "")
+
+    assert run_modem_metrics_hook("echo {}", runner=good_runner)["metrics"] == {"rsrp_dbm": -90}
+    bad = run_modem_metrics_hook("echo []", runner=bad_runner)
+    assert bad["available"] is False
+    assert "not an object" in bad["reason"]
+
+
+def test_link_trace_recorder_appends_jsonl_on_interval(tmp_path: Path) -> None:
+    clock_values = iter([10.0, 10.5, 11.0])
+    trace_path = tmp_path / "status" / "link_trace.jsonl"
+    recorder = LinkTraceRecorder(str(trace_path), interval_s=1.0, clock=lambda: next(clock_values))
+    snapshot = {"generated_at": "2026-07-07T10:00:00.000", "peer": "a", "remote": "b", "topics": []}
+
+    assert recorder.maybe_write(snapshot, None) is True
+    assert recorder.maybe_write(snapshot, None) is False
+    assert recorder.maybe_write(snapshot, None) is True
+
+    rows = [json.loads(line) for line in trace_path.read_text(encoding="utf-8").splitlines()]
+    assert [row["kind"] for row in rows] == ["link_trace", "link_trace"]

--- a/tests/unit/test_status_overview.py
+++ b/tests/unit/test_status_overview.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from types import ModuleType
 
 import pytest
+import yaml
 
 import rosotacom.cli as rosotacom
 
@@ -110,6 +111,43 @@ def test_pipeline_spec_absent_when_flag_off(tmp_path: Path) -> None:
     cfg["shared"]["use_status_overview"] = False
     _generate(cfg, tmp_path)
     assert not (tmp_path / "a" / "pipeline_spec.yaml").exists()
+
+
+def test_link_trace_config_generates_status_recorder_params(tmp_path: Path) -> None:
+    cfg = _heartbeat_cfg()
+    cfg["shared"]["link_trace"] = {
+        "enabled": True,
+        "interval_s": 0.5,
+        "modem_metrics_command": "cat /tmp/modem.json",
+        "modem_metrics_timeout_s": 1.5,
+    }
+    _generate(cfg, tmp_path)
+
+    plugin = yaml.safe_load((tmp_path / "a" / "plugin.yaml").read_text(encoding="utf-8"))
+    params = plugin["parameters"]
+
+    assert params["status_overview"] is True
+    assert params["status_spec_file"] == "${peer_dir}/pipeline_spec.yaml"
+    assert params["status_write_interval_s"] == 0.5
+    assert params["link_trace"] is True
+    assert params["link_trace_interval_s"] == 0.5
+    assert params["link_trace_modem_command"] == "cat /tmp/modem.json"
+    assert params["link_trace_modem_timeout_s"] == 1.5
+    assert (tmp_path / "a" / "pipeline_spec.yaml").is_file()
+
+
+def test_link_trace_requires_status_overview() -> None:
+    cfg = _heartbeat_cfg()
+    cfg["shared"]["use_status_overview"] = False
+    cfg["shared"]["link_trace"] = {"enabled": True}
+
+    with pytest.raises(RuntimeError, match="shared.link_trace.enabled requires"):
+        generator.func(
+            session_config_obj=cfg,
+            output_dir="/tmp/unused",
+            force=True,
+            peer_addresses={"a": "127.0.0.1", "b": "127.0.0.2"},
+        )
 
 
 def test_use_status_overview_must_be_bool() -> None:


### PR DESCRIPTION
## Summary
- add per-peer link_trace.jsonl recording from status overview samples
- record passive /proc/net/dev byte and packet deltas, echo heartbeat RTT/loss provenance, and optional modem JSON hook output
- add shared config and CLI flags for start/smoke/ota-smoke/scenario runs, plus docs and smoke artifact assertions

## Validation
- python3 -m compileall src/rosotacom/resources/ws/ros2src/com_py/com_py/link_bytes.py src/rosotacom/resources/ws/ros2src/com_py/com_py/link_trace.py src/rosotacom/resources/ws/ros2src/com_py/com_py/status_overview_core.py src/rosotacom/resources/ws/ros2src/com_py/com_py/status_overview.py src/rosotacom/resources/ws/session/creation/generate_session_files.py src/rosotacom/resources/ws/session/creation/run_session.py src/rosotacom/cli.py
- python -m pytest tests/unit/test_link_trace.py tests/unit/test_status_overview.py tests/unit/test_cli.py
- python -m pytest tests/contract/test_markdown_links.py tests/contract/test_readme_examples.py
- python -m pytest tests/e2e/test_smoke.py -k link_latency (skipped locally; requires ROSOTACOM_RUN_E2E=1)
- python -m ruff check src tests
- python -m mypy src/rosotacom/cli.py

Closes #153