### PR TITLE
Add geo link-quality map command

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,6 +419,21 @@ saturated/probed/capacity-like; otherwise the converter omits rate instead of
 fabricating capacity. The generated YAML carries a provenance comment with the
 source path, SHA-256, parameters, and these caveats.
 
+Render an offline route map when a run also has GPS or pose samples:
+
+```bash
+rosotacom geomap --bag session-instances/.../rosbags/a/native --gps-topic /fix \
+  --trace session-instances/.../logs/a/status/link_trace.jsonl \
+  --metric observed_tx_kbps \
+  --out-csv artifacts/geo-link-quality.csv \
+  --out-html artifacts/geo-link-quality.html
+```
+
+`geomap` writes georeferenced CSV samples, an HTML report, and a sibling
+`.route.png` route image. The timestamp offset between trace/event time and
+bag/GPS time is explicit; see [docs/geo-link-map.md](docs/geo-link-map.md) for
+the alignment model, CSV fixture workflow, and supported metrics.
+
 Read it from the host with the `status` command:
 
 ```bash

--- a/docs/geo-link-map.md
+++ b/docs/geo-link-map.md
@@ -1,0 +1,93 @@
+# Geo Link-Quality Map
+
+`rosotacom geomap` joins recorded link-quality samples with GPS or pose samples
+and writes three offline artifacts:
+
+- a stable CSV of georeferenced samples, and
+- an HTML report plus sibling `.route.png` image colored by one selected metric.
+
+The command is for post-run analysis: it answers where along a drive route the
+recorded link degraded. It does not run a live map and does not need a tile
+server.
+
+## Inputs
+
+GPS/route samples can come from either:
+
+- `--bag BAG --gps-topic TOPIC`, reading a `sensor_msgs/msg/NavSatFix`,
+  `gps_msgs/msg/GPSFix`, `geometry_msgs/msg/PoseStamped`, or
+  `nav_msgs/msg/Odometry` topic from a rosbag2 bag; or
+- `--gps-csv gps.csv`, for host-only fixtures or legacy CSV exports.
+
+Bag reading imports `rosbag2_py`, `rclpy`, and `rosidl_runtime_py` lazily, so a
+plain Python host can still use the CSV workflow. Local pose and odometry topics
+need `--origin-lat` plus `--origin-lon`; x is interpreted as east meters and y as
+north meters from that origin.
+
+Metric samples can come from one or both of:
+
+- `--trace link_trace.jsonl`, using `observed_tx_kbps`,
+  `observed_rx_kbps`, `rtt_ms`, or `loss_pct`; and
+- `--events events.jsonl`, using binned transit `delivery_pct`,
+  `event_loss_pct`, or `ota_hop_ms`.
+
+## Time Alignment
+
+The join is explicit about clocks. GPS samples keep bag/header/CSV time. Trace
+and event samples keep their recorded timestamp. `--trace-to-gps-offset-s` is
+added to every trace/event timestamp before nearest-neighbor matching:
+
+```text
+aligned_metric_time_s = source_metric_time_s + trace_to_gps_offset_s
+```
+
+Use `0` only when both sources already share the same epoch. If the GPS CSV uses
+bag-relative seconds and a link trace uses epoch wall time, pass the offset that
+converts trace time into the bag-relative domain. Samples whose nearest GPS point
+is farther away than `--max-gap-s` are omitted from the CSV and map.
+
+## Example
+
+```bash
+rosotacom geomap \
+  --bag session-instances/.../rosbags/a/native \
+  --gps-topic /fix \
+  --trace session-instances/.../logs/a/status/link_trace.jsonl \
+  --metric observed_tx_kbps \
+  --trace-to-gps-offset-s 0 \
+  --max-gap-s 1.0 \
+  --out-csv artifacts/geo-link-quality.csv \
+  --out-html artifacts/geo-link-quality.html
+```
+
+Open the HTML file in a browser next to its sibling `.route.png` file. The route
+is drawn as an offline raster image: green is better quality, red is worse
+quality, with the selected metric shown in the legend. Exact sample rows and
+latitude/longitude values are written to the CSV artifact, not embedded in the
+HTML.
+
+## Host-Only Smoke
+
+This fixture smoke runs without ROS installed:
+
+```bash
+tmp="$(mktemp -d)" && \
+printf 'time_s,latitude,longitude\n100,49.0000,8.0000\n101,49.0002,8.0003\n' > "$tmp/gps.csv" && \
+printf '%s\n' \
+  '{"kind":"link_trace","monotonic_s":0,"passive_counter_delta":{"tx":{"observed_kbps":1200}}}' \
+  '{"kind":"link_trace","monotonic_s":1,"passive_counter_delta":{"tx":{"observed_kbps":450}}}' \
+  > "$tmp/link_trace.jsonl" && \
+rosotacom geomap --gps-csv "$tmp/gps.csv" --trace "$tmp/link_trace.jsonl" \
+  --trace-to-gps-offset-s 100 --max-gap-s 0.1 \
+  --metric observed_tx_kbps --out-csv "$tmp/geo.csv" --out-html "$tmp/map.html"
+```
+
+Expected output:
+
+```text
+Wrote 2 georeferenced samples to .../geo.csv
+Wrote geo link-quality map to .../map.html
+```
+
+Open `map.html`; it should show a two-point route colored by observed transmit
+throughput using the sibling `map.route.png` image.

--- a/src/rosotacom/cli.py
+++ b/src/rosotacom/cli.py
@@ -7131,6 +7131,68 @@ def metrics_command(args: argparse.Namespace) -> int:
     return 0
 
 
+def geomap_command(args: argparse.Namespace) -> int:
+    from rosotacom.geomap import (
+        join_metric_samples,
+        load_gps_csv,
+        load_gps_from_bag,
+        load_metrics_for_inputs,
+        write_geo_csv,
+        write_geomap_html,
+        write_manifest,
+    )
+
+    gps_csv = cast(str | None, getattr(args, "gps_csv", None))
+    bag = cast(str | None, getattr(args, "bag", None))
+    if bool(gps_csv) == bool(bag):
+        raise RuntimeError("provide exactly one GPS source: --gps-csv or --bag")
+    if bag and not getattr(args, "gps_topic", None):
+        raise RuntimeError("--bag requires --gps-topic")
+
+    if gps_csv:
+        gps_samples = load_gps_csv(gps_csv)
+    else:
+        assert bag is not None
+        gps_samples = load_gps_from_bag(
+            bag,
+            topic=args.gps_topic,
+            storage_id=args.storage_id,
+            time_source=args.gps_time_source,
+            origin_latitude=args.origin_lat,
+            origin_longitude=args.origin_lon,
+        )
+    metric_samples = load_metrics_for_inputs(
+        traces=tuple(args.trace or ()),
+        events=tuple(args.events or ()),
+        event_bin_s=args.event_bin_s,
+        event_time_field=args.event_time_field,
+        event_topic=args.event_topic,
+    )
+    if not metric_samples:
+        raise RuntimeError("no metric samples found; provide at least one non-empty --trace or --events input")
+
+    joined = join_metric_samples(
+        gps_samples,
+        metric_samples,
+        metric=args.metric,
+        trace_to_gps_offset_s=args.trace_to_gps_offset_s,
+        max_gap_s=args.max_gap_s,
+    )
+    if not joined:
+        raise RuntimeError(
+            "no georeferenced samples after timestamp join; check --trace-to-gps-offset-s, --max-gap-s, and --metric"
+        )
+
+    write_geo_csv(joined, args.out_csv)
+    write_geomap_html(joined, args.out_html, metric=args.metric, title=args.title)
+    if args.manifest:
+        write_manifest(args.manifest, csv_path=args.out_csv, html_path=args.out_html, sample_count=len(joined))
+
+    print(f"Wrote {len(joined)} georeferenced samples to {args.out_csv}")
+    print(f"Wrote geo link-quality map to {args.out_html}")
+    return 0
+
+
 def profile_from_trace_command(args: argparse.Namespace) -> int:
     from rosotacom.trace_profiles import TraceProfileConfig, parse_window, write_trace_profile
 
@@ -7719,6 +7781,7 @@ def main(argv: list[str] | None = None) -> int:
         "status",
         "metrics",
         "videoquality",
+        "geomap",
         "report",
         "test",
         "expect",
@@ -7884,6 +7947,94 @@ def main(argv: list[str] | None = None) -> int:
         "--records", action="store_true", help="Emit joined per-(topic, seq) records instead of a summary."
     )
     metrics_parser.set_defaults(func=metrics_command)
+
+    geomap_parser = subparsers.add_parser(
+        "geomap",
+        help="Join GPS/pose samples with link trace or transit metrics and render a geo-referenced HTML map.",
+    )
+    gps_group = geomap_parser.add_mutually_exclusive_group(required=True)
+    gps_group.add_argument(
+        "--gps-csv",
+        help=(
+            "Host-only GPS CSV fixture with time_s/latitude/longitude columns "
+            "(aliases: stamp_s, timestamp_s, bag_time_s, lat, lon, lng)."
+        ),
+    )
+    gps_group.add_argument("--bag", help="rosbag2 directory, metadata.yaml, or bag file containing the GPS topic.")
+    geomap_parser.add_argument("--gps-topic", help="GPS, NavSatFix, PoseStamped, or Odometry topic to read from --bag.")
+    geomap_parser.add_argument(
+        "--gps-time-source",
+        choices=["bag", "header"],
+        default="bag",
+        help="Timestamp source for --bag GPS samples: rosbag record time or message header.stamp (default: bag).",
+    )
+    geomap_parser.add_argument("--storage-id", help="rosbag2 storage id override (default: metadata storage id).")
+    geomap_parser.add_argument(
+        "--origin-lat",
+        type=float,
+        help="WGS84 latitude used to project local pose/odometry x/y meters; required with --origin-lon.",
+    )
+    geomap_parser.add_argument(
+        "--origin-lon",
+        type=float,
+        help="WGS84 longitude used to project local pose/odometry x/y meters; required with --origin-lat.",
+    )
+    geomap_parser.add_argument("--trace", action="append", default=[], help="link_trace.jsonl input. Repeatable.")
+    geomap_parser.add_argument("--events", action="append", default=[], help="events.jsonl input. Repeatable.")
+    geomap_parser.add_argument(
+        "--event-bin-s",
+        type=float,
+        default=1.0,
+        help="Seconds per transit-metric bin when --events is used (default: 1).",
+    )
+    geomap_parser.add_argument(
+        "--event-time-field",
+        choices=["t_wrap", "t_com_in"],
+        default="t_wrap",
+        help="Transit timestamp field to join when --events is used (default: t_wrap).",
+    )
+    geomap_parser.add_argument(
+        "--event-topic",
+        help="Only use this transit topic or source->target:/topic label from --events.",
+    )
+    geomap_parser.add_argument(
+        "--metric",
+        choices=[
+            "observed_tx_kbps",
+            "observed_rx_kbps",
+            "rtt_ms",
+            "loss_pct",
+            "delivery_pct",
+            "event_loss_pct",
+            "ota_hop_ms",
+        ],
+        default="observed_tx_kbps",
+        help="Metric used to color the route.",
+    )
+    geomap_parser.add_argument(
+        "--trace-to-gps-offset-s",
+        type=float,
+        default=0.0,
+        help=(
+            "Seconds added to each trace/events timestamp before joining to GPS time. "
+            "Use 0 only when both sources already share the same epoch."
+        ),
+    )
+    geomap_parser.add_argument(
+        "--max-gap-s",
+        type=float,
+        default=1.0,
+        help="Maximum absolute nearest GPS/metric timestamp gap to keep (default: 1).",
+    )
+    geomap_parser.add_argument("--out-csv", required=True, help="Output CSV path for georeferenced samples.")
+    geomap_parser.add_argument(
+        "--out-html",
+        required=True,
+        help="Output HTML report; also writes a sibling .route.png.",
+    )
+    geomap_parser.add_argument("--manifest", help="Optional YAML sidecar with output paths and sample count.")
+    geomap_parser.add_argument("--title", help="Optional HTML report title.")
+    geomap_parser.set_defaults(func=geomap_command)
 
     profile_parser = subparsers.add_parser("profile", help="Generate and inspect network profiles.")
     profile_subparsers = profile_parser.add_subparsers(dest="profile_command", required=True)

--- a/src/rosotacom/geomap.py
+++ b/src/rosotacom/geomap.py
@@ -1,0 +1,848 @@
+"""Geo-reference recorded link quality against GPS or pose samples.
+
+The join is deliberately offline and explicit about clocks: metric samples keep
+their source timestamp, the caller provides the seconds offset that converts that
+source timestamp into the GPS/bag timestamp domain, and samples outside the
+nearest-neighbor tolerance are dropped.
+"""
+
+from __future__ import annotations
+
+import bisect
+import csv
+import html
+import importlib
+import json
+import math
+import statistics
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Final
+
+import yaml
+from PIL import Image, ImageDraw
+
+from .anonymize import bag_storage_id, bag_topics_info, load_bag_metadata
+from .transit import join_transit_records, load_transit_records
+
+CSV_COLUMNS: Final[tuple[str, ...]] = (
+    "schema_version",
+    "source",
+    "metric",
+    "gps_time_s",
+    "source_time_s",
+    "aligned_time_s",
+    "time_delta_s",
+    "latitude",
+    "longitude",
+    "altitude_m",
+    "metric_value",
+    "observed_tx_kbps",
+    "observed_rx_kbps",
+    "rtt_ms",
+    "loss_pct",
+    "delivery_pct",
+    "event_loss_pct",
+    "event_expected",
+    "event_delivered",
+    "event_lost",
+    "event_topic",
+)
+DEFAULT_METRIC = "observed_tx_kbps"
+KNOWN_METRICS: Final[tuple[str, ...]] = (
+    "observed_tx_kbps",
+    "observed_rx_kbps",
+    "rtt_ms",
+    "loss_pct",
+    "delivery_pct",
+    "event_loss_pct",
+    "ota_hop_ms",
+)
+HIGHER_IS_BETTER: Final[frozenset[str]] = frozenset({"observed_tx_kbps", "observed_rx_kbps", "delivery_pct"})
+SCHEMA_VERSION = 1
+EARTH_RADIUS_M = 6_378_137.0
+MAP_WIDTH = 960
+MAP_HEIGHT = 560
+MAP_PAD = 40
+
+
+@dataclass(frozen=True)
+class GeoSample:
+    """One GPS or projected local-pose sample."""
+
+    time_s: float
+    latitude: float
+    longitude: float
+    altitude_m: float | None = None
+
+
+@dataclass(frozen=True)
+class MetricSample:
+    """One link-quality sample in its source time domain."""
+
+    time_s: float
+    source: str
+    values: dict[str, float]
+    context: dict[str, object]
+
+
+@dataclass(frozen=True)
+class GeoreferencedSample:
+    """A metric sample joined to the nearest GPS point."""
+
+    source: str
+    metric: str
+    metric_value: float
+    gps: GeoSample
+    source_time_s: float
+    aligned_time_s: float
+    time_delta_s: float
+    values: dict[str, float]
+    context: dict[str, object]
+
+
+def load_gps_csv(path: str | Path) -> list[GeoSample]:
+    """Load fixture/legacy GPS samples from CSV.
+
+    Accepted column aliases:
+    ``time_s``/``stamp_s``/``timestamp_s``/``bag_time_s``/``t``,
+    ``latitude``/``lat``, ``longitude``/``lon``/``lng``, and optional
+    ``altitude_m``/``altitude``/``alt``.
+    """
+
+    csv_path = Path(path)
+    with csv_path.open(newline="", encoding="utf-8") as fp:
+        reader = csv.DictReader(fp)
+        if reader.fieldnames is None:
+            raise ValueError(f"{csv_path}: missing CSV header")
+        samples = [
+            _gps_sample_from_csv_row(row, csv_path=csv_path, line_number=index) for index, row in enumerate(reader, 2)
+        ]
+    return _sorted_gps(samples, source=str(csv_path))
+
+
+def load_gps_from_bag(
+    bag: str | Path,
+    *,
+    topic: str,
+    storage_id: str | None = None,
+    time_source: str = "bag",
+    origin_latitude: float | None = None,
+    origin_longitude: float | None = None,
+) -> list[GeoSample]:
+    """Read GPS or pose samples from a rosbag2 bag.
+
+    ``time_source`` is ``bag`` for the rosbag record timestamp or ``header`` for
+    message ``header.stamp``. Local pose/odometry topics are projected to
+    latitude/longitude from an explicit WGS84 origin, interpreting x=east and
+    y=north meters.
+    """
+
+    if time_source not in {"bag", "header"}:
+        raise ValueError("time_source must be 'bag' or 'header'")
+
+    try:
+        rosbag2_py = importlib.import_module("rosbag2_py")
+        deserialize_message = importlib.import_module("rclpy.serialization").deserialize_message
+        get_message = importlib.import_module("rosidl_runtime_py.utilities").get_message
+    except ImportError as exc:
+        raise RuntimeError(
+            "reading GPS samples from a bag requires a ROS 2 Python environment with "
+            "rosbag2_py, rclpy, and rosidl_runtime_py available; use --gps-csv for host-only fixtures"
+        ) from exc
+
+    bag_dir = _bag_directory(Path(bag))
+    metadata = load_bag_metadata(bag_dir)
+    topic_info = bag_topics_info(metadata)
+    if topic not in topic_info:
+        available = ", ".join(sorted(topic_info)) or "<none>"
+        raise RuntimeError(f"topic {topic!r} not found in {bag_dir}; available topics: {available}")
+
+    msg_type = str(topic_info[topic].get("type") or "")
+    msg_cls = get_message(msg_type)
+    reader = rosbag2_py.SequentialReader()
+    reader.open(
+        rosbag2_py.StorageOptions(uri=str(bag_dir), storage_id=storage_id or bag_storage_id(metadata)),
+        rosbag2_py.ConverterOptions("", ""),
+    )
+
+    samples: list[GeoSample] = []
+    origin = _origin_tuple(origin_latitude, origin_longitude)
+    while reader.has_next():
+        topic_name, payload, timestamp_ns = reader.read_next()
+        if topic_name != topic:
+            continue
+        msg = deserialize_message(payload, msg_cls)
+        time_s = float(timestamp_ns) / 1e9 if time_source == "bag" else _message_header_time_s(msg)
+        if time_s is None:
+            raise RuntimeError(f"{topic}: message has no usable header.stamp for --gps-time-source header")
+        samples.append(_geo_from_message(msg, msg_type=msg_type, time_s=time_s, origin=origin))
+    return _sorted_gps(samples, source=f"{bag_dir}:{topic}")
+
+
+def load_link_trace_metrics(paths: Iterable[str | Path]) -> list[MetricSample]:
+    """Load ``link_trace.jsonl`` rows as metric samples."""
+
+    samples: list[MetricSample] = []
+    for raw_path in paths:
+        path = Path(raw_path)
+        for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+            if not line.strip():
+                continue
+            try:
+                row = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"{path}:{line_number}: invalid JSON: {exc}") from exc
+            if not isinstance(row, Mapping) or row.get("kind") not in (None, "link_trace"):
+                continue
+            sample = _metric_from_link_trace_row(row, path=path, line_number=line_number)
+            if sample is not None:
+                samples.append(sample)
+    return sorted(samples, key=lambda sample: sample.time_s)
+
+
+def load_event_metrics(
+    paths: Iterable[str | Path],
+    *,
+    bin_s: float = 1.0,
+    time_field: str = "t_wrap",
+    topic: str | None = None,
+) -> list[MetricSample]:
+    """Load binned per-topic delivery metrics from ``events.jsonl`` transit rows."""
+
+    if bin_s <= 0:
+        raise ValueError("bin_s must be > 0")
+    if time_field not in {"t_wrap", "t_com_in"}:
+        raise ValueError("time_field must be 't_wrap' or 't_com_in'")
+    path_list = [Path(path) for path in paths]
+    records = join_transit_records(load_transit_records(path_list))
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    for record in records:
+        label = _event_label(record)
+        if topic is not None and topic not in {label, str(record.get("topic") or "")}:
+            continue
+        grouped.setdefault(label, []).append(record)
+
+    samples: list[MetricSample] = []
+    source = "events:" + ",".join(path.name for path in path_list)
+    for label, stream in sorted(grouped.items()):
+        timed = _stream_records_with_times(stream, time_field=time_field)
+        bins: dict[float, list[tuple[dict[str, Any], float]]] = {}
+        for record, stamp in timed:
+            start = math.floor(stamp / bin_s) * bin_s
+            bins.setdefault(start, []).append((record, stamp))
+        for start, entries in sorted(bins.items()):
+            expected = len(entries)
+            lost = sum(record.get("status") == "lost" for record, _stamp in entries)
+            delivered = expected - lost
+            ota_values = [
+                latency
+                for record, _stamp in entries
+                if (latency := _record_latency_ms(record)) is not None and record.get("status") != "lost"
+            ]
+            values = {
+                "delivery_pct": round(100.0 * delivered / expected, 6) if expected else 0.0,
+                "event_loss_pct": round(100.0 * lost / expected, 6) if expected else 0.0,
+            }
+            if ota_values:
+                values["ota_hop_ms"] = round(statistics.median(ota_values), 6)
+            samples.append(
+                MetricSample(
+                    time_s=start + bin_s / 2.0,
+                    source=f"{source}:{label}",
+                    values=values,
+                    context={
+                        "event_topic": label,
+                        "event_expected": expected,
+                        "event_delivered": delivered,
+                        "event_lost": lost,
+                    },
+                )
+            )
+    return sorted(samples, key=lambda sample: sample.time_s)
+
+
+def join_metric_samples(
+    gps_samples: Sequence[GeoSample],
+    metric_samples: Sequence[MetricSample],
+    *,
+    metric: str = DEFAULT_METRIC,
+    trace_to_gps_offset_s: float = 0.0,
+    max_gap_s: float = 1.0,
+) -> list[GeoreferencedSample]:
+    """Join metric samples to nearest GPS sample after applying the time offset."""
+
+    if max_gap_s < 0:
+        raise ValueError("max_gap_s must be >= 0")
+    gps = _sorted_gps(gps_samples, source="gps samples")
+    times = [sample.time_s for sample in gps]
+    joined: list[GeoreferencedSample] = []
+    for sample in sorted(metric_samples, key=lambda item: item.time_s):
+        metric_value = sample.values.get(metric)
+        if metric_value is None or not math.isfinite(metric_value):
+            continue
+        aligned = sample.time_s + trace_to_gps_offset_s
+        nearest = _nearest_gps(gps, times, aligned)
+        if nearest is None:
+            continue
+        delta = nearest.time_s - aligned
+        if abs(delta) > max_gap_s:
+            continue
+        joined.append(
+            GeoreferencedSample(
+                source=sample.source,
+                metric=metric,
+                metric_value=metric_value,
+                gps=nearest,
+                source_time_s=sample.time_s,
+                aligned_time_s=aligned,
+                time_delta_s=delta,
+                values=dict(sample.values),
+                context=dict(sample.context),
+            )
+        )
+    return joined
+
+
+def write_geo_csv(samples: Sequence[GeoreferencedSample], path: str | Path) -> None:
+    """Write the stable georeferenced sample CSV."""
+
+    output = Path(path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with output.open("w", newline="", encoding="utf-8") as fp:
+        writer = csv.DictWriter(fp, fieldnames=list(CSV_COLUMNS))
+        writer.writeheader()
+        for sample in samples:
+            writer.writerow(_csv_row(sample))
+
+
+def render_geomap_html(*, route_image_src: str, metric: str, title: str | None = None) -> str:
+    """Render the HTML report around a sibling route image."""
+
+    metric_title = title or f"rosotacom geo link-quality map: {metric}"
+
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{html.escape(metric_title)}</title>
+  <style>
+    :root {{
+      color-scheme: light;
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background: #f5f7f9;
+      color: #16202a;
+    }}
+    body {{
+      margin: 0;
+      padding: 24px;
+    }}
+    main {{
+      max-width: 1120px;
+      margin: 0 auto;
+    }}
+    h1 {{
+      font-size: 1.5rem;
+      margin: 0 0 8px;
+      letter-spacing: 0;
+    }}
+    .meta {{
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      gap: 8px;
+      margin: 12px 0 18px;
+      color: #425466;
+      font-size: 0.92rem;
+    }}
+    .map {{
+      background: #ffffff;
+      border: 1px solid #d8e0e8;
+      border-radius: 8px;
+      overflow: hidden;
+    }}
+    .map img {{
+      display: block;
+      width: 100%;
+      height: auto;
+    }}
+    .legend {{
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      margin: 14px 0 22px;
+      font-size: 0.92rem;
+      color: #425466;
+    }}
+    .ramp {{
+      width: 180px;
+      height: 12px;
+      border-radius: 999px;
+      background: linear-gradient(90deg, hsl(0 72% 45%), hsl(60 72% 45%), hsl(120 72% 38%));
+      border: 1px solid #c8d1da;
+    }}
+  </style>
+</head>
+<body>
+<main>
+  <h1>{html.escape(metric_title)}</h1>
+  <div class="meta">
+    <div><strong>route image</strong> {html.escape(route_image_src)}</div>
+    <div><strong>coordinates</strong> written to CSV only</div>
+  </div>
+  <div class="map">
+    <img src="{html.escape(route_image_src)}" alt="Route colored by {html.escape(metric)}">
+  </div>
+  <div class="legend">
+    <span>lower quality</span>
+    <span class="ramp" aria-hidden="true"></span>
+    <span>higher quality</span>
+    <span>{html.escape(metric)}</span>
+  </div>
+</main>
+</body>
+</html>
+"""
+
+
+def write_geomap_html(
+    samples: Sequence[GeoreferencedSample],
+    path: str | Path,
+    *,
+    metric: str,
+    title: str | None = None,
+) -> None:
+    """Write an HTML route map and its sibling PNG route image."""
+
+    output = Path(path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    route_image = _route_image_path(output)
+    _write_route_png(samples, route_image, metric=metric)
+    rendered = render_geomap_html(
+        route_image_src=route_image.name,
+        metric=metric,
+        title=title,
+    )
+    output.write_text(rendered, encoding="utf-8")
+
+
+def load_metrics_for_inputs(
+    *,
+    traces: Sequence[str | Path] = (),
+    events: Sequence[str | Path] = (),
+    event_bin_s: float = 1.0,
+    event_time_field: str = "t_wrap",
+    event_topic: str | None = None,
+) -> list[MetricSample]:
+    """Load all configured metric inputs."""
+
+    samples: list[MetricSample] = []
+    if traces:
+        samples.extend(load_link_trace_metrics(traces))
+    if events:
+        samples.extend(load_event_metrics(events, bin_s=event_bin_s, time_field=event_time_field, topic=event_topic))
+    return sorted(samples, key=lambda sample: sample.time_s)
+
+
+def _gps_sample_from_csv_row(row: Mapping[str, str | None], *, csv_path: Path, line_number: int) -> GeoSample:
+    return GeoSample(
+        time_s=_required_csv_float(row, ("time_s", "stamp_s", "timestamp_s", "bag_time_s", "t"), csv_path, line_number),
+        latitude=_required_csv_float(row, ("latitude", "lat"), csv_path, line_number),
+        longitude=_required_csv_float(row, ("longitude", "lon", "lng"), csv_path, line_number),
+        altitude_m=_optional_csv_float(row, ("altitude_m", "altitude", "alt")),
+    )
+
+
+def _required_csv_float(
+    row: Mapping[str, str | None], names: tuple[str, ...], csv_path: Path, line_number: int
+) -> float:
+    value = _optional_csv_float(row, names)
+    if value is None:
+        raise ValueError(f"{csv_path}:{line_number}: missing numeric column from {names}")
+    return value
+
+
+def _optional_csv_float(row: Mapping[str, str | None], names: tuple[str, ...]) -> float | None:
+    for name in names:
+        if name not in row:
+            continue
+        value = row[name]
+        if value is None or value == "":
+            return None
+        return _required_number(value, name)
+    return None
+
+
+def _sorted_gps(samples: Sequence[GeoSample], *, source: str) -> list[GeoSample]:
+    out = sorted(samples, key=lambda sample: sample.time_s)
+    if not out:
+        raise ValueError(f"{source}: no GPS samples found")
+    for sample in out:
+        if not (-90.0 <= sample.latitude <= 90.0 and -180.0 <= sample.longitude <= 180.0):
+            raise ValueError(f"{source}: invalid latitude/longitude at {sample.time_s:g}s")
+    return out
+
+
+def _bag_directory(path: Path) -> Path:
+    if path.name == "metadata.yaml":
+        return path.parent
+    if path.is_file():
+        return path.parent
+    return path
+
+
+def _origin_tuple(latitude: float | None, longitude: float | None) -> tuple[float, float] | None:
+    if latitude is None and longitude is None:
+        return None
+    if latitude is None or longitude is None:
+        raise ValueError("origin latitude and longitude must be provided together")
+    if not (-90.0 <= latitude <= 90.0 and -180.0 <= longitude <= 180.0):
+        raise ValueError("origin latitude/longitude are out of range")
+    return latitude, longitude
+
+
+def _message_header_time_s(msg: Any) -> float | None:
+    header = getattr(msg, "header", None)
+    stamp = getattr(header, "stamp", None)
+    if stamp is None:
+        return None
+    sec = getattr(stamp, "sec", None)
+    nanosec = getattr(stamp, "nanosec", getattr(stamp, "nsec", None))
+    if sec is None or nanosec is None:
+        return None
+    return float(sec) + float(nanosec) / 1e9
+
+
+def _geo_from_message(
+    msg: Any,
+    *,
+    msg_type: str,
+    time_s: float,
+    origin: tuple[float, float] | None,
+) -> GeoSample:
+    latitude = _optional_number(getattr(msg, "latitude", None))
+    longitude = _optional_number(getattr(msg, "longitude", None))
+    altitude = _optional_number(getattr(msg, "altitude", None))
+    if latitude is not None and longitude is not None:
+        return GeoSample(time_s=time_s, latitude=latitude, longitude=longitude, altitude_m=altitude)
+
+    position = _message_position(msg)
+    if position is None:
+        raise RuntimeError(f"{msg_type}: unsupported GPS/pose message shape")
+    if origin is None:
+        raise RuntimeError(
+            f"{msg_type}: local pose/odometry topics require --origin-lat and --origin-lon for geo projection"
+        )
+    east_m = _required_number(getattr(position, "x", None), "position.x")
+    north_m = _required_number(getattr(position, "y", None), "position.y")
+    up_m = _optional_number(getattr(position, "z", None))
+    latitude, longitude = _offset_meters_to_latlon(east_m, north_m, origin_lat=origin[0], origin_lon=origin[1])
+    return GeoSample(time_s=time_s, latitude=latitude, longitude=longitude, altitude_m=up_m)
+
+
+def _message_position(msg: Any) -> Any | None:
+    pose = getattr(msg, "pose", None)
+    if pose is not None:
+        nested = getattr(pose, "pose", pose)
+        position = getattr(nested, "position", None)
+        if position is not None:
+            return position
+    return getattr(msg, "position", None)
+
+
+def _offset_meters_to_latlon(
+    east_m: float, north_m: float, *, origin_lat: float, origin_lon: float
+) -> tuple[float, float]:
+    lat = origin_lat + math.degrees(north_m / EARTH_RADIUS_M)
+    cos_lat = math.cos(math.radians(origin_lat))
+    if abs(cos_lat) < 1e-12:
+        raise ValueError("origin latitude is too close to a pole for local x/y projection")
+    lon = origin_lon + math.degrees(east_m / (EARTH_RADIUS_M * cos_lat))
+    return lat, lon
+
+
+def _metric_from_link_trace_row(row: Mapping[str, Any], *, path: Path, line_number: int) -> MetricSample | None:
+    time_s = _row_time_s(row, path=path, line_number=line_number)
+    passive = _mapping_or_none(row.get("passive_counter_delta"))
+    tx = _mapping_or_none(passive.get("tx") if passive else None)
+    rx = _mapping_or_none(passive.get("rx") if passive else None)
+    probe = _mapping_or_none(row.get("peer_probe"))
+    values: dict[str, float] = {}
+    _add_numeric(values, "observed_tx_kbps", tx.get("observed_kbps") if tx else None)
+    _add_numeric(values, "observed_rx_kbps", rx.get("observed_kbps") if rx else None)
+    _add_numeric(values, "rtt_ms", probe.get("rtt_ms") if probe else None)
+    _add_numeric(values, "loss_pct", probe.get("loss_pct") if probe else None)
+    if not values:
+        return None
+    return MetricSample(
+        time_s=time_s,
+        source=f"link_trace:{path.name}:{line_number}",
+        values=values,
+        context={"peer": str(row.get("peer") or ""), "remote": str(row.get("remote") or "")},
+    )
+
+
+def _row_time_s(row: Mapping[str, Any], *, path: Path, line_number: int) -> float:
+    generated_at = row.get("generated_at")
+    if isinstance(generated_at, str) and generated_at:
+        parsed = _parse_wall_iso(generated_at)
+        if parsed is not None:
+            return parsed
+        raise ValueError(f"{path}:{line_number}: generated_at is not a valid ISO timestamp")
+    return _required_number(row.get("monotonic_s"), f"{path}:{line_number}: monotonic_s")
+
+
+def _parse_wall_iso(value: str) -> float | None:
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00")).timestamp()
+    except ValueError:
+        return None
+
+
+def _mapping_or_none(value: Any) -> Mapping[str, Any] | None:
+    return value if isinstance(value, Mapping) else None
+
+
+def _add_numeric(values: dict[str, float], name: str, raw: Any) -> None:
+    value = _optional_number(raw)
+    if value is not None:
+        values[name] = value
+
+
+def _required_number(value: Any, label: str) -> float:
+    number = _optional_number(value)
+    if number is None:
+        raise ValueError(f"{label} must be a finite number")
+    return number
+
+
+def _optional_number(value: Any) -> float | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    return number if math.isfinite(number) else None
+
+
+def _event_label(record: Mapping[str, Any]) -> str:
+    source = str(record.get("source") or "")
+    target = str(record.get("target") or "")
+    topic = str(record.get("topic") or "")
+    return f"{source}->{target}:{topic}" if source or target else topic
+
+
+def _record_latency_ms(record: Mapping[str, Any]) -> float | None:
+    sections = record.get("sections")
+    if not isinstance(sections, Mapping):
+        return None
+    value = _optional_number(sections.get("ota_hop_ms"))
+    if value is None:
+        value = _optional_number(sections.get("ota_hop_uncorrected_ms"))
+    return value
+
+
+def _stream_records_with_times(
+    stream: Sequence[dict[str, Any]], *, time_field: str
+) -> list[tuple[dict[str, Any], float]]:
+    known = sorted(
+        (int(record["seq"]), float(stamp))
+        for record in stream
+        if (stamp := _optional_number(record.get(time_field))) is not None and record.get("seq") is not None
+    )
+    if not known:
+        return []
+    period_s = _median_sequence_period(known)
+    known_seq = [seq for seq, _stamp in known]
+    known_time = [stamp for _seq, stamp in known]
+    timed: list[tuple[dict[str, Any], float]] = []
+    for record in stream:
+        stamp = _optional_number(record.get(time_field))
+        if stamp is not None:
+            timed.append((record, stamp))
+            continue
+        if record.get("seq") is None:
+            continue
+        inferred = _infer_record_time(int(record["seq"]), known_seq, known_time, period_s=period_s)
+        if inferred is not None:
+            timed.append((record, inferred))
+    return sorted(timed, key=lambda item: item[1])
+
+
+def _median_sequence_period(known: Sequence[tuple[int, float]]) -> float | None:
+    periods = [
+        (t1 - t0) / (seq1 - seq0)
+        for (seq0, t0), (seq1, t1) in zip(known, known[1:], strict=False)
+        if seq1 > seq0 and t1 >= t0
+    ]
+    return statistics.median(periods) if periods else None
+
+
+def _infer_record_time(
+    seq: int, known_seq: Sequence[int], known_time: Sequence[float], *, period_s: float | None
+) -> float | None:
+    index = bisect.bisect_left(known_seq, seq)
+    if 0 < index < len(known_seq):
+        left_seq = known_seq[index - 1]
+        right_seq = known_seq[index]
+        if right_seq > left_seq:
+            share = (seq - left_seq) / (right_seq - left_seq)
+            return known_time[index - 1] + share * (known_time[index] - known_time[index - 1])
+    if period_s is not None and index > 0:
+        return known_time[index - 1] + (seq - known_seq[index - 1]) * period_s
+    if period_s is not None and index < len(known_seq):
+        return known_time[index] - (known_seq[index] - seq) * period_s
+    return None
+
+
+def _nearest_gps(gps: Sequence[GeoSample], times: Sequence[float], stamp: float) -> GeoSample | None:
+    if not gps:
+        return None
+    index = bisect.bisect_left(times, stamp)
+    candidates: list[GeoSample] = []
+    if index > 0:
+        candidates.append(gps[index - 1])
+    if index < len(gps):
+        candidates.append(gps[index])
+    return min(candidates, key=lambda sample: abs(sample.time_s - stamp)) if candidates else None
+
+
+def _csv_row(sample: GeoreferencedSample) -> dict[str, object]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "source": sample.source,
+        "metric": sample.metric,
+        "gps_time_s": _format_number(sample.gps.time_s),
+        "source_time_s": _format_number(sample.source_time_s),
+        "aligned_time_s": _format_number(sample.aligned_time_s),
+        "time_delta_s": _format_number(sample.time_delta_s),
+        "latitude": _format_number(sample.gps.latitude, digits=8),
+        "longitude": _format_number(sample.gps.longitude, digits=8),
+        "altitude_m": _format_optional(sample.gps.altitude_m),
+        "metric_value": _format_number(sample.metric_value),
+        "observed_tx_kbps": _format_optional(sample.values.get("observed_tx_kbps")),
+        "observed_rx_kbps": _format_optional(sample.values.get("observed_rx_kbps")),
+        "rtt_ms": _format_optional(sample.values.get("rtt_ms")),
+        "loss_pct": _format_optional(sample.values.get("loss_pct")),
+        "delivery_pct": _format_optional(sample.values.get("delivery_pct")),
+        "event_loss_pct": _format_optional(sample.values.get("event_loss_pct")),
+        "event_expected": sample.context.get("event_expected", ""),
+        "event_delivered": sample.context.get("event_delivered", ""),
+        "event_lost": sample.context.get("event_lost", ""),
+        "event_topic": sample.context.get("event_topic", ""),
+    }
+
+
+def _format_optional(value: object) -> str:
+    return "" if value is None else _format_number(float(value)) if isinstance(value, int | float) else str(value)
+
+
+def _format_number(value: float, digits: int = 6) -> str:
+    text = f"{value:.{digits}f}".rstrip("0").rstrip(".")
+    return "0" if text == "-0" else text
+
+
+def _project_map_points(samples: Sequence[GeoSample]) -> list[tuple[float, float]]:
+    mean_lat = sum(sample.latitude for sample in samples) / len(samples)
+    cos_lat = max(1e-9, math.cos(math.radians(mean_lat)))
+    coords = [(sample.longitude * cos_lat, sample.latitude) for sample in samples]
+    xs = [coord[0] for coord in coords]
+    ys = [coord[1] for coord in coords]
+    min_x, max_x = min(xs), max(xs)
+    min_y, max_y = min(ys), max(ys)
+    span_x = max(max_x - min_x, 1e-9)
+    span_y = max(max_y - min_y, 1e-9)
+    return [
+        (
+            MAP_PAD + (x - min_x) / span_x * (MAP_WIDTH - 2 * MAP_PAD),
+            MAP_HEIGHT - MAP_PAD - (y - min_y) / span_y * (MAP_HEIGHT - 2 * MAP_PAD),
+        )
+        for x, y in coords
+    ]
+
+
+def _route_image_path(html_path: Path) -> Path:
+    return html_path.with_name(f"{html_path.stem}.route.png")
+
+
+def _write_route_png(
+    rows: Sequence[GeoreferencedSample],
+    path: str | Path,
+    *,
+    metric: str,
+) -> None:
+    output = Path(path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    sorted_rows = sorted(rows, key=lambda sample: sample.gps.time_s)
+    if not sorted_rows:
+        raise ValueError("no georeferenced samples to render")
+
+    values = [row.metric_value for row in sorted_rows]
+    value_min = min(values)
+    value_max = max(values)
+    points = _project_map_points([row.gps for row in sorted_rows])
+    image = Image.new("RGB", (MAP_WIDTH, MAP_HEIGHT), (251, 252, 253))
+    draw = ImageDraw.Draw(image)
+
+    for index in range(1, len(sorted_rows)):
+        x0, y0 = points[index - 1]
+        x1, y1 = points[index]
+        color = _metric_color_rgb(
+            sorted_rows[index].metric_value,
+            value_min=value_min,
+            value_max=value_max,
+            metric=metric,
+        )
+        draw.line([(x0, y0), (x1, y1)], fill=color, width=5)
+
+    for row, (x, y) in zip(sorted_rows, points, strict=True):
+        radius = 5.0
+        color = _metric_color_rgb(row.metric_value, value_min=value_min, value_max=value_max, metric=metric)
+        draw.ellipse(
+            (x - radius, y - radius, x + radius, y + radius),
+            fill=color,
+            outline=(21, 32, 43),
+            width=1,
+        )
+
+    image.save(output, format="PNG", optimize=True)
+
+
+def _metric_quality(value: float, *, value_min: float, value_max: float, metric: str) -> float:
+    normalized = 0.5 if value_max == value_min else (value - value_min) / (value_max - value_min)
+    normalized = max(0.0, min(1.0, normalized))
+    return normalized if metric in HIGHER_IS_BETTER else 1.0 - normalized
+
+
+def _metric_color_rgb(value: float, *, value_min: float, value_max: float, metric: str) -> tuple[int, int, int]:
+    quality = _metric_quality(value, value_min=value_min, value_max=value_max, metric=metric)
+    stops = ((196, 32, 39), (188, 170, 32), (45, 145, 63))
+    if quality <= 0.5:
+        start, end = stops[0], stops[1]
+        fraction = quality * 2.0
+    else:
+        start, end = stops[1], stops[2]
+        fraction = (quality - 0.5) * 2.0
+    red = round(start[0] + (end[0] - start[0]) * fraction)
+    green = round(start[1] + (end[1] - start[1]) * fraction)
+    blue = round(start[2] + (end[2] - start[2]) * fraction)
+    return red, green, blue
+
+
+def write_manifest(path: str | Path, *, csv_path: str | Path, html_path: str | Path, sample_count: int) -> None:
+    """Write a tiny sidecar manifest for scripted smoke checks."""
+
+    output = Path(path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "kind": "geo_link_quality_map",
+        "csv": str(csv_path),
+        "html": str(html_path),
+        "route_image": str(_route_image_path(Path(html_path))),
+        "samples": sample_count,
+    }
+    output.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")

--- a/tests/unit/test_geomap.py
+++ b/tests/unit/test_geomap.py
@@ -1,0 +1,255 @@
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from rosotacom.cli import main
+from rosotacom.geomap import (
+    CSV_COLUMNS,
+    GeoSample,
+    MetricSample,
+    join_metric_samples,
+    load_event_metrics,
+    load_gps_csv,
+    load_link_trace_metrics,
+    write_geo_csv,
+    write_geomap_html,
+)
+
+
+def _write_jsonl(path: Path, rows: list[dict[str, object]]) -> Path:
+    path.write_text("\n".join(json.dumps(row) for row in rows) + "\n", encoding="utf-8")
+    return path
+
+
+def _trace_row(time_s: float, *, tx_kbps: float, rtt_ms: float = 20.0, loss_pct: float = 0.0) -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "kind": "link_trace",
+        "monotonic_s": time_s,
+        "peer": "a",
+        "remote": "b",
+        "passive_counter_delta": {
+            "available": True,
+            "window_s": 1.0,
+            "observed_not_available_bandwidth": True,
+            "tx": {"bytes_delta": 0, "packets_delta": 0, "observed_kbps": tx_kbps},
+            "rx": {"bytes_delta": 0, "packets_delta": 0, "observed_kbps": tx_kbps / 2.0},
+        },
+        "peer_probe": {
+            "available": True,
+            "rtt_ms": rtt_ms,
+            "loss_pct": loss_pct,
+            "assumption": "symmetric_path",
+        },
+    }
+
+
+def _write_gps_csv(path: Path) -> Path:
+    path.write_text(
+        "\n".join(
+            [
+                "time_s,latitude,longitude,altitude_m",
+                "100.0,49.000000,8.000000,110",
+                "101.0,49.000100,8.000150,111",
+                "102.0,49.000220,8.000300,112",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_join_applies_explicit_offset_and_drops_out_of_range_samples() -> None:
+    gps = [
+        GeoSample(time_s=100.0, latitude=49.0, longitude=8.0),
+        GeoSample(time_s=101.0, latitude=49.001, longitude=8.001),
+        GeoSample(time_s=102.0, latitude=49.002, longitude=8.002),
+    ]
+    metrics = [
+        MetricSample(time_s=0.0, source="trace:1", values={"observed_tx_kbps": 500.0}, context={}),
+        MetricSample(time_s=1.0, source="trace:2", values={"observed_tx_kbps": 600.0}, context={}),
+        MetricSample(time_s=3.0, source="trace:3", values={"observed_tx_kbps": 700.0}, context={}),
+    ]
+
+    joined = join_metric_samples(
+        gps,
+        metrics,
+        metric="observed_tx_kbps",
+        trace_to_gps_offset_s=100.0,
+        max_gap_s=0.25,
+    )
+
+    assert [sample.metric_value for sample in joined] == [500.0, 600.0]
+    assert [sample.gps.time_s for sample in joined] == [100.0, 101.0]
+    assert [sample.time_delta_s for sample in joined] == [0.0, 0.0]
+
+
+def test_link_trace_join_writes_stable_csv_shape(tmp_path: Path) -> None:
+    gps = load_gps_csv(_write_gps_csv(tmp_path / "gps.csv"))
+    trace = _write_jsonl(
+        tmp_path / "link_trace.jsonl",
+        [
+            _trace_row(0.0, tx_kbps=1000.0, rtt_ms=20.0),
+            _trace_row(1.0, tx_kbps=800.0, rtt_ms=50.0),
+            _trace_row(3.0, tx_kbps=200.0, rtt_ms=120.0),
+        ],
+    )
+
+    metrics = load_link_trace_metrics([trace])
+    joined = join_metric_samples(
+        gps,
+        metrics,
+        metric="observed_tx_kbps",
+        trace_to_gps_offset_s=100.0,
+        max_gap_s=0.25,
+    )
+    out = tmp_path / "geo.csv"
+    write_geo_csv(joined, out)
+
+    with out.open(newline="", encoding="utf-8") as fp:
+        reader = csv.DictReader(fp)
+        rows = list(reader)
+    assert tuple(reader.fieldnames or ()) == CSV_COLUMNS
+    assert len(rows) == 2
+    assert rows[0]["source"].startswith("link_trace:link_trace.jsonl:")
+    assert rows[0]["metric"] == "observed_tx_kbps"
+    assert rows[0]["gps_time_s"] == "100"
+    assert rows[0]["source_time_s"] == "0"
+    assert rows[0]["aligned_time_s"] == "100"
+    assert rows[0]["time_delta_s"] == "0"
+    assert rows[0]["metric_value"] == "1000"
+    assert rows[0]["rtt_ms"] == "20"
+
+
+def test_event_metrics_bin_delivery_and_infer_bounded_lost_time(tmp_path: Path) -> None:
+    events = _write_jsonl(
+        tmp_path / "events.jsonl",
+        [
+            {
+                "kind": "transit",
+                "source": "a",
+                "target": "b",
+                "topic": "/video",
+                "seq": 1,
+                "status": "delivered",
+                "t_wrap": 100.1,
+                "sections": {"ota_hop_ms": 20.0},
+            },
+            {
+                "kind": "transit",
+                "source": "a",
+                "target": "b",
+                "topic": "/video",
+                "seq": 2,
+                "status": "lost",
+                "t_wrap": None,
+                "sections": {"ota_hop_ms": None},
+            },
+            {
+                "kind": "transit",
+                "source": "a",
+                "target": "b",
+                "topic": "/video",
+                "seq": 3,
+                "status": "delivered",
+                "t_wrap": 100.3,
+                "sections": {"ota_hop_ms": 30.0},
+            },
+        ],
+    )
+
+    samples = load_event_metrics([events], bin_s=0.5, topic="a->b:/video")
+
+    assert len(samples) == 1
+    assert samples[0].time_s == pytest.approx(100.25)
+    assert samples[0].values["delivery_pct"] == pytest.approx(66.666667)
+    assert samples[0].values["event_loss_pct"] == pytest.approx(33.333333)
+    assert samples[0].values["ota_hop_ms"] == pytest.approx(25.0)
+    assert samples[0].context == {
+        "event_topic": "a->b:/video",
+        "event_expected": 3,
+        "event_delivered": 2,
+        "event_lost": 1,
+    }
+
+
+def test_html_map_smoke_writes_route_image_sibling(tmp_path: Path) -> None:
+    samples = join_metric_samples(
+        [
+            GeoSample(time_s=10.0, latitude=49.0, longitude=8.0),
+            GeoSample(time_s=11.0, latitude=49.001, longitude=8.002),
+        ],
+        [
+            MetricSample(time_s=10.0, source="trace:1", values={"loss_pct": 0.0}, context={}),
+            MetricSample(time_s=11.0, source="trace:2", values={"loss_pct": 20.0}, context={}),
+        ],
+        metric="loss_pct",
+        max_gap_s=0.0,
+    )
+    out = tmp_path / "map.html"
+
+    write_geomap_html(samples, out, metric="loss_pct", title="fixture map")
+
+    text = out.read_text(encoding="utf-8")
+    route_image = tmp_path / "map.route.png"
+    assert route_image.read_bytes().startswith(b"\x89PNG\r\n\x1a\n")
+    assert 'src="map.route.png"' in text
+    assert "data:image" not in text
+    assert "<svg" not in text
+    assert "fixture map" in text
+    assert "loss_pct" in text
+    assert "hsl(" in text
+    assert "<th>latitude</th>" not in text
+    assert "<th>longitude</th>" not in text
+    assert "49.001" not in text
+    assert "8.002" not in text
+
+
+def test_cli_geomap_writes_csv_html_and_manifest(tmp_path: Path) -> None:
+    gps = _write_gps_csv(tmp_path / "gps.csv")
+    trace = _write_jsonl(
+        tmp_path / "link_trace.jsonl",
+        [_trace_row(0.0, tx_kbps=1000.0), _trace_row(1.0, tx_kbps=800.0)],
+    )
+    out_csv = tmp_path / "geo.csv"
+    out_html = tmp_path / "map.html"
+    manifest = tmp_path / "manifest.yaml"
+
+    assert (
+        main(
+            [
+                "geomap",
+                "--gps-csv",
+                str(gps),
+                "--trace",
+                str(trace),
+                "--metric",
+                "observed_tx_kbps",
+                "--trace-to-gps-offset-s",
+                "100",
+                "--max-gap-s",
+                "0.25",
+                "--out-csv",
+                str(out_csv),
+                "--out-html",
+                str(out_html),
+                "--manifest",
+                str(manifest),
+            ]
+        )
+        == 0
+    )
+
+    assert out_csv.is_file()
+    assert out_html.is_file()
+    assert (tmp_path / "map.route.png").is_file()
+    payload = yaml.safe_load(manifest.read_text(encoding="utf-8"))
+    assert payload["kind"] == "geo_link_quality_map"
+    assert payload["samples"] == 2
+    assert payload["route_image"].endswith("map.route.png")


### PR DESCRIPTION
Fixes #171.
Refs harness GitLab #29.

## Summary

- Add `rosotacom geomap` for offline GPS/pose plus link-quality joins.
- Support GPS CSV fixtures and lazy rosbag2 topic loading for NavSatFix/GPSFix/Pose/Odometry inputs.
- Write georeferenced CSV samples, an HTML report, and a sibling `.route.png` route image colored by trace or transit metrics.
- Document clock-offset handling and link the docs from the README.

## Validation

- PASS: `just check`
- PASS: host-only geomap smoke with synthetic GPS CSV and `link_trace.jsonl`
- ATTEMPTED: `just test-e2e-smoke` failed on the shared Docker host. Three benchmark cases were blocked by active rosotacom containers from another workspace. One compressed occupancy-grid smoke case failed in the ROS runtime path with missing bridge topics/status STALLED; the failure is unrelated to the new host-only geomap code and was inspected under `session-instances/2026-07-08/3_comp_occ_grid_2026-07-08_01-06-11_57b3d30f/logs/`.

## Owner smoke

Run this command:

```bash
tmp="$(mktemp -d)" && \
printf 'time_s,latitude,longitude\\n100,49.0000,8.0000\\n101,49.0002,8.0003\\n' > "$tmp/gps.csv" && \\\nprintf '%s\\n' \\\n  '{"kind":"link_trace","monotonic_s":0,"passive_counter_delta":{"tx":{"observed_kbps":1200}}}' \\\n  '{"kind":"link_trace","monotonic_s":1,"passive_counter_delta":{"tx":{"observed_kbps":450}}}' \\\n  > "$tmp/link_trace.jsonl" && \\\nrosotacom geomap --gps-csv "$tmp/gps.csv" --trace "$tmp/link_trace.jsonl" \\\n  --trace-to-gps-offset-s 100 --max-gap-s 0.1 \\\n  --metric observed_tx_kbps --out-csv "$tmp/geo.csv" --out-html "$tmp/map.html" && \\\nprintf 'Open %s next to %s\\n' "$tmp/map.html" "$tmp/map.route.png"\n```\n\nExpected output:\n\n```text\nWrote 2 georeferenced samples to .../geo.csv\nWrote geo link-quality map to .../map.html\nOpen .../map.html next to .../map.route.png\n```\n\nOpen the printed `map.html`; it should show a two-point route colored by observed transmit throughput using the sibling `map.route.png` image.\n