### PR TITLE
Add public findings ledger

### DIFF
--- a/README.md
+++ b/README.md
@@ -601,7 +601,8 @@ question under test, pass `--cyclone-spdp-interval 150s` or another longer
 positive `ms`/`s` duration. Making SPDP too frequent improves stale-peer and
 reconnect detection cadence but contaminates tight-link latency more often;
 making it too lax quiets short probes but hides discovery/liveliness overhead and
-delays detection of changed peer state.
+delays detection of changed peer state. The living record for this quirk is the
+[SPDP discovery-burst finding](docs/findings/cyclone-spdp-discovery-bursts.md).
 Use `benchmark probe` when you want a fixed payload/rate under one profile
 instead of a breakpoint search. It writes the normal `result.json` plus
 `time-bins.jsonl` with per-second loss, delivered Hz, payload bandwidth, and
@@ -691,8 +692,9 @@ For contributor setup, local checks, PR workflow, CI, and releases, see
 issue-driven work tracking in [docs/work-items.md](docs/work-items.md).
 
 The test and measurement architecture is recorded in the
-[design RFCs](docs/rfcs/README.md); see [docs/testing.md](docs/testing.md) for the
-test taxonomy. The diagnosis-first quality workflow is described in
+[design RFCs](docs/rfcs/README.md), with measured public effects in the
+[findings ledger](docs/findings/README.md); see [docs/testing.md](docs/testing.md)
+for the test taxonomy. The diagnosis-first quality workflow is described in
 [docs/quality-model.md](docs/quality-model.md), with owner-facing entrypoints in
 [docs/owner-runbook.md](docs/owner-runbook.md). Reusable maintainer procedures
 live in [docs/playbooks/README.md](docs/playbooks/README.md). Quality rules live

--- a/docs/findings/README.md
+++ b/docs/findings/README.md
@@ -1,0 +1,36 @@
+# Public Findings Ledger
+
+This ledger records one measured communication effect per file when the effect is
+reproducible from public material: packaged sessions, public example profiles,
+synthetic loads, anonymized replay fixtures, or deterministic emulation. Findings
+that require private bags, private hosts, real cellular/WLAN links, or operator
+calibration data stay in the operator harness ledger.
+
+Each finding keeps the export-oriented schema:
+
+- Claim
+- Setup
+- Evidence
+- `Verification:` entry
+- Status
+- Publication notes
+
+Run the local schema and index check with:
+
+```bash
+python3 tests/contract/test_findings.py
+python -m pytest -q tests/contract/test_findings.py
+```
+
+The check is intentionally stdlib-only when run as a script, so docs and
+contract lanes can call the same logic. RFC 0007 defines why findings need a
+living verification hook.
+
+## Findings
+
+- [Jitter causes loss while bandwidth shortage builds latency](jitter-loss-bandwidth-latency.md) - 18 KB at 20 Hz separates jitter-induced loss from bandwidth-induced queueing.
+- [Lighter alternating messages can lose more than steady messages](lighter-message-loss.md) - a 1x18KB+1x0KB pattern lost under a tight emulated profile while the steady 18 KB comparison did not.
+- [Delay alone was not the loss boundary for the 18 KB at 20 Hz probe](delay-alone-no-loss.md) - pure delay profiles showed no material loss, and the 300 ms delay-only probe delivered all messages.
+- [Zero-loss boundaries for 18 KB at 20 Hz](zero-loss-boundaries-18kb-20hz.md) - 3.2 Mbit/s and 18 ms jitter were good boundaries; 3.1 Mbit/s and 27 ms jitter were bad.
+- [Head-of-line blocking makes irregularity the dominant failure mode](head-of-line-irregularity.md) - alternating heavy/light payloads can lose more than a steady heavier stream.
+- [Cyclone DDS SPDP discovery bursts can distort tight-link tail latency](cyclone-spdp-discovery-bursts.md) - default 30 s discovery traffic shares the OTA link with payload and is annotated in benchmark diagnostics.

