### PR TITLE
Add trace-to-profile converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,26 @@ the [link trace recorder](docs/link-trace.md). It writes
 `link_trace.jsonl` under the same status directory with `/proc/net/dev` counter
 deltas, echo-heartbeat RTT/loss provenance, and an optional modem-metrics hook.
 
+Convert a recorded link trace into a profiles-file entry when you want to replay
+the same drive conditions in a repeatable benchmark:
+
+```bash
+rosotacom profile from-trace session-instances/.../logs/a/status/link_trace.jsonl \
+  --mode timeline --name drive_replay --out generated-profiles.yaml
+rosotacom benchmark recovery --profiles-file generated-profiles.yaml --profile drive_replay
+```
+
+Timeline mode emits piecewise-constant RFC 0004 segments, turns long sample gaps
+into `outage: reconnect`, and turns sustained 100% probe loss into
+`outage: catchup`. Static mode distills one profile with median valid rate, p90
+one-way delay, delay-spread jitter, and mean loss; constrain it with
+`--window START:END` when only part of a drive should calibrate the profile. RTT
+is mapped to symmetric one-way delay. Passive `/proc/net/dev` throughput is only
+a lower-bound observation, so `rate` is emitted only when a sample is marked as
+saturated/probed/capacity-like; otherwise the converter omits rate instead of
+fabricating capacity. The generated YAML carries a provenance comment with the
+source path, SHA-256, parameters, and these caveats.
+
 Read it from the host with the `status` command:
 
 ```bash

--- a/docs/rfcs/0004-network-profiles.md
+++ b/docs/rfcs/0004-network-profiles.md
@@ -3,7 +3,9 @@
 **Status:** Implemented (pure half) — the schema, `tc`/`netem` command generation,
 fail-safe arm/teardown controller, timeline expansion, both outage kinds,
 `--profile` selection and the `expect.per_profile` invariant/conditional split are
-in `rosotacom.network_profiles` / `network_shaper` / `status_eval`, host-tested. The
+in `rosotacom.network_profiles` / `network_shaper` / `status_eval`, host-tested.
+The link-trace converter lives in `rosotacom.trace_profiles` and emits the same
+profiles-file schema. The
 **privileged per-direction live arming** (wiring the controller into the ota-smoke
 SSH path) and the **manual bench checks** (crash teardown, post-shaping link bytes,
 real two-shaped-interface application) remain. · **Scope:** the
@@ -237,6 +239,11 @@ risk — a stuck `qdisc` silently corrupts every later result on the machine.
 - [x] Add per-profile calibration — realized as `rosotacom test --suggest --profile
   P`, which emits `P`'s conditional band nested under `per_profile`
   (`status_eval.suggest_profile_band`), reusing the RFC 0002 `--suggest` machinery.
+- [x] Convert recorded `link_trace.jsonl` files into profile YAML via
+  `rosotacom profile from-trace`: timeline replay with change-point segmentation
+  and outage steps, plus static distillation from a full trace or window
+  (`trace_profiles.convert_trace_to_profile_yaml`). Passive throughput is omitted
+  as `rate` unless the sample is marked saturated/probed/capacity-like.
 - [ ] Confirm the `/proc/net/dev` link sampler (RFC 0003 / `link_bytes.py`) reports
   post-shaping wire bytes so link-overhead stays meaningful under a profile. *(Bench
   check.)*
@@ -292,6 +299,12 @@ off during implementation). Notes whether automation is feasible; privileged
   unit test that a reference status fixture yields `P`'s conditional band nested
   under `per_profile` (`test_suggest_profile_band_*`), reusing the RFC 0002
   `--suggest` machinery. Done.
+- [x] **Trace-to-profile conversion** (`rosotacom profile from-trace`) — host unit
+  tests on synthetic traces recover known timeline segments, detect sample-gap
+  reconnect outages, compute static percentiles exactly, omit passive-only rates,
+  load generated YAML through `load_profiles_file`, and feed the resulting
+  timeline into dry-run `ProfileShaper` command generation
+  (`tests/unit/test_trace_profiles.py`). Done.
 - [ ] **Emulated-profile gate (rung 2)** — an example session run under one
   canonical profile in the per-promotion CI smoke, asserting a conditional bound
   that differs from the unshaped run. Automatable in the smoke matrix.

--- a/src/rosotacom/cli.py
+++ b/src/rosotacom/cli.py
@@ -7111,6 +7111,36 @@ def metrics_command(args: argparse.Namespace) -> int:
     return 0
 
 
+def profile_from_trace_command(args: argparse.Namespace) -> int:
+    from rosotacom.trace_profiles import TraceProfileConfig, parse_window, write_trace_profile
+
+    window_start_s, window_end_s = parse_window(getattr(args, "window", None))
+    if args.directions == "both":
+        directions = ("uplink", "downlink")
+    else:
+        directions = (args.directions,)
+    mode = str(args.mode)
+    config = TraceProfileConfig(
+        name=args.name or ("trace_static" if mode == "static" else "trace_replay"),
+        directions=directions,
+        min_segment_s=float(args.min_segment_s),
+        change_sensitivity=float(args.change_sensitivity),
+        gap_outage_after_s=args.gap_outage_after_s,
+        loss_outage_min_s=args.loss_outage_min_s,
+        window_start_s=window_start_s,
+        window_end_s=window_end_s,
+        rate_percentile=float(args.rate_percentile),
+        delay_percentile=float(args.delay_percentile),
+        jitter_spread_percentile=float(args.jitter_spread_percentile),
+    )
+    text = write_trace_profile(args.trace, args.out, mode=mode, config=config)
+    if args.out:
+        print(f"Wrote trace-derived profile {config.name!r} to {args.out}")
+    else:
+        print(text, end="")
+    return 0
+
+
 def _add_common_config_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--rosotacom-config",
@@ -7568,6 +7598,7 @@ def main(argv: list[str] | None = None) -> int:
         "examples",
         "config",
         "bundle",
+        "profile",
         "completion",
         "benchmark",
         "ota-benchmark",
@@ -7718,6 +7749,76 @@ def main(argv: list[str] | None = None) -> int:
         "--records", action="store_true", help="Emit joined per-(topic, seq) records instead of a summary."
     )
     metrics_parser.set_defaults(func=metrics_command)
+
+    profile_parser = subparsers.add_parser("profile", help="Generate and inspect network profiles.")
+    profile_subparsers = profile_parser.add_subparsers(dest="profile_command", required=True)
+    profile_from_trace_parser = profile_subparsers.add_parser(
+        "from-trace",
+        help="Convert link_trace.jsonl into an RFC 0004 profiles YAML entry.",
+    )
+    profile_from_trace_parser.add_argument("trace", help="Path to link_trace.jsonl.")
+    profile_from_trace_parser.add_argument("--out", help="Write generated YAML to this path instead of stdout.")
+    profile_from_trace_parser.add_argument("--name", help="Profile name to emit.")
+    profile_from_trace_parser.add_argument(
+        "--mode",
+        choices=["timeline", "static"],
+        default="timeline",
+        help="Emit a piecewise timeline profile or one distilled static profile.",
+    )
+    profile_from_trace_parser.add_argument(
+        "--directions",
+        choices=["both", "uplink", "downlink"],
+        default="both",
+        help="Profile directions to populate from the trace peer's tx/rx counters.",
+    )
+    profile_from_trace_parser.add_argument(
+        "--window",
+        metavar="START:END",
+        help="Only use samples in this relative seconds window; either side may be omitted.",
+    )
+    profile_from_trace_parser.add_argument(
+        "--min-segment-s",
+        type=float,
+        default=5.0,
+        help="Minimum normal timeline segment duration before a change point may split it.",
+    )
+    profile_from_trace_parser.add_argument(
+        "--change-sensitivity",
+        type=float,
+        default=0.25,
+        help="Relative sensitivity for timeline change points; lower values split more readily.",
+    )
+    profile_from_trace_parser.add_argument(
+        "--gap-outage-after",
+        dest="gap_outage_after_s",
+        type=float,
+        help="Sample gap duration that becomes a reconnect outage; default is 3x the trace interval.",
+    )
+    profile_from_trace_parser.add_argument(
+        "--loss-outage-min",
+        dest="loss_outage_min_s",
+        type=float,
+        help="Minimum sustained 100%% probe-loss duration emitted as a catchup outage.",
+    )
+    profile_from_trace_parser.add_argument(
+        "--rate-percentile",
+        type=float,
+        default=50.0,
+        help="Percentile for valid saturated/probed rate samples (default: median).",
+    )
+    profile_from_trace_parser.add_argument(
+        "--delay-percentile",
+        type=float,
+        default=90.0,
+        help="Static-profile delay percentile; timeline segments use median delay.",
+    )
+    profile_from_trace_parser.add_argument(
+        "--jitter-spread-percentile",
+        type=float,
+        default=90.0,
+        help="Jitter is this delay percentile minus median delay.",
+    )
+    profile_from_trace_parser.set_defaults(func=profile_from_trace_command)
 
     test_parser = subparsers.add_parser(
         "test", help="Assert a running/recent session meets its status + per-topic expect contract."

--- a/src/rosotacom/trace_profiles.py
+++ b/src/rosotacom/trace_profiles.py
@@ -1,0 +1,561 @@
+"""Convert recorded link traces into RFC 0004 network profiles."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import statistics
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, cast
+
+import yaml
+
+from rosotacom.network_profiles import OUTAGE_CATCHUP, OUTAGE_RECONNECT
+
+PROFILE_MODES = ("timeline", "static")
+PROFILE_DIRECTIONS = ("uplink", "downlink")
+
+
+@dataclass(frozen=True)
+class TraceSample:
+    """One normalized row from ``link_trace.jsonl``."""
+
+    time_s: float
+    window_s: float | None = None
+    delay_ms: float | None = None
+    loss_pct: float | None = None
+    uplink_rate_bps: float | None = None
+    downlink_rate_bps: float | None = None
+
+
+@dataclass(frozen=True)
+class TraceProfileConfig:
+    """Conversion knobs for trace-derived profiles."""
+
+    name: str
+    directions: tuple[str, ...] = PROFILE_DIRECTIONS
+    min_segment_s: float = 5.0
+    change_sensitivity: float = 0.25
+    gap_outage_after_s: float | None = None
+    loss_outage_min_s: float | None = None
+    window_start_s: float | None = None
+    window_end_s: float | None = None
+    rate_percentile: float = 50.0
+    delay_percentile: float = 90.0
+    jitter_spread_percentile: float = 90.0
+
+    def __post_init__(self) -> None:
+        if not self.name:
+            raise ValueError("profile name must be non-empty")
+        invalid = sorted(set(self.directions) - set(PROFILE_DIRECTIONS))
+        if invalid:
+            raise ValueError(f"directions must be drawn from {PROFILE_DIRECTIONS}, got {invalid}")
+        if not self.directions:
+            raise ValueError("at least one direction must be selected")
+        if self.min_segment_s <= 0:
+            raise ValueError("min_segment_s must be > 0")
+        if self.change_sensitivity <= 0:
+            raise ValueError("change_sensitivity must be > 0")
+        if self.gap_outage_after_s is not None and self.gap_outage_after_s <= 0:
+            raise ValueError("gap_outage_after_s must be > 0")
+        if self.loss_outage_min_s is not None and self.loss_outage_min_s <= 0:
+            raise ValueError("loss_outage_min_s must be > 0")
+        if self.window_start_s is not None and self.window_start_s < 0:
+            raise ValueError("window_start_s must be >= 0")
+        if self.window_end_s is not None and self.window_end_s <= 0:
+            raise ValueError("window_end_s must be > 0")
+        if (
+            self.window_start_s is not None
+            and self.window_end_s is not None
+            and self.window_start_s >= self.window_end_s
+        ):
+            raise ValueError("window start must be before window end")
+        for name, value in (
+            ("rate_percentile", self.rate_percentile),
+            ("delay_percentile", self.delay_percentile),
+            ("jitter_spread_percentile", self.jitter_spread_percentile),
+        ):
+            if not 0 <= value <= 100:
+                raise ValueError(f"{name} must be within [0, 100]")
+
+
+def parse_window(value: str | None) -> tuple[float | None, float | None]:
+    """Parse ``START:END`` seconds; either side may be omitted."""
+    if value is None:
+        return None, None
+    if ":" not in value:
+        raise ValueError("--window must use START:END seconds")
+    start_text, end_text = value.split(":", 1)
+    start = float(start_text) if start_text else None
+    end = float(end_text) if end_text else None
+    if start is not None and start < 0:
+        raise ValueError("--window start must be >= 0")
+    if end is not None and end <= 0:
+        raise ValueError("--window end must be > 0")
+    if start is not None and end is not None and start >= end:
+        raise ValueError("--window start must be before end")
+    return start, end
+
+
+def load_link_trace(path: str | Path) -> list[TraceSample]:
+    """Load and normalize a link-trace JSONL file."""
+    trace_path = Path(path)
+    samples: list[TraceSample] = []
+    for line_number, line in enumerate(trace_path.read_text(encoding="utf-8").splitlines(), start=1):
+        if not line.strip():
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"{trace_path}:{line_number}: invalid JSON: {exc}") from exc
+        if not isinstance(row, Mapping):
+            raise ValueError(f"{trace_path}:{line_number}: each trace row must be a JSON object")
+        if row.get("kind") not in (None, "link_trace"):
+            continue
+        samples.append(_sample_from_row(row, line_number=line_number))
+    if not samples:
+        raise ValueError(f"{trace_path}: no link_trace rows found")
+
+    first_time = min(sample.time_s for sample in samples)
+    normalized = [
+        TraceSample(
+            time_s=sample.time_s - first_time,
+            window_s=sample.window_s,
+            delay_ms=sample.delay_ms,
+            loss_pct=sample.loss_pct,
+            uplink_rate_bps=sample.uplink_rate_bps,
+            downlink_rate_bps=sample.downlink_rate_bps,
+        )
+        for sample in sorted(samples, key=lambda item: item.time_s)
+    ]
+    return normalized
+
+
+def convert_trace_to_profile_yaml(
+    trace_path: str | Path,
+    *,
+    mode: str,
+    config: TraceProfileConfig,
+) -> str:
+    """Convert ``trace_path`` into a profiles-file YAML string with provenance comments."""
+    if mode not in PROFILE_MODES:
+        raise ValueError(f"mode must be one of {PROFILE_MODES}, got {mode!r}")
+
+    path = Path(trace_path)
+    samples = _window_samples(load_link_trace(path), config)
+    if mode == "timeline":
+        profile_doc = _timeline_profile(samples, config)
+    else:
+        profile_doc = _static_profile(samples, config)
+
+    body = yaml.safe_dump({"profiles": {config.name: profile_doc}}, sort_keys=False)
+    return _provenance_header(path, mode=mode, config=config) + body
+
+
+def write_trace_profile(
+    trace_path: str | Path,
+    output_path: str | Path | None,
+    *,
+    mode: str,
+    config: TraceProfileConfig,
+) -> str:
+    """Write the generated profile when requested and return the YAML text."""
+    text = convert_trace_to_profile_yaml(trace_path, mode=mode, config=config)
+    if output_path is not None:
+        Path(output_path).write_text(text, encoding="utf-8")
+    return text
+
+
+def _sample_from_row(row: Mapping[str, Any], *, line_number: int) -> TraceSample:
+    time_s = _required_number(row.get("monotonic_s"), f"line {line_number}: monotonic_s")
+    passive = _mapping_or_none(row.get("passive_counter_delta"))
+    probe = _mapping_or_none(row.get("peer_probe"))
+    window_s = _optional_number(passive.get("window_s") if passive is not None else None)
+    delay_ms: float | None = None
+    loss_pct: float | None = None
+
+    if probe is not None and probe.get("available", True):
+        rtt_ms = _optional_number(probe.get("rtt_ms"))
+        if rtt_ms is not None:
+            delay_ms = max(0.0, rtt_ms / 2.0)
+        raw_loss = _optional_number(probe.get("loss_pct"))
+        if raw_loss is not None:
+            loss_pct = min(100.0, max(0.0, raw_loss))
+
+    return TraceSample(
+        time_s=time_s,
+        window_s=window_s,
+        delay_ms=delay_ms,
+        loss_pct=loss_pct,
+        uplink_rate_bps=_direction_rate_bps(passive, "tx"),
+        downlink_rate_bps=_direction_rate_bps(passive, "rx"),
+    )
+
+
+def _mapping_or_none(value: Any) -> Mapping[str, Any] | None:
+    return cast(Mapping[str, Any], value) if isinstance(value, Mapping) else None
+
+
+def _required_number(value: Any, label: str) -> float:
+    number = _optional_number(value)
+    if number is None:
+        raise ValueError(f"{label} must be a number")
+    return number
+
+
+def _optional_number(value: Any) -> float | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(number):
+        return None
+    return number
+
+
+def _direction_rate_bps(passive: Mapping[str, Any] | None, direction: str) -> float | None:
+    if passive is None or not passive.get("available", True):
+        return None
+    direction_block = _mapping_or_none(passive.get(direction))
+    if direction_block is None or not _rate_is_capacity_like(passive, direction_block):
+        return None
+
+    for key, multiplier in (
+        ("available_bps", 1.0),
+        ("capacity_bps", 1.0),
+        ("rate_bps", 1.0),
+        ("throughput_bps", 1.0),
+        ("observed_bps", 1.0),
+        ("available_kbps", 1_000.0),
+        ("capacity_kbps", 1_000.0),
+        ("rate_kbps", 1_000.0),
+        ("throughput_kbps", 1_000.0),
+        ("observed_kbps", 1_000.0),
+    ):
+        value = _optional_number(direction_block.get(key))
+        if value is not None and value > 0:
+            return value * multiplier
+    return None
+
+
+def _rate_is_capacity_like(passive: Mapping[str, Any], direction_block: Mapping[str, Any]) -> bool:
+    for block in (direction_block, passive):
+        for key in ("available_bandwidth", "capacity_probe", "probed", "rate_valid", "saturated"):
+            if block.get(key) is True:
+                return True
+        source = str(block.get("rate_source") or block.get("provenance") or "").lower()
+        if any(token in source for token in ("available", "capacity", "probe", "saturated")):
+            return True
+    return False
+
+
+def _window_samples(samples: Sequence[TraceSample], config: TraceProfileConfig) -> list[TraceSample]:
+    selected = [
+        sample
+        for sample in samples
+        if (config.window_start_s is None or sample.time_s >= config.window_start_s)
+        and (config.window_end_s is None or sample.time_s <= config.window_end_s)
+    ]
+    if not selected:
+        raise ValueError("trace window contains no samples")
+    first_time = selected[0].time_s
+    return [
+        TraceSample(
+            time_s=sample.time_s - first_time,
+            window_s=sample.window_s,
+            delay_ms=sample.delay_ms,
+            loss_pct=sample.loss_pct,
+            uplink_rate_bps=sample.uplink_rate_bps,
+            downlink_rate_bps=sample.downlink_rate_bps,
+        )
+        for sample in selected
+    ]
+
+
+def _static_profile(samples: Sequence[TraceSample], config: TraceProfileConfig) -> dict[str, Any]:
+    profile: dict[str, Any] = {}
+    for direction in config.directions:
+        direction_doc = _direction_doc(
+            samples,
+            direction,
+            delay_percentile=config.delay_percentile,
+            rate_percentile=config.rate_percentile,
+            jitter_spread_percentile=config.jitter_spread_percentile,
+        )
+        if direction_doc:
+            profile[direction] = direction_doc
+    if not profile:
+        profile["uplink"] = {}
+    return profile
+
+
+def _timeline_profile(samples: Sequence[TraceSample], config: TraceProfileConfig) -> dict[str, Any]:
+    interval_s = _typical_interval_s(samples)
+    gap_outage_after_s = config.gap_outage_after_s or max(interval_s * 3.0, interval_s + 0.001)
+    loss_outage_min_s = config.loss_outage_min_s or interval_s
+    timeline: list[dict[str, Any]] = []
+    normal_segment: list[TraceSample] = []
+
+    def flush_normal() -> None:
+        nonlocal normal_segment
+        if not normal_segment:
+            return
+        segment_doc: dict[str, Any] = {"for": _duration_text(_samples_duration_s(normal_segment, interval_s))}
+        for direction in config.directions:
+            direction_doc = _direction_doc(
+                normal_segment,
+                direction,
+                delay_percentile=50.0,
+                rate_percentile=config.rate_percentile,
+                jitter_spread_percentile=config.jitter_spread_percentile,
+            )
+            if direction_doc:
+                segment_doc[direction] = direction_doc
+        timeline.append(segment_doc)
+        normal_segment = []
+
+    def append_normal(sample: TraceSample) -> None:
+        nonlocal normal_segment
+        if not normal_segment:
+            normal_segment = [sample]
+            return
+        if _is_change_point(normal_segment, sample, interval_s, config):
+            flush_normal()
+            normal_segment = [sample]
+        else:
+            normal_segment.append(sample)
+
+    index = 0
+    while index < len(samples):
+        sample = samples[index]
+        if index > 0:
+            gap_s = sample.time_s - samples[index - 1].time_s
+            if gap_s >= gap_outage_after_s:
+                flush_normal()
+                timeline.append(
+                    {"for": _duration_text(max(interval_s, gap_s - interval_s)), "outage": OUTAGE_RECONNECT}
+                )
+
+        if _is_full_loss_sample(sample):
+            flush_normal()
+            loss_samples = [sample]
+            index += 1
+            while index < len(samples) and _is_full_loss_sample(samples[index]):
+                if samples[index].time_s - samples[index - 1].time_s >= gap_outage_after_s:
+                    break
+                loss_samples.append(samples[index])
+                index += 1
+            duration_s = _samples_duration_s(loss_samples, interval_s)
+            if duration_s >= loss_outage_min_s:
+                timeline.append({"for": _duration_text(duration_s), "outage": OUTAGE_CATCHUP})
+            else:
+                for loss_sample in loss_samples:
+                    append_normal(loss_sample)
+            continue
+
+        append_normal(sample)
+        index += 1
+
+    flush_normal()
+    if not timeline:
+        timeline.append({"for": _duration_text(interval_s)})
+    return {"timeline": timeline}
+
+
+def _direction_doc(
+    samples: Sequence[TraceSample],
+    direction: str,
+    *,
+    delay_percentile: float,
+    rate_percentile: float,
+    jitter_spread_percentile: float,
+) -> dict[str, Any]:
+    delays = [sample.delay_ms for sample in samples if sample.delay_ms is not None]
+    losses = [sample.loss_pct for sample in samples if sample.loss_pct is not None]
+    rates: list[float] = []
+    for sample in samples:
+        rate = _rate_for_direction(sample, direction)
+        if rate is not None:
+            rates.append(rate)
+
+    doc: dict[str, Any] = {}
+    if rates:
+        doc["rate"] = _rate_text(_percentile(rates, rate_percentile))
+    if delays:
+        delay_ms = _percentile(delays, delay_percentile)
+        doc["delay"] = _ms_text(delay_ms)
+        jitter_ms = max(0.0, _percentile(delays, jitter_spread_percentile) - statistics.median(delays))
+        if jitter_ms > 0:
+            doc["jitter"] = _ms_text(jitter_ms)
+            doc["distribution"] = "normal"
+    if losses:
+        loss_pct = statistics.fmean(losses)
+        if loss_pct > 0:
+            doc["loss"] = _pct_text(loss_pct)
+    return doc
+
+
+def _rate_for_direction(sample: TraceSample, direction: str) -> float | None:
+    if direction == "uplink":
+        return sample.uplink_rate_bps
+    if direction == "downlink":
+        return sample.downlink_rate_bps
+    raise ValueError(f"unsupported direction {direction!r}")
+
+
+def _typical_interval_s(samples: Sequence[TraceSample]) -> float:
+    diffs = [
+        right.time_s - left.time_s
+        for left, right in zip(samples, samples[1:], strict=False)
+        if right.time_s > left.time_s
+    ]
+    if diffs:
+        return max(0.001, statistics.median(diffs))
+    windows = [sample.window_s for sample in samples if sample.window_s is not None and sample.window_s > 0]
+    if windows:
+        return max(0.001, statistics.median(windows))
+    return 1.0
+
+
+def _samples_duration_s(samples: Sequence[TraceSample], interval_s: float) -> float:
+    if not samples:
+        return interval_s
+    return max(interval_s, samples[-1].time_s - samples[0].time_s + interval_s)
+
+
+def _is_full_loss_sample(sample: TraceSample) -> bool:
+    return sample.loss_pct is not None and sample.loss_pct >= 100.0
+
+
+def _is_change_point(
+    current: Sequence[TraceSample],
+    sample: TraceSample,
+    interval_s: float,
+    config: TraceProfileConfig,
+) -> bool:
+    if _samples_duration_s(current, interval_s) < config.min_segment_s:
+        return False
+
+    current_features = _segment_features(current, config.directions, rate_percentile=config.rate_percentile)
+    sample_features = _segment_features([sample], config.directions, rate_percentile=config.rate_percentile)
+    for key, current_value in current_features.items():
+        sample_value = sample_features.get(key)
+        if current_value is None and sample_value is None:
+            continue
+        if current_value is None or sample_value is None:
+            return True
+        if _changed(key, current_value, sample_value, config.change_sensitivity):
+            return True
+    return False
+
+
+def _segment_features(
+    samples: Sequence[TraceSample],
+    directions: Sequence[str],
+    *,
+    rate_percentile: float,
+) -> dict[str, float | None]:
+    features: dict[str, float | None] = {
+        "delay_ms": _maybe_percentile([sample.delay_ms for sample in samples], 50.0),
+        "loss_pct": _maybe_mean([sample.loss_pct for sample in samples]),
+    }
+    for direction in directions:
+        features[f"{direction}_rate_bps"] = _maybe_percentile(
+            [_rate_for_direction(sample, direction) for sample in samples],
+            rate_percentile,
+        )
+    return features
+
+
+def _changed(key: str, current_value: float, sample_value: float, sensitivity: float) -> bool:
+    diff = abs(current_value - sample_value)
+    if key.endswith("_rate_bps"):
+        threshold = max(100_000.0, abs(current_value) * sensitivity)
+    elif key == "loss_pct":
+        threshold = max(1.0, abs(current_value) * sensitivity)
+    else:
+        threshold = max(5.0, abs(current_value) * sensitivity)
+    return diff > threshold
+
+
+def _maybe_percentile(values: Sequence[float | None], percentile: float) -> float | None:
+    present = [value for value in values if value is not None]
+    return _percentile(present, percentile) if present else None
+
+
+def _maybe_mean(values: Sequence[float | None]) -> float | None:
+    present = [value for value in values if value is not None]
+    return statistics.fmean(present) if present else None
+
+
+def _percentile(values: Sequence[float], percentile: float) -> float:
+    if not values:
+        raise ValueError("cannot compute percentile of empty values")
+    ordered = sorted(values)
+    if percentile == 50:
+        return float(statistics.median(ordered))
+    if percentile <= 0:
+        return float(ordered[0])
+    if percentile >= 100:
+        return float(ordered[-1])
+    index = math.ceil((percentile / 100.0) * len(ordered)) - 1
+    return float(ordered[max(0, min(index, len(ordered) - 1))])
+
+
+def _duration_text(value: float) -> str:
+    return f"{value:g}s"
+
+
+def _ms_text(value: float) -> str:
+    return f"{value:g}ms"
+
+
+def _pct_text(value: float) -> str:
+    return f"{value:g}%"
+
+
+def _rate_text(value: float) -> str:
+    return f"{int(round(value))}bit"
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _provenance_header(path: Path, *, mode: str, config: TraceProfileConfig) -> str:
+    params = {
+        "mode": mode,
+        "name": config.name,
+        "directions": ",".join(config.directions),
+        "min_segment_s": config.min_segment_s,
+        "change_sensitivity": config.change_sensitivity,
+        "gap_outage_after_s": config.gap_outage_after_s,
+        "loss_outage_min_s": config.loss_outage_min_s,
+        "window": (
+            f"{config.window_start_s if config.window_start_s is not None else ''}:"
+            f"{config.window_end_s if config.window_end_s is not None else ''}"
+        ),
+        "rate_percentile": config.rate_percentile,
+        "delay_percentile": config.delay_percentile,
+        "jitter_spread_percentile": config.jitter_spread_percentile,
+    }
+    param_text = ", ".join(f"{key}={value}" for key, value in params.items() if value is not None)
+    return (
+        "# Generated by `rosotacom profile from-trace`.\n"
+        f"# Source trace: {path}\n"
+        f"# Source sha256: {_sha256(path)}\n"
+        f"# Conversion parameters: {param_text}\n"
+        "# Caveat: this is an approximate piecewise-constant replay profile, not packet-level replay.\n"
+        "# Caveat: passive throughput is a lower-bound observation; rate is emitted only for "
+        "saturated/probed samples.\n"
+        "# Caveat: RTT is mapped to symmetric one-way delay when peer_probe declares the path assumption.\n"
+    )

--- a/tests/unit/test_trace_profiles.py
+++ b/tests/unit/test_trace_profiles.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import yaml
+
+from rosotacom.cli import main
+from rosotacom.network_profiles import (
+    OUTAGE_CATCHUP,
+    OUTAGE_RECONNECT,
+    expand_timeline,
+    load_profiles_file,
+    parse_rate_bps,
+)
+from rosotacom.network_shaper import ProfileShaper
+from rosotacom.trace_profiles import TraceProfileConfig, convert_trace_to_profile_yaml
+
+
+def _write_trace(path: Path, rows: list[dict[str, object]]) -> Path:
+    path.write_text("\n".join(json.dumps(row) for row in rows) + "\n", encoding="utf-8")
+    return path
+
+
+def _row(
+    time_s: float,
+    *,
+    rtt_ms: float,
+    loss_pct: float,
+    tx_kbps: float = 0.0,
+    rx_kbps: float = 0.0,
+    tx_marked: bool = False,
+    rx_marked: bool = False,
+) -> dict[str, object]:
+    tx: dict[str, object] = {"bytes_delta": 0, "packets_delta": 0, "observed_kbps": tx_kbps}
+    rx: dict[str, object] = {"bytes_delta": 0, "packets_delta": 0, "observed_kbps": rx_kbps}
+    if tx_marked:
+        tx["saturated"] = True
+    if rx_marked:
+        rx["capacity_probe"] = True
+    return {
+        "schema_version": 1,
+        "kind": "link_trace",
+        "monotonic_s": time_s,
+        "peer": "a",
+        "remote": "b",
+        "passive_counter_delta": {
+            "available": True,
+            "window_s": 1.0,
+            "observed_not_available_bandwidth": True,
+            "tx": tx,
+            "rx": rx,
+        },
+        "peer_probe": {
+            "available": True,
+            "rtt_ms": rtt_ms,
+            "loss_pct": loss_pct,
+            "assumption": "symmetric_path",
+        },
+    }
+
+
+def test_timeline_recovers_known_segments_and_arms_in_dry_run(tmp_path: Path) -> None:
+    trace = _write_trace(
+        tmp_path / "link_trace.jsonl",
+        [
+            *[_row(float(second), rtt_ms=20.0, loss_pct=0.0, tx_kbps=2_000.0, tx_marked=True) for second in range(5)],
+            *[
+                _row(float(second), rtt_ms=100.0, loss_pct=5.0, tx_kbps=1_000.0, tx_marked=True)
+                for second in range(5, 10)
+            ],
+        ],
+    )
+
+    text = convert_trace_to_profile_yaml(
+        trace,
+        mode="timeline",
+        config=TraceProfileConfig(
+            name="drive_replay",
+            directions=("uplink",),
+            min_segment_s=3.0,
+            change_sensitivity=0.2,
+        ),
+    )
+    out = tmp_path / "profiles.yaml"
+    out.write_text(text, encoding="utf-8")
+
+    doc = yaml.safe_load(text)
+    timeline = doc["profiles"]["drive_replay"]["timeline"]
+    assert timeline == [
+        {"for": "5s", "uplink": {"rate": "2000000bit", "delay": "10ms"}},
+        {"for": "5s", "uplink": {"rate": "1000000bit", "delay": "50ms", "loss": "5%"}},
+    ]
+
+    profile = load_profiles_file(out)["drive_replay"]
+    steps = expand_timeline(profile, "tun0", direction="uplink")
+    assert len(steps) == 2
+    calls: list[list[str]] = []
+    ProfileShaper("tun0", lambda argv: calls.append(list(argv))).arm(steps[0].commands)
+    assert ["tc", "qdisc", "replace", "dev", "tun0", "root", "handle", "1:", "tbf"] == calls[2][:9]
+
+
+def test_timeline_emits_reconnect_outage_for_sample_gap(tmp_path: Path) -> None:
+    trace = _write_trace(
+        tmp_path / "link_trace.jsonl",
+        [
+            _row(0.0, rtt_ms=20.0, loss_pct=0.0),
+            _row(1.0, rtt_ms=20.0, loss_pct=0.0),
+            _row(2.0, rtt_ms=20.0, loss_pct=0.0),
+            _row(8.0, rtt_ms=20.0, loss_pct=0.0),
+            _row(9.0, rtt_ms=20.0, loss_pct=0.0),
+        ],
+    )
+
+    text = convert_trace_to_profile_yaml(
+        trace,
+        mode="timeline",
+        config=TraceProfileConfig(
+            name="gap_replay",
+            directions=("uplink",),
+            min_segment_s=1.0,
+            gap_outage_after_s=3.0,
+        ),
+    )
+    out = tmp_path / "profiles.yaml"
+    out.write_text(text, encoding="utf-8")
+
+    profile = load_profiles_file(out)["gap_replay"]
+    assert [segment.outage for segment in profile.timeline] == [None, OUTAGE_RECONNECT, None]
+    assert profile.timeline[1].for_s == 5.0
+    steps = expand_timeline(profile, "tun0", direction="uplink")
+    assert steps[1].commands == [["ip", "link", "set", "dev", "tun0", "down"]]
+
+
+def test_timeline_emits_catchup_outage_for_sustained_probe_loss(tmp_path: Path) -> None:
+    trace = _write_trace(
+        tmp_path / "link_trace.jsonl",
+        [
+            _row(0.0, rtt_ms=20.0, loss_pct=0.0),
+            _row(1.0, rtt_ms=20.0, loss_pct=0.0),
+            _row(2.0, rtt_ms=20.0, loss_pct=100.0),
+            _row(3.0, rtt_ms=20.0, loss_pct=100.0),
+            _row(4.0, rtt_ms=20.0, loss_pct=0.0),
+        ],
+    )
+
+    text = convert_trace_to_profile_yaml(
+        trace,
+        mode="timeline",
+        config=TraceProfileConfig(
+            name="loss_replay",
+            directions=("uplink",),
+            min_segment_s=1.0,
+            loss_outage_min_s=2.0,
+        ),
+    )
+    out = tmp_path / "profiles.yaml"
+    out.write_text(text, encoding="utf-8")
+
+    profile = load_profiles_file(out)["loss_replay"]
+    assert [segment.outage for segment in profile.timeline] == [None, OUTAGE_CATCHUP, None]
+    steps = expand_timeline(profile, "tun0", direction="uplink")
+    assert steps[1].commands[-1][-3:] == ["netem", "loss", "100%"]
+
+
+def test_static_percentiles_and_passive_rate_omission_are_exact(tmp_path: Path) -> None:
+    trace = _write_trace(
+        tmp_path / "link_trace.jsonl",
+        [
+            _row(0.0, rtt_ms=20.0, loss_pct=0.0, tx_kbps=9_000.0, rx_kbps=1_000.0, rx_marked=True),
+            _row(1.0, rtt_ms=40.0, loss_pct=10.0, tx_kbps=9_000.0, rx_kbps=2_000.0, rx_marked=True),
+            _row(2.0, rtt_ms=100.0, loss_pct=20.0, tx_kbps=9_000.0, rx_kbps=4_000.0, rx_marked=True),
+        ],
+    )
+
+    text = convert_trace_to_profile_yaml(
+        trace,
+        mode="static",
+        config=TraceProfileConfig(name="drive_static"),
+    )
+    profile_doc = yaml.safe_load(text)["profiles"]["drive_static"]
+
+    assert profile_doc["uplink"] == {
+        "delay": "50ms",
+        "jitter": "30ms",
+        "distribution": "normal",
+        "loss": "10%",
+    }
+    assert profile_doc["downlink"] == {
+        "rate": "2000000bit",
+        "delay": "50ms",
+        "jitter": "30ms",
+        "distribution": "normal",
+        "loss": "10%",
+    }
+
+    out = tmp_path / "profiles.yaml"
+    out.write_text(text, encoding="utf-8")
+    profile = load_profiles_file(out)["drive_static"]
+    assert profile.uplink is not None and profile.uplink.rate_bps is None
+    assert profile.downlink is not None and profile.downlink.rate_bps == parse_rate_bps("2mbit")
+
+
+def test_cli_profile_from_trace_writes_loadable_yaml(tmp_path: Path) -> None:
+    trace = _write_trace(
+        tmp_path / "link_trace.jsonl",
+        [_row(0.0, rtt_ms=20.0, loss_pct=0.0), _row(1.0, rtt_ms=40.0, loss_pct=0.0)],
+    )
+    out = tmp_path / "generated-profiles.yaml"
+
+    assert (
+        main(
+            [
+                "profile",
+                "from-trace",
+                str(trace),
+                "--mode",
+                "static",
+                "--name",
+                "owner_smoke",
+                "--out",
+                str(out),
+            ]
+        )
+        == 0
+    )
+    profiles = load_profiles_file(out)
+    assert set(profiles) == {"owner_smoke"}


### PR DESCRIPTION
Closes #162.

Harness issue: https://ids-git.fzi.de/go914/rosotacom_test/-/issues/19

## Summary

- Add `rosotacom profile from-trace` for timeline and static profile generation from `link_trace.jsonl`.
- Emit provenance comments with trace path/hash, conversion parameters, and replay caveats.
- Map RTT/loss/rate into RFC 0004 profile YAML while omitting passive-only rates unless marked saturated/probed/capacity-like.
- Document conversion semantics in the README and RFC 0004, with synthetic unit coverage for segmentation, outages, static percentiles, loading, and dry-run arming.

## Validation

- `pytest -q tests/unit/test_trace_profiles.py tests/unit/test_network_profiles.py tests/unit/test_network_shaper.py tests/contract/test_markdown_links.py`
- `ruff check src/rosotacom/trace_profiles.py src/rosotacom/cli.py tests/unit/test_trace_profiles.py`
- `PYTHONPATH=src python3 -m compileall -q src/rosotacom/trace_profiles.py src/rosotacom/cli.py tests/unit/test_trace_profiles.py`
- CLI smoke: generated a synthetic `link_trace.jsonl`, ran `PYTHONPATH=src python3 -m rosotacom.cli profile from-trace ... --mode static --out ...`, and loaded the result through `load_profiles_file`.

Local environment notes:

- `mypy src/rosotacom` could not run because `mypy` is not installed in this checkout.
- `pytest -q tests/unit tests/contract` is blocked locally by the missing `ros2docker.config.load_config` import; the failing tests are scenario/anonymize/package-resource tests that require the dependency, not the trace-profile path.

## Owner smoke

```bash
set -euo pipefail
tmpdir=$(mktemp -d)
trace="$tmpdir/link_trace.jsonl"
cat > "$trace" <<'JSONL'
{"kind":"link_trace","monotonic_s":0,"passive_counter_delta":{"available":true,"window_s":1,"observed_not_available_bandwidth":true,"tx":{"observed_kbps":1000,"saturated":true},"rx":{"observed_kbps":2000,"capacity_probe":true}},"peer_probe":{"available":true,"rtt_ms":20,"loss_pct":0,"assumption":"symmetric_path"}}
{"kind":"link_trace","monotonic_s":1,"passive_counter_delta":{"available":true,"window_s":1,"observed_not_available_bandwidth":true,"tx":{"observed_kbps":1000,"saturated":true},"rx":{"observed_kbps":2000,"capacity_probe":true}},"peer_probe":{"available":true,"rtt_ms":20,"loss_pct":0,"assumption":"symmetric_path"}}
JSONL
PYTHONPATH=src python3 -m rosotacom.cli profile from-trace "$trace" --mode timeline --name owner_smoke --out "$tmpdir/profiles.yaml" >/dev/null
PYTHONPATH=src python3 - <<'PY' "$tmpdir/profiles.yaml"
import sys
from rosotacom.network_profiles import load_profiles_file
profile = load_profiles_file(sys.argv[1])["owner_smoke"]
uplink = profile.timeline[0].uplink
print(f"profile {profile.name} {profile.kind} segments={len(profile.timeline)}")
print(f"uplink rate={int(uplink.rate_bps)}bit delay={uplink.delay_ms:g}ms")
PY
```

Expected output:

```text
profile owner_smoke timeline segments=1
uplink rate=1000000bit delay=10ms
```
