### PR TITLE
Add whole-bag expect generation

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -49,6 +49,43 @@ excluding it from the synthetic local smoke publisher/probe set and from the
 local smoke self-report assertion. Use it only for redundant replay-shape topics
 when a nearby representative stream already proves that path in CI.
 
+### Whole-Bag Expect Generation
+
+For replay gates, a bag's `metadata.yaml` is a ground-truth source: it records
+which topics exist, how many messages each contains, the bag duration, and the
+offered QoS. Generate a mergeable `expect:` fragment for the topics a session
+carries with:
+
+```bash
+rosotacom expect from-bag ./native_bag --session remote_assist --out whole-bag-expect.yaml
+```
+
+The generator reads only rosbag2 metadata. It does not rewrite the session in
+place. The output is a YAML fragment under `topics:` with one commented
+derivation per generated entry, so it can be reviewed and merged into a
+session-definition manually.
+
+Stream topics receive `min_count` plus `completeness.min_ratio` and
+`completeness.vs_bag_ratio`. The count and bag-relative rate are scaled by
+intended session shaping before the threshold is emitted: `drop` applies its
+keep fraction, and `throttle_hz` caps the expected post-drop rate. That means
+planned decimation is not counted as OTA loss. The default `--min-ratio 0.9`
+leaves a safety margin for a healthy link; tune it per gate instead of
+committing a brittle 100% threshold.
+
+Transient-local or explicitly latched topics become `mode: latched`, because the
+contract is that the held value arrives, not that the topic keeps ticking.
+Sparse volatile topics become `mode: existence`; the current expect model has no
+separate finite "delivered once and may now be stale" mode, so those entries
+assert graph presence without changing evaluator semantics.
+
+Generated whole-bag contracts complement hand-curated contracts. Keep the
+hand-curated session for the operator-facing steady-state checks that humans
+understand and maintain. Use a generated whole-bag variant when the question is
+"does this replay carry every session topic from the reference recording, after
+the session's intended shaping?" Regenerate the fragment when the reference bag
+or the session pipeline changes.
+
 ## Local Check Eligibility
 
 OTA suite membership is the default. There is no `multi_machine` marker.

--- a/src/rosotacom/bag_ground_truth.py
+++ b/src/rosotacom/bag_ground_truth.py
@@ -14,10 +14,15 @@ up, so such a floor is unsatisfiable no matter how healthy the link.
 
 from __future__ import annotations
 
+import math
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import yaml
+
+DEFAULT_EXPECT_MIN_RATIO = 0.9
+DEFAULT_STREAM_MIN_HZ = 0.1
 
 
 def _native_hz(count: int, duration_s: float) -> float | None:
@@ -109,3 +114,282 @@ def validate_expect_against_bag(
                 f"but expect is a stream with an hz floor -- consider `mode: latched`."
             )
     return warnings