--- a/docs/findings/cyclone-spdp-discovery-bursts.md
+++ b/docs/findings/cyclone-spdp-discovery-bursts.md
@@ -1,0 +1,56 @@
+# Cyclone DDS SPDP Discovery Bursts Can Distort Tight-Link Tail Latency
+
+## Claim
+
+Cyclone DDS default `SPDPInterval=30s` discovery traffic shares the OTA link with
+payload data and can produce periodic p99/max latency spikes on tight shaped
+links. The traffic is real end-to-end DDS behavior, but payload-only benchmark
+characterization should either annotate it or deliberately use a longer SPDP
+interval.
+
+## Setup
+
+- Host pair / topology: host-deterministic diagnostic classification for
+  rosotacom benchmark mode, plus public live re-run material using the packaged
+  example project, synthetic `bench_1_1_capacity` session, one
+  `a->b:/bench_capacity` stream, uplink shaping only.
+- rosotacom SHA: seeded in the public ledger at the issue-173 implementation
+  commit; public re-runs record the current checkout SHA in
+  `result.json.context`.
+- Profile: `finding-spdp-tight` in
+  [`src/rosotacom/resources/examples/profiles.yaml`](../../src/rosotacom/resources/examples/profiles.yaml),
+  a 3.2 Mbit/s tight uplink that makes an 18 KB at 20 Hz stream consume about
+  90% of the shaped rate.
+- Seed policy: no stochastic netem seed is needed for the diagnostic; the live
+  profile is rate-only and seedless.
+
+## Evidence
+
+Evidence grade: existing host unit test plus exact public re-run command.
+
+The host test constructs a 3.2 Mbit/s tight profile, a Cyclone benchmark run, and
+an 18 KB at 20 Hz payload. It asserts the diagnostic reports `risk: possible`,
+offered/shaped-rate about `0.9`, and a warning containing `SPDPInterval=30s`.
+
+Public live re-run:
+
+```bash
+rosotacom benchmark probe --project src/rosotacom/resources/examples/rosotacom.yaml --profile finding-spdp-tight --size 18000 --rate-hz 20 --duration 25 --repeats 1 --rmw cyclone --no-plot
+```
+
+Inspect the resulting `result.json` at
+`context.diagnostics.cyclonedds_spdp`. A representative diagnostic contains the
+RMW, interval, duration-to-interval ratio, profile rate limit, offered bandwidth,
+offered-to-rate utilization, risk classification, and warning text.
+
+Verification: `python -m pytest -q tests/unit/test_cli_benchmark.py::test_probe_spdp_diagnostics_warn_on_tight_cyclone_profile`; the RFC 0007 nightly row can re-prove the live tail-latency effect once the row registry exists.
+
+## Status
+
+confirmed, 2026-07-08.
+
+## Publication notes
+
+Feeds benchmark-method text and result interpretation. Plots that show tight-link
+p99/max latency under Cyclone DDS should state whether default discovery traffic
+was included, annotated, or quieted with `--cyclone-spdp-interval`.

--- a/docs/findings/delay-alone-no-loss.md
+++ b/docs/findings/delay-alone-no-loss.md
@@ -1,0 +1,70 @@
+# Delay Alone Was Not The Loss Boundary For The 18 KB At 20 Hz Probe
+
+## Claim
+
+Pure uplink delay, without jitter, configured loss, or bandwidth limiting, was
+not the observed loss boundary for the 18 KB at 20 Hz benchmark probe: the
+300 ms delay-only run delivered all messages, while lower delay-only repeats
+showed only residual single-message losses.
+
+## Setup
+
+- Host pair / topology: rosotacom local benchmark mode using the packaged example
+  project, synthetic `bench_1_1_capacity` session, one `a->b:/bench_capacity`
+  stream, uplink shaping only.
+- rosotacom SHA: original migrated summary was measured at `9dfc157`; public
+  re-runs record the current checkout SHA in `result.json.context`.
+- Profiles: `finding-delay-5ms`, `finding-delay-50ms`, and
+  `finding-delay-300ms` in
+  [`src/rosotacom/resources/examples/profiles.yaml`](../../src/rosotacom/resources/examples/profiles.yaml),
+  with delay-only uplink shaping and empty downlink.
+- Seed policy: delay-only profiles have no stochastic netem seed; lower-delay
+  profiles use seedless repeats and `finding-delay-300ms` is a seedless single
+  run in the migrated evidence.
+
+## Evidence
+
+Evidence grade: migrated benchmark summaries plus exact public re-run commands.
+
+5 ms delay:
+
+```bash
+rosotacom benchmark capacity --project src/rosotacom/resources/examples/rosotacom.yaml --profile finding-delay-5ms --knob size --low 18000 --high 18000 --rate-hz 20 --duration 20 --repeats 10 --max-loss 100 --max-latency-ms 100000
+```
+
+Migrated summary: 10 attempts, 5123 expected, 5123 delivered, 0 lost.
+
+50 ms delay:
+
+```bash
+rosotacom benchmark capacity --project src/rosotacom/resources/examples/rosotacom.yaml --profile finding-delay-50ms --knob size --low 18000 --high 18000 --rate-hz 20 --duration 20 --repeats 10 --max-loss 100 --max-latency-ms 100000
+```
+
+Migrated summary: 10 attempts, 5133 expected, 5123 delivered, 10 lost, max
+attempt loss 0.196%, max p95 latency 56.817 ms. This run is not perfectly
+zero-loss, but its low loss is not consistent with delay being the dominant loss
+mechanism.
+
+300 ms delay:
+
+```bash
+rosotacom benchmark capacity --project src/rosotacom/resources/examples/rosotacom.yaml --profile finding-delay-300ms --knob size --low 18000 --high 18000 --rate-hz 20 --duration 20 --repeats 1 --max-loss 100 --max-latency-ms 100000
+```
+
+Migrated summary: 400 expected, 400 delivered, 0 lost, max p95 latency
+306.927 ms.
+
+Verification: manual: run the commands above from a source checkout with Docker
+and `tc` privileges; automation waits for the RFC 0007 regression and boundary
+rows because the public row registry does not exist yet.
+
+## Status
+
+confirmed, 2026-06-29.
+
+## Publication notes
+
+Feeds the network-characterization paper as a negative control. The plot should
+separate fixed latency from jitter and bandwidth constraints, and should mention
+the small lower-delay losses as residual benchmark noise rather than a delay
+boundary.

