### PR TITLE
Add Cyclone SPDP benchmark diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,6 +519,18 @@ shaping context, thresholds, verdict, and per-topic loss/latency/jitter metrics.
 For live benchmark probes, `--duration` is the shaped publish window; after that
 rosotacom stops synthetic publishers and waits `--drain-s` seconds before
 tearing down shaping, so delayed in-flight messages are not miscounted as loss.
+Cyclone DDS benchmark sessions keep the default tuned OTA
+`SPDPInterval=30s`. On tight rate-limited profiles, this periodic discovery
+metatraffic can share the shaped link with payload traffic and appear as regular
+p99/max latency spikes. rosotacom records a `cyclonedds_spdp` diagnostic in
+`result.json` and prints a warning when the probe duration and offered/shaped
+bandwidth make that effect plausible. Keep the default for end-to-end DDS
+behavior. For payload-only characterization where discovery bursts would mask the
+question under test, pass `--cyclone-spdp-interval 150s` or another longer
+positive `ms`/`s` duration. Making SPDP too frequent improves stale-peer and
+reconnect detection cadence but contaminates tight-link latency more often;
+making it too lax quiets short probes but hides discovery/liveliness overhead and
+delays detection of changed peer state.
 Use `benchmark probe` when you want a fixed payload/rate under one profile
 instead of a breakpoint search. It writes the normal `result.json` plus
 `time-bins.jsonl` with per-second loss, delivered Hz, payload bandwidth, and
@@ -528,6 +540,7 @@ when the optional plotting dependency is installed:
 ```bash
 rosotacom benchmark probe --profile cellular-4g-typical --size 18000 --rate-hz 20 --duration 20 --repeats 1
 rosotacom benchmark probe --profile cellular-4g-typical --size-pattern 1x20KB+1x0KB --rate-hz 10 --duration 20 --repeats 1
+rosotacom benchmark probe --profile cellular-4g-typical --size 18000 --rate-hz 20 --duration 20 --cyclone-spdp-interval 150s
 rosotacom benchmark plot time-bins.jsonl --type probe
 ```
 

--- a/docs/rfcs/0005-benchmark-genres-and-ci.md
+++ b/docs/rfcs/0005-benchmark-genres-and-ci.md
@@ -144,6 +144,12 @@ harness, not in this public repo.
 - **Averages hide the failure mode.** Head-of-line blocking and reconnect bursts
   are only visible per-message (RFC 0003) and under irregular load (the a/b
   pattern) — a benchmark on averages would miss exactly what matters.
+- **Discovery traffic is real load.** Cyclone DDS SPDP discovery uses the same
+  OTA link as payload data. Keeping the default `SPDPInterval=30s` is honest for
+  end-to-end DDS behavior, but tight shaped probes can show regular p99/max
+  latency spikes from SPDP bursts. A longer benchmark-only SPDP interval is useful
+  for payload characterization, but it makes the run less representative and
+  delays stale-peer/reconnect detection.
 
 ## Implementation checklist
 
@@ -168,6 +174,11 @@ slice and reuses RFC 0003 + 0004.
   packaged benchmark sessions to Cyclone DDS, while keeping `--rmw fastdds` and
   other supported session RMW values available for explicit comparisons
   (`cli_benchmark --rmw`, artifact-backed session copy).
+- [x] Keep Cyclone DDS `SPDPInterval=30s` as the tuned default, add an explicit
+  benchmark/session override for quiet-discovery probes, and annotate fixed
+  probes when SPDP traffic can plausibly distort tight-link tail latency
+  (`--cyclone-spdp-interval`, `shared.rmw.ota.cyclone.spdp_interval`,
+  `result.json.context.diagnostics.cyclonedds_spdp`).
 - [x] Persist a self-contained per-run `result.json` with selected RMW, local/OTA
   mode, configured load, offered bandwidth, profile shaping context, thresholds,
   verdict, and per-topic loss/latency/jitter metrics; keep `budgets.jsonl` as the
@@ -225,6 +236,13 @@ reviewed rather than asserted in a blocking test.
   *(`test_benchmark_subcommand_arg_parsing`,
   `test_benchmark_session_copy_pins_requested_rmw`,
   `test_benchmark_capacity_*`.)*
+- [x] **Cyclone DDS SPDP benchmark awareness** (default 30s retained, optional
+  override, fixed-probe diagnostic warning for tight links) — host unit tests for
+  XML rendering, session copy, generated plugin parameters, and diagnostic
+  classification. Automatable. *(`test_ota_xml_renders_default_and_overridden_spdp_interval`,
+  `test_benchmark_session_copy_applies_cyclone_spdp_override`,
+  `test_run_session_passes_cyclone_spdp_interval_to_plugin`,
+  `test_probe_spdp_diagnostics_warn_on_tight_cyclone_profile`.)*
 - [x] **Self-contained benchmark result artifact** (`result.json` with context,
   metrics, verdict, and artifact references) — host unit tests assert the capacity,
   ramp, and sweep result files and the CI-readable metric output. Automatable.

--- a/src/rosotacom/cli_benchmark.py
+++ b/src/rosotacom/cli_benchmark.py
@@ -35,6 +35,9 @@ import yaml
 
 DEFAULT_BENCHMARK_RMW = "cyclone"
 DEFAULT_BENCHMARK_DRAIN_S = 2.0