+
+
+@dataclass(frozen=True)
+class GeneratedTopicExpect:
+    direction: str
+    topic: str
+    expect: dict[str, Any]
+    comment: str
+
+
+@dataclass(frozen=True)
+class WholeBagExpectFragment:
+    topics: dict[str, tuple[GeneratedTopicExpect, ...]]
+    missing_session_topics: tuple[str, ...]
+    uncarried_bag_topics: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class _Shaping:
+    expected_count: float
+    expected_hz: float | None
+    vs_bag_factor: float | None
+    comments: tuple[str, ...]
+
+
+def _topic_name(item: Any) -> str | None:
+    if isinstance(item, str):
+        return item
+    if isinstance(item, dict) and isinstance(item.get("topic"), str):
+        return cast(str, item["topic"])
+    return None
+
+
+def _processing(item: Any) -> dict[str, Any]:
+    if isinstance(item, dict) and isinstance(item.get("processing"), dict):
+        return cast(dict[str, Any], item["processing"])
+    return {}
+
+
+def _qos_is_transient_local(value: Any) -> bool:
+    if not isinstance(value, dict):
+        return False
+    durability = value.get("durability")
+    if isinstance(durability, str) and durability.strip().lower() == "transient_local":
+        return True
+    for nested in value.values():
+        if _qos_is_transient_local(nested):
+            return True
+    return False
+
+
+def _is_latched(item: Any, gt: dict[str, Any]) -> tuple[bool, str | None]:
+    proc = _processing(item)
+    if bool(proc.get("latch")):
+        return True, "session processing.latch=true"
+    if gt.get("durability") == "transient_local":
+        return True, "bag QoS durability=transient_local"
+    if isinstance(item, dict) and _qos_is_transient_local(item.get("qos")):
+        return True, "session qos durability=transient_local"
+    return False, None
+
+
+def _float_or_none(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        out = float(value)
+    except (TypeError, ValueError):
+        return None
+    return out if math.isfinite(out) else None
+
+
+def _round_metric(value: float, digits: int = 3) -> float:
+    rounded = round(float(value), digits)
+    if rounded == 0 and value > 0:
+        return float(f"{value:.3g}")
+    return rounded
+
+
+def _shape_expected_delivery(item: Any, gt: dict[str, Any]) -> _Shaping:
+    count = float(int(gt.get("count") or 0))
+    duration_s = _float_or_none(gt.get("duration_s")) or 0.0
+    native_hz = _float_or_none(gt.get("native_hz"))
+    expected_count = count
+    expected_hz = native_hz
+    comments: list[str] = []
+
+    proc = _processing(item)
+    drop = proc.get("drop")
+    if isinstance(drop, dict) and drop.get("drop_count") is not None and drop.get("window_size") is not None:
+        drop_count = int(drop.get("drop_count") or 0)
+        window_size = int(drop.get("window_size") or 0)
+        if window_size > 0 and 0 <= drop_count < window_size:
+            keep_ratio = (window_size - drop_count) / window_size
+            expected_count *= keep_ratio
+            if expected_hz is not None:
+                expected_hz *= keep_ratio
+            comments.append(f"drop {drop_count}/{window_size} keeps x{keep_ratio:.3g}")
+
+    throttle = proc.get("throttle_hz")
+    if throttle is not None:
+        throttle_hz = float(throttle)
+        if throttle_hz > 0:
+            if expected_hz is None:
+                if duration_s > 0:
+                    expected_count = min(expected_count, throttle_hz * duration_s + 1)
+                comments.append(f"throttle_hz {throttle_hz:g}")
+            elif expected_hz > throttle_hz:
+                before = expected_hz
+                expected_hz = throttle_hz
+                if duration_s > 0:
+                    expected_count = min(expected_count, throttle_hz * duration_s + 1)
+                comments.append(f"throttle_hz {throttle_hz:g} caps {before:.3g} Hz")
+            else:
+                comments.append(f"throttle_hz {throttle_hz:g} is not limiting")
+
+    vs_bag_factor = expected_hz / native_hz if native_hz and native_hz > 0 and expected_hz is not None else None
+    return _Shaping(
+        expected_count=expected_count,
+        expected_hz=expected_hz,
+        vs_bag_factor=vs_bag_factor,
+        comments=tuple(comments),
+    )
+
+
+def _mode_for_topic(
+    item: Any,
+    gt: dict[str, Any],
+    *,
+    stream_min_hz: float,
+) -> tuple[str, str]:
+    latched, reason = _is_latched(item, gt)
+    if latched:
+        return "latched", str(reason)
+
+    count = int(gt.get("count") or 0)
+    native_hz = _float_or_none(gt.get("native_hz"))
+    if count <= 1:
+        return "existence", "bag has at most one message and is not transient_local"
+    if native_hz is None or native_hz < stream_min_hz:
+        hz_text = "unknown" if native_hz is None else f"{native_hz:.3g} Hz"
+        return "existence", f"native rate {hz_text} is below stream_min_hz {stream_min_hz:g}"
+    return "stream", f"native rate {native_hz:.3g} Hz is stream-like"
+
+
+def _base_derivation(topic: str, gt: dict[str, Any]) -> str:
+    native_hz = _float_or_none(gt.get("native_hz"))
+    hz_text = "unknown Hz" if native_hz is None else f"{native_hz:.3g} Hz"
+    return (
+        f"{topic}: bag_count={int(gt.get('count') or 0)}, "
+        f"duration={float(gt.get('duration_s') or 0):g}s, native={hz_text}"
+    )
+
+
+def generate_whole_bag_expectations(
+    cfg: dict[str, Any],
+    ground_truth: dict[str, dict[str, Any]],
+    *,
+    min_ratio: float = DEFAULT_EXPECT_MIN_RATIO,
+    stream_min_hz: float = DEFAULT_STREAM_MIN_HZ,
+) -> WholeBagExpectFragment:
+    """Generate mergeable per-topic ``expect`` blocks from bag metadata.
+
+    The result covers session-carried topics that are present in the bag ground
+    truth. Stream thresholds are scaled for intended send-side shaping
+    (``drop`` and ``throttle_hz``), so configured decimation is not counted as
+    OTA loss.
+    """
+    if not 0 < min_ratio <= 1:
+        raise ValueError("min_ratio must be > 0 and <= 1")
+    if stream_min_hz < 0:
+        raise ValueError("stream_min_hz must be >= 0")
+
+    topics = cfg.get("topics")
+    if not isinstance(topics, dict):
+        return WholeBagExpectFragment(
+            topics={},
+            missing_session_topics=(),
+            uncarried_bag_topics=tuple(sorted(ground_truth)),
+        )
+
+    generated: dict[str, list[GeneratedTopicExpect]] = {}
+    missing: list[str] = []
+    carried_topics: set[str] = set()
+    for direction, entries in topics.items():
+        if not isinstance(entries, list):
+            continue
+        direction_key = str(direction)
+        for item in entries:
+            topic = _topic_name(item)
+            if topic is None:
+                continue
+            carried_topics.add(topic)
+            gt = ground_truth.get(topic)
+            if gt is None:
+                missing.append(f"{direction_key}:{topic}")
+                continue
+
+            mode, mode_reason = _mode_for_topic(item, gt, stream_min_hz=stream_min_hz)
+            expect: dict[str, Any] = {"presence": "required", "mode": mode}
+            derivation = [_base_derivation(topic, gt), f"mode={mode} ({mode_reason})"]
+            if mode == "stream":
+                shaping = _shape_expected_delivery(item, gt)
+                min_count = max(1, int(math.floor(shaping.expected_count * min_ratio)))
+                completeness: dict[str, Any] = {"min_ratio": _round_metric(min_ratio)}
+                if shaping.vs_bag_factor is not None:
+                    completeness["vs_bag_ratio"] = _round_metric(shaping.vs_bag_factor * min_ratio)
+                expect["min_count"] = min_count
+                expect["completeness"] = completeness
+                shape_text = "; ".join(shaping.comments) if shaping.comments else "none"
+                expected_hz = "unknown" if shaping.expected_hz is None else f"{shaping.expected_hz:.3g} Hz"
+                derivation.append(
+                    f"shaping={shape_text}; expected={shaping.expected_count:.3g} msgs/{expected_hz}; "
+                    f"min_ratio={min_ratio:g} -> min_count={min_count}"
+                )
+            elif mode == "latched":
+                derivation.append("latched mode checks held-value delivery, not rate or full count")
+            else:
+                derivation.append("existence mode checks graph presence for sparse/irregular non-latched topics")
+
+            generated.setdefault(direction_key, []).append(
+                GeneratedTopicExpect(
+                    direction=direction_key,
+                    topic=topic,
+                    expect=expect,
+                    comment="; ".join(derivation),
+                )
+            )
+
+    uncarried = tuple(sorted(set(ground_truth) - carried_topics))
+    return WholeBagExpectFragment(
+        topics={direction: tuple(items) for direction, items in generated.items()},
+        missing_session_topics=tuple(sorted(missing)),
+        uncarried_bag_topics=uncarried,
+    )
+
+
+def _yaml_scalar(value: str) -> str:
+    dumped = str(yaml.safe_dump(value, default_flow_style=True, sort_keys=False)).strip()
+    if dumped.endswith("\n..."):
+        dumped = dumped[:-4].strip()
+    return dumped
+
+
+def _indent(text: str, spaces: int) -> list[str]:
+    pad = " " * spaces
+    return [pad + line if line else line for line in text.splitlines()]
+
+
+def render_whole_bag_expect_fragment(
+    fragment: WholeBagExpectFragment,
+    *,
+    bag: str | Path | None = None,
+    session: str | Path | None = None,
+) -> str:
+    """Render a parseable YAML fragment with derivation comments."""
+    lines = ["# Generated by `rosotacom expect from-bag`."]
+    if bag is not None:
+        lines.append(f"# Bag: {bag}")
+    if session is not None:
+        lines.append(f"# Session: {session}")
+    if fragment.missing_session_topics:
+        lines.append("# Session topics not found in the bag and skipped: " + ", ".join(fragment.missing_session_topics))
+    if fragment.uncarried_bag_topics:
+        lines.append("# Bag topics not carried by this session: " + ", ".join(fragment.uncarried_bag_topics))
+    lines.append("topics:")
+    for direction, entries in fragment.topics.items():
+        lines.append(f"  {direction}:")
+        for entry in entries:
+            lines.append(f"    - topic: {_yaml_scalar(entry.topic)}")
+            lines.append(f"      # {entry.comment}")
+            dumped = yaml.safe_dump(
+                {"expect": entry.expect},
+                sort_keys=False,
+                default_flow_style=False,
+                allow_unicode=True,
+            ).rstrip()
+            lines.extend(_indent(dumped, 6))
+    return "\n".join(lines)

--- a/src/rosotacom/cli.py
+++ b/src/rosotacom/cli.py
@@ -6112,6 +6112,55 @@ def calibrate_command(args: argparse.Namespace) -> int:
     return 1 if warnings else 0
 
 
+def expect_from_bag_command(args: argparse.Namespace) -> int:
+    """Generate a mergeable whole-bag ``expect`` fragment from bag metadata."""
+    from . import bag_ground_truth
+
+    runtime = _load_runtime_config(args)
+    session = _resolve_session(args.session_dir, runtime)
+    cfg = _effective_session_config(session.host_dir, runtime)
+    gt = bag_ground_truth.bag_ground_truth(args.bag)
+    if not gt:
+        print(f"No topics found in bag metadata: {args.bag}", file=sys.stderr)
+        return 1
+
+    fragment = bag_ground_truth.generate_whole_bag_expectations(
+        cfg,
+        gt,
+        min_ratio=float(args.min_ratio),
+        stream_min_hz=float(args.stream_min_hz),
+    )
+    generated_count = sum(len(entries) for entries in fragment.topics.values())
+    if generated_count == 0:
+        print(
+            f"No session-carried topics from {session.host_dir} were found in bag metadata: {args.bag}",
+            file=sys.stderr,
+        )
+        return 1
+
+    text = bag_ground_truth.render_whole_bag_expect_fragment(fragment, bag=args.bag, session=session.host_dir)
+    out = getattr(args, "out", None)
+    if out:
+        out_path = Path(out).expanduser()
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(text + "\n", encoding="utf-8")
+        print(f"Wrote {generated_count} generated expect block(s) to {out_path}")
+    else:
+        print(text)
+
+    if fragment.missing_session_topics:
+        print(
+            "Warning: skipped session topics absent from the bag: " + ", ".join(fragment.missing_session_topics),
+            file=sys.stderr,
+        )
+    if fragment.uncarried_bag_topics:
+        print(
+            "Warning: bag topics not carried by this session: " + ", ".join(fragment.uncarried_bag_topics),
+            file=sys.stderr,
+        )
+    return 0
+
+
 def test_command(args: argparse.Namespace) -> int:
     """Assert a running/recent session meets its status + per-topic `expect` contract.
 
@@ -7507,6 +7556,7 @@ def main(argv: list[str] | None = None) -> int:
         "status",
         "metrics",
         "test",
+        "expect",
         "calibrate",
         "verify",  # retired; keep guarded so it is not rewritten as `start verify`.
         "probe-publish",
@@ -7688,6 +7738,36 @@ def main(argv: list[str] | None = None) -> int:
         help="Print a suggested `expect` block per topic from the current run instead of asserting.",
     )
     test_parser.set_defaults(func=test_command)
+
+    expect_parser = subparsers.add_parser("expect", help="Generate or inspect per-topic expect contracts.")
+    expect_subparsers = expect_parser.add_subparsers(dest="expect_command", required=True)
+    expect_from_bag_parser = expect_subparsers.add_parser(
+        "from-bag",
+        help="Generate a whole-bag expect YAML fragment from rosbag2 metadata.",
+    )
+    _add_common_config_args(expect_from_bag_parser)
+    expect_from_bag_parser.add_argument("bag", help="Path to a rosbag2 bag directory or its metadata.yaml.")
+    _add_session_arg(
+        expect_from_bag_parser,
+        "--session",
+        dest="session_dir",
+        required=True,
+        help="Session name or directory whose carried topics should receive generated expect blocks.",
+    )
+    expect_from_bag_parser.add_argument("--out", help="Write the YAML fragment to this path instead of stdout.")
+    expect_from_bag_parser.add_argument(
+        "--min-ratio",
+        type=float,
+        default=0.9,
+        help="Safety margin for generated min_count/completeness thresholds (default: 0.9).",
+    )
+    expect_from_bag_parser.add_argument(
+        "--stream-min-hz",
+        type=float,
+        default=0.1,
+        help="Minimum native rate classified as stream instead of existence (default: 0.1).",
+    )
+    expect_from_bag_parser.set_defaults(func=expect_from_bag_command)
 
     calibrate_parser = subparsers.add_parser(
         "calibrate",

--- a/src/rosotacom/resources/examples/README.md
+++ b/src/rosotacom/resources/examples/README.md
@@ -119,6 +119,21 @@ recording (message-size distribution and inter-message regularity), the
 reference point for judging how well the received stream preserves the input
 cadence.
 
+## Whole-bag expect generation
+
+The example project includes a tiny rosbag2 `metadata.yaml` fixture for
+`8_drop`. It lets you inspect the whole-bag expect generator without needing a
+large MCAP:
+
+```bash
+rosotacom expect from-bag bags/8_drop_reference --session 8_drop --out whole-bag-expect.yaml
+```
+
+The generated fragment accounts for the session's configured `drop` stage before
+emitting `min_count` and bag-relative completeness thresholds. Review the
+comments in the output, then merge the `expect:` block into a session variant
+when you want a replay gate that asserts the reference bag's carried topics.
+
 ## Two-machine runs
 
 For a real two-machine run, pass both reachable addresses on both hosts:
@@ -137,6 +152,7 @@ Use `--identity b` on the second host. Alternatively copy
 - `rosotacom.yaml`: project-local rosotacom setup
 - `ros2docker.json`: Docker runtime defaults used by the communication containers
 - `deployment.example.yaml`: optional named-host deployment example
+- `bags/`: small rosbag metadata fixtures used by documentation and host tests
 - `sessions/`: tracked static session definitions/templates
 - `scenarios/`: complete use cases that combine a session with local applications
 - `session-instances/`: ignored generated runtime configs, catmux logs, smoke logs, and rosbags

--- a/src/rosotacom/resources/examples/bags/8_drop_reference/metadata.yaml
+++ b/src/rosotacom/resources/examples/bags/8_drop_reference/metadata.yaml
@@ -1,0 +1,17 @@
+rosbag2_bagfile_information:
+  version: 5
+  storage_identifier: mcap
+  duration:
+    nanoseconds: 10000000000
+  starting_time:
+    nanoseconds_since_epoch: 0
+  message_count: 101
+  topics_with_message_count:
+    - topic_metadata:
+        name: /drop_demo
+        type: std_msgs/msg/String
+        serialization_format: cdr
+        offered_qos_profiles:
+          - reliability: reliable
+            durability: volatile
+      message_count: 101

--- a/tests/contract/test_packaged_resources.py
+++ b/tests/contract/test_packaged_resources.py
@@ -23,6 +23,7 @@ def test_packaged_resources_include_curated_examples_and_runtime_workspace() -> 
         "resources/examples/ros2docker.json",
         "resources/examples/profiles.yaml",
         "resources/examples/deployment.example.yaml",
+        "resources/examples/bags/8_drop_reference/metadata.yaml",
         "resources/examples/sessions/1_heartbeat/session-definition.yaml",
         "resources/examples/sessions/1_heartbeat_status/session-definition.yaml",
         "resources/examples/sessions/14_remote_assist_anonymized/session-definition.yaml",

--- a/tests/unit/test_bag_ground_truth.py
+++ b/tests/unit/test_bag_ground_truth.py
@@ -4,8 +4,12 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import yaml
+
 from rosotacom.bag_ground_truth import (
     bag_ground_truth,
+    generate_whole_bag_expectations,
+    render_whole_bag_expect_fragment,
     validate_expect_against_bag,
 )
 
@@ -88,3 +92,76 @@ def test_validate_latched_static_has_no_warning(tmp_path: Path) -> None:
 def test_validate_ignores_topics_absent_from_bag(tmp_path: Path) -> None:
     gt = bag_ground_truth(_write_bag(tmp_path))
     assert validate_expect_against_bag({"/not_in_bag": {"hz": {"min": 999}}}, gt) == []
+
+
+def test_generate_whole_bag_expect_scales_counts_for_drop_and_throttle(tmp_path: Path) -> None:
+    gt = bag_ground_truth(_write_bag(tmp_path))
+    cfg = {
+        "topics": {
+            "b_to_a": [
+                {
+                    "topic": "/tf",
+                    "processing": {"drop": {"drop_count": 1, "window_size": 2}, "throttle_hz": 20},
+                },
+                {"topic": "/site"},
+                {"topic": "/tf_static"},
+                {"topic": "/not_in_bag"},
+            ]
+        }
+    }
+
+    fragment = generate_whole_bag_expectations(cfg, gt, min_ratio=0.8)
+    by_topic = {entry.topic: entry for entry in fragment.topics["b_to_a"]}
+
+    tf_expect = by_topic["/tf"].expect
+    assert tf_expect["mode"] == "stream"
+    assert tf_expect["min_count"] == 1600  # throttle caps the post-drop 53.7 Hz stream to 20 Hz over 100s.
+    assert tf_expect["completeness"] == {"min_ratio": 0.8, "vs_bag_ratio": 0.149}
+    assert "drop 1/2" in by_topic["/tf"].comment
+    assert "throttle_hz 20 caps" in by_topic["/tf"].comment
+
+    assert by_topic["/site"].expect["min_count"] == 80
+    assert by_topic["/site"].expect["completeness"] == {"min_ratio": 0.8, "vs_bag_ratio": 0.8}
+    assert by_topic["/tf_static"].expect == {"presence": "required", "mode": "latched"}
+    assert fragment.missing_session_topics == ("b_to_a:/not_in_bag",)
+    assert fragment.uncarried_bag_topics == ()
+
+
+def test_generate_whole_bag_expect_classifies_sparse_volatile_as_existence(tmp_path: Path) -> None:
+    bag = tmp_path / "bag"
+    bag.mkdir()
+    (bag / "metadata.yaml").write_text(
+        """\
+rosbag2_bagfile_information:
+  duration: {nanoseconds: 100000000000}
+  topics_with_message_count:
+    - topic_metadata:
+        name: /oneshot
+        type: std_msgs/msg/String
+        offered_qos_profiles:
+          - {reliability: reliable, durability: volatile}
+      message_count: 1
+""",
+        encoding="utf-8",
+    )
+    gt = bag_ground_truth(bag)
+
+    fragment = generate_whole_bag_expectations({"topics": {"b_to_a": [{"topic": "/oneshot"}]}}, gt)
+    entry = fragment.topics["b_to_a"][0]
+
+    assert entry.expect == {"presence": "required", "mode": "existence"}
+    assert "at most one message" in entry.comment
+
+
+def test_render_whole_bag_expect_fragment_is_parseable_yaml_with_derivation_comments(tmp_path: Path) -> None:
+    gt = bag_ground_truth(_write_bag(tmp_path))
+    cfg = {"topics": {"b_to_a": [{"topic": "/tf"}]}}
+    fragment = generate_whole_bag_expectations(cfg, gt)
+
+    text = render_whole_bag_expect_fragment(fragment, bag=tmp_path, session="session")
+    parsed = yaml.safe_load(text)
+
+    assert parsed["topics"]["b_to_a"][0]["topic"] == "/tf"
+    assert parsed["topics"]["b_to_a"][0]["expect"]["min_count"] == 9673
+    assert "# /tf: bag_count=10748" in text
+    assert "# Bag topics not carried by this session: /site, /tf_static" in text

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import base64
 import io
+import json
 import os
 import re
 import struct
@@ -1531,6 +1532,115 @@ def test_probe_verbs_dispatch_not_wrapped_in_start(monkeypatch: pytest.MonkeyPat
     ]
     assert all(args.session_dir == "1_heartbeat" for _, args in seen)
     assert seen[1][1].expect == "absent"
+
+
+def test_expect_from_bag_fragment_passes_rosotacom_test(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    project = tmp_path / "project"
+    session_dir = project / "sessions" / "whole_bag"
+    bag_dir = project / "bags" / "fixture_bag"
+    instance_dir = project / "session-instances" / "2026-01-01" / "whole_bag_2026-01-01_00-00-00_run1"
+    session_dir.mkdir(parents=True)
+    bag_dir.mkdir(parents=True)
+    (project / "ros2docker.json").write_text('{"image_name": "unit"}\n', encoding="utf-8")
+    (project / "rosotacom.yaml").write_text(
+        "ros2docker_config: ros2docker.json\n"
+        "session_configs_dir:\n"
+        "  - sessions\n"
+        "session_instances_dir: session-instances\n",
+        encoding="utf-8",
+    )
+    (bag_dir / "metadata.yaml").write_text(
+        """\
+rosbag2_bagfile_information:
+  duration: {nanoseconds: 10000000000}
+  topics_with_message_count:
+    - topic_metadata:
+        name: /stream
+        type: std_msgs/msg/String
+        offered_qos_profiles:
+          - {reliability: reliable, durability: volatile}
+      message_count: 101
+""",
+        encoding="utf-8",
+    )
+    session_cfg = {
+        "peers": {"a": {}, "b": {}},
+        "shared": {"use_status_overview": True},
+        "topics": {
+            "b_to_a": [
+                {
+                    "topic": "/stream",
+                    "type": "std_msgs/msg/String",
+                    "processing": {"drop": {"drop_count": 1, "window_size": 2}},
+                }
+            ]
+        },
+    }
+    session_path = session_dir / "session-definition.yaml"
+    session_path.write_text(yaml.safe_dump(session_cfg, sort_keys=False), encoding="utf-8")
+
+    generated_path = tmp_path / "whole-bag-expect.yaml"
+    rc = rosotacom.main(
+        [
+            "expect",
+            "from-bag",
+            str(bag_dir),
+            "--session",
+            "whole_bag",
+            "--project",
+            str(project / "rosotacom.yaml"),
+            "--out",
+            str(generated_path),
+            "--min-ratio",
+            "0.8",
+        ]
+    )
+
+    assert rc == 0
+    assert "Wrote 1 generated expect block" in capsys.readouterr().out
+    generated = yaml.safe_load(generated_path.read_text(encoding="utf-8"))
+    session_cfg["topics"]["b_to_a"][0]["expect"] = generated["topics"]["b_to_a"][0]["expect"]
+    session_path.write_text(yaml.safe_dump(session_cfg, sort_keys=False), encoding="utf-8")
+
+    status_dir = instance_dir / "logs" / "a" / "status"
+    status_dir.mkdir(parents=True)
+    status = {
+        "peer": "a",
+        "topics": [
+            {
+                "base": "/stream",
+                "direction": "inbound",
+                "overall": "OK",
+                "stages": [
+                    {"stage": "com_in", "state": "FLOWING", "hz": 5.0, "messages_total": 50, "publishers": 1},
+                    {"stage": "app_in", "state": "FLOWING", "hz": 5.0, "messages_total": 45, "publishers": 1},
+                ],
+            }
+        ],
+    }
+    (status_dir / "status.json").write_text(json.dumps(status), encoding="utf-8")
+
+    assert (
+        rosotacom.main(
+            [
+                "test",
+                "whole_bag",
+                "--project",
+                str(project / "rosotacom.yaml"),
+                "--instance-id",
+                "run1",
+                "--bag",
+                str(bag_dir),
+                "--timeout",
+                "0",
+            ]
+        )
+        == 0
+    )
+    assert "TEST OK" in capsys.readouterr().out
 
 
 def test_start_and_stop_compat_entrypoints_prefix_commands(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Fixes #156.
Refs go914/rosotacom_test#15.

## Summary

- Add `rosotacom expect from-bag <bag> --session <session>` to generate mergeable per-topic `expect:` fragments from rosbag2 metadata.
- Scale stream thresholds by intended `drop` and `throttle_hz` shaping, classify transient-local/latched topics, and emit derivation comments in parseable YAML.
- Document whole-bag contracts, add a packaged `8_drop` metadata fixture, and cover generate -> merge -> `rosotacom test --bag` in host tests.

## Validation

- `python -m ruff check .`
- `python -m ruff format --check .`
- `python -m mypy`
- `python -m pytest -q tests/unit/test_bag_ground_truth.py tests/unit/test_cli.py tests/contract/test_markdown_links.py tests/contract/test_readme_examples.py tests/contract/test_pytest_policy.py tests/contract/test_packaged_resources.py`
- `just --set python /home/go914/dev/rosotacom_test/ros_communication_devcontainer/.venv/bin/python --set bin /home/go914/dev/rosotacom_test/ros_communication_devcontainer/.venv/bin package`
