### PR TITLE
Add stream-stage stats command

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,6 +440,24 @@ summary. Wrapped-topic corrected latency requires `shared.use_heartbeat: true`;
 sample age, and symmetric-path assumption. Uncorrected OTA delay remains a
 separate field.
 
+Compare how a stream changes across recorded stages — for example native
+pre-processing, processed handoff, and post-OTA transit rows:
+
+```bash
+rosotacom stream-stats \
+  --bag pre=logs/b/metrics/stages_20260702_172900:/sensors/camera/front_medium/resized/image_rect_color \
+  --bag handoff=logs/b/metrics/stages_20260702_172900:/sensors/camera/front_medium/resized/image_rect_color/compressed/restamped/drop1of2/ffmpeg \
+  --events post=logs/b/status/events.jsonl:/sensors/camera/front_medium/resized/image_rect_color \
+  --out stream-stats
+```
+
+The command emits a side-by-side Markdown table plus `stream-stats.json`, with
+per-stage size distributions, observed rate, interval regularity, and FFMPEG
+GOP/keyframe shape when available. Bag sources require `rosbag2_py`; `events`
+sources work from the recorded RFC 0003 transit rows. See
+[docs/ffmpeg-keyframes.md](docs/ffmpeg-keyframes.md) for the GOP methodology
+and example camera interpretation.
+
 Turn a whole recorded instance into an explanation of *where* and *how*
 delivery degraded — loss bursts, latency excursions, and rate collapses with
 exact boundaries, joined with link-trace/profile/keyframe context:

--- a/docs/ffmpeg-keyframes.md
+++ b/docs/ffmpeg-keyframes.md
@@ -45,6 +45,50 @@ Grouping a stream into GOPs is then just splitting at keyframes. Note the
 encoder may emit keyframes *early* (scene cuts), so GOPs can be shorter than
 `gop_size` — assert spacing `<= gop_size`, not `== gop_size`.
 
+## Automated stream-stage stats
+
+`rosotacom stream-stats` applies the same packet parser and GOP grouping to
+recorded stage bags, then lines the aggregate results up beside post-OTA
+`events.jsonl` transit rows. This is the repeatable version of the manual
+remote-assist camera analysis:
+
+```bash
+rosotacom stream-stats \
+  --bag pre=logs/b/metrics/stages_20260702_172900:/sensors/camera/front_medium/resized/image_rect_color \
+  --bag handoff=logs/b/metrics/stages_20260702_172900:/sensors/camera/front_medium/resized/image_rect_color/compressed/restamped/drop1of2/ffmpeg \
+  --events post=logs/b/status/events.jsonl:/sensors/camera/front_medium/resized/image_rect_color \
+  --out stream-stats
+```
+
+Inputs are explicit and repeatable:
+
+- `--bag LABEL=PATH:/topic` reads one rosbag2 topic, using message timestamps and
+  serialized sizes. When the bag metadata declares `FFMPEGPacket`, the command
+  parses the CDR payload and reports encoded-frame payload sizes plus keyframes
+  from `flags & 1`. Bag reading uses `rosbag2_py`, so run it in a ROS
+  environment for MCAP sources.
+- `--events LABEL=PATH:/topic` reads delivered RFC 0003 transit rows from
+  `events.jsonl`, using receiver-side `t_com_in` timestamps and `size_bytes`.
+  Transit rows do not carry raw CDR flags, so GOP annotation uses the documented
+  size-bimodality fallback when the keyframe share looks like a real GOP.
+
+The Markdown output starts with the comparison table:
+
+```text
+| stage | kind | topic | msgs | hz | mean B | p90 B | gap std ms | gaps within +/-10% | GOP spacing |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `pre` | bag | `/.../image_rect_color` | ... | 20 | ... | ... | ... | ... | - |
+| `handoff` | bag | `/.../ffmpeg` | ... | 10 | ... | ... | ... | ... | 5 |
+| `post` | events | `/.../image_rect_color` | ... | ... | ... | ... | ... | ... | 5 |
+```
+
+The JSON output (`stream-stats/stream-stats.json`) carries the same rows plus
+the full size and interval distributions, per-GOP-position size table, keyframe
+spacing distribution, and the most extreme GOP by keyframe-to-delta mean ratio.
+The comparison is intentionally aggregate-only: it does not join individual
+messages across decimating stages such as drop or throttle, matching the
+index-join caveat in [RFC 0003](rfcs/0003-metric-backbone.md).
+
 ## Fallback: size bimodality
 
 If `flags` is unavailable (foreign recordings, or bags anonymized before
@@ -61,6 +105,9 @@ scene at a very low bitrate) — prefer `flags` whenever present.
 - `tests/unit/test_ffmpeg_packet.py` — CDR parsing (alignment across
   odd-length strings), flag semantics, and the size fallback on a synthetic
   GOP pattern.
+- `tests/unit/test_stream_stats.py` — exact stream statistics, per-GOP-position
+  tables from hand-built CDR packets, events-row source loading, comparison
+  table shape, and CLI output writing.
 - `tests/unit/test_anonymize.py::test_anonymize_msg_preserves_ffmpeg_keyframe_structure`
   — anonymization keeps `flags`/`pts` while zeroing payloads.
 - `tests/e2e/test_anonymize_e2e.py` — headless end-to-end: a trace bag written