+DEFAULT_CYCLONE_SPDP_INTERVAL = "30s"
+SPDP_EFFECT_DURATION_FRACTION = 2.0 / 3.0
+SPDP_TIGHT_LINK_UTILIZATION = 0.70
 BENCHMARK_RESULT_FILE = "result.json"
 BENCHMARK_SESSIONS_BY_GENRE = {
     "probe": "bench_1_1_capacity",
@@ -229,6 +232,19 @@ def _benchmark_rmw(args: argparse.Namespace) -> str:
     return str(getattr(args, "rmw", None) or DEFAULT_BENCHMARK_RMW)
 
 
+def _benchmark_cyclone_spdp_interval(args: argparse.Namespace) -> str | None:
+    raw = getattr(args, "cyclone_spdp_interval", None)
+    if raw is None:
+        return None
+    value = str(raw).strip()
+    if not value:
+        return None
+    from .network_profiles import parse_seconds
+
+    parse_seconds(value, "--cyclone-spdp-interval")
+    return value
+
+
 def _normalize_benchmark_profile(profile: str | None) -> str | None:
     if profile is None:
         return None
@@ -260,6 +276,114 @@ def _profile_requires_netem_seed(profile: Any) -> bool:
     return _direction_requires_netem_seed(getattr(profile, "uplink", None)) or _direction_requires_netem_seed(
         getattr(profile, "downlink", None)
     )
+
+
+def _profile_rate_limits_bps(profile: str | None, profiles_file: Path | None) -> list[float]:
+    if not profile or profiles_file is None:
+        return []
+    try:
+        from .network_profiles import load_profiles_file
+
+        profile_obj = load_profiles_file(profiles_file).get(profile)
+    except Exception:
+        return []
+    if profile_obj is None:
+        return []
+
+    def rate_of(shaping: Any) -> float | None:
+        value = getattr(shaping, "rate_bps", None) if shaping is not None else None
+        return float(value) if value is not None else None
+
+    rates: list[float] = []
+    if getattr(profile_obj, "is_timeline", False):
+        for segment in getattr(profile_obj, "timeline", ()):
+            for shaping in (getattr(segment, "uplink", None), getattr(segment, "downlink", None)):
+                rate = rate_of(shaping)
+                if rate is not None:
+                    rates.append(rate)
+    else:
+        for shaping in (getattr(profile_obj, "uplink", None), getattr(profile_obj, "downlink", None)):
+            rate = rate_of(shaping)
+            if rate is not None:
+                rates.append(rate)
+    return rates
+
+
+def _probe_spdp_diagnostics(
+    *,
+    args: argparse.Namespace,
+    profile: str | None,
+    duration_s: float,
+    load_info: dict[str, Any],
+) -> dict[str, Any] | None:
+    rmw = _benchmark_rmw(args)
+    if rmw != "cyclone":
+        return None
+
+    from .cli import _load_runtime_config
+    from .network_profiles import parse_seconds
+
+    runtime = _load_runtime_config(args)
+    profiles_file = _benchmark_profiles_file(profile, runtime.profiles_file)
+    configured_interval = _benchmark_cyclone_spdp_interval(args)
+    interval_text = configured_interval or DEFAULT_CYCLONE_SPDP_INTERVAL
+    interval_s = parse_seconds(interval_text, "CycloneDDS SPDP interval")
+    offered_bps = load_info.get("offered_bandwidth_bps")
+    rates = _profile_rate_limits_bps(profile, profiles_file)
+    min_rate = min(rates) if rates else None
+    utilization = (
+        float(offered_bps) / float(min_rate)
+        if offered_bps is not None and min_rate is not None and min_rate > 0.0
+        else None
+    )
+    duration_ratio = float(duration_s) / interval_s if interval_s > 0.0 else None
+    risk = "low"
+    warnings: list[str] = []
+    if (
+        duration_ratio is not None
+        and duration_ratio >= SPDP_EFFECT_DURATION_FRACTION
+        and utilization is not None
+        and utilization >= SPDP_TIGHT_LINK_UTILIZATION
+    ):
+        risk = "possible"
+        warnings.append(
+            "CycloneDDS SPDP discovery traffic may affect probe p99/max latency: "
+            f"SPDPInterval={interval_text}, duration={duration_s:g}s, "
+            f"offered/shaped-rate={utilization:.2f}. Keep this for end-to-end DDS behavior; "
+            "raise --cyclone-spdp-interval only for payload-only characterization."
+        )
+    return {
+        "rmw": rmw,
+        "interval": interval_text,
+        "interval_s": round(interval_s, 6),
+        "override": configured_interval is not None,
+        "duration_s": float(duration_s),
+        "duration_to_interval_ratio": round(duration_ratio, 6) if duration_ratio is not None else None,
+        "profile_rate_limits_bps": rates,
+        "minimum_profile_rate_bps": min_rate,
+        "offered_bandwidth_bps": offered_bps,
+        "offered_to_minimum_profile_rate": round(utilization, 6) if utilization is not None else None,
+        "risk": risk,
+        "warnings": warnings,
+    }
+
+
+def _attach_benchmark_diagnostics(
+    context: dict[str, Any],
+    *,
+    spdp: dict[str, Any] | None = None,
+) -> None:
+    if spdp is None:
+        return
+    diagnostics = context.setdefault("diagnostics", {})
+    diagnostics["cyclonedds_spdp"] = spdp
+    warnings = diagnostics.setdefault("warnings", [])
+    warnings.extend(spdp.get("warnings", []))
+
+
+def _print_benchmark_warnings(context: dict[str, Any]) -> None:
+    for warning in context.get("diagnostics", {}).get("warnings", []):
+        print(f"WARN: {warning}")
 
 
 def _benchmark_drain_s(args: argparse.Namespace) -> float:
@@ -333,7 +457,13 @@ def _prepare_benchmark_session_config(args: argparse.Namespace, session_name: st
     shared = cfg.setdefault("shared", {})
     if not isinstance(shared, dict):
         raise RuntimeError(f"Benchmark session config 'shared' must be a mapping: {config_path}")
-    shared["rmw"] = rmw
+    cyclone_spdp_interval = _benchmark_cyclone_spdp_interval(args)
+    if cyclone_spdp_interval is not None:
+        if rmw != "cyclone":
+            raise ValueError("--cyclone-spdp-interval can only be used with --rmw cyclone.")
+        shared["rmw"] = {"local": "cyclone", "ota": {"cyclone": {"spdp_interval": cyclone_spdp_interval}}}
+    else:
+        shared["rmw"] = rmw
     qos_options = _apply_benchmark_qos_options(
         cfg,
         reliability=getattr(args, "qos_reliability", None),
@@ -366,6 +496,7 @@ def _prepare_benchmark_session_config(args: argparse.Namespace, session_name: st
         "config_path": config_path,
         "rmw": rmw,
         "runtime_implementation": _rmw_runtime_implementation(rmw),
+        "cyclone_spdp_interval": cyclone_spdp_interval,
         "qos": qos_options,
         "streams": stream_options,
     }
@@ -4486,6 +4617,14 @@ def _add_benchmark_common_args(parser: argparse.ArgumentParser, *, ota_benchmark
         help=f"RMW implementation or rosotacom RMW alias for benchmark sessions (default: {DEFAULT_BENCHMARK_RMW}).",
     )
     parser.add_argument(
+        "--cyclone-spdp-interval",
+        help=(
+            "Override CycloneDDS SPDPInterval for benchmark session OTA XML, e.g. 150s. "
+            f"Default remains {DEFAULT_CYCLONE_SPDP_INTERVAL}; use longer values only for quiet-discovery "
+            "payload characterization, not for normal end-to-end DDS behavior."
+        ),
+    )
+    parser.add_argument(
         "--qos-reliability",
         choices=["best_effort", "reliable"],
         help="Override benchmark session OTA pub/sub reliability for the whole run.",
@@ -5062,10 +5201,28 @@ def benchmark_probe(args: argparse.Namespace) -> int:
         run_dir=run_dir,
         session=session_context,
     )
+    probe_load = _probe_load(
+        size=getattr(args, "size", 18_000),
+        size_pattern=getattr(args, "size_pattern", None),
+        rate_hz=getattr(args, "rate_hz", 20.0),
+        streams=getattr(args, "streams", 1),
+        interval_jitter_ms=getattr(args, "interval_jitter_ms", 0.0),
+        interval_jitter_seed=getattr(args, "interval_jitter_seed", 42),
+    )
+    _attach_benchmark_diagnostics(
+        result_context,
+        spdp=_probe_spdp_diagnostics(
+            args=args,
+            profile=_normalize_benchmark_profile(args.profile),
+            duration_s=float(getattr(args, "duration", 60.0)),
+            load_info=_load_context(probe_load),
+        ),
+    )
 
     run_point = getattr(args, "_test_run_point", None) or _make_live_run_point(args, "bench_1_1_capacity")
 
     with log_stdout_stderr_to_file(run_dir / "stdout.txt"):
+        _print_benchmark_warnings(result_context)
         result = drive_probe(
             run_point,
             profile=args.profile,

--- a/src/rosotacom/resources/ws/ota_configs/cyclonedds_tuned.xml.template
+++ b/src/rosotacom/resources/ws/ota_configs/cyclonedds_tuned.xml.template
@@ -17,7 +17,7 @@
             </Peers>
             <EnableTopicDiscoveryEndpoints>false</EnableTopicDiscoveryEndpoints>
             <LeaseDuration>60s</LeaseDuration>
-            <SPDPInterval>30s</SPDPInterval>
+            <SPDPInterval>#spdp_interval</SPDPInterval>
         </Discovery>
 
         <Internal>

--- a/src/rosotacom/resources/ws/ota_configs/get_ota_xml.py
+++ b/src/rosotacom/resources/ws/ota_configs/get_ota_xml.py
@@ -2,8 +2,8 @@
 """Unified OTA DDS XML generator.
 
 Loads an XML template from /ws/ota_configs/<config>(.template), detects which
-placeholders it uses (#host_ip, #peer, #easy_mode_ip), substitutes already
-resolved addresses, and prints the resulting XML to stdout.
+placeholders it uses (#host_ip, #peer, #easy_mode_ip, #spdp_interval),
+substitutes already resolved addresses, and prints the resulting XML to stdout.
 
 Replaces the old per-template scripts (get_fastdds_xml.py,
 get_fastdds_easy_mode_xml.py, get_cyclonedds_xml.py).
@@ -14,8 +14,9 @@ import os
 import re
 
 
-KNOWN_PLACEHOLDERS = {"#host_ip", "#peer", "#easy_mode_ip"}
+KNOWN_PLACEHOLDERS = {"#host_ip", "#peer", "#easy_mode_ip", "#spdp_interval"}
 PLACEHOLDER_PATTERN = re.compile(r"#[A-Za-z_][A-Za-z0-9_]*")
+DEFAULT_SPDP_INTERVAL = "30s"
 
 
 def _template_path(name: str) -> str:
@@ -43,6 +44,19 @@ def _resolved_address(value: str, label: str) -> str:
     if not address:
         raise ValueError(f"{label} must be a non-empty resolved address.")
     return address
+
+
+def _resolved_spdp_interval(value: str) -> str:
+    interval = value.strip().lower()
+    if not interval:
+        raise ValueError("SPDP interval must be a non-empty duration.")
+    match = re.fullmatch(r"(\d+(?:\.\d+)?)\s*(ms|s)?", interval)
+    if not match:
+        raise ValueError("SPDP interval must use seconds or milliseconds, e.g. '30s' or '500ms'.")
+    number = float(match.group(1))
+    if number <= 0.0:
+        raise ValueError("SPDP interval must be > 0.")
+    return interval
 
 
 def _resolve_peer_ips(value: str) -> list:
@@ -124,6 +138,7 @@ def main(
     host_ip: str = None,
     peer: str = None,
     easy_mode_ip: str = None,
+    spdp_interval: str = DEFAULT_SPDP_INTERVAL,
 ) -> str:
     path = _template_path(config)
     if not os.path.exists(path):
@@ -156,6 +171,9 @@ def main(
             "#easy_mode_ip", _resolved_address(easy_mode_ip, "Easy Mode IP")
         )
 
+    if "#spdp_interval" in found:
+        content = content.replace("#spdp_interval", _resolved_spdp_interval(spdp_interval))
+
     if "#peer" in found:
         if not peer:
             raise RuntimeError(
@@ -185,6 +203,12 @@ if __name__ == "__main__":
     parser.add_argument(
         "-e", "--easy-mode-ip", dest="easy_mode_ip",
         help="Resolved Fast DDS Easy Mode address (#easy_mode_ip).",
+    )
+    parser.add_argument(
+        "--spdp-interval",
+        dest="spdp_interval",
+        default=DEFAULT_SPDP_INTERVAL,
+        help=f"CycloneDDS SPDP interval duration (#spdp_interval, default: {DEFAULT_SPDP_INTERVAL}).",
     )
     args = parser.parse_args()
     print(main(**{k: v for k, v in vars(args).items() if v is not None}))

--- a/src/rosotacom/resources/ws/session/content/base/session_plugin_base.yaml
+++ b/src/rosotacom/resources/ws/session/content/base/session_plugin_base.yaml
@@ -6,6 +6,7 @@ parameters:
   local_config_template: # e.g. fastdds_v1.xml, cyclonedds.xml. Empty => use RMW default config.
   local_config_file: ${peer_dir}/local_dds.xml # destination path for the resolved local DDS XML
   local_easy_mode_ip: # resolved address for #easy_mode_ip (only honored when the template uses it)
+  local_spdp_interval: # CycloneDDS SPDP interval override, e.g. 150s. Empty => template default.
   use_domain_bridge: false
   local_domain_id:   # pinned per-peer ROS_DOMAIN_ID (from peer_settings.<peer>.domain_id)
   ota_domain_id:
@@ -35,6 +36,7 @@ parameters:
   ota_config_template: # e.g. fastdds_v1.xml, cyclonedds.xml. Empty => use the RMW's default config.
   ota_config_file: ${peer_dir}/ota_dds.xml # destination path for the resolved DDS XML
   ota_easy_mode_ip: # resolved address for #easy_mode_ip (only honored when the template uses it)
+  ota_spdp_interval: # CycloneDDS SPDP interval override, e.g. 150s. Empty => template default.
   # Z2D (zenoh_ros2dds) parameters — used only when use_zenoh_ros2dds=true
   zen_mode: # e.g. router, peer or client
   zen_endpoint_role: # e.g. listen or connect
@@ -241,7 +243,7 @@ common:
   before_commands:
     - if [ '${local_domain_id}' != "None" ] && [ -n '${local_domain_id}' ]; then export ROS_DOMAIN_ID='${local_domain_id}'; fi
     - if [ '${rmw_local}' != "None" ]; then case ${rmw_local} in cyclone) export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp;; fastdds) export RMW_IMPLEMENTATION=rmw_fastrtps_cpp; export FASTDDS_BUILTIN_TRANSPORTS=${FASTDDS_BUILTIN_TRANSPORTS:-UDPv4};; zenoh) export RMW_IMPLEMENTATION=rmw_zenoh_cpp;; *) export RMW_IMPLEMENTATION='${rmw_local}';; esac; fi
-    - if [ '${local_config_template}' != "None" ] && [ -n '${local_config_template}' ]; then local_args=(--config "${local_config_template}" --host-ip "${ip_local}" --peer "${ip_remote}"); [ '${local_easy_mode_ip}' != "None" ] && [ -n '${local_easy_mode_ip}' ] && local_args+=(--easy-mode-ip "${local_easy_mode_ip}"); /ws/ota_configs/get_ota_xml.py "${local_args[@]}" > "${local_config_file}"; case ${rmw_local} in cyclone) export CYCLONEDDS_URI="file://${local_config_file}";; fastdds) export FASTDDS_DEFAULT_PROFILES_FILE="${local_config_file}"; export RMW_FASTRTPS_USE_QOS_FROM_XML=1;; esac; fi
+    - if [ '${local_config_template}' != "None" ] && [ -n '${local_config_template}' ]; then local_args=(--config "${local_config_template}" --host-ip "${ip_local}" --peer "${ip_remote}"); [ '${local_easy_mode_ip}' != "None" ] && [ -n '${local_easy_mode_ip}' ] && local_args+=(--easy-mode-ip "${local_easy_mode_ip}"); [ '${local_spdp_interval}' != "None" ] && [ -n '${local_spdp_interval}' ] && local_args+=(--spdp-interval "${local_spdp_interval}"); /ws/ota_configs/get_ota_xml.py "${local_args[@]}" > "${local_config_file}"; case ${rmw_local} in cyclone) export CYCLONEDDS_URI="file://${local_config_file}";; fastdds) export FASTDDS_DEFAULT_PROFILES_FILE="${local_config_file}"; export RMW_FASTRTPS_USE_QOS_FROM_XML=1;; esac; fi
     - if [ '${before_command}' != "None" ]; then ${before_command}; fi
 
 windows:
@@ -275,7 +277,7 @@ windows:
     if: use_domain_bridge
     splits:
       - commands:
-        - if [ '${ota_config_template}' != "None" ] && [ -n '${ota_config_template}' ]; then ota_args=(--config "${ota_config_template}" --host-ip "${ip_local}" --peer "${ip_remote}"); [ '${ota_easy_mode_ip}' != "None" ] && [ -n '${ota_easy_mode_ip}' ] && ota_args+=(--easy-mode-ip "${ota_easy_mode_ip}"); /ws/ota_configs/get_ota_xml.py "${ota_args[@]}" > "${ota_config_file}"; case ${rmw_ota} in cyclone) export CYCLONEDDS_URI="file://${ota_config_file}";; fastdds) export FASTDDS_DEFAULT_PROFILES_FILE="${ota_config_file}"; export RMW_FASTRTPS_USE_QOS_FROM_XML=1;; esac; fi
+        - if [ '${ota_config_template}' != "None" ] && [ -n '${ota_config_template}' ]; then ota_args=(--config "${ota_config_template}" --host-ip "${ip_local}" --peer "${ip_remote}"); [ '${ota_easy_mode_ip}' != "None" ] && [ -n '${ota_easy_mode_ip}' ] && ota_args+=(--easy-mode-ip "${ota_easy_mode_ip}"); [ '${ota_spdp_interval}' != "None" ] && [ -n '${ota_spdp_interval}' ] && ota_args+=(--spdp-interval "${ota_spdp_interval}"); /ws/ota_configs/get_ota_xml.py "${ota_args[@]}" > "${ota_config_file}"; case ${rmw_ota} in cyclone) export CYCLONEDDS_URI="file://${ota_config_file}";; fastdds) export FASTDDS_DEFAULT_PROFILES_FILE="${ota_config_file}"; export RMW_FASTRTPS_USE_QOS_FROM_XML=1;; esac; fi
         - ros2 run domain_bridge domain_bridge --wait-for-publisher false ${domain_bridge_config_file}
   - name: IN
     if: in
@@ -283,7 +285,7 @@ windows:
       - commands:
         - if [ '${ota_domain_id}' != "None" ] && [ -n '${ota_domain_id}' ]; then export ROS_DOMAIN_ID='${ota_domain_id}'; fi
         - case ${rmw_ota} in cyclone) export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp;; fastdds) export RMW_IMPLEMENTATION=rmw_fastrtps_cpp; export FASTDDS_BUILTIN_TRANSPORTS=${FASTDDS_BUILTIN_TRANSPORTS:-UDPv4};; zenoh) export RMW_IMPLEMENTATION=rmw_zenoh_cpp;; esac
-        - if [ '${ota_config_template}' != "None" ] && [ -n '${ota_config_template}' ]; then ota_args=(--config "${ota_config_template}" --host-ip "${ip_local}" --peer "${ip_remote}"); [ '${ota_easy_mode_ip}' != "None" ] && [ -n '${ota_easy_mode_ip}' ] && ota_args+=(--easy-mode-ip "${ota_easy_mode_ip}"); /ws/ota_configs/get_ota_xml.py "${ota_args[@]}" > "${ota_config_file}"; case ${rmw_ota} in cyclone) export CYCLONEDDS_URI="file://${ota_config_file}";; fastdds) export FASTDDS_DEFAULT_PROFILES_FILE="${ota_config_file}"; export RMW_FASTRTPS_USE_QOS_FROM_XML=1;; esac; fi
+        - if [ '${ota_config_template}' != "None" ] && [ -n '${ota_config_template}' ]; then ota_args=(--config "${ota_config_template}" --host-ip "${ip_local}" --peer "${ip_remote}"); [ '${ota_easy_mode_ip}' != "None" ] && [ -n '${ota_easy_mode_ip}' ] && ota_args+=(--easy-mode-ip "${ota_easy_mode_ip}"); [ '${ota_spdp_interval}' != "None" ] && [ -n '${ota_spdp_interval}' ] && ota_args+=(--spdp-interval "${ota_spdp_interval}"); /ws/ota_configs/get_ota_xml.py "${ota_args[@]}" > "${ota_config_file}"; case ${rmw_ota} in cyclone) export CYCLONEDDS_URI="file://${ota_config_file}";; fastdds) export FASTDDS_DEFAULT_PROFILES_FILE="${ota_config_file}"; export RMW_FASTRTPS_USE_QOS_FROM_XML=1;; esac; fi
         # For zenoh_ros2dds the OTA domain is loopback-only (zenoh is the inter-host
         # transport), so confine discovery to localhost instead of statically peering
         # the remote host — otherwise the OTA-domain DDS double-delivers alongside zenoh.
@@ -308,7 +310,7 @@ windows:
       - commands:
         - if [ '${ota_domain_id}' != "None" ] && [ -n '${ota_domain_id}' ]; then export ROS_DOMAIN_ID='${ota_domain_id}'; fi
         - case ${rmw_ota} in cyclone) export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp;; fastdds) export RMW_IMPLEMENTATION=rmw_fastrtps_cpp; export FASTDDS_BUILTIN_TRANSPORTS=${FASTDDS_BUILTIN_TRANSPORTS:-UDPv4};; zenoh) export RMW_IMPLEMENTATION=rmw_zenoh_cpp;; esac
-        - if [ '${ota_config_template}' != "None" ] && [ -n '${ota_config_template}' ]; then ota_args=(--config "${ota_config_template}" --host-ip "${ip_local}" --peer "${ip_remote}"); [ '${ota_easy_mode_ip}' != "None" ] && [ -n '${ota_easy_mode_ip}' ] && ota_args+=(--easy-mode-ip "${ota_easy_mode_ip}"); /ws/ota_configs/get_ota_xml.py "${ota_args[@]}" > "${ota_config_file}"; case ${rmw_ota} in cyclone) export CYCLONEDDS_URI="file://${ota_config_file}";; fastdds) export FASTDDS_DEFAULT_PROFILES_FILE="${ota_config_file}"; export RMW_FASTRTPS_USE_QOS_FROM_XML=1;; esac; fi
+        - if [ '${ota_config_template}' != "None" ] && [ -n '${ota_config_template}' ]; then ota_args=(--config "${ota_config_template}" --host-ip "${ip_local}" --peer "${ip_remote}"); [ '${ota_easy_mode_ip}' != "None" ] && [ -n '${ota_easy_mode_ip}' ] && ota_args+=(--easy-mode-ip "${ota_easy_mode_ip}"); [ '${ota_spdp_interval}' != "None" ] && [ -n '${ota_spdp_interval}' ] && ota_args+=(--spdp-interval "${ota_spdp_interval}"); /ws/ota_configs/get_ota_xml.py "${ota_args[@]}" > "${ota_config_file}"; case ${rmw_ota} in cyclone) export CYCLONEDDS_URI="file://${ota_config_file}";; fastdds) export FASTDDS_DEFAULT_PROFILES_FILE="${ota_config_file}"; export RMW_FASTRTPS_USE_QOS_FROM_XML=1;; esac; fi
         # For zenoh_ros2dds the OTA domain is loopback-only (zenoh is the inter-host
         # transport), so confine discovery to localhost instead of statically peering
         # the remote host — otherwise the OTA-domain DDS double-delivers alongside zenoh.

--- a/src/rosotacom/resources/ws/session/creation/generate_session_files.py
+++ b/src/rosotacom/resources/ws/session/creation/generate_session_files.py
@@ -132,7 +132,7 @@ class YamlBlockScalar:
 #   - a string: cyclone | fastdds | zenoh_connect_endpoints | zenoh_ros2dds | <raw rmw string>
 #     (zenoh_ros2dds is allowed for ota only; raw rmw strings are for local only)
 #   - a tagged-union mapping with exactly one key (the RMW name):
-#       {cyclone: {config?: <fname.xml>, easy_mode_ip?: <address>}}
+#       {cyclone: {config?: <fname.xml>, easy_mode_ip?: <address>, spdp_interval?: <duration>}}
 #       {fastdds: {config?: <fname.xml>, easy_mode_ip?: <address>}}
 #       {zenoh_connect_endpoints: {main_peer?: <peer_key>, main_port?: 7447}}
 #       {zenoh_ros2dds: {transport?: udp|tcp, main_peer?: <peer_key>, main_port?: 7447}}
@@ -145,7 +145,7 @@ _OTA_SHORTS = {"cyclone", "fastdds", *_NATIVE_ZENOH_OTA_SHORTS, "zenoh_ros2dds"}
 _LOCAL_SHORTS = {"cyclone", "fastdds", "zenoh"}
 _SHORTCUT_ALLOWED = {"cyclone", "fastdds", "zenoh"}
 
-_DDS_CFG_KEYS = {"config", "easy_mode_ip"}
+_DDS_CFG_KEYS = {"config", "easy_mode_ip", "spdp_interval"}
 _ZEN_OTA_CFG_KEYS = {"main_peer", "main_port"}
 _ZEN_R2D_CFG_KEYS = {"transport", "main_peer", "main_port"}
 
@@ -159,6 +159,16 @@ _DDS_OTA_DEFAULT_CONFIG = {
     "cyclone": "cyclonedds_tuned.xml",
     "fastdds": "fastdds_unicast.xml",
 }
+
+
+def _validate_positive_seconds(value: str, ctx: str) -> None:
+    text = value.strip().lower()
+    match = re.fullmatch(r"(\d+(?:\.\d+)?)\s*(ms|s)?", text)
+    if not match:
+        raise RuntimeError(f"{ctx}: expected e.g. '30s' or '500ms', got {value!r}.")
+    seconds = float(match.group(1)) / 1000.0 if match.group(2) == "ms" else float(match.group(1))
+    if seconds <= 0.0:
+        raise RuntimeError(f"{ctx} must be > 0, got {value!r}.")
 
 
 def _is_native_zenoh_ota(impl: Optional[str]) -> bool:
@@ -180,6 +190,7 @@ class RmwSideSpec:
     # DDS-specific (cyclone, fastdds)
     dds_config: Optional[str] = None
     dds_easy_mode_ip: Optional[str] = None
+    dds_spdp_interval: Optional[str] = None
     # zenoh / zenoh_ros2dds
     zen_main_peer: Optional[str] = None
     # zenoh_ros2dds only
@@ -239,6 +250,13 @@ def _parse_rmw_side(value: Any, ctx: str, *, is_local: bool) -> RmwSideSpec:
             if not isinstance(cfg["easy_mode_ip"], str) or not cfg["easy_mode_ip"].strip():
                 raise RuntimeError(f"{ctx}.{impl}.easy_mode_ip must be a non-empty string if provided.")
             spec.dds_easy_mode_ip = cfg["easy_mode_ip"].strip()
+        if cfg.get("spdp_interval") is not None:
+            if impl != "cyclone":
+                raise RuntimeError(f"{ctx}.{impl}.spdp_interval is only supported for CycloneDDS.")
+            if not isinstance(cfg["spdp_interval"], str) or not cfg["spdp_interval"].strip():
+                raise RuntimeError(f"{ctx}.{impl}.spdp_interval must be a non-empty duration if provided.")
+            _validate_positive_seconds(cfg["spdp_interval"], f"{ctx}.{impl}.spdp_interval")
+            spec.dds_spdp_interval = cfg["spdp_interval"].strip()
     elif _is_native_zenoh_ota(impl):
         extra = set(cfg.keys()) - _ZEN_OTA_CFG_KEYS
         if extra:
@@ -1980,6 +1998,8 @@ def func(
                         side.dds_easy_mode_ip or peer_ip[peer_keys[0]],
                     )
                 )
+            if side.impl == "cyclone" and side.dds_spdp_interval:
+                items.append(("local_spdp_interval", side.dds_spdp_interval))
         return items
 
     def _build_ota_rmw_items() -> List[Tuple[str, Any]]:
@@ -2005,6 +2025,8 @@ def func(
                         ota.dds_easy_mode_ip or peer_ip[peer_keys[0]],
                     )
                 )
+            if ota.impl == "cyclone" and ota.dds_spdp_interval:
+                items.append(("ota_spdp_interval", ota.dds_spdp_interval))
         return items
 
     def _build_zenoh_block(

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -2581,6 +2581,47 @@ def test_run_session_generates_into_instance_config_without_touching_static_sour
     assert not (source / "a").exists()
 
 
+def test_run_session_passes_cyclone_spdp_interval_to_plugin(tmp_path: Path) -> None:
+    from session.creation import run_session
+
+    source = tmp_path / "sessions" / "spdp"
+    output = tmp_path / "session-instances" / "2026-01-01" / "spdp_run" / "config"
+    source.mkdir(parents=True)
+    (source / "session-definition.yaml").write_text(
+        "\n".join(
+            [
+                "peers:",
+                "  a: {}",
+                "  b: {}",
+                "shared:",
+                "  rmw:",
+                "    local: cyclone",
+                "    ota:",
+                "      cyclone:",
+                "        spdp_interval: 150s",
+                "topics:",
+                "  a_to_b:",
+                "    - topic: /x",
+                "      type: std_msgs/msg/String",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    peer_dir = run_session._resolve_peer_dir(
+        str(source),
+        str(output),
+        "a",
+        force=True,
+        rewrite_formatting=False,
+        peer_address=["a=127.0.0.1", "b=127.0.0.2"],
+    )
+
+    plugin = yaml.safe_load((Path(peer_dir) / "plugin.yaml").read_text(encoding="utf-8"))
+    assert plugin["parameters"]["ota_spdp_interval"] == "150s"
+
+
 def test_create_session_yaml_injects_catmux_logging_command(tmp_path: Path) -> None:
     from session.creation import create_session_yaml
 

--- a/tests/unit/test_cli_benchmark.py
+++ b/tests/unit/test_cli_benchmark.py
@@ -36,6 +36,8 @@ from rosotacom.cli_benchmark import (
     _parse_values,
     _peer_catmux_attach_script,
     _prepare_benchmark_session_config,
+    _probe_load,
+    _probe_spdp_diagnostics,
     _profile_requires_netem_seed,
     _requirements_jitter_loss_pct,
     _requirements_target_quality,
@@ -1522,6 +1524,7 @@ def test_benchmark_subcommand_arg_parsing() -> None:
     assert args.bin_s == 1.0
     assert args.plot is True
     assert args.size_pattern is None
+    assert args.cyclone_spdp_interval is None
 
     args = parser.parse_args(["benchmark", "probe", "--profile", "losssless-typical", "--no-plot"])
     assert args.plot is False
@@ -1536,10 +1539,13 @@ def test_benchmark_subcommand_arg_parsing() -> None:
             "1x20KB+1x0KB",
             "--rate-hz",
             "10",
+            "--cyclone-spdp-interval",
+            "150s",
         ]
     )
     assert args.size_pattern == "1x20KB+1x0KB"
     assert args.rate_hz == 10.0
+    assert args.cyclone_spdp_interval == "150s"
 
     # Capacity.
     args = parser.parse_args(
@@ -1894,7 +1900,143 @@ def test_benchmark_session_copy_pins_requested_rmw(tmp_path: Path) -> None:
     assert copied["shared"]["qos"]["for_role"]["ota_pub"]["reliability"] == "reliable"
     assert args.session_configs_dir[0] == str(run_dir / "session-configs")
     assert context["runtime_implementation"] == "rmw_cyclonedds_cpp"
+    assert context["cyclone_spdp_interval"] is None
     assert context["qos"] == {"reliability": "reliable", "depth": 10}
+
+
+def test_benchmark_session_copy_applies_cyclone_spdp_override(tmp_path: Path) -> None:
+    import argparse
+
+    project = tmp_path / "project"
+    session_dir = project / "sessions" / "bench_1_1_capacity"
+    session_dir.mkdir(parents=True)
+    (session_dir / "session-definition.yaml").write_text(
+        "peers:\n  a: {}\n  b: {}\nshared:\n  rmw: cyclone\n",
+        encoding="utf-8",
+    )
+    ros2docker = project / "ros2docker.json"
+    ros2docker.write_text("{}", encoding="utf-8")
+    config_file = project / "rosotacom.yaml"
+    config_file.write_text(
+        yaml.safe_dump(
+            {
+                "ros2docker_config": str(ros2docker),
+                "session_configs_dir": ["sessions"],
+                "session_instances_dir": "session-instances",
+            }
+        ),
+        encoding="utf-8",
+    )
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    args = argparse.Namespace(
+        rosotacom_config=str(config_file),
+        ros2docker_config=None,
+        session_configs_dir=None,
+        scenario_configs_dir=None,
+        session_instances_dir=None,
+        deployment=None,
+        profiles_file=None,
+        artifacts_dir=None,
+        rmw="cyclone",
+        qos_reliability=None,
+        qos_depth=None,
+        cyclone_spdp_interval="150s",
+    )
+
+    context = _prepare_benchmark_session_config(args, "bench_1_1_capacity", run_dir)
+
+    copied = yaml.safe_load(Path(context["config_path"]).read_text(encoding="utf-8"))
+    assert copied["shared"]["rmw"] == {
+        "local": "cyclone",
+        "ota": {"cyclone": {"spdp_interval": "150s"}},
+    }
+    assert context["cyclone_spdp_interval"] == "150s"
+
+
+def test_benchmark_session_copy_rejects_spdp_override_for_non_cyclone(tmp_path: Path) -> None:
+    import argparse
+
+    project = tmp_path / "project"
+    session_dir = project / "sessions" / "bench_1_1_capacity"
+    session_dir.mkdir(parents=True)
+    (session_dir / "session-definition.yaml").write_text(
+        "peers:\n  a: {}\n  b: {}\nshared:\n  rmw: fastdds\n",
+        encoding="utf-8",
+    )
+    (project / "ros2docker.json").write_text("{}", encoding="utf-8")
+    config_file = project / "rosotacom.yaml"
+    config_file.write_text(
+        yaml.safe_dump(
+            {
+                "ros2docker_config": "ros2docker.json",
+                "session_configs_dir": ["sessions"],
+                "session_instances_dir": "session-instances",
+            }
+        ),
+        encoding="utf-8",
+    )
+    args = argparse.Namespace(
+        rosotacom_config=str(config_file),
+        ros2docker_config=None,
+        session_configs_dir=None,
+        scenario_configs_dir=None,
+        session_instances_dir=None,
+        deployment=None,
+        profiles_file=None,
+        artifacts_dir=None,
+        rmw="fastdds",
+        cyclone_spdp_interval="150s",
+    )
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+
+    with pytest.raises(ValueError, match="--rmw cyclone"):
+        _prepare_benchmark_session_config(args, "bench_1_1_capacity", run_dir)
+
+
+def test_probe_spdp_diagnostics_warn_on_tight_cyclone_profile(tmp_path: Path) -> None:
+    import argparse
+
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "ros2docker.json").write_text("{}", encoding="utf-8")
+    (project / "profiles.yaml").write_text(
+        "profiles:\n  tight:\n    uplink: { rate: 3.2mbit }\n",
+        encoding="utf-8",
+    )
+    config_file = project / "rosotacom.yaml"
+    config_file.write_text(
+        yaml.safe_dump(
+            {
+                "ros2docker_config": "ros2docker.json",
+                "profiles": "profiles.yaml",
+                "session_instances_dir": "session-instances",
+            }
+        ),
+        encoding="utf-8",
+    )
+    args = argparse.Namespace(
+        rosotacom_config=str(config_file),
+        ros2docker_config=None,
+        session_configs_dir=None,
+        scenario_configs_dir=None,
+        session_instances_dir=None,
+        deployment=None,
+        profiles_file=None,
+        artifacts_dir=None,
+        rmw="cyclone",
+        cyclone_spdp_interval=None,
+    )
+    load_info = benchmark_cli._load_context(_probe_load(size=18_000, size_pattern=None, rate_hz=20.0, streams=1))
+
+    diagnostic = _probe_spdp_diagnostics(args=args, profile="tight", duration_s=25.0, load_info=load_info)
+
+    assert diagnostic is not None
+    assert diagnostic["interval"] == "30s"
+    assert diagnostic["risk"] == "possible"
+    assert diagnostic["offered_to_minimum_profile_rate"] == pytest.approx(0.9)
+    assert "SPDPInterval=30s" in diagnostic["warnings"][0]
 
 
 def test_benchmark_session_copy_expands_capacity_stream_topics(tmp_path: Path) -> None:

--- a/tests/unit/test_ota_xml.py
+++ b/tests/unit/test_ota_xml.py
@@ -40,6 +40,16 @@ def test_ota_xml_uses_resolved_literal_addresses(tmp_path: Path, monkeypatch: py
     assert rendered == "<host>10.0.0.10</host><peer>10.0.0.11</peer><easy>10.0.0.10</easy>\n"
 
 
+def test_ota_xml_renders_default_and_overridden_spdp_interval(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    module = _module()
+    template = tmp_path / "test.xml.template"
+    template.write_text("<SPDPInterval>#spdp_interval</SPDPInterval>\n", encoding="utf-8")
+    monkeypatch.setattr(module, "_template_path", lambda _name: str(template))
+
+    assert module.main(config="test.xml") == "<SPDPInterval>30s</SPDPInterval>\n"
+    assert module.main(config="test.xml", spdp_interval="150s") == "<SPDPInterval>150s</SPDPInterval>\n"
+
+
 def test_ota_xml_rejects_empty_resolved_address(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     module = _module()
     template = tmp_path / "test.xml.template"
@@ -48,3 +58,13 @@ def test_ota_xml_rejects_empty_resolved_address(tmp_path: Path, monkeypatch: pyt
 
     with pytest.raises(ValueError, match="non-empty resolved address"):
         module.main(config="test.xml", host_ip=" ")
+
+
+def test_ota_xml_rejects_invalid_spdp_interval(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    module = _module()
+    template = tmp_path / "test.xml.template"
+    template.write_text("<SPDPInterval>#spdp_interval</SPDPInterval>\n", encoding="utf-8")
+    monkeypatch.setattr(module, "_template_path", lambda _name: str(template))
+
+    with pytest.raises(ValueError, match="seconds or milliseconds"):
+        module.main(config="test.xml", spdp_interval="2min")


### PR DESCRIPTION
## Summary

- keep the CycloneDDS tuned OTA default at `SPDPInterval=30s` while adding an explicit benchmark/session override for quiet-discovery probes
- record `context.diagnostics.cyclonedds_spdp` in probe `result.json` and print a warning when duration plus offered/shaped load make SPDP tail-latency effects plausible
- document the SPDP spike tradeoff and update RFC 0005 validation coverage

## Linked Issue

- Fixes #159

## Release Notes

- [ ] Release PR: includes `docs/release-notes/vX.Y.Z.md`
- [ ] Release PR: summarizes user-facing changes since the previous release
- [ ] Release PR: documents compatibility, migration, and validation notes
- [ ] Release PR: records the intended `main` commit and previous release tag
- [x] Not a release PR

## Public Behavior

- [x] Changes public CLI/config/API/Docker behavior
- [ ] Does not change public behavior

## Checks

- [x] `just lint-workflows` (via `just check`)
- [x] `just lint-build` (via `just check`)
- [x] `just lint` (via `just check`)
- [x] `just typecheck` (via `just check`)
- [x] `just test-unit` (via `just check`; 391 unit tests also passed standalone)
- [x] `just test-contract` (via `just check`)
- [x] `just docs` (via `just check`)
- [x] `just package` (via `just check`)
- [x] `just check` (433 passed; coverage 70.52%; package smoke passed)
- [x] `just test-e2e-smoke` (20 passed, 4 skipped in 35:09)

## Test Integrity

- [x] Tests/CI were not skipped, weakened, or removed to make this pass

## Maintainer Evidence

- Required CI links: pending after PR creation
- Manual/runtime evidence: local Docker smoke passed (`just test-e2e-smoke`: 20 passed, 4 skipped)
- External OTA evidence, if this PR is part of a `main` promotion: not applicable