--- a/docs/findings/head-of-line-irregularity.md
+++ b/docs/findings/head-of-line-irregularity.md
@@ -1,0 +1,61 @@
+# Head-Of-Line Blocking Makes Irregularity The Dominant Failure Mode
+
+## Claim
+
+Irregular message sizes can cause effective loss through head-of-line blocking:
+a heavy message delays the following light message, order is preserved, and the
+delayed light message can be overwritten by the next update.
+
+## Setup
+
+- Host pair / topology: rosotacom local benchmark mode using the packaged example
+  project, synthetic `bench_1_1_capacity` session, one `a->b:/bench_capacity`
+  stream, uplink shaping only.
+- rosotacom SHA: original migrated reproduction summary was measured at
+  `4b11973`; public re-runs record the current checkout SHA in
+  `result.json.context`.
+- Profile: `finding-tight-irregular` in
+  [`src/rosotacom/resources/examples/profiles.yaml`](../../src/rosotacom/resources/examples/profiles.yaml),
+  a tight emulated uplink with rate, delay, and jitter.
+- Seed policy: seedless single-run reproduction (`n=1`) and still needs seedless
+  `n >= 10` confirmation for a general claim.
+
+## Evidence
+
+Evidence grade: migrated benchmark summaries plus exact public re-run commands.
+
+Current minimal reproduction:
+
+```bash
+rosotacom benchmark probe --project src/rosotacom/resources/examples/rosotacom.yaml --profile finding-tight-irregular --size-pattern 1x18KB+1x0KB --rate-hz 20 --duration 20 --repeats 1 --no-plot
+```
+
+Migrated summary: 390 expected, 347 delivered, 43 lost, 11.026% loss, p50
+transit jitter 57.906 ms.
+
+Steady comparison:
+
+```bash
+rosotacom benchmark probe --project src/rosotacom/resources/examples/rosotacom.yaml --profile finding-tight-irregular --size-pattern 1x18KB+1x18KB --rate-hz 20 --duration 20 --repeats 1 --no-plot
+```
+
+Migrated summary: 405 expected, 405 delivered, 0 lost.
+
+The mechanism is visible only per message: the stream carrying alternating
+heavy/light samples can lose more than the steady stream despite lower mean
+payload bandwidth.
+
+Verification: manual: run the two commands above from a source checkout with
+Docker and `tc` privileges; automation waits for the RFC 0007 regression matrix
+row for patterned loads because the public row registry does not exist yet.
+
+## Status
+
+confirmed, 2026-07-02.
+
+## Publication notes
+
+Feeds both the benchmark-suite paper and the recovery/forensics paper as the
+mechanism behind patterned synthetic loads. The paper adaptation should add a
+per-message timeline plot before publication, because averages alone hide this
+effect.