--- a/src/rosotacom/cli.py
+++ b/src/rosotacom/cli.py
@@ -7200,6 +7200,27 @@ def report_command(args: argparse.Namespace) -> int:
     return 0
 
 
+def stream_stats_command(args: argparse.Namespace) -> int:
+    from rosotacom.stream_stats import build_report, load_sources, render_markdown, write_report
+
+    sources = load_sources(
+        bag_specs=tuple(args.bag or ()),
+        events_specs=tuple(args.events or ()),
+        storage_id=args.storage_id,
+    )
+    report = build_report(sources, argv=["rosotacom", "stream-stats", *sys.argv[2:]])
+    written: dict[str, Path] = {}
+    if args.out:
+        written = write_report(report, Path(args.out).expanduser().resolve())
+    if args.json:
+        print(json.dumps(report, indent=2))
+    else:
+        print(render_markdown(report), end="")
+    for kind, path in written.items():
+        print(f"{kind}: {path}", file=sys.stderr)
+    return 0
+
+
 def _add_common_config_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--rosotacom-config",
@@ -7720,6 +7741,7 @@ def main(argv: list[str] | None = None) -> int:
         "metrics",
         "videoquality",
         "report",
+        "stream-stats",
         "test",
         "expect",
         "calibrate",
@@ -8078,6 +8100,36 @@ def main(argv: list[str] | None = None) -> int:
         "--json", action="store_true", help="Print report.json to stdout instead of the markdown summary."
     )
     report_parser.set_defaults(func=report_command)
