### PR TITLE
Add benchmark ab: A/B tuning experiments (candidate configs vs baseline) (#181)

### DIFF
--- a/README.md
+++ b/README.md
@@ -701,6 +701,25 @@ rosotacom benchmark loss-boundaries --rate-hz 20 --size 18000 --qos-reliability 
 rosotacom benchmark loss-boundaries --rate-hz 20 --size 18000 --qos-reliability best_effort --qos-depth 1 --max-latency-ms 250 --latency-base-ms 30 --downlink-mode lan --bandwidth-low 2.8mbit --bandwidth-high 4mbit --bandwidth-step 0.1mbit --jitter-low-ms 0 --jitter-high-ms 40 --jitter-step-ms 1 --min-duration 20 --min-messages 100 --probe-repeats 1 --netem-seeds 101,102,103,104,105,106,107,108,109,110
 ```
 
+Use `benchmark ab` when the question is a **tuning** one: "does candidate config
+B beat baseline config A on the same load and profile?" Each `--baseline` and
+`--candidate label=…` is a whole session config (a directory or a
+`session-definition.yaml`) that shares the synthetic `a_to_b` load and differs
+only in the pipeline knobs under test (`throttle_hz`, `drop`, QoS, compression,
+…). The driver runs them interleaved with a rotating start over `--repeats`,
+then classifies every candidate against the baseline per topic and metric as
+**IMPROVED / WITHIN / REGRESSED** — the same verdict language the regression gate
+uses — with a two-sided tolerance band (`--rel-tolerance`, `--abs-tolerance`).
+The overall verdict fails if any watched metric regressed; the repeat spread
+(min/median/max) travels with every cell so small-N effects are read honestly.
+It writes `result.json`, a markdown table (`ab.md`), the per-config YAML diffs,
+and `ab.jsonl`. See [docs/benchmark-ab.md](docs/benchmark-ab.md) for the config
+model, interleaving, and the statistical-power note:
+
+```bash
+rosotacom benchmark ab --profile cellular-4g-degraded --baseline configs/gop30 --candidate gop15=configs/gop15 --size 18000 --rate-hz 20 --duration 20 --repeats 3
+```
+
 Use `rosotacom ota-benchmark` for the same probes over deployment peers, without
 having to name a target:
 

--- a/docs/benchmark-ab.md
+++ b/docs/benchmark-ab.md
@@ -1,0 +1,157 @@
+# A/B tuning experiments (`rosotacom benchmark ab`)
+
+`rosotacom` is a tuning suite as much as a measurement one: the *fix* step of the
+closed-loop workflow needs a first-class answer to **"does candidate config B
+beat baseline config A on the same load and profile — what improved, what
+regressed, what is unchanged?"** `benchmark ab` is that verdict.
+
+It is the sibling of the regression gate (RFC 0005 / RFC 0007). The gate asks
+"is this run within a committed envelope?"; A/B asks "is B better or worse than
+A, right now, on the same load?". Both are two-sided and both speak the same
+**IMPROVED / WITHIN / REGRESSED** language — an A/B cell is exactly a band
+verdict on the ephemeral `[baseline ± tolerance]` envelope.
+
+## What varies, what is held constant
+
+| Held constant across every run | Varied between configs |
+|---|---|
+| the load — the synthetic `sized_publisher` stream on `a_to_b` (`--size`/`--size-pattern`, `--rate-hz`, `--streams`) | the **session config**: the OTA pipeline knobs (`throttle_hz`, `drop`, QoS reliability/depth/lifespan, compression, ffmpeg settings, …) |
+| the network profile and its seed policy (`--profile`) | |
+| the RMW and any run-wide QoS override (`--rmw`, `--qos-*`) | |
+
+Each `--baseline` and `--candidate` is a **whole session config** — a directory
+or a `session-definition.yaml`, no patch format. Every config must carry the same
+`a_to_b` load topic(s) (that is what the synthetic publisher drives); they should
+differ *only* in the pipeline knob under test. The run records the YAML diff of
+each candidate against the baseline (`configs/<label>.diff`) so what actually
+changed is explicit and reviewable — and so the "same load" assumption is
+auditable rather than assumed.
+
+## Running it
+
+```bash
+rosotacom benchmark ab \
+  --profile cellular-4g-degraded \
+  --baseline configs/gop30 \
+  --candidate gop15=configs/gop15 \
+  --candidate gop15-crf28=configs/gop15_crf28 \
+  --size 18000 --rate-hz 20 --duration 20 --repeats 5
+```
+
+`--candidate` is repeatable; the first (implicit) config is always the
+`baseline`. Useful flags:
+
+- `--repeats N` — runs per config (default 3). Higher N narrows the spread and
+  lets smaller effects clear the tolerance band.
+- `--metrics` — comma list of watched metrics (default
+  `completeness_pct,loss_pct,latency_p95_ms,jitter_p95_ms`). Full set:
+  `completeness_pct`, `loss_pct`, `latency_p50_ms`, `latency_p95_ms`,
+  `jitter_p50_ms`, `jitter_p95_ms`.
+- `--rel-tolerance` / `--abs-tolerance` — the unchanged band half-width around the
+  baseline median is `max(abs, rel · |baseline|)`. Defaults: `rel = 0.10`; a
+  small absolute floor on the latency/jitter tails (2 ms on p95) so sub-floor
+  noise on a tiny baseline never reads as a change. Loss and completeness are
+  exact percentages and get no floor.
+- `--topic` — restrict the verdict to one topic.
+- `--fail-on-regression` — exit non-zero when any candidate regressed (default:
+  the verdict lives in `result.json`, exit 0), so a fix playbook can gate on it.
+
+## Interleaving: guarding the verdict against drift
+
+Runs are **interleaved**, not "all of A then all of B": each repeat runs every
+config once, and the starting config rotates each repeat (`baseline, cand,
+cand, baseline, …`). Interleaving spreads any slow host/thermal drift across
+every config instead of loading it onto whichever ran last; the rotation removes
+the residual first-slot warm-up bias. The schedule is deterministic, so a verdict
+is reproducible from the same runs. The exact execution order is recorded in
+`configuration.schedule`.
+
+## The verdict
+
+Per candidate, per topic, per metric, the candidate's **median** across repeats
+is compared to the baseline's median (a median so one unlucky repeat cannot flip
+a cell). The cell is `IMPROVED`, `WITHIN`, or `REGRESSED` by the metric's
+better-direction and the tolerance band. A candidate **passes** iff nothing
+regressed beyond tolerance and it did not drop a topic the baseline delivered;
+the overall experiment passes iff every candidate passes.
+
+Both spreads (min/median/max) travel with each cell, plus a `separated` flag —
+`yes` when the baseline and candidate spreads do **not** overlap, i.e. the effect
+is distinguishable at this repeat count.
+
+## Statistical power — read small N honestly
+
+A/B here is a **directional screen**, not a significance test. With a handful of
+repeats you can only claim **large** effects: a candidate whose median moves by
+less than the run-to-run spread is not really separated from the baseline
+(`separated: no`), no matter which side of the tolerance band its median lands
+on. Two practical rules:
+
+- **Prefer the boundary regime.** Effects are sharpest where the system is near
+  a cliff — a rate-limited profile at the capacity breakpoint, or one of the
+  documented boundary pairs (RFC 0007) — so a real knob change produces a big,
+  clearly-separated delta instead of a wiggle inside the noise. On a fat,
+  unstressed link most knobs look "unchanged" simply because nothing is
+  constrained.
+- **Raise `--repeats` before you trust a marginal call.** A cell that is
+  `IMPROVED`/`REGRESSED` but `separated: no` is a "maybe"; more repeats either
+  separate it or reveal it as noise.
+
+Latency/jitter tails are host-timing-dominated and noisier than the
+bottleneck-dominated `loss_pct`/`completeness_pct` (which are counted off exact
+sequence numbers) — weight the completeness/loss verdict accordingly, exactly as
+the regression gate does.
+
+## Outputs (self-describing — the publication byproduct)
+
+Under the run directory:
+
+- `result.json` — `genre: "ab"`: the full per-cell verdict (`result`), the
+  per-run measurements (`measurements.runs`), the resolved
+  `configuration` (baseline, configs, profile, load, tolerances, schedule), the
+  rosotacom `sha` and runner fingerprint, and the overall `verdict`.
+- `ab.md` — a markdown table per candidate (topic × metric, both spreads, Δ,
+  `sep?`, verdict) — a paper-grade figure with no rework.
+- `configs/<label>/…` + `configs/<label>.diff` — each materialized config and its
+  YAML diff against the baseline.
+- `ab.jsonl` — one row per run.
+
+## Non-goals
+
+- **No automatic parameter search / optimization.** The agent (or human) picks
+  the candidate configs; `benchmark ab` only renders the verdict between them.
+- **No live-drive A/B.** Replay / emulated-profile conditions only, so the
+  comparison is reproducible and the only thing that changed is the config.
+
+## Owner smoke
+
+Two configs that differ only in `throttle_hz`, on the packaged example project,
+under a tight uplink where the heavier-throttle candidate offers ~5× the load
+into the same pipe and must therefore regress:
+
+```bash
+rosotacom examples create /tmp/ab-demo && cd /tmp/ab-demo
+printf 'profiles:\n  ab-ci:\n    uplink: { rate: 1mbit }\n    downlink: { rate: 10mbit }\n' > profiles.yaml
+for hz in 4 20; do d="cfg_$hz"; mkdir -p "$d"; cat > "$d/session-definition.yaml" <<YAML
+peers: { a: {}, b: {} }
+peer_settings: { a: { domain_id: 50 }, b: { domain_id: 51 } }
+shared: { use_status_overview: true, ota_domain_id: 52, rmw: cyclone }
+topics:
+  a_to_b:
+    - topic: "/bench_capacity"
+      type: "com_msgs/msg/SizedPayload"
+      processing: { use_ota_wrapper: true, throttle_hz: $hz }
+YAML
+done
+rosotacom benchmark ab --profile ab-ci --baseline cfg_4 --candidate unthrottled=cfg_20 \
+  --size 18000 --rate-hz 20 --duration 15 --repeats 1
+```
+
+Expected: overall verdict **FAIL** — `unthrottled` regresses on `loss_pct` /
+`completeness_pct` (it congests the 1 Mbit/s uplink while the throttled baseline
+stays clean); the printed `ab.md` table shows the two REGRESSED cells.
+
+See also: [RFC 0005](rfcs/0005-benchmark-genres-and-ci.md) (benchmark genres),
+[RFC 0007](rfcs/0007-regression-gate.md) (the two-sided band / verdict language),
+and [docs/performance-bands.md](performance-bands.md) (the committed-band gate
+this shares its verdict vocabulary with).

--- a/docs/rfcs/0005-benchmark-genres-and-ci.md
+++ b/docs/rfcs/0005-benchmark-genres-and-ci.md
@@ -86,6 +86,24 @@ Apply a **step change** to the environment — a *timeline profile* (RFC 0004), 
 
 A recovery benchmark **is** a timeline profile plus recovery-specific metrics.
 
+### A/B tuning experiments (#22)
+
+The genres above measure *one* configuration against a boundary or a committed
+budget. The **fix** step of the loop needs the sibling question — "does candidate
+config B beat baseline config A on the **same** load and profile?" — as a
+first-class verdict. `benchmark ab` holds the synthetic `a_to_b` load and the
+profile/seed constant and varies the whole session config (the pipeline knobs:
+`throttle_hz`, `drop`, QoS, compression, ffmpeg …), runs baseline and candidates
+**interleaved with a rotating start** over `--repeats`, and classifies each
+candidate against the baseline per topic and metric as **IMPROVED / WITHIN /
+REGRESSED**. This is the *same* two-sided verdict as the committed-band gate
+(§Budgets, RFC 0007) — a band on the ephemeral `[baseline ± tolerance]` envelope
+rather than a committed one — so an A/B cell and a gate cell read identically.
+The repeat spread (min/median/max) and a `separated` flag travel with every cell
+so small-N effects are read honestly (a directional screen, not a significance
+test; sharpest in the boundary regime). Full design, config model and the
+statistical-power note: [../benchmark-ab.md](../benchmark-ab.md).
+
 ## Budgets & baselines — the verdict for benchmarks
 
 A benchmark does not pass/fail against an absolute bound; it **regresses or not
@@ -209,6 +227,11 @@ slice and reuses RFC 0003 + 0004.
   0004 / the harness, the metric extraction is here).
 - [x] Add coarse linear-ramp curves (latency-vs-load) for trend
   (`benchmark.linear_ramp`).
+- [x] Add the A/B tuning-experiment driver (#22): interleaved baseline-vs-candidate
+  runs on the same load/profile, per topic+metric IMPROVED/WITHIN/REGRESSED verdict
+  reusing the RFC 0007 `Better`/`Verdict` language, repeat-spread + separation
+  reporting (`benchmark.ab_verdict`, `cli_benchmark.drive_ab` / `benchmark ab`;
+  [../benchmark-ab.md](../benchmark-ab.md)).
 - [ ] Wire the nightly benchmark run as a **monitor** (alerts on budget regression,
   never blocks); the harness wires the actual runner. *(FZI-private — see below.)*
 - [x] Cover the driver oracle, budget compare, and recovery metrics with tests
@@ -286,6 +309,14 @@ reviewed rather than asserted in a blocking test.
 - [x] **Coarse linear-ramp curves** — curve builder host-tested
   (`test_linear_ramp_builds_the_response_curve`); the trend output stays
   **monitor-only**: nightly, reviewed, not gated.
+- [x] **A/B tuning experiments** (#22) — host unit tests on the pure verdict layer
+  (interleave schedule + rotation, three-way classification with the tolerance
+  band, spread aggregation, determinism, dropped-topic failure, markdown render:
+  `test_ab_*`, `test_classify_change_*`, `test_render_ab_markdown_*` in
+  `test_benchmark.py`) and on the driver + handler with a stubbed `run_point`
+  (`test_drive_ab_*`, `test_benchmark_ab_handler_*` in `test_cli_benchmark.py`);
+  one Docker-backed slow-lane E2E proves the directional verdict on a `throttle_hz`
+  difference (`tests/e2e/test_benchmark_ab.py`, `ROSOTACOM_RUN_E2E=1`). Automatable.
 - [ ] **Nightly benchmark run wired as a monitor** (alerts on budget regression,
   never blocks) — **operator/harness check**: the public repo defines the genre;
   the actual runner topology is FZI-private, so the wiring is confirmed manually in

--- a/src/rosotacom/benchmark.py
+++ b/src/rosotacom/benchmark.py
@@ -411,13 +411,22 @@ class BandComparison:
     verdict: Verdict
 
 
+def _two_sided_verdict(value: float, *, lo: float, hi: float, better: Better) -> Verdict:
+    """WITHIN / IMPROVED / REGRESSED for a value against a closed ``[lo, hi]`` envelope.
+
+    Shared by the committed-band gate (:func:`band_verdict`) and A/B experiments
+    (:func:`classify_change`) so both speak one verdict language.
+    """
+    if value < lo:
+        return Verdict.REGRESSED if better is Better.HIGHER else Verdict.IMPROVED
+    if value > hi:
+        return Verdict.IMPROVED if better is Better.HIGHER else Verdict.REGRESSED
+    return Verdict.WITHIN
+
+
 def band_verdict(band: Band, value: float) -> Verdict:
     """Two-sided verdict; the interval is closed (values on the edge are WITHIN)."""
-    if value < band.lo:
-        return Verdict.REGRESSED if band.better is Better.HIGHER else Verdict.IMPROVED
-    if value > band.hi:
-        return Verdict.IMPROVED if band.better is Better.HIGHER else Verdict.REGRESSED
-    return Verdict.WITHIN
+    return _two_sided_verdict(value, lo=band.lo, hi=band.hi, better=band.better)
 
 
 def compare_to_band(band: Band, value: float, *, fingerprint: str) -> BandComparison:
@@ -1251,3 +1260,361 @@ class RampPoint:
 def linear_ramp(values: Iterable[float], measure: Callable[[float], float]) -> list[RampPoint]:
     """The whole response curve (latency-vs-load). Monitor-only: trended, never gated."""
     return [RampPoint(float(value), float(measure(value))) for value in values]
+
+
+# --------------------------------------------------------------------------- #
+# A/B tuning experiments (#22): candidate config vs baseline, same load+profile
+# --------------------------------------------------------------------------- #
+#
+# The regression gate asks "is this run within a committed envelope?"; an A/B
+# experiment asks the sibling question "is candidate config B better, worse or
+# unchanged vs baseline config A on the *same* load and profile?". Both are
+# two-sided and both speak the same Better/Verdict language: an A/B cell is just
+# :func:`_two_sided_verdict` on the ephemeral ``[baseline +/- tolerance]``
+# envelope. This layer is pure and host-testable; the live runs (Docker graphs,
+# emulated profiles) live in the CLI, injected as a ``run_point`` (RFC 0005).
+
+# The per-topic metrics an A/B experiment watches, with their better-direction.
+# Names mirror the gate's band metrics (``_DEFAULT_BETTER``) so a verdict reads
+# the same in both places. Read off ``transit.summarize_transit_records``.
+AB_METRICS: dict[str, Better] = {
+    "completeness_pct": Better.HIGHER,
+    "loss_pct": Better.LOWER,
+    "latency_p50_ms": Better.LOWER,
+    "latency_p95_ms": Better.LOWER,
+    "jitter_p50_ms": Better.LOWER,
+    "jitter_p95_ms": Better.LOWER,
+}
+
+# The default watched set: the completeness/loss pair (bottleneck-dominated —
+# counted off exact sequence numbers, so trustworthy even on a shared runner)
+# plus the p95 tails (host-timing-dominated — directional hints, which is why the
+# spread is always reported, not just the median).
+DEFAULT_AB_METRICS: tuple[str, ...] = ("completeness_pct", "loss_pct", "latency_p95_ms", "jitter_p95_ms")
+
+# A candidate median within this relative OR the metric's absolute half-width of
+# the baseline median is called unchanged (WITHIN). The absolute floors keep
+# sub-millisecond tail noise on a tiny baseline from reading as a change; loss
+# and completeness are exact percentages and get no floor (a real 1% delta is
+# signal).
+DEFAULT_AB_REL_TOLERANCE = 0.10
+DEFAULT_AB_ABS_TOLERANCE: dict[str, float] = {
+    "latency_p50_ms": 1.0,
+    "latency_p95_ms": 2.0,
+    "jitter_p50_ms": 1.0,
+    "jitter_p95_ms": 2.0,
+}
+
+
+def ab_better(metric: str) -> Better:
+    """The better-direction of an A/B-watched metric (raises on an unknown one)."""
+    better = AB_METRICS.get(metric)
+    if better is None:
+        raise BandError(f"metric {metric!r} is not an A/B-watched metric; known: {sorted(AB_METRICS)}")
+    return better
+
+
+def _bare_topic(label: str) -> str:
+    """``a->b:/topic`` -> ``/topic``; a plain topic label is returned unchanged."""
+    return label.split(":", 1)[1] if ":" in label else label
+
+
+def ab_metrics_from_topic(topic_summary: Mapping[str, Any]) -> dict[str, float | None]:
+    """Pull the A/B-watched metrics out of one topic's transit-summary block.
+
+    A metric is ``None`` when the run produced no sample for it (e.g. latency
+    with 100% loss); the aggregator drops ``None`` holes from a spread.
+    """
+    expected = topic_summary.get("expected")
+    delivered = topic_summary.get("delivered")
+    completeness: float | None = None
+    if expected and delivered is not None:
+        completeness = round(100.0 * float(delivered) / float(expected), 3)
+    ota = topic_summary.get("ota_hop_ms") or {}
+    jitter = topic_summary.get("jitter_ms") or {}
+
+    def opt(value: Any) -> float | None:
+        return None if value is None else float(value)
+
+    return {
+        "completeness_pct": completeness,
+        "loss_pct": opt(topic_summary.get("loss_pct")),
+        "latency_p50_ms": opt(ota.get("p50")),
+        "latency_p95_ms": opt(ota.get("p95")),
+        "jitter_p50_ms": opt(jitter.get("p50")),
+        "jitter_p95_ms": opt(jitter.get("p95")),
+    }
+
+
+@dataclass(frozen=True)
+class AbTolerance:
+    """Half-width of the unchanged band around a baseline value: ``max(abs, rel*|baseline|)``."""
+
+    rel: float = DEFAULT_AB_REL_TOLERANCE
+    abs: float = 0.0
+
+    def half_width(self, baseline: float) -> float:
+        return max(self.abs, abs(baseline) * self.rel)
+
+
+def default_ab_tolerance(metric: str, *, rel: float = DEFAULT_AB_REL_TOLERANCE) -> AbTolerance:
+    """The default tolerance for a metric: ``rel`` plus the metric's absolute floor."""
+    return AbTolerance(rel=rel, abs=DEFAULT_AB_ABS_TOLERANCE.get(metric, 0.0))
+
+
+def classify_change(baseline: float, candidate: float, *, better: Better, tol: AbTolerance) -> Verdict:
+    """Candidate vs baseline as WITHIN / IMPROVED / REGRESSED.
+
+    ``_two_sided_verdict`` on the ephemeral ``[baseline +/- tol]`` envelope, so an
+    A/B cell classifies identically to a committed-band gate cell.
+    """
+    half = tol.half_width(baseline)
+    return _two_sided_verdict(candidate, lo=baseline - half, hi=baseline + half, better=better)
+
+
+def ab_schedule(configs: Sequence[str], repeats: int) -> list[tuple[str, int]]:
+    """Deterministic interleaving of ``configs`` over ``repeats`` as ``(config, repeat)``.
+
+    Every repeat runs each config exactly once; the starting config rotates each
+    repeat so no config is always measured first. Interleaving (not "all of A,
+    then all of B") spreads any slow host-drift across every config, and the
+    rotation removes the residual first-slot warm-up bias — both guard the verdict
+    against drift being mistaken for a config effect. Deterministic by
+    construction, so a verdict is reproducible from the same runs.
+    """
+    if repeats < 1:
+        raise ValueError("repeats must be >= 1.")
+    if not configs:
+        raise ValueError("need at least one config.")
+    order: list[tuple[str, int]] = []
+    count = len(configs)
+    for repeat in range(1, repeats + 1):
+        rotation = (repeat - 1) % count
+        rotated = [*configs[rotation:], *configs[:rotation]]
+        order.extend((config, repeat) for config in rotated)
+    return order
+
+
+@dataclass(frozen=True)
+class MetricSpread:
+    """Repeat-to-repeat spread of one metric for one config+topic."""
+
+    n: int  # repeats that produced a value
+    min: float
+    median: float
+    max: float
+    values: list[float]  # per-repeat, in execution order
+
+
+def _metric_spread(values: Sequence[float]) -> MetricSpread | None:
+    vals = [float(v) for v in values]
+    if not vals:
+        return None
+    return MetricSpread(
+        n=len(vals),
+        min=round(min(vals), 3),
+        median=round(_median(vals), 3),
+        max=round(max(vals), 3),
+        values=[round(v, 3) for v in vals],
+    )
+
+
+@dataclass(frozen=True)
+class AbRun:
+    """One executed run in an experiment: which config, which 1-based repeat, its summary."""
+
+    config: str
+    repeat: int
+    summary: Mapping[str, Any]  # transit.summarize_transit_records output
+
+
+@dataclass(frozen=True)
+class AbCell:
+    """One (topic, metric) candidate-vs-baseline verdict, both spreads carried."""
+
+    topic: str
+    metric: str
+    better: str  # Better value
+    baseline: MetricSpread | None
+    candidate: MetricSpread | None
+    verdict: str | None  # Verdict value; None when a side has no sample
+    delta: float | None  # candidate.median - baseline.median
+    separated: bool | None  # spreads disjoint => effect separable at this N
+
+
+@dataclass(frozen=True)
+class CandidateReport:
+    """A candidate config's full comparison against the baseline."""
+
+    config: str
+    cells: list[AbCell]
+    regressed: list[list[str]]  # [topic, metric] pairs that regressed beyond tolerance
+    improved: list[list[str]]  # [topic, metric] pairs that improved beyond tolerance
+    dropped_topics: list[str]  # topics the baseline delivered that this config did not
+    passed: bool  # no regression and no dropped topic
+
+
+@dataclass(frozen=True)
+class AbReport:
+    baseline: str
+    metrics: list[str]
+    repeats: int
+    candidates: list[CandidateReport]
+    passed: bool  # every candidate passed
+
+
+def _collect_ab_metrics(
+    runs: Iterable[AbRun], *, metrics: Sequence[str], topic_filter: str
+) -> dict[str, dict[str, dict[str, list[float]]]]:
+    """``{config: {topic: {metric: [per-repeat values]}}}`` in execution order."""
+    collected: dict[str, dict[str, dict[str, list[float]]]] = {}
+    for run in runs:
+        topics = run.summary.get("topics") or {}
+        for topic_label, topic_summary in topics.items():
+            if topic_filter and topic_filter not in {topic_label, _bare_topic(topic_label)}:
+                continue
+            values = ab_metrics_from_topic(topic_summary)
+            per_topic = collected.setdefault(run.config, {}).setdefault(topic_label, {})
+            for metric in metrics:
+                value = values.get(metric)
+                if value is not None:
+                    per_topic.setdefault(metric, []).append(value)
+    return collected
+
+
+def ab_verdict(
+    runs: Sequence[AbRun],
+    *,
+    baseline: str,
+    metrics: Sequence[str] = DEFAULT_AB_METRICS,
+    tolerances: Mapping[str, AbTolerance] | None = None,
+    topic: str = "",
+) -> AbReport:
+    """Classify every candidate config against the baseline, per topic and metric.
+
+    Comparison is on the per-config **median** of each metric across repeats (one
+    unlucky repeat cannot flip a verdict), and both spreads travel with the cell
+    so a reader sees whether the medians are actually separable at this N
+    (``separated``). A candidate ``passed`` iff nothing regressed beyond tolerance
+    and it did not drop a topic the baseline delivered.
+    """
+    metric_list = list(metrics)
+    tol_map = {metric: (tolerances or {}).get(metric) or default_ab_tolerance(metric) for metric in metric_list}
+    ordered = sorted(runs, key=lambda run: (run.config, run.repeat))
+    collected = _collect_ab_metrics(ordered, metrics=metric_list, topic_filter=topic)
+
+    if baseline not in collected:
+        raise BandError(f"baseline config {baseline!r} produced no runs to compare against.")
+
+    configs_in_order: list[str] = []
+    for run in ordered:
+        if run.config not in configs_in_order:
+            configs_in_order.append(run.config)
+    repeats = max((run.repeat for run in ordered), default=0)
+    baseline_topics = collected[baseline]
+
+    candidates: list[CandidateReport] = []
+    for config in configs_in_order:
+        if config == baseline:
+            continue
+        candidate_topics = collected.get(config, {})
+        cells: list[AbCell] = []
+        regressed: list[list[str]] = []
+        improved: list[list[str]] = []
+        dropped: list[str] = []
+        for topic_label in sorted(baseline_topics):
+            candidate_metrics = candidate_topics.get(topic_label)
+            if candidate_metrics is None:
+                dropped.append(topic_label)
+                continue
+            baseline_metrics = baseline_topics[topic_label]
+            for metric in metric_list:
+                better = ab_better(metric)
+                baseline_spread = _metric_spread(baseline_metrics.get(metric, []))
+                candidate_spread = _metric_spread(candidate_metrics.get(metric, []))
+                verdict: Verdict | None = None
+                delta: float | None = None
+                separated: bool | None = None
+                if baseline_spread is not None and candidate_spread is not None:
+                    verdict = classify_change(
+                        baseline_spread.median, candidate_spread.median, better=better, tol=tol_map[metric]
+                    )
+                    delta = round(candidate_spread.median - baseline_spread.median, 3)
+                    separated = candidate_spread.max < baseline_spread.min or baseline_spread.max < candidate_spread.min
+                    if verdict is Verdict.REGRESSED:
+                        regressed.append([topic_label, metric])
+                    elif verdict is Verdict.IMPROVED:
+                        improved.append([topic_label, metric])
+                cells.append(
+                    AbCell(
+                        topic=topic_label,
+                        metric=metric,
+                        better=better.value,
+                        baseline=baseline_spread,
+                        candidate=candidate_spread,
+                        verdict=None if verdict is None else verdict.value,
+                        delta=delta,
+                        separated=separated,
+                    )
+                )
+        candidates.append(
+            CandidateReport(
+                config=config,
+                cells=cells,
+                regressed=regressed,
+                improved=improved,
+                dropped_topics=dropped,
+                passed=not regressed and not dropped,
+            )
+        )
+
+    return AbReport(
+        baseline=baseline,
+        metrics=metric_list,
+        repeats=repeats,
+        candidates=candidates,
+        passed=all(candidate.passed for candidate in candidates),
+    )
+
+
+def _fmt_spread(spread: MetricSpread | None) -> str:
+    if spread is None:
+        return "n/a"
+    if spread.min == spread.max:
+        return f"{spread.median:g}"
+    return f"{spread.median:g} ({spread.min:g}–{spread.max:g})"
+
+
+def render_ab_markdown(report: AbReport) -> str:
+    """A self-describing markdown table per candidate: the paper-grade byproduct."""
+    lines: list[str] = []
+    verdict_word = "PASS" if report.passed else "FAIL"
+    lines.append(f"# A/B verdict: **{verdict_word}** (baseline `{report.baseline}`, {report.repeats} repeats)")
+    lines.append("")
+    lines.append(
+        "Cells compare the candidate median against the baseline median; "
+        "`baseline`/`candidate` show `median (min–max)` across repeats. "
+        "`sep?` is yes when the two spreads do not overlap (the effect is "
+        "separable at this repeat count)."
+    )
+    for candidate in report.candidates:
+        lines.append("")
+        status = "PASS" if candidate.passed else "FAIL"
+        lines.append(f"## `{candidate.config}` vs `{report.baseline}` — **{status}**")
+        if candidate.dropped_topics:
+            lines.append("")
+            lines.append(
+                f"Dropped topics (baseline delivered, candidate did not): {', '.join(candidate.dropped_topics)}"
+            )
+        lines.append("")
+        lines.append("| topic | metric | better | baseline | candidate | Δ | sep? | verdict |")
+        lines.append("|---|---|---|---|---|---|---|---|")
+        for cell in candidate.cells:
+            delta = "" if cell.delta is None else f"{cell.delta:+g}"
+            sep = "" if cell.separated is None else ("yes" if cell.separated else "no")
+            verdict = cell.verdict or "n/a"
+            lines.append(
+                f"| {cell.topic} | {cell.metric} | {cell.better} | "
+                f"{_fmt_spread(cell.baseline)} | {_fmt_spread(cell.candidate)} | {delta} | {sep} | {verdict} |"
+            )
+    return "\n".join(lines)

--- a/src/rosotacom/cli_benchmark.py
+++ b/src/rosotacom/cli_benchmark.py
@@ -55,6 +55,11 @@ BENCHMARK_SESSIONS_BY_GENRE = {
     "loss-boundaries": "bench_1_1_capacity",
 }
 
+# A/B experiments (#22) install every config under one internal session name and
+# switch which one resolves by swapping ``session_configs_dir`` per run, so the
+# same synthetic load (the a_to_b sized_publisher stream) drives each config.
+AB_SESSION_NAME = "ab_experiment"
+
 
 class TeeStream:
     def __init__(self, original_stream: Any, file_path: Path):
@@ -2639,6 +2644,127 @@ def drive_sensitivity(
     )
     print(f"Sensitivity rows saved to {sensitivity_path}")
     return rows
+
+
+def drive_ab(
+    run_point: RunPointFn,
+    *,
+    configs: Sequence[dict[str, Any]],
+    baseline_label: str,
+    profile: str | None,
+    load: dict[str, Any],
+    duration_s: float,
+    repeats: int,
+    metrics: Sequence[str],
+    tolerances: dict[str, Any],
+    topic: str,
+    out_dir: Path,
+    result_context: dict[str, Any] | None = None,
+    config_diffs: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    """Run baseline + candidates interleaved and classify each candidate.
+
+    ``configs`` are ``{"label", "is_baseline", "source", "configs_root"}`` dicts;
+    ``run_point`` receives a ``config`` kwarg naming the active one so the CLI
+    wrapper can point ``session_configs_dir`` at it (a stub in tests reads it to
+    return config-specific summaries). The load and profile are held identical
+    across every run — only the config changes.
+    """
+    from .benchmark import AbRun, ab_schedule, ab_verdict, render_ab_markdown
+
+    labels = [str(config["label"]) for config in configs]
+    config_by_label = {str(config["label"]): config for config in configs}
+    schedule = ab_schedule(labels, repeats)
+
+    profile = _normalize_benchmark_profile(profile)
+    profile_label = _benchmark_profile_label(profile)
+    load_info = _load_context(load)
+
+    runs: list[AbRun] = []
+    run_rows: list[dict[str, Any]] = []
+    for order, (label, repeat) in enumerate(schedule, start=1):
+        config = config_by_label[label]
+        run_dir = out_dir / "runs" / f"{order:03d}_{_safe_case_token(label)}_r{repeat}"
+        run_dir.mkdir(parents=True, exist_ok=True)
+        summary = run_point(profile=profile, load=load, duration_s=duration_s, out_dir=run_dir, config=config)
+        runs.append(AbRun(config=label, repeat=repeat, summary=summary))
+        rows = _topic_rows(summary, topic)
+        run_rows.append(
+            {
+                "order": order,
+                "config": label,
+                "repeat": repeat,
+                "is_baseline": bool(config.get("is_baseline")),
+                "profile": profile_label,
+                "artifact_dir": str(run_dir.relative_to(out_dir)),
+                "topics": rows,
+            }
+        )
+        print(
+            f"  ab[{order}/{len(schedule)}] config={label} repeat={repeat}: "
+            f"offered_bw={_format_bps(load_info.get('offered_bandwidth_bps'))} {_format_topic_rows(rows)}"
+        )
+
+    report = ab_verdict(runs, baseline=baseline_label, metrics=metrics, tolerances=tolerances, topic=topic)
+    report_doc = cast(dict[str, Any], _jsonable(report))
+
+    ab_rows_path = out_dir / "ab.jsonl"
+    ab_rows_path.write_text(
+        "\n".join(json.dumps(row, sort_keys=True) for row in run_rows) + "\n",
+        encoding="utf-8",
+    )
+    markdown = render_ab_markdown(report)
+    ab_md_path = out_dir / "ab.md"
+    ab_md_path.write_text(markdown + "\n", encoding="utf-8")
+
+    _write_benchmark_result(
+        out_dir,
+        genre="ab",
+        context=result_context,
+        configuration={
+            "baseline": baseline_label,
+            "configs": [
+                {
+                    "label": config["label"],
+                    "is_baseline": bool(config.get("is_baseline")),
+                    "source": str(config["source"]),
+                }
+                for config in configs
+            ],
+            "profile": profile_label,
+            "load": load_info,
+            "duration_s": duration_s,
+            "repeats": repeats,
+            "metrics": list(metrics),
+            "tolerances": {metric: {"rel": tol.rel, "abs": tol.abs} for metric, tol in tolerances.items()},
+            "topic": topic or None,
+            "schedule": [{"order": i, "config": lbl, "repeat": rp} for i, (lbl, rp) in enumerate(schedule, start=1)],
+        },
+        result=report_doc,
+        measurements={"runs": run_rows},
+        verdict={
+            "passed": report.passed,
+            "status": "no_regression" if report.passed else "candidate_regressed",
+            "regressed": {
+                candidate.config: candidate.regressed
+                for candidate in report.candidates
+                if candidate.regressed or candidate.dropped_topics
+            },
+            "improved": {candidate.config: candidate.improved for candidate in report.candidates if candidate.improved},
+        },
+        artifacts={
+            "ab_rows": ab_rows_path.name,
+            "ab_markdown": ab_md_path.name,
+            "configs_dir": "configs",
+            "config_diffs": dict(config_diffs or {}),
+            "stdout": "stdout.txt",
+        },
+    )
+    print()
+    print(markdown)
+    print()
+    print(f"A/B verdict: {'PASS' if report.passed else 'FAIL'} — rows saved to {ab_rows_path}")
+    return report_doc
 
 
 def drive_matrix(
@@ -6009,6 +6135,239 @@ def benchmark_sweep(args: argparse.Namespace) -> int:
     return 0
 
 
+def _parse_ab_candidates(raw: Sequence[str]) -> list[tuple[str, str]]:
+    """Parse ``--candidate label=path`` values into ``(label, path)`` pairs."""
+    parsed: list[tuple[str, str]] = []
+    for item in raw:
+        if "=" not in item:
+            raise ValueError(f"--candidate must be label=config, got {item!r}.")
+        label, path = item.split("=", 1)
+        label = label.strip()
+        if not label or not path.strip():
+            raise ValueError(f"--candidate must be label=config, got {item!r}.")
+        parsed.append((label, path.strip()))
+    return parsed
+
+
+def _resolve_ab_config_path(raw: str) -> Path:
+    """A config is a session directory or a session-definition.yaml; return the YAML."""
+    path = Path(raw).expanduser()
+    if path.is_dir():
+        candidate = path / "session-definition.yaml"
+        if not candidate.is_file():
+            raise FileNotFoundError(f"A/B config directory {path} has no session-definition.yaml.")
+        return candidate
+    if path.is_file():
+        return path
+    raise FileNotFoundError(f"A/B config {raw!r} is neither a session directory nor a session YAML.")
+
+
+def _prepare_ab_config(
+    args: argparse.Namespace,
+    *,
+    label: str,
+    source_yaml: Path,
+    is_baseline: bool,
+    run_dir: Path,
+) -> dict[str, Any]:
+    """Materialize one A/B config as an ``AB_SESSION_NAME`` session under ``run_dir``.
+
+    Every config is a whole session-definition.yaml (no patch format). The
+    run-wide knobs (``shared.rmw`` and any ``--qos-*`` overrides) are pinned
+    identically on all configs so the only thing that varies between runs is what
+    the user actually changed in the file.
+    """
+    cfg = yaml.safe_load(source_yaml.read_text(encoding="utf-8")) or {}
+    if not isinstance(cfg, dict):
+        raise RuntimeError(f"A/B config {source_yaml} must be a YAML mapping.")
+    topics = cfg.get("topics")
+    a_to_b = topics.get("a_to_b") if isinstance(topics, dict) else None
+    if not a_to_b:
+        raise ValueError(
+            f"A/B config {source_yaml} defines no topics.a_to_b stream. The synthetic load "
+            "publishes on a_to_b, so every config must carry the same a_to_b load topic(s) and "
+            "differ only in the pipeline knobs under test (throttle_hz, drop, QoS, compression, ...)."
+        )
+    shared = cfg.setdefault("shared", {})
+    if not isinstance(shared, dict):
+        raise RuntimeError(f"A/B config {source_yaml} 'shared' must be a mapping.")
+    rmw = _benchmark_rmw(args)
+    cyclone_spdp_interval = _benchmark_cyclone_spdp_interval(args)
+    if cyclone_spdp_interval is not None:
+        if rmw != "cyclone":
+            raise ValueError("--cyclone-spdp-interval can only be used with --rmw cyclone.")
+        shared["rmw"] = {"local": "cyclone", "ota": {"cyclone": {"spdp_interval": cyclone_spdp_interval}}}
+    else:
+        shared["rmw"] = rmw
+    _apply_benchmark_qos_options(
+        cfg,
+        reliability=getattr(args, "qos_reliability", None),
+        depth=getattr(args, "qos_depth", None),
+    )
+
+    configs_root = run_dir / "configs" / _safe_case_token(label)
+    session_dir = configs_root / AB_SESSION_NAME
+    session_dir.mkdir(parents=True, exist_ok=True)
+    config_path = session_dir / "session-definition.yaml"
+    config_path.write_text(yaml.safe_dump(cfg, sort_keys=False), encoding="utf-8")
+    return {
+        "label": label,
+        "is_baseline": is_baseline,
+        "source": source_yaml,
+        "configs_root": configs_root,
+        "config_path": config_path,
+        "cfg": cfg,
+    }
+
+
+def _write_ab_config_diffs(configs: Sequence[dict[str, Any]], run_dir: Path) -> dict[str, str]:
+    """Unified diff of each candidate config against the baseline (self-describing)."""
+    import difflib
+
+    baseline = next(config for config in configs if config["is_baseline"])
+    baseline_text = yaml.safe_dump(baseline["cfg"], sort_keys=True).splitlines(keepends=True)
+    diffs: dict[str, str] = {}
+    for config in configs:
+        if config["is_baseline"]:
+            continue
+        candidate_text = yaml.safe_dump(config["cfg"], sort_keys=True).splitlines(keepends=True)
+        diff = "".join(
+            difflib.unified_diff(
+                baseline_text,
+                candidate_text,
+                fromfile=f"{baseline['label']}/session-definition.yaml",
+                tofile=f"{config['label']}/session-definition.yaml",
+            )
+        )
+        diff_name = f"{_safe_case_token(str(config['label']))}.diff"
+        (run_dir / "configs" / diff_name).write_text(diff, encoding="utf-8")
+        diffs[str(config["label"])] = f"configs/{diff_name}"
+    return diffs
+
+
+def benchmark_ab(args: argparse.Namespace) -> int:
+    """Handler for ``rosotacom benchmark ab`` — candidate configs vs a baseline."""
+    from .benchmark import AB_METRICS, DEFAULT_AB_METRICS, AbTolerance, default_ab_tolerance
+    from .cli import _load_runtime_config
+
+    runtime = _load_runtime_config(args)
+    artifacts_dir = Path(args.artifacts_dir) if getattr(args, "artifacts_dir", None) else runtime.benchmarks_dir
+    profile = str(args.profile)
+    repeats = int(getattr(args, "repeats", 3))
+    if repeats < 1:
+        raise ValueError("--repeats must be >= 1.")
+
+    baseline_label = "baseline"
+    candidate_specs = _parse_ab_candidates(getattr(args, "candidate", None) or [])
+    if not candidate_specs:
+        raise ValueError("benchmark ab needs at least one --candidate label=config.")
+    labels = [baseline_label, *(label for label, _ in candidate_specs)]
+    if len(set(labels)) != len(labels):
+        raise ValueError("A/B config labels must be unique and none may be 'baseline'.")
+
+    metrics_arg = getattr(args, "metrics", None)
+    metrics = [m.strip() for m in metrics_arg.split(",") if m.strip()] if metrics_arg else list(DEFAULT_AB_METRICS)
+    unknown = [metric for metric in metrics if metric not in AB_METRICS]
+    if unknown:
+        raise ValueError(f"unknown A/B metric(s) {unknown}; known: {sorted(AB_METRICS)}.")
+    rel = getattr(args, "rel_tolerance", None)
+    abs_override = getattr(args, "abs_tolerance", None)
+    tolerances: dict[str, AbTolerance] = {}
+    for metric in metrics:
+        base = default_ab_tolerance(metric) if rel is None else default_ab_tolerance(metric, rel=rel)
+        tolerances[metric] = base if abs_override is None else AbTolerance(rel=base.rel, abs=float(abs_override))
+
+    run_dir = _setup_benchmark_run_dir(args, "ab", profile)
+    configs: list[dict[str, Any]] = [
+        _prepare_ab_config(
+            args,
+            label=baseline_label,
+            source_yaml=_resolve_ab_config_path(args.baseline),
+            is_baseline=True,
+            run_dir=run_dir,
+        )
+    ]
+    for label, raw in candidate_specs:
+        configs.append(
+            _prepare_ab_config(
+                args,
+                label=label,
+                source_yaml=_resolve_ab_config_path(raw),
+                is_baseline=False,
+                run_dir=run_dir,
+            )
+        )
+    config_diffs = _write_ab_config_diffs(configs, run_dir)
+
+    result_context = _benchmark_result_context(args, genre="ab", profile=profile, run_dir=run_dir, session=None)
+    result_context["ab"] = {
+        "baseline": baseline_label,
+        "configs": [{"label": config["label"], "source": str(config["source"])} for config in configs],
+    }
+
+    load = _probe_load(
+        size=int(getattr(args, "size", 18_000)),
+        size_pattern=getattr(args, "size_pattern", None),
+        rate_hz=float(getattr(args, "rate_hz", 20.0)),
+        streams=int(getattr(args, "streams", 1)),
+        interval_jitter_ms=float(getattr(args, "interval_jitter_ms", 0.0)),
+        interval_jitter_seed=int(getattr(args, "interval_jitter_seed", 42)),
+    )
+
+    raw_run_point = getattr(args, "_test_run_point", None) or _make_live_run_point(args, AB_SESSION_NAME)
+
+    def run_point_with_config(
+        *,
+        profile: str | None,
+        load: dict[str, Any],
+        duration_s: float,
+        out_dir: Path,
+        config: dict[str, Any],
+    ) -> dict[str, Any]:
+        previous = getattr(args, "session_configs_dir", None)
+        if previous is None:
+            existing: list[Any] = []
+        elif isinstance(previous, list | tuple):
+            existing = list(previous)
+        else:
+            existing = [previous]
+        args.session_configs_dir = [str(config["configs_root"]), *[str(path) for path in existing]]
+        try:
+            return raw_run_point(profile=profile, load=load, duration_s=duration_s, out_dir=out_dir)
+        finally:
+            args.session_configs_dir = previous
+
+    with log_stdout_stderr_to_file(run_dir / "stdout.txt"):
+        drive_ab(
+            run_point_with_config,
+            configs=configs,
+            baseline_label=baseline_label,
+            profile=profile,
+            load=load,
+            duration_s=float(getattr(args, "duration", 20.0)),
+            repeats=repeats,
+            metrics=metrics,
+            tolerances=tolerances,
+            topic=getattr(args, "topic", ""),
+            out_dir=run_dir,
+            result_context=result_context,
+            config_diffs=config_diffs,
+        )
+
+    out_file_name = getattr(args, "out", "ab.jsonl")
+    out_path = artifacts_dir / Path(out_file_name).name if artifacts_dir else Path(out_file_name)
+    run_ab_file = run_dir / "ab.jsonl"
+    if run_ab_file.is_file():
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(run_ab_file, out_path)
+        print(f"A/B rows copied to {out_path}")
+
+    passed = json.loads((run_dir / BENCHMARK_RESULT_FILE).read_text(encoding="utf-8")).get("verdict", {}).get("passed")
+    if not passed and getattr(args, "fail_on_regression", False):
+        return 1
+    return 0
+
+
 def benchmark_sensitivity(args: argparse.Namespace) -> int:
     """Handler for ``rosotacom benchmark sensitivity``."""
     from .cli import _load_runtime_config
@@ -6708,6 +7067,62 @@ def _register_benchmark_driver_parsers(benchmark_subparsers: Any, *, ota_benchma
     )
     sensitivity_parser.add_argument("--out", default="sensitivity.jsonl", help="Output sensitivity JSONL file.")
     sensitivity_parser.set_defaults(func=benchmark_sensitivity)
+
+    # --- ab ---
+    ab_parser = benchmark_subparsers.add_parser(
+        "ab",
+        help="A/B tuning: compare candidate session configs against a baseline on the same load and profile.",
+    )
+    _add_benchmark_common_args(ab_parser, ota_benchmark=ota_benchmark)
+    ab_parser.add_argument("--profile", required=True, help="Network profile, held identical across every config.")
+    ab_parser.add_argument(
+        "--baseline",
+        required=True,
+        help="Baseline session config: a session directory or a session-definition.yaml.",
+    )
+    ab_parser.add_argument(
+        "--candidate",
+        action="append",
+        metavar="LABEL=CONFIG",
+        help="Candidate config as label=path (session dir or session-definition.yaml). Repeatable.",
+    )
+    ab_parser.add_argument("--repeats", type=int, default=3, help="Repeats per config (spread + median vote).")
+    ab_parser.add_argument("--size", type=int, default=18_000, help="Synthetic load payload size (bytes).")
+    ab_parser.add_argument(
+        "--size-pattern",
+        default=None,
+        help="Cyclic payload sizes such as 1x20KB+1x0KB; overrides --size when set.",
+    )
+    ab_parser.add_argument("--rate-hz", type=float, default=20.0, help="Synthetic load publish rate (Hz).")
+    ab_parser.add_argument("--streams", type=int, default=1, help="Parallel stream count.")
+    ab_parser.add_argument("--interval-jitter-ms", type=float, default=0.0, help="Std dev of interval jitter (ms).")
+    ab_parser.add_argument("--interval-jitter-seed", type=int, default=42, help="Seed for interval jitter.")
+    ab_parser.add_argument("--duration", type=float, default=20.0, help="Seconds per run.")
+    ab_parser.add_argument("--topic", default="", help="Restrict the verdict to one topic (default: all).")
+    ab_parser.add_argument(
+        "--metrics",
+        default=None,
+        help="Comma list of watched metrics (default: completeness_pct,loss_pct,latency_p95_ms,jitter_p95_ms).",
+    )
+    ab_parser.add_argument(
+        "--rel-tolerance",
+        type=float,
+        default=None,
+        help="Relative half-width of the unchanged band around the baseline median (default: 0.10).",
+    )
+    ab_parser.add_argument(
+        "--abs-tolerance",
+        type=float,
+        default=None,
+        help="Override the absolute half-width floor (metric units) for every watched metric.",
+    )
+    ab_parser.add_argument(
+        "--fail-on-regression",
+        action="store_true",
+        help="Exit non-zero when any candidate regressed (default: verdict in result.json, exit 0).",
+    )
+    ab_parser.add_argument("--out", default="ab.jsonl", help="Output per-run JSONL file.")
+    ab_parser.set_defaults(func=benchmark_ab)
 
     # --- matrix ---
     matrix_parser = benchmark_subparsers.add_parser(

--- a/tests/e2e/test_benchmark_ab.py
+++ b/tests/e2e/test_benchmark_ab.py
@@ -1,0 +1,172 @@
+"""Slow-lane E2E for ``rosotacom benchmark ab`` (#22).
+
+Two configs that differ only in ``throttle_hz`` on the synthetic load topic, run
+under a tight rate-limited profile, must produce the expected directional
+verdict: the light-throttle *baseline* offers little load and stays clean, while
+the heavy-throttle *candidate* offers the full 20 Hz × 18 KB (≈2.9 Mbit/s) into a
+1 Mbit/s uplink, congests, and therefore **regresses** on completeness/loss.
+That the A/B driver detects this direction — on a real graph, real shaping — is
+the end-to-end proof the pure-logic unit tests cannot give.
+
+Docker-backed, so gated behind ``ROSOTACOM_RUN_E2E=1`` like the other e2e lanes.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[2]
+BENCHMARK_TIMEOUT_S = 900
+SMOKE_NETWORK_NAME = "rosotacom-smoke"
+AB_PROFILE = "ab-congestion-ci"
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.skipif(
+        os.environ.get("ROSOTACOM_RUN_E2E") != "1",
+        reason="Docker-backed E2E tests require ROSOTACOM_RUN_E2E=1.",
+    ),
+]
+
+
+def _cleanup_smoke_network() -> None:
+    inspect = subprocess.run(
+        ["docker", "network", "inspect", SMOKE_NETWORK_NAME, "--format", "{{json .Containers}}"],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if inspect.returncode == 0 and inspect.stdout.strip():
+        try:
+            containers = json.loads(inspect.stdout)
+        except json.JSONDecodeError:
+            containers = {}
+        for container_id in containers:
+            subprocess.run(["docker", "rm", "-f", container_id], text=True, capture_output=True, check=False)
+    subprocess.run(["docker", "network", "rm", SMOKE_NETWORK_NAME], text=True, capture_output=True, check=False)
+
+
+def _run(command: list[str], *, timeout: int) -> subprocess.CompletedProcess[str]:
+    try:
+        result = subprocess.run(
+            command,
+            cwd=PACKAGE_ROOT,
+            text=True,
+            capture_output=True,
+            timeout=timeout,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        _cleanup_smoke_network()
+        raise AssertionError(f"Command timed out after {timeout}s: {' '.join(command)}") from exc
+    if result.returncode != 0:
+        raise AssertionError(
+            f"Command failed with {result.returncode}: {' '.join(command)}\n"
+            f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+        )
+    return result
+
+
+def _ab_config(throttle_hz: int) -> dict[str, object]:
+    """A bench_1_1-style single-stream config; only ``throttle_hz`` varies."""
+    return {
+        "peers": {"a": {}, "b": {}},
+        "peer_settings": {"a": {"domain_id": 50}, "b": {"domain_id": 51}},
+        "shared": {
+            "use_status_overview": True,
+            "ota_domain_id": 52,
+            "rmw": "cyclone",
+            "qos": {
+                "defaults": {"depth": 1},
+                "for_role": {"ota_sub": {"reliability": "best_effort"}, "ota_pub": {"reliability": "best_effort"}},
+            },
+        },
+        "topics": {
+            "a_to_b": [
+                {
+                    "topic": "/bench_capacity",
+                    "type": "com_msgs/msg/SizedPayload",
+                    "processing": {"use_ota_wrapper": True, "throttle_hz": throttle_hz},
+                }
+            ]
+        },
+    }
+
+
+@pytest.fixture(scope="session")
+def ab_project(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    project = tmp_path_factory.mktemp("rosotacom") / "examples"
+    _run([sys.executable, "-m", "rosotacom", "examples", "create", str(project)], timeout=60)
+
+    # Tight uplink: 20 Hz × 18 KB ≈ 2.9 Mbit/s does not fit 1 Mbit/s, but the
+    # throttled 4 Hz ≈ 0.58 Mbit/s does — so the difference is pure congestion.
+    (project / "profiles.yaml").write_text(
+        f"profiles:\n  {AB_PROFILE}:\n    uplink:   {{ rate: 1mbit }}\n    downlink: {{ rate: 10mbit }}\n",
+        encoding="utf-8",
+    )
+    baseline = project / "ab-configs" / "baseline"
+    candidate = project / "ab-configs" / "unthrottled"
+    baseline.mkdir(parents=True)
+    candidate.mkdir(parents=True)
+    (baseline / "session-definition.yaml").write_text(yaml.safe_dump(_ab_config(4)), encoding="utf-8")
+    (candidate / "session-definition.yaml").write_text(yaml.safe_dump(_ab_config(20)), encoding="utf-8")
+    return project
+
+
+def _result_path(stdout: str) -> Path:
+    prefix = "Benchmark result saved to "
+    paths = [Path(line.removeprefix(prefix)) for line in stdout.splitlines() if line.startswith(prefix)]
+    if not paths:
+        raise AssertionError(f"benchmark ab did not report a result.json path.\nSTDOUT:\n{stdout}")
+    return paths[-1]
+
+
+def test_benchmark_ab_directional_verdict(ab_project: Path) -> None:
+    """Heavier throttle (more offered load) regresses under congestion."""
+    result = _run(
+        [
+            sys.executable,
+            "-m",
+            "rosotacom",
+            "benchmark",
+            "ab",
+            "--rosotacom-config",
+            str(ab_project / "rosotacom.yaml"),
+            "--profile",
+            AB_PROFILE,
+            "--baseline",
+            str(ab_project / "ab-configs" / "baseline"),
+            "--candidate",
+            f"unthrottled={ab_project / 'ab-configs' / 'unthrottled'}",
+            "--size",
+            "18000",
+            "--rate-hz",
+            "20",
+            "--duration",
+            "15",
+            "--repeats",
+            "1",
+            "--rmw",
+            "cyclone",
+        ],
+        timeout=BENCHMARK_TIMEOUT_S,
+    )
+
+    doc = json.loads(_result_path(result.stdout).read_text(encoding="utf-8"))
+    assert doc["genre"] == "ab"
+    # The candidate offered ~5× the baseline load into the same 1 Mbit/s pipe, so
+    # the driver must call it a regression on the bottleneck-dominated metrics.
+    assert doc["verdict"]["passed"] is False
+    regressed = doc["verdict"]["regressed"].get("unthrottled", [])
+    regressed_metrics = {metric for _topic, metric in regressed}
+    assert regressed_metrics & {"loss_pct", "completeness_pct"}, doc["verdict"]
+    # Exactly one candidate, and its per-run measurements were recorded.
+    assert len(doc["result"]["candidates"]) == 1
+    assert len(doc["measurements"]["runs"]) == 2  # baseline + candidate, 1 repeat each

--- a/tests/unit/test_benchmark.py
+++ b/tests/unit/test_benchmark.py
@@ -8,6 +8,8 @@ from pathlib import Path
 import pytest
 
 from rosotacom.benchmark import (
+    AbRun,
+    AbTolerance,
     Band,
     BandError,
     BandProvenance,
@@ -19,10 +21,16 @@ from rosotacom.benchmark import (
     SweepBounds,
     Verdict,
     WideningRefused,
+    ab_better,
+    ab_metrics_from_topic,
+    ab_schedule,
+    ab_verdict,
     band_verdict,
     capacity_binary_search,
     characterize_probe_records,
+    classify_change,
     compare_to_band,
+    default_ab_tolerance,
     default_better,
     exclude_probe_warmup,
     expand_size_pattern,
@@ -42,6 +50,7 @@ from rosotacom.benchmark import (
     pattern_mean_bytes,
     ratchet_band,
     recovery_metrics,
+    render_ab_markdown,
     result_row_id,
     runner_fingerprint,
     save_bands,
@@ -822,3 +831,169 @@ def test_linear_ramp_builds_the_response_curve() -> None:
         (2_000.0, 40.0),
         (4_000.0, 80.0),
     ]
+
+
+# --- A/B tuning experiments (#22) ------------------------------------------ #
+
+
+def _ab_summary(
+    *,
+    delivered: int = 100,
+    expected: int = 100,
+    latency_p95: float = 100.0,
+    jitter_p95: float = 5.0,
+    topic: str = "a->b:/t",
+) -> dict[str, object]:
+    lost = expected - delivered
+    return {
+        "schema_version": 1,
+        "topics": {
+            topic: {
+                "expected": expected,
+                "delivered": delivered,
+                "lost": lost,
+                "loss_pct": round(100.0 * lost / expected, 3) if expected else 0.0,
+                "ota_hop_ms": {"p50": round(latency_p95 * 0.6, 3), "p95": latency_p95},
+                "jitter_ms": {"p50": round(jitter_p95 * 0.4, 3), "p95": jitter_p95},
+            }
+        },
+    }
+
+
+def test_ab_schedule_interleaves_and_rotates() -> None:
+    # Each repeat runs every config once; the starting config rotates each repeat.
+    assert ab_schedule(["A", "B"], 3) == [("A", 1), ("B", 1), ("B", 2), ("A", 2), ("A", 3), ("B", 3)]
+    assert ab_schedule(["A", "B", "C"], 2) == [
+        ("A", 1),
+        ("B", 1),
+        ("C", 1),
+        ("B", 2),
+        ("C", 2),
+        ("A", 2),
+    ]
+    # Every (config, repeat) appears exactly once.
+    order = ab_schedule(["A", "B", "C"], 4)
+    assert sorted(order) == sorted((c, r) for r in range(1, 5) for c in "ABC")
+
+
+def test_ab_schedule_rejects_empty_inputs() -> None:
+    with pytest.raises(ValueError):
+        ab_schedule([], 3)
+    with pytest.raises(ValueError):
+        ab_schedule(["A"], 0)
+
+
+def test_classify_change_both_directions_with_tolerance() -> None:
+    tol = AbTolerance(rel=0.05, abs=0.0)
+    # HIGHER better (completeness/capacity): up = improved, down = regressed.
+    assert classify_change(100.0, 110.0, better=Better.HIGHER, tol=tol) is Verdict.IMPROVED
+    assert classify_change(100.0, 90.0, better=Better.HIGHER, tol=tol) is Verdict.REGRESSED
+    assert classify_change(100.0, 103.0, better=Better.HIGHER, tol=tol) is Verdict.WITHIN
+    # LOWER better (loss/latency): down = improved, up = regressed.
+    assert classify_change(20.0, 10.0, better=Better.LOWER, tol=tol) is Verdict.IMPROVED
+    assert classify_change(20.0, 30.0, better=Better.LOWER, tol=tol) is Verdict.REGRESSED
+    # The band is closed: a value exactly on the edge is unchanged.
+    assert classify_change(100.0, 105.0, better=Better.HIGHER, tol=tol) is Verdict.WITHIN
+
+
+def test_classify_change_absolute_floor_swallows_tiny_noise() -> None:
+    # 2 ms latency floor keeps a sub-floor wiggle on a tiny baseline as unchanged.
+    tol = default_ab_tolerance("latency_p95_ms")  # rel 0.10, abs 2.0
+    assert classify_change(5.0, 6.5, better=Better.LOWER, tol=tol) is Verdict.WITHIN
+    assert classify_change(5.0, 8.0, better=Better.LOWER, tol=tol) is Verdict.REGRESSED
+
+
+def test_ab_metrics_from_topic_reads_completeness_and_none_holes() -> None:
+    metrics = ab_metrics_from_topic(_ab_summary(delivered=80, expected=100)["topics"]["a->b:/t"])
+    assert metrics["completeness_pct"] == 80.0
+    assert metrics["loss_pct"] == 20.0
+    assert metrics["latency_p95_ms"] == 100.0
+    # A wiped-out stream carries no latency sample -> None (dropped from a spread).
+    wiped = {"expected": 100, "delivered": 0, "lost": 100, "loss_pct": 100.0, "ota_hop_ms": {"p95": None}}
+    assert ab_metrics_from_topic(wiped)["latency_p95_ms"] is None
+    assert ab_metrics_from_topic(wiped)["completeness_pct"] == 0.0
+
+
+def test_ab_better_rejects_unknown_metric() -> None:
+    assert ab_better("loss_pct") is Better.LOWER
+    assert ab_better("completeness_pct") is Better.HIGHER
+    with pytest.raises(BandError):
+        ab_better("bogus_metric")
+
+
+def test_ab_verdict_aggregates_spread_and_classifies() -> None:
+    # Baseline: heavy loss; candidate: clean. Two repeats each.
+    runs = [
+        AbRun("baseline", 1, _ab_summary(delivered=60, latency_p95=150.0)),
+        AbRun("baseline", 2, _ab_summary(delivered=70, latency_p95=130.0)),
+        AbRun("cand", 1, _ab_summary(delivered=99, latency_p95=90.0)),
+        AbRun("cand", 2, _ab_summary(delivered=97, latency_p95=95.0)),
+    ]
+    report = ab_verdict(runs, baseline="baseline")
+    assert report.passed is True  # candidate only improves / holds
+    candidate = report.candidates[0]
+    assert candidate.config == "cand"
+    cells = {(c.topic, c.metric): c for c in candidate.cells}
+    completeness = cells[("a->b:/t", "completeness_pct")]
+    # Spread reported as min/median/max, not just the mean.
+    assert completeness.baseline is not None and completeness.candidate is not None
+    assert (completeness.baseline.min, completeness.baseline.max) == (60.0, 70.0)
+    assert completeness.candidate.median == 98.0
+    assert completeness.verdict == Verdict.IMPROVED.value
+    assert completeness.separated is True  # 60–70 vs 97–99 do not overlap
+    assert ["a->b:/t", "completeness_pct"] in candidate.improved
+    assert candidate.regressed == []
+
+
+def test_ab_verdict_flags_regression_and_overall_fail() -> None:
+    runs = [
+        AbRun("baseline", 1, _ab_summary(delivered=99, latency_p95=90.0)),
+        AbRun("worse", 1, _ab_summary(delivered=70, latency_p95=200.0)),
+    ]
+    report = ab_verdict(runs, baseline="baseline")
+    candidate = report.candidates[0]
+    assert candidate.passed is False
+    assert ["a->b:/t", "loss_pct"] in candidate.regressed
+    assert ["a->b:/t", "latency_p95_ms"] in candidate.regressed
+    assert report.passed is False
+
+
+def test_ab_verdict_dropped_topic_is_a_failure() -> None:
+    runs = [
+        AbRun("baseline", 1, _ab_summary(topic="a->b:/t")),
+        AbRun("cand", 1, _ab_summary(topic="a->b:/other")),  # baseline's /t vanished
+    ]
+    report = ab_verdict(runs, baseline="baseline")
+    candidate = report.candidates[0]
+    assert candidate.dropped_topics == ["a->b:/t"]
+    assert candidate.passed is False
+
+
+def test_ab_verdict_is_deterministic_regardless_of_run_order() -> None:
+    runs = [
+        AbRun("baseline", 1, _ab_summary(delivered=80)),
+        AbRun("baseline", 2, _ab_summary(delivered=82)),
+        AbRun("cand", 1, _ab_summary(delivered=95)),
+        AbRun("cand", 2, _ab_summary(delivered=97)),
+    ]
+    first = dataclasses.asdict(ab_verdict(runs, baseline="baseline"))
+    shuffled = [runs[2], runs[0], runs[3], runs[1]]
+    second = dataclasses.asdict(ab_verdict(shuffled, baseline="baseline"))
+    assert first == second
+
+
+def test_ab_verdict_rejects_missing_baseline() -> None:
+    with pytest.raises(BandError):
+        ab_verdict([AbRun("cand", 1, _ab_summary())], baseline="baseline")
+
+
+def test_render_ab_markdown_is_self_describing() -> None:
+    runs = [
+        AbRun("baseline", 1, _ab_summary(delivered=70)),
+        AbRun("cand", 1, _ab_summary(delivered=98)),
+    ]
+    markdown = render_ab_markdown(ab_verdict(runs, baseline="baseline"))
+    assert "A/B verdict: **PASS**" in markdown
+    assert "`cand` vs `baseline`" in markdown
+    assert "| topic | metric |" in markdown
+    assert "IMPROVED" in markdown

--- a/tests/unit/test_cli_benchmark.py
+++ b/tests/unit/test_cli_benchmark.py
@@ -20,6 +20,7 @@ import yaml
 
 import rosotacom.cli as cli
 import rosotacom.cli_benchmark as benchmark_cli
+from rosotacom.benchmark import AbTolerance, default_ab_tolerance
 from rosotacom.cli_benchmark import (
     BENCHMARK_RESULT_FILE,
     DEFAULT_BENCHMARK_DRAIN_S,
@@ -43,7 +44,9 @@ from rosotacom.cli_benchmark import (
     _requirements_target_quality,
     _result_once_script,
     _start_interactive_benchmark,
+    benchmark_ab,
     collect_transit_summary,
+    drive_ab,
     drive_capacity,
     drive_loss_boundaries,
     drive_matrix,
@@ -2953,3 +2956,225 @@ def test_probe_driver_prints_latency_and_arrival_spacing_details(
     row = result["attempts"][0]["topics"][0]
     assert row["latency_trend_ms"]["delta"] == 40.0
     assert row["inter_arrival_ms"]["stall_then_bunch_pct"] == 100.0
+
+
+# --------------------------------------------------------------------------- #
+# A/B tuning experiments (#22): candidate configs vs baseline, same load
+# --------------------------------------------------------------------------- #
+
+
+def _ab_topic_summary(*, delivered: int, expected: int = 100, latency_p95: float = 100.0) -> dict[str, Any]:
+    lost = expected - delivered
+    return {
+        "topics": {
+            "a->b:/bench_capacity": {
+                "expected": expected,
+                "delivered": delivered,
+                "lost": lost,
+                "loss_pct": round(100.0 * lost / expected, 3),
+                "ota_hop_ms": {"p50": latency_p95 * 0.6, "p95": latency_p95},
+                "jitter_ms": {"p50": 2.0, "p95": 5.0},
+            }
+        }
+    }
+
+
+def _ab_configs(base: Path, labels: list[str]) -> list[dict[str, Any]]:
+    configs: list[dict[str, Any]] = []
+    for index, label in enumerate(labels):
+        root = base / "configs" / label
+        (root / benchmark_cli.AB_SESSION_NAME).mkdir(parents=True)
+        configs.append(
+            {"label": label, "is_baseline": index == 0, "source": base / f"{label}.yaml", "configs_root": root}
+        )
+    return configs
+
+
+def _ab_tols(metrics: list[str]) -> dict[str, AbTolerance]:
+    return {metric: default_ab_tolerance(metric) for metric in metrics}
+
+
+def test_drive_ab_interleaves_aggregates_and_writes_result(tmp_path: Path) -> None:
+    canned = {
+        "baseline": _ab_topic_summary(delivered=70, latency_p95=150.0),
+        "fast": _ab_topic_summary(delivered=98, latency_p95=95.0),
+        "worse": _ab_topic_summary(delivered=40, latency_p95=250.0),
+    }
+    order: list[str] = []
+
+    def stub(*, profile: str | None, load: dict[str, Any], duration_s: float, out_dir: Path, config: dict[str, Any]):
+        order.append(str(config["label"]))
+        return canned[str(config["label"])]
+
+    metrics = ["completeness_pct", "loss_pct", "latency_p95_ms"]
+    report = drive_ab(
+        stub,
+        configs=_ab_configs(tmp_path, ["baseline", "fast", "worse"]),
+        baseline_label="baseline",
+        profile="ab-ci",
+        load={"size_a": 18_000, "rate": 20},
+        duration_s=1.0,
+        repeats=2,
+        metrics=metrics,
+        tolerances=_ab_tols(metrics),
+        topic="",
+        out_dir=tmp_path,
+    )
+
+    # Interleaved with a rotating start (ab_schedule), one run per (config, repeat).
+    assert order == ["baseline", "fast", "worse", "fast", "worse", "baseline"]
+
+    result = json.loads((tmp_path / BENCHMARK_RESULT_FILE).read_text())
+    assert result["genre"] == "ab"
+    assert result["verdict"]["passed"] is False  # "worse" regresses; "fast" does not
+    assert "worse" in result["verdict"]["regressed"]
+    assert "fast" not in result["verdict"]["regressed"]
+    assert [(s["order"], s["config"]) for s in result["configuration"]["schedule"][:3]] == [
+        (1, "baseline"),
+        (2, "fast"),
+        (3, "worse"),
+    ]
+    rows = [json.loads(line) for line in (tmp_path / "ab.jsonl").read_text().splitlines()]
+    assert len(rows) == 6
+    assert (tmp_path / "ab.md").read_text().count("vs `baseline`") == 2
+    assert report["passed"] is False
+
+
+def test_drive_ab_verdict_is_deterministic(tmp_path: Path) -> None:
+    def stub(*, profile: str | None, load: dict[str, Any], duration_s: float, out_dir: Path, config: dict[str, Any]):
+        return _ab_topic_summary(delivered=80 if config["is_baseline"] else 96)
+
+    def once(name: str) -> dict[str, Any]:
+        out = tmp_path / name
+        out.mkdir()
+        metrics = ["completeness_pct", "loss_pct"]
+        return drive_ab(
+            stub,
+            configs=_ab_configs(out, ["baseline", "cand"]),
+            baseline_label="baseline",
+            profile="p",
+            load={"size_a": 1, "rate": 20},
+            duration_s=1.0,
+            repeats=3,
+            metrics=metrics,
+            tolerances=_ab_tols(metrics),
+            topic="",
+            out_dir=out,
+        )
+
+    assert once("run_a") == once("run_b")
+
+
+def _write_ab_config(path: Path, throttle_hz: int) -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    cfg = {
+        "peers": {"a": {}, "b": {}},
+        "peer_settings": {"a": {"domain_id": 50}, "b": {"domain_id": 51}},
+        "shared": {"ota_domain_id": 52, "rmw": "cyclone", "use_status_overview": True},
+        "topics": {
+            "a_to_b": [
+                {
+                    "topic": "/bench_capacity",
+                    "type": "com_msgs/msg/SizedPayload",
+                    "processing": {"use_ota_wrapper": True, "throttle_hz": throttle_hz},
+                }
+            ]
+        },
+    }
+    (path / "session-definition.yaml").write_text(yaml.safe_dump(cfg), encoding="utf-8")
+    return path
+
+
+def _ab_handler_args(tmp_path: Path, *, baseline: Path, candidate: Path, **overrides: Any) -> argparse.Namespace:
+    project = tmp_path / "proj"
+    project.mkdir(parents=True, exist_ok=True)
+    (project / "rosotacom.yaml").write_text("profiles: profiles.yaml\n", encoding="utf-8")
+    (project / "profiles.yaml").write_text(
+        "profiles:\n  ab-ci:\n    uplink: { rate: 1mbit }\n    downlink: { rate: 10mbit }\n", encoding="utf-8"
+    )
+    args: dict[str, Any] = {
+        "rosotacom_config": str(project / "rosotacom.yaml"),
+        "ros2docker_config": None,
+        "deployment": None,
+        "session_configs_dir": None,
+        "scenario_configs_dir": None,
+        "session_instances_dir": None,
+        "profiles_file": str(project / "profiles.yaml"),
+        "artifacts_dir": str(tmp_path / "artifacts"),
+        "profile": "ab-ci",
+        "baseline": str(baseline),
+        "candidate": [f"unthrottled={candidate}"],
+        "repeats": 2,
+        "size": 18_000,
+        "size_pattern": None,
+        "rate_hz": 20.0,
+        "streams": 1,
+        "interval_jitter_ms": 0.0,
+        "interval_jitter_seed": 42,
+        "duration": 1.0,
+        "topic": "",
+        "metrics": None,
+        "rel_tolerance": None,
+        "abs_tolerance": None,
+        "fail_on_regression": False,
+        "out": "ab.jsonl",
+        "rmw": "cyclone",
+        "qos_reliability": None,
+        "qos_depth": None,
+        "cyclone_spdp_interval": None,
+    }
+    args.update(overrides)
+    namespace = argparse.Namespace(**args)
+
+    # The stub reads throttle_hz from the config the wrapper just activated via
+    # session_configs_dir — so the test exercises the real materialize+swap path.
+    def run_point(*, profile: str | None, load: dict[str, Any], duration_s: float, out_dir: Path) -> dict[str, Any]:
+        root = Path(namespace.session_configs_dir[0])
+        cfg = yaml.safe_load((root / benchmark_cli.AB_SESSION_NAME / "session-definition.yaml").read_text())
+        throttle = cfg["topics"]["a_to_b"][0]["processing"]["throttle_hz"]
+        # Heavier throttle => more offered load => more loss under the tight profile.
+        return _ab_topic_summary(delivered=96 if throttle <= 5 else 55)
+
+    namespace._test_run_point = run_point
+    return namespace
+
+
+def test_benchmark_ab_handler_materializes_configs_and_gates_exit_code(tmp_path: Path) -> None:
+    baseline = _write_ab_config(tmp_path / "base", throttle_hz=5)
+    candidate = _write_ab_config(tmp_path / "cand", throttle_hz=20)
+
+    # Default: verdict lives in result.json, exit 0 even on a regression.
+    args = _ab_handler_args(tmp_path, baseline=baseline, candidate=candidate)
+    assert benchmark_ab(args) == 0
+
+    run_dir = next((tmp_path / "artifacts").rglob("result.json")).parent
+    result = json.loads((run_dir / BENCHMARK_RESULT_FILE).read_text())
+    assert result["genre"] == "ab"
+    assert result["verdict"]["passed"] is False
+    assert "unthrottled" in result["verdict"]["regressed"]
+    # The knob difference is captured in the self-describing diff.
+    assert "throttle_hz" in (run_dir / "configs" / "unthrottled.diff").read_text()
+
+    # --fail-on-regression makes the process exit reflect the verdict.
+    args2 = _ab_handler_args(tmp_path / "again", baseline=baseline, candidate=candidate, fail_on_regression=True)
+    assert benchmark_ab(args2) == 1
+
+
+def test_prepare_ab_config_requires_an_a_to_b_load_topic(tmp_path: Path) -> None:
+    source = tmp_path / "no_load"
+    source.mkdir()
+    (source / "session-definition.yaml").write_text(
+        yaml.safe_dump(
+            {"peers": {"a": {}, "b": {}}, "topics": {"b_to_a": [{"topic": "/x", "type": "std_msgs/msg/String"}]}}
+        ),
+        encoding="utf-8",
+    )
+    args = argparse.Namespace(rmw="cyclone", cyclone_spdp_interval=None, qos_reliability=None, qos_depth=None)
+    with pytest.raises(ValueError, match="a_to_b"):
+        benchmark_cli._prepare_ab_config(
+            args,
+            label="baseline",
+            source_yaml=source / "session-definition.yaml",
+            is_baseline=True,
+            run_dir=tmp_path / "run",
+        )


### PR DESCRIPTION
Closes #181. Implements harness roadmap issue go914/rosotacom_test#22
(milestone "Closed-loop vision").

## What

`rosotacom benchmark ab` — the tuning verdict the *fix* step of the loop needs:
**"does candidate config B beat baseline config A on the same load and
profile?"**

It holds the synthetic `a_to_b` `sized_publisher` load and the network
profile/seed constant, and varies the **whole session config** (the pipeline
knobs under test — `throttle_hz`, `drop`, QoS reliability/depth/lifespan,
compression, ffmpeg …). Baseline + candidates run **interleaved with a rotating
start** over `--repeats`; each candidate is then classified against the baseline
per topic and metric as **IMPROVED / WITHIN / REGRESSED** — the same two-sided
verdict language as the RFC 0007 regression gate, here evaluated on the ephemeral
`[baseline ± tolerance]` envelope (`--rel-tolerance`/`--abs-tolerance`). The
overall verdict fails if any watched metric regressed. The repeat spread
(min/median/max) and a `separated` flag travel with every cell so small-N effects
are read honestly.

## How it's built

- **Pure, host-tested verdict layer** (`benchmark.py`): `ab_verdict`,
  `classify_change`, `ab_schedule` (deterministic interleave + rotation),
  `render_ab_markdown`. `band_verdict` and A/B now share `_two_sided_verdict`, so
  the gate and A/B classify identically.
- **CLI orchestration** (`cli_benchmark.py`): `drive_ab` + `benchmark ab`.
  Whole-file config resolution (a directory or a `session-definition.yaml`, no
  patch format), per-config `session_configs_dir` swap around the existing live
  run-point, `result.json` (`genre: "ab"`) + `ab.md` markdown table + per-config
  YAML diffs + `ab.jsonl`.
- **Docs**: `docs/benchmark-ab.md` (config model, interleaving, and an honest
  statistical-power note), linked from the README benchmark section; RFC 0005
  gains an A/B section + implementation/validation checklist entries.

## Non-goals (per the issue)

No automatic parameter search (the agent/human picks candidates); no live-drive
A/B (replay/emulated only).

## Validation

```bash
# pure verdict layer + driver + handler (host, no Docker):
python -m pytest tests/unit/test_benchmark.py tests/unit/test_cli_benchmark.py -k "ab or classify or render_ab or schedule"
# slow-lane e2e (Docker): a throttle_hz difference produces the directional verdict
ROSOTACOM_RUN_E2E=1 python -m pytest tests/e2e/test_benchmark_ab.py
```

`ruff check` / `ruff format --check` clean; `mypy` clean on the changed modules.
The Docker `fast-e2e` lane exercises `tests/e2e/test_benchmark_ab.py`.

## Owner smoke

Two configs that differ only in `throttle_hz`, on the packaged example project,
under a tight 1 Mbit/s uplink where the heavier-throttle candidate offers ~5× the
load into the same pipe and must therefore regress:

```bash
rosotacom examples create /tmp/ab-demo && cd /tmp/ab-demo
printf 'profiles:\n  ab-ci:\n    uplink: { rate: 1mbit }\n    downlink: { rate: 10mbit }\n' > profiles.yaml
for hz in 4 20; do d="cfg_$hz"; mkdir -p "$d"; cat > "$d/session-definition.yaml" <<YAML
peers: { a: {}, b: {} }
peer_settings: { a: { domain_id: 50 }, b: { domain_id: 51 } }
shared: { use_status_overview: true, ota_domain_id: 52, rmw: cyclone }
topics:
  a_to_b:
    - topic: "/bench_capacity"
      type: "com_msgs/msg/SizedPayload"
      processing: { use_ota_wrapper: true, throttle_hz: $hz }
YAML
done
rosotacom benchmark ab --profile ab-ci --baseline cfg_4 --candidate unthrottled=cfg_20 \
  --size 18000 --rate-hz 20 --duration 15 --repeats 1
```

Expected: overall verdict **FAIL** — `unthrottled` regresses on
`loss_pct` / `completeness_pct` (it congests the 1 Mbit/s uplink while the
throttled baseline stays clean); the printed `ab.md` table shows the two
REGRESSED cells and the verdict is written to `result.json`.