--- a/docs/findings/jitter-loss-bandwidth-latency.md
+++ b/docs/findings/jitter-loss-bandwidth-latency.md
@@ -1,0 +1,86 @@
+# Jitter Causes Loss While Bandwidth Shortage Builds Latency
+
+## Claim
+
+For 18 KB at 20 Hz, injected jitter causes message loss once the 30 ms delay /
+27 ms jitter profile is reached, while a slight bandwidth shortage at 3.1 Mbit/s
+primarily builds latency before or alongside loss.
+
+## Setup
+
+- Host pair / topology: rosotacom local benchmark mode using the packaged example
+  project, synthetic `bench_1_1_capacity` session, one `a->b:/bench_capacity`
+  stream, uplink shaping only.
+- rosotacom SHA: original migrated summaries were measured at `678be64` for the
+  June 29 capacity probes and `2313a26` for the July 1 latency-buildup probe;
+  public re-runs record the current checkout SHA in `result.json.context`.
+- Profiles: `finding-jitter18`, `finding-jitter27`, `finding-3.2mbit`, and
+  `finding-3.1mbit` in
+  [`src/rosotacom/resources/examples/profiles.yaml`](../../src/rosotacom/resources/examples/profiles.yaml).
+- Seed policy: seedless netem runs; the boundary probes use seedless replicates
+  (`n=9` or `n=10`) for generality, and the latency-buildup probe is a seedless
+  single diagnostic run (`n=1`).
+
+## Evidence
+
+Evidence grade: migrated benchmark summaries plus exact public re-run commands.
+
+Good jitter boundary:
+
+```bash
+rosotacom benchmark capacity --project src/rosotacom/resources/examples/rosotacom.yaml --profile finding-jitter18 --knob size --low 18000 --high 18000 --rate-hz 20 --duration 20 --repeats 10 --max-loss 100 --max-latency-ms 100000
+```
+
+Migrated summary: 10 attempts, 4000 expected, 4000 delivered, 0 lost, max p95
+latency 85.501 ms.
+
+Bad jitter boundary:
+
+```bash
+rosotacom benchmark capacity --project src/rosotacom/resources/examples/rosotacom.yaml --profile finding-jitter27 --knob size --low 18000 --high 18000 --rate-hz 20 --duration 20 --repeats 10 --max-loss 100 --max-latency-ms 100000
+```
+
+Migrated summary: 10 attempts, 4000 expected, 3957 delivered, 43 lost, max
+attempt loss 1.5%, max p95 latency 107.689 ms.
+
+Good bandwidth boundary:
+
+```bash
+rosotacom benchmark capacity --project src/rosotacom/resources/examples/rosotacom.yaml --profile finding-3.2mbit --knob size --low 18000 --high 18000 --rate-hz 20 --duration 20 --repeats 9 --max-loss 100 --max-latency-ms 100000
+```
+
+Migrated summary: 9 attempts, 3600 expected, 3600 delivered, 0 lost, max p95
+latency 45.942 ms.
+
+Bad bandwidth boundary:
+
+```bash
+rosotacom benchmark capacity --project src/rosotacom/resources/examples/rosotacom.yaml --profile finding-3.1mbit --knob size --low 18000 --high 18000 --rate-hz 20 --duration 20 --repeats 9 --max-loss 100 --max-latency-ms 100000
+```
+
+Migrated summary: 9 attempts, 3598 expected, 2897 delivered, 701 lost, max
+attempt loss 20.0%, max p95 latency 114.336 ms.
+
+Latency-buildup diagnostic:
+
+```bash
+rosotacom benchmark probe --project src/rosotacom/resources/examples/rosotacom.yaml --profile finding-3.1mbit --size 18000 --rate-hz 20 --duration 20 --repeats 1 --no-plot
+```
+
+Migrated summary: 406 expected, 406 delivered, 0 lost, p95 latency rose to
+447.429 ms by the last time bin under the 3.1 Mbit/s profile.
+
+Verification: manual: run the commands above from a source checkout with Docker
+and `tc` privileges; automation waits for the RFC 0007 regression and boundary
+rows because the public row registry does not exist yet.
+
+## Status
+
+confirmed, 2026-07-07.
+
+## Publication notes
+
+Feeds the network-characterization paper as a contrast plot: jitter-boundary
+loss vs bandwidth-boundary queue buildup. The paper adaptation should plot
+per-attempt loss and p95 latency, and it should label the seed policy as
+seedless replicates.

