### PR TITLE
Support pure MCAP stream stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,7 +453,8 @@ rosotacom stream-stats \
 
 The command emits a side-by-side Markdown table plus `stream-stats.json`, with
 per-stage size distributions, observed rate, interval regularity, and FFMPEG
-GOP/keyframe shape when available. Bag sources require `rosbag2_py`; `events`
+GOP/keyframe shape when available. MCAP bag sources use the Python `mcap`
+reader; other rosbag2 storage backends require `rosbag2_py`. `events`
 sources work from the recorded RFC 0003 transit rows. See
 [docs/ffmpeg-keyframes.md](docs/ffmpeg-keyframes.md) for the GOP methodology
 and example camera interpretation.

--- a/docs/ffmpeg-keyframes.md
+++ b/docs/ffmpeg-keyframes.md
@@ -65,8 +65,8 @@ Inputs are explicit and repeatable:
 - `--bag LABEL=PATH:/topic` reads one rosbag2 topic, using message timestamps and
   serialized sizes. When the bag metadata declares `FFMPEGPacket`, the command
   parses the CDR payload and reports encoded-frame payload sizes plus keyframes
-  from `flags & 1`. Bag reading uses `rosbag2_py`, so run it in a ROS
-  environment for MCAP sources.
+  from `flags & 1`. MCAP bags are read through the Python `mcap` package; other
+  rosbag2 storage backends fall back to `rosbag2_py` in a ROS environment.
 - `--events LABEL=PATH:/topic` reads delivered RFC 0003 transit rows from
   `events.jsonl`, using receiver-side `t_com_in` timestamps and `size_bytes`.
   Transit rows do not carry raw CDR flags, so GOP annotation uses the documented
@@ -88,6 +88,20 @@ spacing distribution, and the most extreme GOP by keyframe-to-delta mean ratio.
 The comparison is intentionally aggregate-only: it does not join individual
 messages across decimating stages such as drop or throttle, matching the
 index-join caveat in [RFC 0003](rfcs/0003-metric-backbone.md).
+
+The July 2 remote-assist handoff traces used by examples 15/16 produce this
+handoff-only comparison:
+
+```text
+| stage | kind | topic | msgs | hz | mean B | p90 B | gap std ms | gaps within +/-10% | GOP spacing |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `costmap` | bag | `/costmap/costmap/restamped/globalframe/bz2` | 1396 | 10.001 | 8332.97 | 10208 | 12.701 | 68.817% | - |
+| `camera` | bag | `/sensors/camera/front_medium/resized/image_rect_color/compressed/restamped/drop1of2/ffmpeg` | 1396 | 9.999 | 12398.8 | 42300 | 19.691 | 48.459% | 5 |
+```
+
+The camera GOP-position table is the expected bimodal GOP-5 shape: position 0
+averages 43,723 B, while positions 1-4 average 3,738 B, 4,512 B, 4,834 B, and
+4,335 B respectively.
 
 ## Fallback: size bimodality
 

