### PR TITLE
Fix profile direction CLI typing

### DIFF
--- a/src/rosotacom/cli.py
+++ b/src/rosotacom/cli.py
@@ -7115,10 +7115,11 @@ def profile_from_trace_command(args: argparse.Namespace) -> int:
     from rosotacom.trace_profiles import TraceProfileConfig, parse_window, write_trace_profile
 
     window_start_s, window_end_s = parse_window(getattr(args, "window", None))
+    directions: tuple[str, ...]
     if args.directions == "both":
         directions = ("uplink", "downlink")
     else:
-        directions = (args.directions,)
+        directions = (str(args.directions),)
     mode = str(args.mode)
     config = TraceProfileConfig(
         name=args.name or ("trace_static" if mode == "static" else "trace_replay"),


### PR DESCRIPTION
Follow-up to #164 for #162.

## Summary

- Fix the `profile from-trace` CLI direction tuple typing that CI's mypy lane caught after #164 merged.

## Validation

- `pytest -q tests/unit/test_trace_profiles.py tests/unit/test_network_profiles.py tests/unit/test_network_shaper.py tests/contract/test_markdown_links.py`
- `ruff check src/rosotacom/trace_profiles.py src/rosotacom/cli.py tests/unit/test_trace_profiles.py`
- `git diff --check`

## Owner smoke

```bash
set -euo pipefail
tmpdir=$(mktemp -d)
trace="$tmpdir/link_trace.jsonl"
cat > "$trace" <<'JSONL'
{"kind":"link_trace","monotonic_s":0,"passive_counter_delta":{"available":true,"window_s":1,"observed_not_available_bandwidth":true,"tx":{"observed_kbps":1000,"saturated":true},"rx":{"observed_kbps":2000,"capacity_probe":true}},"peer_probe":{"available":true,"rtt_ms":20,"loss_pct":0,"assumption":"symmetric_path"}}
{"kind":"link_trace","monotonic_s":1,"passive_counter_delta":{"available":true,"window_s":1,"observed_not_available_bandwidth":true,"tx":{"observed_kbps":1000,"saturated":true},"rx":{"observed_kbps":2000,"capacity_probe":true}},"peer_probe":{"available":true,"rtt_ms":20,"loss_pct":0,"assumption":"symmetric_path"}}
JSONL
PYTHONPATH=src python3 -m rosotacom.cli profile from-trace "$trace" --mode timeline --name owner_smoke --out "$tmpdir/profiles.yaml" >/dev/null
PYTHONPATH=src python3 - <<'PY' "$tmpdir/profiles.yaml"
import sys
from rosotacom.network_profiles import load_profiles_file
profile = load_profiles_file(sys.argv[1])["owner_smoke"]
uplink = profile.timeline[0].uplink
print(f"profile {profile.name} {profile.kind} segments={len(profile.timeline)}")
print(f"uplink rate={int(uplink.rate_bps)}bit delay={uplink.delay_ms:g}ms")
PY
```

Expected output:

```text
profile owner_smoke timeline segments=1
uplink rate=1000000bit delay=10ms
```