+
+    stream_stats_parser = subparsers.add_parser(
+        "stream-stats",
+        help="Compare stream sizes, rate, interval regularity, and FFMPEG GOP shape across recorded stages.",
+    )
+    stream_stats_parser.add_argument(
+        "--bag",
+        action="append",
+        metavar="LABEL=PATH:/topic",
+        help=(
+            "Analyze one rosbag2/stage-bag topic. Requires rosbag2_py in the active environment. "
+            "Repeat to compare stages."
+        ),
+    )
+    stream_stats_parser.add_argument(
+        "--events",
+        action="append",
+        metavar="LABEL=PATH:/topic",
+        help="Analyze one RFC 0003 events.jsonl transit topic. Repeat to compare stages.",
+    )
+    stream_stats_parser.add_argument(
+        "--storage-id",
+        default="mcap",
+        help="rosbag2 storage id for --bag sources (default: mcap).",
+    )
+    stream_stats_parser.add_argument("--out", help="Output directory for stream-stats.json and stream-stats.md.")
+    stream_stats_parser.add_argument(
+        "--json", action="store_true", help="Print stream-stats.json to stdout instead of the markdown summary."
+    )
+    stream_stats_parser.set_defaults(func=stream_stats_command)
 
     test_parser = subparsers.add_parser(
         "test", help="Assert a running/recent session meets its status + per-topic expect contract."

--- a/src/rosotacom/stream_stats.py
+++ b/src/rosotacom/stream_stats.py
@@ -1,0 +1,517 @@
+"""Offline stream-stage statistics for bags and RFC 0003 transit rows."""
+
+from __future__ import annotations
+
+import json
+import math
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from statistics import median
+from typing import Any
+
+from . import __version__
+from .ffmpeg_packet import FFMPEGPacketInfo, keyframes_by_size, parse_ffmpeg_packet
+from .transit import join_transit_records, load_transit_records
+
+FFMPEG_TYPE = "ffmpeg_image_transport_msgs/msg/FFMPEGPacket"
+KEYFRAME_SHARE_MIN = 0.02
+KEYFRAME_SHARE_MAX = 0.40
+
+
+@dataclass(frozen=True)
+class SourceSpec:
+    kind: str
+    label: str
+    path: Path
+    topic: str
+
+
+@dataclass(frozen=True)
+class StreamSample:
+    timestamp_ns: int
+    size_bytes: int
+    serialized_size_bytes: int | None = None
+    keyframe: bool | None = None
+    ffmpeg: FFMPEGPacketInfo | None = None
+
+
+@dataclass(frozen=True)
+class StreamSource:
+    label: str
+    kind: str
+    path: Path | None
+    topic: str
+    samples: tuple[StreamSample, ...]
+    message_type: str | None = None
+    size_basis: str = "message_bytes"
+
+
+def parse_source_spec(kind: str, value: str) -> SourceSpec:
+    """Parse ``LABEL=PATH:/topic`` source arguments."""
+    label: str | None
+    rest: str
+    if "=" in value:
+        label, rest = value.split("=", 1)
+        label = label.strip()
+        if not label:
+            raise ValueError(f"{kind} source has an empty label: {value!r}")
+    else:
+        label, rest = None, value
+    if ":" not in rest:
+        raise ValueError(f"{kind} source must be LABEL=PATH:/topic, got {value!r}")
+    path_text, topic = rest.rsplit(":", 1)
+    if not path_text:
+        raise ValueError(f"{kind} source has an empty path: {value!r}")
+    if not topic.startswith("/"):
+        raise ValueError(f"{kind} source topic must start with '/', got {topic!r}")
+    path = Path(path_text).expanduser()
+    return SourceSpec(kind=kind, label=label or f"{path.name}:{topic}", path=path, topic=topic)
+
+
+def _round(value: float | None, digits: int = 3) -> float | None:
+    if value is None:
+        return None
+    rounded = round(float(value), digits)
+    if rounded == 0.0 and value > 0.0:
+        return float(f"{value:.3g}")
+    return rounded
+
+
+def _percentile(values: Sequence[float], percentile: float) -> float | None:
+    if not values:
+        return None
+    ordered = sorted(float(value) for value in values)
+    rank = max(0, min(len(ordered) - 1, math.ceil(percentile * len(ordered)) - 1))
+    return _round(ordered[rank])
+
+
+def distribution(values: Sequence[float]) -> dict[str, float | None]:
+    if not values:
+        return dict.fromkeys(("min", "mean", "median", "p90", "max", "std"))
+    vals = [float(value) for value in values]
+    mean = sum(vals) / len(vals)
+    std = math.sqrt(sum((value - mean) ** 2 for value in vals) / len(vals))
+    return {
+        "min": _round(min(vals)),
+        "mean": _round(mean),
+        "median": _round(float(median(vals))),
+        "p90": _percentile(vals, 0.90),
+        "max": _round(max(vals)),
+        "std": _round(std),
+    }
+
+
+def _ordered_samples(samples: Iterable[StreamSample]) -> list[StreamSample]:
+    return sorted(samples, key=lambda sample: sample.timestamp_ns)
+
+
+def _intervals_s(samples: Sequence[StreamSample]) -> list[float]:
+    ordered = _ordered_samples(samples)
+    return [
+        (right.timestamp_ns - left.timestamp_ns) / 1_000_000_000.0
+        for left, right in zip(ordered, ordered[1:], strict=False)
+        if right.timestamp_ns >= left.timestamp_ns
+    ]
+
+
+def interval_stats(samples: Sequence[StreamSample]) -> dict[str, Any]:
+    intervals = _intervals_s(samples)
+    stats: dict[str, Any] = distribution([gap * 1000.0 for gap in intervals])
+    nominal_s = float(median(intervals)) if intervals else None
+    stats["nominal_ms"] = _round(nominal_s * 1000.0 if nominal_s is not None else None)
+    stats["nominal_hz"] = _round(1.0 / nominal_s if nominal_s and nominal_s > 0.0 else None)
+    if intervals and nominal_s and nominal_s > 0.0:
+        within = sum(abs(gap - nominal_s) <= 0.10 * nominal_s for gap in intervals)
+        stats["within_10pct_nominal_pct"] = _round(100.0 * within / len(intervals))
+    else:
+        stats["within_10pct_nominal_pct"] = None
+    return stats
+
+
+def _rate_hz(samples: Sequence[StreamSample]) -> tuple[float | None, float | None]:
+    ordered = _ordered_samples(samples)
+    if len(ordered) < 2:
+        return None, None
+    duration_s = (ordered[-1].timestamp_ns - ordered[0].timestamp_ns) / 1_000_000_000.0
+    if duration_s <= 0.0:
+        return None, _round(duration_s)
+    return _round((len(ordered) - 1) / duration_s), _round(duration_s)
+
+
+def samples_from_cdr_records(
+    records: Iterable[tuple[int, bytes]],
+    *,
+    message_type: str | None,
+) -> tuple[StreamSample, ...]:
+    """Build samples from ``(timestamp_ns, serialized_message)`` records."""
+    parse_ffmpeg = message_type == FFMPEG_TYPE or (message_type is not None and "FFMPEGPacket" in message_type)
+    samples: list[StreamSample] = []
+    for timestamp_ns, data in records:
+        serialized = bytes(data)
+        if parse_ffmpeg:
+            info = parse_ffmpeg_packet(serialized)
+            samples.append(
+                StreamSample(
+                    timestamp_ns=int(timestamp_ns),
+                    size_bytes=info.payload_size,
+                    serialized_size_bytes=len(serialized),
+                    keyframe=info.is_keyframe,
+                    ffmpeg=info,
+                )
+            )
+        else:
+            samples.append(
+                StreamSample(
+                    timestamp_ns=int(timestamp_ns),
+                    size_bytes=len(serialized),
+                    serialized_size_bytes=len(serialized),
+                )
+            )
+    return tuple(samples)
+
+
+def load_bag_source(spec: SourceSpec, *, storage_id: str = "mcap") -> StreamSource:
+    """Load one topic from a rosbag2 bag using optional ``rosbag2_py``."""
+    try:
+        import rosbag2_py  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError(
+            "bag sources require rosbag2_py. Run inside a ROS environment, or use --events for events.jsonl sources."
+        ) from exc
+
+    reader = rosbag2_py.SequentialReader()
+    reader.open(
+        rosbag2_py.StorageOptions(uri=str(spec.path), storage_id=storage_id),
+        rosbag2_py.ConverterOptions("", ""),
+    )
+    topics = {topic.name: topic.type for topic in reader.get_all_topics_and_types()}
+    if spec.topic not in topics:
+        available = ", ".join(sorted(topics)) or "none"
+        raise RuntimeError(f"{spec.path}: topic {spec.topic!r} not found; available topics: {available}")
+    message_type = topics.get(spec.topic)
+    records: list[tuple[int, bytes]] = []
+    while reader.has_next():
+        topic, serialized, timestamp_ns = reader.read_next()
+        if topic == spec.topic:
+            records.append((int(timestamp_ns), bytes(serialized)))
+    samples = samples_from_cdr_records(records, message_type=message_type)
+    size_basis = (
+        "ffmpeg_payload_bytes" if message_type and "FFMPEGPacket" in message_type else "serialized_message_bytes"
+    )
+    return StreamSource(
+        label=spec.label,
+        kind="bag",
+        path=spec.path,
+        topic=spec.topic,
+        samples=samples,
+        message_type=message_type,
+        size_basis=size_basis,
+    )
+
+
+def load_events_source(spec: SourceSpec) -> StreamSource:
+    records = [
+        record
+        for record in join_transit_records(load_transit_records([spec.path]))
+        if str(record.get("topic") or "") == spec.topic and record.get("status") != "lost"
+    ]
+    samples: list[StreamSample] = []
+    for record in records:
+        size = record.get("size_bytes")
+        if size is None:
+            continue
+        stamp = record.get("t_com_in")
+        if stamp is None:
+            stamp = record.get("t_wrap")
+        if stamp is None:
+            continue
+        samples.append(StreamSample(timestamp_ns=int(float(stamp) * 1_000_000_000), size_bytes=int(size)))
+    return StreamSource(
+        label=spec.label,
+        kind="events",
+        path=spec.path,
+        topic=spec.topic,
+        samples=tuple(samples),
+        size_basis="events_size_bytes",
+    )
+
+
+def _keyframe_mask(source: StreamSource) -> tuple[list[bool], str] | None:
+    if not source.samples:
+        return None
+    explicit = [sample.keyframe for sample in source.samples]
+    if any(value is not None for value in explicit):
+        return [bool(value) for value in explicit], "ffmpeg_packet.flags"
+
+    flags = keyframes_by_size([sample.size_bytes for sample in source.samples])
+    count = sum(flags)
+    if count < 2:
+        return None
+    share = count / len(flags)
+    if not (KEYFRAME_SHARE_MIN <= share <= KEYFRAME_SHARE_MAX):
+        return None
+    return flags, f"size_bimodality ({share * 100.0:.1f}% frames)"
+
+
+def _gop_stats(source: StreamSource) -> dict[str, Any] | None:
+    mask_with_method = _keyframe_mask(source)
+    if mask_with_method is None:
+        return None
+    flags, method = mask_with_method
+    key_indices = [index for index, is_keyframe in enumerate(flags) if is_keyframe]
+    if not key_indices:
+        return None
+
+    spacings = [right - left for left, right in zip(key_indices, key_indices[1:], strict=False)]
+    gops: list[list[StreamSample]] = []
+    for current, next_start in zip(key_indices, [*key_indices[1:], len(source.samples)], strict=False):
+        gop = list(source.samples[current:next_start])
+        if gop:
+            gops.append(gop)
+
+    by_position: dict[int, list[float]] = {}
+    for gop in gops:
+        for position, sample in enumerate(gop):
+            by_position.setdefault(position, []).append(float(sample.size_bytes))
+    position_table = [
+        {"position": position, "count": len(values), **distribution(values)}
+        for position, values in sorted(by_position.items())
+    ]
+
+    extreme: dict[str, Any] | None = None
+    best_ratio = -1.0
+    for start_index, gop in zip(key_indices, gops, strict=True):
+        if len(gop) < 2:
+            continue
+        delta_mean = sum(sample.size_bytes for sample in gop[1:]) / (len(gop) - 1)
+        if delta_mean <= 0:
+            continue
+        ratio = gop[0].size_bytes / delta_mean
+        if ratio > best_ratio:
+            best_ratio = ratio
+            extreme = {
+                "start_index": start_index,
+                "start_time_s": _round((gop[0].timestamp_ns - source.samples[0].timestamp_ns) / 1_000_000_000.0),
+                "length": len(gop),
+                "keyframe_size_bytes": gop[0].size_bytes,
+                "delta_mean_bytes": _round(delta_mean),
+                "key_to_delta_mean_ratio": _round(ratio),
+                "sizes_bytes": [sample.size_bytes for sample in gop],
+            }
+
+    return {
+        "method": method,
+        "keyframes": len(key_indices),
+        "gops": len(gops),
+        "keyframe_spacing_frames": distribution([float(value) for value in spacings]),
+        "gop_length_frames": distribution([float(len(gop)) for gop in gops]),
+        "position_size_bytes": position_table,
+        "most_extreme_gop": extreme,
+    }
+
+
+def summarize_source(source: StreamSource) -> dict[str, Any]:
+    ordered = _ordered_samples(source.samples)
+    rate_hz, duration_s = _rate_hz(ordered)
+    sizes = [float(sample.size_bytes) for sample in ordered]
+    ordered_source = StreamSource(
+        label=source.label,
+        kind=source.kind,
+        path=source.path,
+        topic=source.topic,
+        samples=tuple(ordered),
+        message_type=source.message_type,
+        size_basis=source.size_basis,
+    )
+    return {
+        "label": source.label,
+        "kind": source.kind,
+        "path": str(source.path) if source.path else None,
+        "topic": source.topic,
+        "message_type": source.message_type,
+        "size_basis": source.size_basis,
+        "count": len(ordered),
+        "duration_s": duration_s,
+        "rate_hz": rate_hz,
+        "size_bytes": distribution(sizes),
+        "interval_ms": interval_stats(ordered),
+        "gop": _gop_stats(ordered_source),
+    }
+
+
+def build_report(sources: Sequence[StreamSource], *, argv: Sequence[str] | None = None) -> dict[str, Any]:
+    summaries = [summarize_source(source) for source in sources]
+    comparison_rows = [
+        {
+            "stage": entry["label"],
+            "kind": entry["kind"],
+            "topic": entry["topic"],
+            "count": entry["count"],
+            "rate_hz": entry["rate_hz"],
+            "size_mean_bytes": entry["size_bytes"]["mean"],
+            "size_p90_bytes": entry["size_bytes"]["p90"],
+            "size_max_bytes": entry["size_bytes"]["max"],
+            "interval_std_ms": entry["interval_ms"]["std"],
+            "within_10pct_nominal_pct": entry["interval_ms"]["within_10pct_nominal_pct"],
+            "gop_keyframes": (entry["gop"] or {}).get("keyframes"),
+            "gop_spacing_median_frames": ((entry["gop"] or {}).get("keyframe_spacing_frames") or {}).get("median"),
+        }
+        for entry in summaries
+    ]
+    return {
+        "kind": "stream_stats",
+        "schema_version": 1,
+        "provenance": {
+            "generated_at": datetime.now().isoformat(timespec="seconds"),
+            "rosotacom_version": __version__,
+            "command": " ".join(argv or ()),
+        },
+        "sources": summaries,
+        "comparison": {
+            "note": ("Aggregate stage comparison only; no per-message join is attempted across decimating stages."),
+            "rows": comparison_rows,
+        },
+    }
+
+
+def _fmt(value: Any, *, suffix: str = "") -> str:
+    if value is None:
+        return "-"
+    if isinstance(value, float):
+        return f"{value:g}{suffix}"
+    return f"{value}{suffix}"
+
+
+def _markdown_table(headers: Sequence[str], rows: Sequence[Sequence[Any]]) -> list[str]:
+    lines = ["| " + " | ".join(headers) + " |", "| " + " | ".join("---" for _ in headers) + " |"]
+    for row in rows:
+        lines.append("| " + " | ".join(str(cell) for cell in row) + " |")
+    return lines
+
+
+def render_markdown(report: dict[str, Any]) -> str:
+    lines = [
+        "# Stream stats",
+        "",
+        f"- generated: {report['provenance']['generated_at']} by rosotacom {report['provenance']['rosotacom_version']}",
+    ]
+    command = report["provenance"].get("command")
+    if command:
+        lines.append(f"- command: `{command}`")
+    lines += ["", "## Stage Comparison", "", report["comparison"]["note"], ""]
+    rows = []
+    for row in report["comparison"]["rows"]:
+        rows.append(
+            [
+                f"`{row['stage']}`",
+                row["kind"],
+                f"`{row['topic']}`",
+                row["count"],
+                _fmt(row["rate_hz"]),
+                _fmt(row["size_mean_bytes"]),
+                _fmt(row["size_p90_bytes"]),
+                _fmt(row["interval_std_ms"]),
+                _fmt(row["within_10pct_nominal_pct"], suffix="%"),
+                _fmt(row["gop_spacing_median_frames"]),
+            ]
+        )
+    lines.extend(
+        _markdown_table(
+            [
+                "stage",
+                "kind",
+                "topic",
+                "msgs",
+                "hz",
+                "mean B",
+                "p90 B",
+                "gap std ms",
+                "gaps within +/-10%",
+                "GOP spacing",
+            ],
+            rows,
+        )
+    )
+
+    lines += ["", "## Per-Source Details", ""]
+    for source in report["sources"]:
+        lines.append(f"### {source['label']}")
+        lines.append("")
+        lines.append(f"- topic: `{source['topic']}`")
+        lines.append(f"- size basis: `{source['size_basis']}`")
+        lines.append(f"- count/rate: {source['count']} messages, {_fmt(source['rate_hz'])} Hz")
+        size = source["size_bytes"]
+        interval = source["interval_ms"]
+        lines.append(
+            "- size bytes: "
+            f"min {_fmt(size['min'])}, mean {_fmt(size['mean'])}, median {_fmt(size['median'])}, "
+            f"p90 {_fmt(size['p90'])}, max {_fmt(size['max'])}, std {_fmt(size['std'])}"
+        )
+        lines.append(
+            "- intervals: "
+            f"nominal {_fmt(interval['nominal_ms'])} ms, std {_fmt(interval['std'])} ms, "
+            f"{_fmt(interval['within_10pct_nominal_pct'], suffix='%')} within +/-10%"
+        )
+        gop = source.get("gop")
+        if gop:
+            spacing = gop["keyframe_spacing_frames"]
+            lines.append(
+                f"- GOP: {gop['keyframes']} keyframes across {gop['gops']} GOPs "
+                f"({gop['method']}), median spacing {_fmt(spacing['median'])} frames"
+            )
+            extreme = gop.get("most_extreme_gop")
+            if extreme:
+                lines.append(
+                    "- most extreme GOP: "
+                    f"index {extreme['start_index']}, length {extreme['length']}, "
+                    f"ratio {_fmt(extreme['key_to_delta_mean_ratio'])}, sizes {extreme['sizes_bytes']}"
+                )
+            lines.append("")
+            lines.extend(
+                _markdown_table(
+                    ["GOP pos", "count", "mean B", "median B", "p90 B", "max B"],
+                    [
+                        [
+                            entry["position"],
+                            entry["count"],
+                            _fmt(entry["mean"]),
+                            _fmt(entry["median"]),
+                            _fmt(entry["p90"]),
+                            _fmt(entry["max"]),
+                        ]
+                        for entry in gop["position_size_bytes"]
+                    ],
+                )
+            )
+        else:
+            lines.append("- GOP: not detected")
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def write_report(report: dict[str, Any], out_dir: str | Path) -> dict[str, Path]:
+    out = Path(out_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    json_path = out / "stream-stats.json"
+    markdown_path = out / "stream-stats.md"
+    json_path.write_text(json.dumps(report, indent=2, sort_keys=False) + "\n", encoding="utf-8")
+    markdown_path.write_text(render_markdown(report), encoding="utf-8")
+    return {"json": json_path, "markdown": markdown_path}
+
+
+def load_sources(
+    *,
+    bag_specs: Sequence[str] = (),
+    events_specs: Sequence[str] = (),
+    storage_id: str = "mcap",
+) -> list[StreamSource]:
+    sources: list[StreamSource] = []
+    for value in bag_specs:
+        sources.append(load_bag_source(parse_source_spec("bag", value), storage_id=storage_id))
+    for value in events_specs:
+        sources.append(load_events_source(parse_source_spec("events", value)))
+    if not sources:
+        raise ValueError("provide at least one --bag or --events source")
+    return sources

--- a/tests/unit/test_stream_stats.py
+++ b/tests/unit/test_stream_stats.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import json
+import struct
+from pathlib import Path
+
+import rosotacom.cli as rosotacom
+from rosotacom.ffmpeg_packet import AV_PKT_FLAG_KEY
+from rosotacom.stream_stats import (
+    FFMPEG_TYPE,
+    StreamSample,
+    StreamSource,
+    build_report,
+    load_events_source,
+    parse_source_spec,
+    render_markdown,
+    samples_from_cdr_records,
+    summarize_source,
+)
+
+
+def _cdr_string(offset: int, value: str) -> tuple[bytes, int]:
+    pad = (-offset) % 4
+    raw = value.encode() + b"\x00"
+    chunk = b"\x00" * pad + struct.pack("<I", len(raw)) + raw
+    return chunk, offset + len(chunk)
+
+
+def _packet(*, flags: int, payload_size: int, pts: int = 0) -> bytes:
+    body = b""
+    offset = 0
+    body += struct.pack("<iI", 7, 9)
+    offset += 8
+    chunk, offset = _cdr_string(offset, "camera")
+    body += chunk
+    pad = (-offset) % 4
+    body += b"\x00" * pad + struct.pack("<ii", 640, 480)
+    offset += pad + 8
+    chunk, offset = _cdr_string(offset, "h264")
+    body += chunk
+    pad = (-offset) % 8
+    body += b"\x00" * pad + struct.pack("<Q", pts)
+    offset += pad + 8
+    body += struct.pack("<BB", flags, 0)
+    offset += 2
+    pad = (-offset) % 4
+    body += b"\x00" * pad + struct.pack("<I", payload_size) + b"\xaa" * payload_size
+    return b"\x00\x01\x00\x00" + body
+
+
+def _event(seq: int, *, size: int, topic: str = "/cam", period_s: float = 0.1) -> dict:
+    t_wrap = 1_782_000_000.0 + seq * period_s
+    return {
+        "kind": "transit",
+        "source": "a",
+        "target": "b",
+        "topic": topic,
+        "seq": seq,
+        "status": "delivered",
+        "t_wrap": t_wrap,
+        "t_com_in": t_wrap + 0.012,
+        "sections": {"ota_hop_ms": 12.0},
+        "size_bytes": size,
+        "inter_arrival_ms": period_s * 1000.0,
+    }
+
+
+def test_source_stats_are_exact_for_regular_samples() -> None:
+    source = StreamSource(
+        label="native",
+        kind="fixture",
+        path=None,
+        topic="/numbers",
+        samples=tuple(
+            StreamSample(timestamp_ns=index * 100_000_000, size_bytes=size)
+            for index, size in enumerate([100, 200, 300, 400, 500])
+        ),
+    )
+
+    stats = summarize_source(source)
+
+    assert stats["count"] == 5
+    assert stats["duration_s"] == 0.4
+    assert stats["rate_hz"] == 10.0
+    assert stats["size_bytes"] == {
+        "min": 100.0,
+        "mean": 300.0,
+        "median": 300.0,
+        "p90": 500.0,
+        "max": 500.0,
+        "std": 141.421,
+    }
+    assert stats["interval_ms"]["nominal_ms"] == 100.0
+    assert stats["interval_ms"]["std"] == 0.0
+    assert stats["interval_ms"]["within_10pct_nominal_pct"] == 100.0
+
+
+def test_ffmpeg_gop_table_uses_packet_flags_and_payload_sizes() -> None:
+    sizes = [44000, 3000, 4000, 4200, 3900, 88000, 500, 500, 500, 500]
+    records = [
+        (
+            index * 100_000_000,
+            _packet(
+                flags=AV_PKT_FLAG_KEY if index % 5 == 0 else 0,
+                payload_size=size,
+                pts=index,
+            ),
+        )
+        for index, size in enumerate(sizes)
+    ]
+    source = StreamSource(
+        label="handoff",
+        kind="fixture",
+        path=None,
+        topic="/cam/ffmpeg",
+        samples=samples_from_cdr_records(records, message_type=FFMPEG_TYPE),
+        message_type=FFMPEG_TYPE,
+        size_basis="ffmpeg_payload_bytes",
+    )
+
+    stats = summarize_source(source)
+    gop = stats["gop"]
+
+    assert stats["size_bytes"]["max"] == 88000.0
+    assert gop["method"] == "ffmpeg_packet.flags"
+    assert gop["keyframes"] == 2
+    assert gop["keyframe_spacing_frames"]["median"] == 5.0
+    by_position = {entry["position"]: entry for entry in gop["position_size_bytes"]}
+    assert by_position[0]["mean"] == 66000.0
+    assert by_position[1]["mean"] == 1750.0
+    assert gop["most_extreme_gop"]["start_index"] == 5
+    assert gop["most_extreme_gop"]["key_to_delta_mean_ratio"] == 176.0
+
+
+def test_events_source_filters_topic_and_detects_gop_by_size(tmp_path: Path) -> None:
+    rows = []
+    for seq in range(10):
+        rows.append(_event(seq, size=40000 if seq % 5 == 0 else 3000))
+        rows.append(_event(seq, size=999, topic="/other"))
+    events = tmp_path / "events.jsonl"
+    events.write_text("\n".join(json.dumps(row) for row in rows) + "\n", encoding="utf-8")
+    spec = parse_source_spec("events", f"post={events}:/cam")
+
+    source = load_events_source(spec)
+    stats = summarize_source(source)
+
+    assert source.label == "post"
+    assert stats["count"] == 10
+    assert stats["rate_hz"] == 10.0
+    assert stats["gop"]["method"].startswith("size_bimodality")
+    assert stats["gop"]["keyframes"] == 2
+
+
+def test_comparison_markdown_has_one_row_per_stage() -> None:
+    sources = [
+        StreamSource("pre", "fixture", None, "/cam", (StreamSample(0, 100), StreamSample(100_000_000, 110))),
+        StreamSource("handoff", "fixture", None, "/cam/ffmpeg", (StreamSample(0, 40), StreamSample(100_000_000, 4))),
+        StreamSource("post", "fixture", None, "/cam", (StreamSample(0, 40), StreamSample(120_000_000, 4))),
+    ]
+
+    report = build_report(sources, argv=["rosotacom", "stream-stats"])
+    markdown = render_markdown(report)
+
+    assert [row["stage"] for row in report["comparison"]["rows"]] == ["pre", "handoff", "post"]
+    assert "| `pre` | fixture | `/cam` |" in markdown
+    assert "| `handoff` | fixture | `/cam/ffmpeg` |" in markdown
+    assert "| `post` | fixture | `/cam` |" in markdown
+
+
+def test_cli_stream_stats_events_writes_json_and_markdown(tmp_path: Path, capsys) -> None:
+    events = tmp_path / "events.jsonl"
+    events.write_text("\n".join(json.dumps(_event(seq, size=1000 + seq)) for seq in range(3)) + "\n", encoding="utf-8")
+    out = tmp_path / "out"
+
+    rc = rosotacom.main(["stream-stats", "--events", f"post={events}:/cam", "--out", str(out)])
+
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "# Stream stats" in captured.out
+    assert (out / "stream-stats.json").is_file()
+    assert (out / "stream-stats.md").is_file()
+    payload = json.loads((out / "stream-stats.json").read_text(encoding="utf-8"))
+    assert payload["sources"][0]["label"] == "post"


### PR DESCRIPTION
Fixes #170.

## Summary

- Adds `rosotacom stream-stats` for side-by-side aggregate stream-stage comparisons from rosbag2/stage-bag topics and RFC 0003 `events.jsonl` transit rows.
- Reports size distribution, observed rate, interval regularity, and GOP/keyframe stats with FFMPEGPacket CDR parsing when bag sources expose packet flags, falling back to size bimodality for transit rows.
- Documents the workflow in the README-reachable keyframe methodology page and adds focused unit coverage for exact stats, GOP tables, events loading, markdown comparison shape, and CLI writing.

## Validation

- `python -m pytest tests/unit/test_stream_stats.py tests/unit/test_ffmpeg_packet.py -q` — 16 passed.
- `python -m ruff check . && python -m ruff format --check . && python -m py_compile src/rosotacom/*.py run_session_in_container.py stop_session_in_container.py` — passed.
- `python -m pytest -q tests/unit tests/contract --cov=rosotacom --cov-report=term-missing --cov-report=xml:coverage.xml` — 485 passed, coverage 71.83%.
- `python -m mypy` — passed.
- `python -m pre_commit run actionlint --all-files` — passed.
- `shellcheck install.sh src/rosotacom/resources/ws/session/creation/catmux_log_setup.sh src/rosotacom/resources/examples/scripts/**/*.sh && python -m pytest -q tests/contract/test_packaged_resources.py` — 11 passed.
- `python -m build && python -m twine check dist/* && check-wheel-contents dist/*.whl` plus wheel install/package smoke — passed.
- `PYTHONPATH=src ROSOTACOM_RUN_E2E=1 python -m pytest -q tests/e2e/ -m e2e` — 20 passed, 4 skipped, 1 failed in the upstream `17_synthetic_camera_quality` video-quality smoke added on `develop`; the failure is the decoded `/camera/image/ffmpeg/raw` status latency reporting about `1.78e9s` against a 1000 ms expectation. No rosotacom containers or Docker networks were left running after cleanup.

## Example 15/16 reproduction

Ran against the existing remote-assist 100 s native bag and anonymized single-stream bags from `fzi_projects/remote_assist` in the ROS container with `rosbag2_py`:

```bash
docker run --rm \
  -v /home/go914/dev/rosotacom_test/ros_communication_devcontainer:/repo:ro \
  -v /home/go914/dev/rosotacom_test/fzi_projects/remote_assist:/remote_assist:ro \
  ros-communication:latest \
  bash -lc 'source /opt/ros/kilted/setup.bash && cd /repo && PYTHONPATH=/repo/src:$PYTHONPATH python3 -m rosotacom stream-stats \
    --bag native_camera=/remote_assist/data/native_bag_remote_assist_100s:/sensors/camera/front_medium/resized/image_rect_color/compressed \
    --bag native_costmap=/remote_assist/data/native_bag_remote_assist_100s:/costmap/costmap \
    --bag handoff_camera=/remote_assist/anonymized/scenarios/anonymized_remote_assist_camera/anonymized_bag:/topic1 \
    --bag handoff_costmap=/remote_assist/anonymized/scenarios/anonymized_remote_assist_costmap/anonymized_bag:/topic1'
```

Key rows:

| stage | kind | topic | msgs | hz | mean B | p90 B | gap std ms | gaps within +/-10% | GOP spacing |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| `native_camera` | bag | `/sensors/camera/front_medium/resized/image_rect_color/compressed` | 2000 | 20 | 184418 | 246824 | 17.339 | 26.513% | - |
| `native_costmap` | bag | `/costmap/costmap` | 1000 | 10 | 217276 | 217276 | 9.013 | 79.98% | - |
| `handoff_camera` | bag | `/topic1` | 1396 | 9.999 | 12398.8 | 42300 | 19.691 | 48.459% | 5 |
| `handoff_costmap` | bag | `/topic1` | 1396 | 10.001 | 8331.5 | 10208 | 12.701 | 68.817% | - |

Camera GOP detail: 285 keyframes across 285 GOPs from `ffmpeg_packet.flags`, median spacing 5 frames; GOP position 0 mean 43723.4 B and p90 56965 B, while delta positions have means 3738.27-4833.82 B. Costmap handoff is 10 Hz regular with 5.7-11.3 KiB serialized compressed packets.

## Owner smoke

```bash
tmpdir="$(mktemp -d)" && python3 - "$tmpdir/events.jsonl" <<'PY' && PYTHONPATH=src python3 -m rosotacom stream-stats --events "post=$tmpdir/events.jsonl:/cam"
import json, sys
path = sys.argv[1]
rows = []
t0 = 1782000000.0
for seq in range(10):
    rows.append({
        "kind": "transit",
        "source": "a",
        "target": "b",
        "topic": "/cam",
        "seq": seq,
        "status": "delivered",
        "t_wrap": t0 + seq * 0.1,
        "t_com_in": t0 + seq * 0.1 + 0.012,
        "sections": {"ota_hop_ms": 12.0},
        "size_bytes": 40000 if seq % 5 == 0 else 3000,
        "inter_arrival_ms": 100.0,
    })
open(path, "w", encoding="utf-8").write("\n".join(json.dumps(row) for row in rows) + "\n")
PY
```

Expected output includes:

```text
| `post` | events | `/cam` | 10 | 10 | 10400 | 40000 | ... | 100% | 5 |
- GOP: 2 keyframes across 2 GOPs (size_bimodality (20.0% frames)), median spacing 5 frames
```