--- a/src/rosotacom/cli.py
+++ b/src/rosotacom/cli.py
@@ -8110,8 +8110,8 @@ def main(argv: list[str] | None = None) -> int:
         action="append",
         metavar="LABEL=PATH:/topic",
         help=(
-            "Analyze one rosbag2/stage-bag topic. Requires rosbag2_py in the active environment. "
-            "Repeat to compare stages."
+            "Analyze one rosbag2/stage-bag topic. MCAP uses the Python mcap reader; other storage "
+            "backends require rosbag2_py. Repeat to compare stages."
         ),
     )
     stream_stats_parser.add_argument(

--- a/src/rosotacom/stream_stats.py
+++ b/src/rosotacom/stream_stats.py
@@ -11,6 +11,8 @@ from pathlib import Path
 from statistics import median
 from typing import Any
 
+import yaml
+
 from . import __version__
 from .ffmpeg_packet import FFMPEGPacketInfo, keyframes_by_size, parse_ffmpeg_packet
 from .transit import join_transit_records, load_transit_records
@@ -18,6 +20,10 @@ from .transit import join_transit_records, load_transit_records
 FFMPEG_TYPE = "ffmpeg_image_transport_msgs/msg/FFMPEGPacket"
 KEYFRAME_SHARE_MIN = 0.02
 KEYFRAME_SHARE_MAX = 0.40
+
+
+class McapUnavailableError(RuntimeError):
+    pass
 
 
 @dataclass(frozen=True)
@@ -172,13 +178,140 @@ def samples_from_cdr_records(
     return tuple(samples)
 
 
+def _metadata_path(path: Path) -> Path | None:
+    if path.is_dir() and (path / "metadata.yaml").is_file():
+        return path / "metadata.yaml"
+    if path.is_file() and path.name == "metadata.yaml":
+        return path
+    return None
+
+
+def _load_bag_metadata(path: Path) -> dict[str, Any] | None:
+    metadata = _metadata_path(path)
+    if metadata is None:
+        return None
+    loaded = yaml.safe_load(metadata.read_text(encoding="utf-8")) or {}
+    if not isinstance(loaded, dict):
+        raise ValueError(f"bag metadata must be a mapping: {metadata}")
+    info = loaded.get("rosbag2_bagfile_information") or {}
+    if not isinstance(info, dict):
+        raise ValueError(f"bag metadata missing rosbag2_bagfile_information: {metadata}")
+    return loaded
+
+
+def _bag_info(metadata: dict[str, Any]) -> dict[str, Any]:
+    info = metadata.get("rosbag2_bagfile_information") or {}
+    if not isinstance(info, dict):
+        raise ValueError("bag metadata missing rosbag2_bagfile_information")
+    return info
+
+
+def _bag_base_dir(path: Path) -> Path:
+    metadata = _metadata_path(path)
+    if metadata is None:
+        raise ValueError(f"not a rosbag2 directory or metadata.yaml: {path}")
+    return metadata.parent
+
+
+def _bag_file_paths(path: Path, metadata: dict[str, Any], suffix: str) -> list[Path]:
+    base = _bag_base_dir(path)
+    info = _bag_info(metadata)
+    raw_paths = info.get("relative_file_paths") or []
+    if isinstance(raw_paths, list) and raw_paths:
+        files = [base / str(raw) for raw in raw_paths]
+    else:
+        files = sorted(base.glob(f"*{suffix}"))
+    if not files:
+        raise ValueError(f"bag has no {suffix} storage files: {base}")
+    return files
+
+
+def _topic_types_from_metadata(metadata: dict[str, Any]) -> dict[str, str]:
+    topics = _bag_info(metadata).get("topics_with_message_count") or []
+    result: dict[str, str] = {}
+    if not isinstance(topics, list):
+        return result
+    for entry in topics:
+        if not isinstance(entry, dict):
+            continue
+        topic_metadata = entry.get("topic_metadata") or {}
+        if not isinstance(topic_metadata, dict):
+            continue
+        name = topic_metadata.get("name")
+        msg_type = topic_metadata.get("type")
+        if name is not None and msg_type is not None:
+            result[str(name)] = str(msg_type)
+    return result
+
+
+def _mcap_paths(path: Path, metadata: dict[str, Any] | None) -> list[Path]:
+    if metadata is not None:
+        return _bag_file_paths(path, metadata, ".mcap")
+    if path.is_file() and path.suffix == ".mcap":
+        return [path]
+    raise ValueError(f"not an mcap rosbag2 directory, metadata.yaml, or .mcap file: {path}")
+
+
+def _load_mcap_bag_source(spec: SourceSpec) -> StreamSource:
+    try:
+        from mcap.reader import make_reader
+    except ImportError as exc:
+        raise McapUnavailableError(
+            "mcap bag sources require the Python package `mcap`; reinstall rosotacom or install mcap"
+        ) from exc
+
+    metadata = _load_bag_metadata(spec.path)
+    message_type = None
+    if metadata is not None:
+        topic_types = _topic_types_from_metadata(metadata)
+        if spec.topic not in topic_types:
+            available = ", ".join(sorted(topic_types)) or "none"
+            raise RuntimeError(f"{spec.path}: topic {spec.topic!r} not found; available topics: {available}")
+        message_type = topic_types[spec.topic]
+
+    records: list[tuple[int, bytes]] = []
+    for mcap_path in _mcap_paths(spec.path, metadata):
+        with mcap_path.open("rb") as fp:
+            reader = make_reader(fp)
+            for schema, channel, message in reader.iter_messages(topics=[spec.topic]):
+                if channel.topic != spec.topic:
+                    continue
+                if message_type is None and schema is not None:
+                    schema_name = getattr(schema, "name", None)
+                    message_type = str(schema_name) if schema_name is not None else None
+                records.append((int(message.log_time), bytes(message.data)))
+    if not records:
+        raise RuntimeError(f"{spec.path}: no messages found for topic {spec.topic!r}")
+    records.sort(key=lambda row: row[0])
+    samples = samples_from_cdr_records(records, message_type=message_type)
+    size_basis = (
+        "ffmpeg_payload_bytes" if message_type and "FFMPEGPacket" in message_type else "serialized_message_bytes"
+    )
+    return StreamSource(
+        label=spec.label,
+        kind="bag",
+        path=spec.path,
+        topic=spec.topic,
+        samples=samples,
+        message_type=message_type,
+        size_basis=size_basis,
+    )
+
+
 def load_bag_source(spec: SourceSpec, *, storage_id: str = "mcap") -> StreamSource:
-    """Load one topic from a rosbag2 bag using optional ``rosbag2_py``."""
+    """Load one topic from a rosbag2 bag."""
+    if storage_id == "mcap":
+        try:
+            return _load_mcap_bag_source(spec)
+        except McapUnavailableError:
+            pass
+
     try:
         import rosbag2_py  # type: ignore[import-not-found]
     except ImportError as exc:
         raise RuntimeError(
-            "bag sources require rosbag2_py. Run inside a ROS environment, or use --events for events.jsonl sources."
+            "bag sources require the Python package `mcap` for MCAP bags or rosbag2_py in a ROS environment. "
+            "Use --events for events.jsonl sources."
         ) from exc
 
     reader = rosbag2_py.SequentialReader()

--- a/tests/unit/test_stream_stats.py
+++ b/tests/unit/test_stream_stats.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import json
 import struct
+import sys
+import types
 from pathlib import Path
 
 import rosotacom.cli as rosotacom
@@ -11,6 +13,7 @@ from rosotacom.stream_stats import (
     StreamSample,
     StreamSource,
     build_report,
+    load_bag_source,
     load_events_source,
     parse_source_spec,
     render_markdown,
@@ -149,6 +152,47 @@ def test_events_source_filters_topic_and_detects_gop_by_size(tmp_path: Path) -> 
     assert stats["rate_hz"] == 10.0
     assert stats["gop"]["method"].startswith("size_bimodality")
     assert stats["gop"]["keyframes"] == 2
+
+
+def test_mcap_bag_source_reads_metadata_without_rosbag2(tmp_path: Path, monkeypatch) -> None:
+    bag = tmp_path / "bag"
+    bag.mkdir()
+    (bag / "stage_0.mcap").write_bytes(b"not a real mcap; fake reader supplies rows")
+    (bag / "metadata.yaml").write_text(
+        """
+rosbag2_bagfile_information:
+  storage_identifier: mcap
+  relative_file_paths:
+    - stage_0.mcap
+  topics_with_message_count:
+    - topic_metadata:
+        name: /numbers
+        type: std_msgs/msg/UInt8MultiArray
+      message_count: 2
+""",
+        encoding="utf-8",
+    )
+
+    class FakeReader:
+        def iter_messages(self, *, topics):
+            assert topics == ["/numbers"]
+            schema = types.SimpleNamespace(name="std_msgs/msg/UInt8MultiArray")
+            channel = types.SimpleNamespace(topic="/numbers")
+            yield schema, channel, types.SimpleNamespace(log_time=100, data=b"abcd")
+            yield schema, channel, types.SimpleNamespace(log_time=200, data=b"abcdef")
+
+    reader_module = types.ModuleType("mcap.reader")
+    reader_module.make_reader = lambda _fp: FakeReader()
+    monkeypatch.setitem(sys.modules, "mcap", types.ModuleType("mcap"))
+    monkeypatch.setitem(sys.modules, "mcap.reader", reader_module)
+
+    source = load_bag_source(parse_source_spec("bag", f"handoff={bag}:/numbers"))
+    stats = summarize_source(source)
+
+    assert source.message_type == "std_msgs/msg/UInt8MultiArray"
+    assert source.size_basis == "serialized_message_bytes"
+    assert stats["count"] == 2
+    assert stats["size_bytes"]["mean"] == 5.0
 
 
 def test_comparison_markdown_has_one_row_per_stage() -> None:


### PR DESCRIPTION
## Summary

- Add a pure-Python MCAP reader path for `rosotacom stream-stats --bag`, using the existing `mcap` dependency and retaining `rosbag2_py` fallback for other storage backends.
- Keep FFMPEGPacket GOP parsing on raw CDR payloads for MCAP stage bags, including GOP-position size tables and extreme-GOP reporting.
- Update README/FFMPEG docs with the real July 2 handoff trace table for costmap and camera examples 15/16.

## Validation

- `python3 -m pytest tests/unit/test_ffmpeg_packet.py tests/unit/test_stream_stats.py` -> 17 passed.
- `python3 -m ruff check src/rosotacom/stream_stats.py tests/unit/test_stream_stats.py src/rosotacom/cli.py` -> passed.
- `python3 -m mypy src/rosotacom/stream_stats.py --ignore-missing-imports --follow-imports=skip --disable-error-code unused-ignore --disable-error-code import-untyped` -> passed. The local full mypy run is still blocked by missing PyYAML stubs/baseline errors in unrelated modules.
- `PYTHONPATH=/tmp/rosotacom-stream-stats-py:src python3 -m rosotacom stream-stats --bag costmap=... --bag camera=... --out /tmp/rosotacom-stream-stats-handoff-rebased` -> reproduced the documented costmap/camera table.
- `PYTHONPATH=src python3 -m rosotacom stream-stats --events post=.../events.jsonl:/bench_capacity --out /tmp/rosotacom-stream-stats-events-rebased` -> post-OTA bench events table: 5873 messages, 19.998 Hz, 18100 B.

## Owner smoke

Copy-paste command:

```bash
PYTHONPATH=src python3 -m rosotacom stream-stats --bag "costmap=${HARNESS:-..}/fzi_projects/remote_assist/session-instances/2026-07-02/remote_assist_2026-07-02_17-14-31_anon-trace-1/traces/costmap_handoff:/costmap/costmap/restamped/globalframe/bz2" --bag "camera=${HARNESS:-..}/fzi_projects/remote_assist/session-instances/2026-07-02/remote_assist_2026-07-02_17-14-31_anon-trace-1/traces/camera_handoff:/sensors/camera/front_medium/resized/image_rect_color/compressed/restamped/drop1of2/ffmpeg" --out /tmp/rosotacom-stream-stats-owner
```

Expected output:

```text
| `costmap` | bag | `/costmap/costmap/restamped/globalframe/bz2` | 1396 | 10.001 | 8332.97 | 10208 | 12.701 | 68.817% | - |
| `camera` | bag | `/sensors/camera/front_medium/resized/image_rect_color/compressed/restamped/drop1of2/ffmpeg` | 1396 | 9.999 | 12398.8 | 42300 | 19.691 | 48.459% | 5 |
```