--- a/docs/findings/lighter-message-loss.md
+++ b/docs/findings/lighter-message-loss.md
@@ -1,0 +1,62 @@
+# Lighter Alternating Messages Can Lose More Than Steady Messages
+
+## Claim
+
+Under a tight emulated profile, replacing every second 18 KB message with a
+0 KB message can increase loss even though the average payload bandwidth is
+lower.
+
+## Setup
+
+- Host pair / topology: rosotacom local benchmark mode using the packaged example
+  project, synthetic `bench_1_1_capacity` session, one `a->b:/bench_capacity`
+  stream, uplink shaping only.
+- rosotacom SHA: original migrated summary was measured at `4b11973`; public
+  re-runs record the current checkout SHA in `result.json.context`.
+- Profile: `finding-tight-irregular` in
+  [`src/rosotacom/resources/examples/profiles.yaml`](../../src/rosotacom/resources/examples/profiles.yaml),
+  uplink `rate: 3.2mbit`, `delay: 50ms`, `jitter: 18ms`, `distribution: normal`.
+- Seed policy: seedless single-run comparison (`n=1` for the alternating run and
+  each steady comparison run); no `seed` field is recorded in the profile.
+
+## Evidence
+
+Evidence grade: migrated benchmark summaries plus exact public re-run commands.
+This is a reproduced counterexample, but it still needs seedless `n >= 10`
+confirmation before being used as a generality claim.
+
+Alternating lighter-message run:
+
+```bash
+rosotacom benchmark probe --project src/rosotacom/resources/examples/rosotacom.yaml --profile finding-tight-irregular --size-pattern 1x18KB+1x0KB --rate-hz 20 --duration 20 --repeats 1 --no-plot
+```
+
+Migrated summary: 390 expected, 347 delivered, 43 lost, 11.026% loss, p50
+latency 73.758 ms, p50 transit jitter 57.906 ms.
+
+Steady 18 KB comparison:
+
+```bash
+rosotacom benchmark probe --project src/rosotacom/resources/examples/rosotacom.yaml --profile finding-tight-irregular --size-pattern 1x18KB+1x18KB --rate-hz 20 --duration 20 --repeats 1 --no-plot
+```
+
+Migrated summaries: one steady run had 405 expected, 404 delivered, 1 lost,
+0.247% loss; a second steady run had 405 expected, 405 delivered, 0 lost. The
+alternating run used mean payload 9000 bytes and offered payload bandwidth
+1.44 Mbit/s, while the steady comparison used 18000 bytes at 20 Hz, about
+2.88 Mbit/s.
+
+Verification: manual: run the two commands above from a source checkout with
+Docker and `tc` privileges; automation waits for the RFC 0007 regression matrix
+row for patterned loads because the public row registry does not exist yet.
+
+## Status
+
+confirmed, 2026-07-02.
+
+## Publication notes
+
+Feeds the benchmark-suite paper as the motivating anomaly for patterned
+synthetic loads. The paper adaptation should show the lower average bandwidth of
+`1x18KB+1x0KB` next to the higher loss rate, and should avoid calling this
+statistically general until replicated.

--- a/docs/findings/zero-loss-boundaries-18kb-20hz.md
+++ b/docs/findings/zero-loss-boundaries-18kb-20hz.md
@@ -1,0 +1,83 @@
+# Zero-Loss Boundaries For 18 KB At 20 Hz
+
+## Claim
+
+For the 18 KB at 20 Hz synthetic stream, 3.2 Mbit/s bandwidth and 18 ms jitter
+were observed as zero-loss good cases, while 3.1 Mbit/s bandwidth and 27 ms
+jitter were observed as bad cases; the combined 3.2 Mbit/s plus 18 ms jitter case
+was also zero-loss.
+
+## Setup
+
+- Host pair / topology: rosotacom local benchmark mode using the packaged example
+  project, synthetic `bench_1_1_capacity` session, one `a->b:/bench_capacity`
+  stream, uplink shaping only.
+- rosotacom SHA: original migrated summaries were measured at `678be64`; public
+  re-runs record the current checkout SHA in `result.json.context`.
+- Profiles: `finding-3.2mbit`, `finding-3.1mbit`, `finding-jitter18`,
+  `finding-jitter27`, and `finding-3.2mbit-jitter18` in
+  [`src/rosotacom/resources/examples/profiles.yaml`](../../src/rosotacom/resources/examples/profiles.yaml).
+- Seed policy: seedless netem replicates (`n=9` for the two bandwidth-only
+  boundary runs; `n=10` for the jitter and combined runs). No `seed` field is
+  recorded in the profiles.
+
+## Evidence
+
+Evidence grade: migrated benchmark summaries plus exact public re-run commands.
+
+Good bandwidth:
+
+```bash
+rosotacom benchmark capacity --project src/rosotacom/resources/examples/rosotacom.yaml --profile finding-3.2mbit --knob size --low 18000 --high 18000 --rate-hz 20 --duration 20 --repeats 9 --max-loss 100 --max-latency-ms 100000
+```
+
+Migrated summary: 3600 expected, 3600 delivered, 0 lost.
+
+Bad bandwidth:
+
+```bash
+rosotacom benchmark capacity --project src/rosotacom/resources/examples/rosotacom.yaml --profile finding-3.1mbit --knob size --low 18000 --high 18000 --rate-hz 20 --duration 20 --repeats 9 --max-loss 100 --max-latency-ms 100000
+```
+
+Migrated summary: 3598 expected, 2897 delivered, 701 lost, max attempt loss
+20.0%.
+
+Good jitter:
+
+```bash
+rosotacom benchmark capacity --project src/rosotacom/resources/examples/rosotacom.yaml --profile finding-jitter18 --knob size --low 18000 --high 18000 --rate-hz 20 --duration 20 --repeats 10 --max-loss 100 --max-latency-ms 100000
+```
+
+Migrated summary: 4000 expected, 4000 delivered, 0 lost.
+
+Bad jitter:
+
+```bash
+rosotacom benchmark capacity --project src/rosotacom/resources/examples/rosotacom.yaml --profile finding-jitter27 --knob size --low 18000 --high 18000 --rate-hz 20 --duration 20 --repeats 10 --max-loss 100 --max-latency-ms 100000
+```
+
+Migrated summary: 4000 expected, 3957 delivered, 43 lost.
+
+Combined good case:
+
+```bash
+rosotacom benchmark capacity --project src/rosotacom/resources/examples/rosotacom.yaml --profile finding-3.2mbit-jitter18 --knob size --low 18000 --high 18000 --rate-hz 20 --duration 20 --repeats 10 --max-loss 100 --max-latency-ms 100000
+```
+
+Migrated summary: 4000 expected, 4000 delivered, 0 lost, max p95 latency
+93.138 ms.
+
+Verification: manual: run the commands above from a source checkout with Docker
+and `tc` privileges; automation waits for the RFC 0007 boundary rows because the
+public row registry does not exist yet.
+
+## Status
+
+confirmed, 2026-06-29.
+
+## Publication notes
+
+Feeds the network-characterization paper boundary table and the benchmark-suite
+paper's reference profile choice. The paper adaptation should present both the
+independent boundaries and the combined good case, with the exact seedless
+replicate counts.

--- a/docs/rfcs/0007-regression-gate.md
+++ b/docs/rfcs/0007-regression-gate.md
@@ -217,7 +217,7 @@ slices these into issues.
 - [ ] **Boundary must-fail rows**: oracle inversion (assert the failure
   signature) + happy-red messaging; seed with the documented 18 KB @ 20 Hz
   pairs.
-- [ ] **Findings ledger here** with the `Verification:` field and a schema
+- [x] **Findings ledger here** with the `Verification:` field and a schema
   check; migrate the emulated-reproducible findings from the operator harness;
   seed the SPDP-30 s quirk finding.
 
@@ -238,7 +238,7 @@ slices these into issues.
   benchmark-capacity E2E), runtime bounded by the workflow timeout.
 - [ ] **Nightly matrix** — one deliberately injected regression (canary
   branch) turns the lane red end-to-end; documented one-off exercise.
-- [ ] **Findings checker** — contract test: a finding without `Verification:`
+- [x] **Findings checker** — contract test: a finding without `Verification:`
   fails the ledger check.
 - [ ] **Manual (explicit):** the first calibration is reviewed by the operator
   — band widths sane against the known noise findings (short-run

--- a/justfile
+++ b/justfile
@@ -65,7 +65,7 @@ test-e2e-rmw session:
 
 
 docs:
-	{{python}} -m pytest -q tests/contract/test_markdown_links.py tests/contract/test_readme_examples.py tests/contract/test_pytest_policy.py
+	{{python}} -m pytest -q tests/contract/test_markdown_links.py tests/contract/test_readme_examples.py tests/contract/test_pytest_policy.py tests/contract/test_findings.py
 
 package: _package-build _package-smoke
 

--- a/src/rosotacom/resources/examples/profiles.yaml
+++ b/src/rosotacom/resources/examples/profiles.yaml
@@ -23,3 +23,45 @@ profiles:
       - { for: 15s, uplink: { rate: 1mbit,   delay: 180ms, loss: 3%   } }
       - { for: 5s,  outage: catchup }
       - { for: 40s, uplink: { rate: 2.5mbit, delay: 90ms,  loss: 1%   } }
+
+  # Public finding fixtures. These are small, deterministic emulation points used
+  # by docs/findings; they intentionally carry no private host or calibration data.
+  finding-3.2mbit:
+    uplink: { rate: 3.2mbit }
+    downlink: {}
+
+  finding-3.1mbit:
+    uplink: { rate: 3.1mbit }
+    downlink: {}
+
+  finding-delay-5ms:
+    uplink: { delay: 5ms }
+    downlink: {}
+
+  finding-delay-50ms:
+    uplink: { delay: 50ms }
+    downlink: {}
+
+  finding-delay-300ms:
+    uplink: { delay: 300ms }
+    downlink: {}
+
+  finding-jitter18:
+    uplink: { delay: 30ms, jitter: 18ms, distribution: normal }
+    downlink: {}
+
+  finding-jitter27:
+    uplink: { delay: 30ms, jitter: 27ms, distribution: normal }
+    downlink: {}
+
+  finding-3.2mbit-jitter18:
+    uplink: { rate: 3.2mbit, delay: 30ms, jitter: 18ms, distribution: normal }
+    downlink: {}
+
+  finding-tight-irregular:
+    uplink: { rate: 3.2mbit, delay: 50ms, jitter: 18ms, distribution: normal }
+    downlink: {}
+
+  finding-spdp-tight:
+    uplink: { rate: 3.2mbit }
+    downlink: {}

--- a/tests/contract/test_findings.py
+++ b/tests/contract/test_findings.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+from urllib.parse import unquote
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[2]
+FINDINGS_DIR = PACKAGE_ROOT / "docs" / "findings"
+INDEX_FILE = FINDINGS_DIR / "README.md"
+ROOT_README = PACKAGE_ROOT / "README.md"
+
+REQUIRED_SECTIONS = ["Claim", "Setup", "Evidence", "Status", "Publication notes"]
+SECTION_RE = re.compile(r"^## (?P<section>.+?)\s*$", re.MULTILINE)
+LINK_RE = re.compile(r"\[[^\]]+\]\((?P<target>[^)]+)\)")
+STATUS_RE = re.compile(r"^(confirmed|refuted|superseded-by\s+\S+),\s+\d{4}-\d{2}-\d{2}\.", re.IGNORECASE)
+VERIFICATION_RE = re.compile(r"^Verification:\s+\S", re.MULTILINE)
+
+
+def _markdown_links(path: Path) -> set[str]:
+    text = path.read_text(encoding="utf-8")
+    links: set[str] = set()
+    for match in LINK_RE.finditer(text):
+        target = unquote(match.group("target").split("#", 1)[0])
+        if target:
+            links.add(target)
+    return links
+
+
+def _section_spans(text: str) -> dict[str, str]:
+    matches = list(SECTION_RE.finditer(text))
+    spans: dict[str, str] = {}
+    for index, match in enumerate(matches):
+        start = match.end()
+        end = matches[index + 1].start() if index + 1 < len(matches) else len(text)
+        spans[match.group("section")] = text[start:end].strip()
+    return spans
+
+
+def _check_finding(path: Path) -> str | None:
+    text = path.read_text(encoding="utf-8")
+    if not re.search(r"^# .+", text, re.MULTILINE):
+        return "missing H1 title"
+
+    headings = [match.group("section") for match in SECTION_RE.finditer(text)]
+    if headings != REQUIRED_SECTIONS:
+        return f"headings {headings!r} != {REQUIRED_SECTIONS!r}"
+
+    sections = _section_spans(text)
+    for section in REQUIRED_SECTIONS:
+        if not sections[section]:
+            return f"empty section {section!r}"
+
+    if not VERIFICATION_RE.search(text):
+        return "missing Verification: entry"
+
+    setup = sections["Setup"].lower()
+    for required in ("host pair / topology", "rosotacom sha", "profile", "seed policy"):
+        if required not in setup:
+            return f"setup missing {required!r}"
+
+    status = sections["Status"].splitlines()[0]
+    if not STATUS_RE.match(status):
+        return "status must be 'confirmed|refuted|superseded-by <link>, YYYY-MM-DD.'"
+
+    return None
+
+
+def _ledger_errors() -> list[str]:
+    errors: list[str] = []
+    if not FINDINGS_DIR.is_dir():
+        return [f"missing {FINDINGS_DIR.relative_to(PACKAGE_ROOT)}"]
+    if not INDEX_FILE.is_file():
+        return [f"missing {INDEX_FILE.relative_to(PACKAGE_ROOT)}"]
+
+    finding_files = sorted(path for path in FINDINGS_DIR.glob("*.md") if path.name != "README.md")
+    if len(finding_files) < 6:
+        errors.append(f"expected at least 6 finding files, found {len(finding_files)}")
+
+    for path in finding_files:
+        error = _check_finding(path)
+        if error:
+            errors.append(f"{path.relative_to(PACKAGE_ROOT)}: {error}")
+
+    index_links = {Path(target).name for target in _markdown_links(INDEX_FILE)}
+    missing_from_index = [path.name for path in finding_files if path.name not in index_links]
+    if missing_from_index:
+        errors.append(f"findings missing from index: {', '.join(missing_from_index)}")
+
+    extra_index_links = sorted(
+        name for name in index_links if name.endswith(".md") and not (FINDINGS_DIR / name).exists()
+    )
+    if extra_index_links:
+        errors.append(f"index links missing files: {', '.join(extra_index_links)}")
+
+    root_links = _markdown_links(ROOT_README)
+    if "docs/findings/README.md" not in root_links:
+        errors.append("README.md must link docs/findings/README.md")
+
+    return errors
+
+
+def test_findings_ledger_contract() -> None:
+    assert not _ledger_errors()
+
+
+def test_finding_without_verification_entry_fails(tmp_path: Path) -> None:
+    finding = tmp_path / "finding.md"
+    finding.write_text(
+        """# Missing Verification
+
+## Claim
+
+Claim text.
+
+## Setup
+
+- Host pair / topology: public local benchmark.
+- rosotacom SHA: test.
+- Profile: test.
+- Seed policy: seedless.
+
+## Evidence
+
+Evidence text.
+
+## Status
+
+confirmed, 2026-07-08.
+
+## Publication notes
+
+Notes.
+""",
+        encoding="utf-8",
+    )
+
+    assert _check_finding(finding) == "missing Verification: entry"
+
+
+def main() -> int:
+    errors = _ledger_errors()
+    if errors:
+        for error in errors:
+            print(f"findings: FAIL: {error}", file=sys.stderr)
+        return 1
+    print("findings: OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Add a README-reachable public findings ledger under docs/findings with required Verification entries.
- Add a stdlib-runnable contract checker and include it in the docs lane.
- Move the public emulated findings onto packaged example profiles and seed the Cyclone SPDP discovery-burst quirk.

Fixes #173

## Validation

- PYTHONPATH=src /home/go914/dev/rosotacom_test/ros_communication_devcontainer/.venv/bin/python -m pytest -q tests/contract
- PYTHONPATH=src /home/go914/dev/rosotacom_test/ros_communication_devcontainer/.venv/bin/python -m pytest -q tests/unit/test_cli_benchmark.py::test_probe_spdp_diagnostics_warn_on_tight_cyclone_profile
- /home/go914/dev/rosotacom_test/ros_communication_devcontainer/.venv/bin/python -m ruff check tests/contract/test_findings.py
- git diff --check

## Owner Smoke

Run from the PR checkout:

```bash
PYTHONPATH=src /home/go914/dev/rosotacom_test/ros_communication_devcontainer/.venv/bin/python -m pytest -q tests/contract/test_findings.py && PYTHONPATH=src /home/go914/dev/rosotacom_test/ros_communication_devcontainer/.venv/bin/python -m pytest -q tests/unit/test_cli_benchmark.py::test_probe_spdp_diagnostics_warn_on_tight_cyclone_profile
```

Expected output:

```text
2 passed
1 passed
```