### PR TITLE
Gate + fix the A/B experiment E2E (topic-preserving QoS knob) (#181)

### DIFF
--- a/README.md
+++ b/README.md
@@ -705,8 +705,10 @@ Use `benchmark ab` when the question is a **tuning** one: "does candidate config
 B beat baseline config A on the same load and profile?" Each `--baseline` and
 `--candidate label=…` is a whole session config (a directory or a
 `session-definition.yaml`) that shares the synthetic `a_to_b` load and differs
-only in the pipeline knobs under test (`throttle_hz`, `drop`, QoS, compression,
-…). The driver runs them interleaved with a rotating start over `--repeats`,
+only in the pipeline knobs under test (QoS reliability/depth/lifespan,
+compression, ffmpeg gop/bitrate/crf, … — knobs that keep the delivered topic
+name, unlike `throttle_hz`/`drop` which republish to a renamed topic; see the
+doc). The driver runs them interleaved with a rotating start over `--repeats`,
 then classifies every candidate against the baseline per topic and metric as
 **IMPROVED / WITHIN / REGRESSED** — the same verdict language the regression gate
 uses — with a two-sided tolerance band (`--rel-tolerance`, `--abs-tolerance`).

--- a/docs/benchmark-ab.md
+++ b/docs/benchmark-ab.md
@@ -15,7 +15,7 @@ verdict on the ephemeral `[baseline ± tolerance]` envelope.
 
 | Held constant across every run | Varied between configs |
 |---|---|
-| the load — the synthetic `sized_publisher` stream on `a_to_b` (`--size`/`--size-pattern`, `--rate-hz`, `--streams`) | the **session config**: the OTA pipeline knobs (`throttle_hz`, `drop`, QoS reliability/depth/lifespan, compression, ffmpeg settings, …) |
+| the load — the synthetic `sized_publisher` stream on `a_to_b` (`--size`/`--size-pattern`, `--rate-hz`, `--streams`) | the **session config**: the OTA pipeline knobs (QoS reliability/depth/lifespan, compression, ffmpeg gop/bitrate/crf, …) |
 | the network profile and its seed policy (`--profile`) | |
 | the RMW and any run-wide QoS override (`--rmw`, `--qos-*`) | |
 
@@ -26,6 +26,15 @@ differ *only* in the pipeline knob under test. The run records the YAML diff of
 each candidate against the baseline (`configs/<label>.diff`) so what actually
 changed is explicit and reviewable — and so the "same load" assumption is
 auditable rather than assumed.
+
+**Compare knobs that keep the topic name.** The verdict matches topics by name,
+so the clean A/B knobs are the ones that leave the delivered topic identical
+across configs: QoS (reliability/depth/lifespan), compression, ffmpeg settings.
+`throttle_hz` and `drop` are implemented as a `topic_tools` republish to a
+rate-suffixed topic (`/topic/max20hz`), so two throttle values produce two
+*different* topic names — not a like-for-like comparison. To compare rate caps,
+give both configs the same fixed suffix and vary elsewhere, or measure the rate
+knob with `benchmark sensitivity`/`capacity` instead.
 
 ## Running it
 
@@ -125,31 +134,37 @@ Under the run directory:
 
 ## Owner smoke
 
-Two configs that differ only in `throttle_hz`, on the packaged example project,
-under a tight uplink where the heavier-throttle candidate offers ~5× the load
-into the same pipe and must therefore regress:
+Two configs that differ only in OTA QoS **reliability**, on the packaged example
+project, under an emulated 20% packet loss (QoS keeps the delivered topic name
+identical across configs, which throttle/drop do not — they republish to a
+Hz/N-renamed topic — so QoS is the clean knob for a like-for-like A/B):
 
 ```bash
 rosotacom examples create /tmp/ab-demo && cd /tmp/ab-demo
-printf 'profiles:\n  ab-ci:\n    uplink: { rate: 1mbit }\n    downlink: { rate: 10mbit }\n' > profiles.yaml
-for hz in 4 20; do d="cfg_$hz"; mkdir -p "$d"; cat > "$d/session-definition.yaml" <<YAML
+printf 'profiles:\n  ab-loss:\n    uplink: { rate: 8mbit, loss: 20%% }\n    downlink: { rate: 8mbit }\n' > profiles.yaml
+for rel in best_effort reliable; do d="cfg_$rel"; mkdir -p "$d"; cat > "$d/session-definition.yaml" <<YAML
 peers: { a: {}, b: {} }
 peer_settings: { a: { domain_id: 50 }, b: { domain_id: 51 } }
-shared: { use_status_overview: true, ota_domain_id: 52, rmw: cyclone }
+shared:
+  use_status_overview: true
+  ota_domain_id: 52
+  rmw: cyclone
+  qos: { for_role: { ota_pub: { depth: 1, reliability: $rel }, ota_sub: { depth: 1, reliability: $rel } } }
 topics:
   a_to_b:
     - topic: "/bench_capacity"
       type: "com_msgs/msg/SizedPayload"
-      processing: { use_ota_wrapper: true, throttle_hz: $hz }
+      processing: { use_ota_wrapper: true }
 YAML
 done
-rosotacom benchmark ab --profile ab-ci --baseline cfg_4 --candidate unthrottled=cfg_20 \
+rosotacom benchmark ab --profile ab-loss --baseline cfg_best_effort --candidate reliable=cfg_reliable \
   --size 18000 --rate-hz 20 --duration 15 --repeats 1
 ```
 
-Expected: overall verdict **FAIL** — `unthrottled` regresses on `loss_pct` /
-`completeness_pct` (it congests the 1 Mbit/s uplink while the throttled baseline
-stays clean); the printed `ab.md` table shows the two REGRESSED cells.
+Expected: both configs are measured on `/bench_capacity`, and the printed `ab.md`
+table classifies the `reliable` candidate's `completeness_pct` as **IMPROVED** (it
+recovers the dropped samples best_effort loses) or **WITHIN** — never REGRESSED.
+The verdict JSON is written to `result.json`.
 
 See also: [RFC 0005](rfcs/0005-benchmark-genres-and-ci.md) (benchmark genres),
 [RFC 0007](rfcs/0007-regression-gate.md) (the two-sided band / verdict language),

--- a/justfile
+++ b/justfile
@@ -55,7 +55,7 @@ test-e2e-remote-assist:
 # every test in the other files (contract-tested in test_benched_set_registry).
 test-e2e-runtime-tools:
 	ROSOTACOM_RUN_E2E=1 {{python}} -m pytest -q tests/e2e/test_smoke.py -k "link_latency"
-	ROSOTACOM_RUN_E2E=1 {{python}} -m pytest -q tests/e2e/test_timeline_stepping.py tests/e2e/test_benchmark_capacity.py
+	ROSOTACOM_RUN_E2E=1 {{python}} -m pytest -q tests/e2e/test_timeline_stepping.py tests/e2e/test_benchmark_capacity.py tests/e2e/test_benchmark_ab.py
 
 test-e2e-concurrency:
 	ROSOTACOM_RUN_E2E=1 {{python}} -m pytest -q tests/e2e/test_parallel_smoke.py

--- a/tests/contract/test_benched_set_registry.py
+++ b/tests/contract/test_benched_set_registry.py
@@ -141,7 +141,8 @@ def test_gate_workflows_exist_and_consume_the_registry(rows: list[GateRow]) -> N
 
 def test_merge_gate_lane_actually_selects_the_benchmark_e2e() -> None:
     """Regression contract for the silent deselection this work found: the
-    runtime-tools recipe must run tests/e2e/test_benchmark_capacity.py in a
+    runtime-tools recipe must run both benchmark E2E files
+    (tests/e2e/test_benchmark_capacity.py and tests/e2e/test_benchmark_ab.py) in a
     pytest invocation that carries no `-k` filter (a `-k` from another file's
     selection would deselect every benchmark test without failing)."""
     recipe = re.search(
@@ -150,7 +151,8 @@ def test_merge_gate_lane_actually_selects_the_benchmark_e2e() -> None:
         re.MULTILINE,
     )
     assert recipe, "justfile recipe test-e2e-runtime-tools is missing"
-    benchmark_lines = [line for line in recipe.group(1).splitlines() if "test_benchmark_capacity.py" in line]
-    assert benchmark_lines, "test-e2e-runtime-tools no longer runs tests/e2e/test_benchmark_capacity.py"
-    poisoned = [line for line in benchmark_lines if re.search(r"\s-k\s", line)]
-    assert not poisoned, f"a -k filter would silently deselect the benchmark E2E: {poisoned}"
+    for e2e_file in ("test_benchmark_capacity.py", "test_benchmark_ab.py"):
+        benchmark_lines = [line for line in recipe.group(1).splitlines() if e2e_file in line]
+        assert benchmark_lines, f"test-e2e-runtime-tools no longer runs tests/e2e/{e2e_file}"
+        poisoned = [line for line in benchmark_lines if re.search(r"\s-k\s", line)]
+        assert not poisoned, f"a -k filter would silently deselect the benchmark E2E {e2e_file}: {poisoned}"

--- a/tests/e2e/test_benchmark_ab.py
+++ b/tests/e2e/test_benchmark_ab.py
@@ -1,14 +1,18 @@
 """Slow-lane E2E for ``rosotacom benchmark ab`` (#22).
 
-Two configs that differ only in ``throttle_hz`` on the synthetic load topic, run
-under a tight rate-limited profile, must produce the expected directional
-verdict: the light-throttle *baseline* offers little load and stays clean, while
-the heavy-throttle *candidate* offers the full 20 Hz × 18 KB (≈2.9 Mbit/s) into a
-1 Mbit/s uplink, congests, and therefore **regresses** on completeness/loss.
-That the A/B driver detects this direction — on a real graph, real shaping — is
-the end-to-end proof the pure-logic unit tests cannot give.
+Two configs that differ only in the OTA **QoS reliability** on the synthetic load
+topic, run under an emulated lossy link. QoS is the knob that keeps the topic
+name identical across configs (throttle/drop republish to a renamed topic via
+`topic_tools`, so they are not 1:1 comparable), which is exactly what an A/B
+verdict needs. The baseline uses `best_effort`; the candidate uses `reliable`,
+which recovers dropped samples by retransmission and therefore must never have
+*worse* completeness than best_effort under loss.
 
-Docker-backed, so gated behind ``ROSOTACOM_RUN_E2E=1`` like the other e2e lanes.
+The point is the end-to-end proof the pure-logic unit tests cannot give: on a
+real graph, under real shaping, `benchmark ab` materializes both configs, runs
+them interleaved, measures the *same* topic for both, and renders a coherent
+verdict. Docker-backed, so gated behind ``ROSOTACOM_RUN_E2E=1`` like the other
+e2e lanes.
 """
 
 from __future__ import annotations
@@ -25,7 +29,7 @@ import yaml
 PACKAGE_ROOT = Path(__file__).resolve().parents[2]
 BENCHMARK_TIMEOUT_S = 900
 SMOKE_NETWORK_NAME = "rosotacom-smoke"
-AB_PROFILE = "ab-congestion-ci"
+AB_PROFILE = "ab-loss-ci"
 
 pytestmark = [
     pytest.mark.e2e,
@@ -74,8 +78,12 @@ def _run(command: list[str], *, timeout: int) -> subprocess.CompletedProcess[str
     return result
 
 
-def _ab_config(throttle_hz: int) -> dict[str, object]:
-    """A bench_1_1-style single-stream config; only ``throttle_hz`` varies."""
+def _ab_config(reliability: str) -> dict[str, object]:
+    """A bench_1_1-style single-stream config; only the OTA QoS reliability varies.
+
+    QoS is pub/sub metadata, so the delivered topic stays ``/bench_capacity`` for
+    every config — the property the A/B topic-by-topic comparison relies on.
+    """
     return {
         "peers": {"a": {}, "b": {}},
         "peer_settings": {"a": {"domain_id": 50}, "b": {"domain_id": 51}},
@@ -85,7 +93,10 @@ def _ab_config(throttle_hz: int) -> dict[str, object]:
             "rmw": "cyclone",
             "qos": {
                 "defaults": {"depth": 1},
-                "for_role": {"ota_sub": {"reliability": "best_effort"}, "ota_pub": {"reliability": "best_effort"}},
+                "for_role": {
+                    "ota_sub": {"depth": 1, "reliability": reliability},
+                    "ota_pub": {"depth": 1, "reliability": reliability},
+                },
             },
         },
         "topics": {
@@ -93,7 +104,7 @@ def _ab_config(throttle_hz: int) -> dict[str, object]:
                 {
                     "topic": "/bench_capacity",
                     "type": "com_msgs/msg/SizedPayload",
-                    "processing": {"use_ota_wrapper": True, "throttle_hz": throttle_hz},
+                    "processing": {"use_ota_wrapper": True},
                 }
             ]
         },
@@ -105,18 +116,19 @@ def ab_project(tmp_path_factory: pytest.TempPathFactory) -> Path:
     project = tmp_path_factory.mktemp("rosotacom") / "examples"
     _run([sys.executable, "-m", "rosotacom", "examples", "create", str(project)], timeout=60)
 
-    # Tight uplink: 20 Hz × 18 KB ≈ 2.9 Mbit/s does not fit 1 Mbit/s, but the
-    # throttled 4 Hz ≈ 0.58 Mbit/s does — so the difference is pure congestion.
+    # Ample bandwidth (no congestion) with a plain per-packet loss — deterministic
+    # enough for CI without a netem seed (GitHub tc rejects `seed`), and it is the
+    # loss that best_effort cannot recover but reliable can.
     (project / "profiles.yaml").write_text(
-        f"profiles:\n  {AB_PROFILE}:\n    uplink:   {{ rate: 1mbit }}\n    downlink: {{ rate: 10mbit }}\n",
+        f"profiles:\n  {AB_PROFILE}:\n    uplink:   {{ rate: 8mbit, loss: 20% }}\n    downlink: {{ rate: 8mbit }}\n",
         encoding="utf-8",
     )
     baseline = project / "ab-configs" / "baseline"
-    candidate = project / "ab-configs" / "unthrottled"
+    candidate = project / "ab-configs" / "reliable"
     baseline.mkdir(parents=True)
     candidate.mkdir(parents=True)
-    (baseline / "session-definition.yaml").write_text(yaml.safe_dump(_ab_config(4)), encoding="utf-8")
-    (candidate / "session-definition.yaml").write_text(yaml.safe_dump(_ab_config(20)), encoding="utf-8")
+    (baseline / "session-definition.yaml").write_text(yaml.safe_dump(_ab_config("best_effort")), encoding="utf-8")
+    (candidate / "session-definition.yaml").write_text(yaml.safe_dump(_ab_config("reliable")), encoding="utf-8")
     return project
 
 
@@ -128,8 +140,9 @@ def _result_path(stdout: str) -> Path:
     return paths[-1]
 
 
-def test_benchmark_ab_directional_verdict(ab_project: Path) -> None:
-    """Heavier throttle (more offered load) regresses under congestion."""
+def test_benchmark_ab_reliability_verdict(ab_project: Path) -> None:
+    """End-to-end: both configs are measured on the same topic and the reliable
+    candidate never regresses completeness vs best_effort under loss."""
     result = _run(
         [
             sys.executable,
@@ -144,7 +157,7 @@ def test_benchmark_ab_directional_verdict(ab_project: Path) -> None:
             "--baseline",
             str(ab_project / "ab-configs" / "baseline"),
             "--candidate",
-            f"unthrottled={ab_project / 'ab-configs' / 'unthrottled'}",
+            f"reliable={ab_project / 'ab-configs' / 'reliable'}",
             "--size",
             "18000",
             "--rate-hz",
@@ -161,12 +174,20 @@ def test_benchmark_ab_directional_verdict(ab_project: Path) -> None:
 
     doc = json.loads(_result_path(result.stdout).read_text(encoding="utf-8"))
     assert doc["genre"] == "ab"
-    # The candidate offered ~5× the baseline load into the same 1 Mbit/s pipe, so
-    # the driver must call it a regression on the bottleneck-dominated metrics.
-    assert doc["verdict"]["passed"] is False
-    regressed = doc["verdict"]["regressed"].get("unthrottled", [])
-    regressed_metrics = {metric for _topic, metric in regressed}
-    assert regressed_metrics & {"loss_pct", "completeness_pct"}, doc["verdict"]
-    # Exactly one candidate, and its per-run measurements were recorded.
-    assert len(doc["result"]["candidates"]) == 1
     assert len(doc["measurements"]["runs"]) == 2  # baseline + candidate, 1 repeat each
+    assert len(doc["result"]["candidates"]) == 1
+
+    candidate = doc["result"]["candidates"][0]
+    assert candidate["config"] == "reliable"
+    # The core end-to-end guarantee: the reliable run kept the same topic as the
+    # baseline (no topic-rename), so both were measured and none dropped.
+    assert candidate["dropped_topics"] == [], candidate
+    measured = [
+        cell for cell in candidate["cells"] if cell["metric"] == "completeness_pct" and cell["verdict"] is not None
+    ]
+    assert measured, f"completeness was not measured for both configs: {candidate['cells']}"
+    # Directional claim that holds regardless of how effective retransmission is
+    # on this runner: reliable recovers losses, so it never *regresses*
+    # completeness vs best_effort (it improves it or leaves it unchanged).
+    completeness_regressed = [pair for pair in candidate["regressed"] if pair[1] == "completeness_pct"]
+    assert not completeness_regressed, f"reliable regressed completeness vs best_effort: {candidate}"


### PR DESCRIPTION
Follow-up to #182 (#181), completing the "one slow-lane e2e" acceptance criterion.

**Two problems this fixes:**
1. **Not gated:** the PR-merge-gate e2e lanes select files explicitly, so `tests/e2e/test_benchmark_ab.py` (landed in #182) ran only in the nightly `test-e2e-smoke` sweep — its verdict was never validated on a PR. Added to `test-e2e-runtime-tools` next to the capacity e2e, with the coverage contract extended to guard both benchmark e2e files.
2. **Wrong knob:** the first gated run showed `throttle_hz` is a `topic_tools` republish to a rate-suffixed topic (`/bench_capacity/max20hz` vs `/max4hz`), so two throttle values produce two different topic names → both runs had `no topic metrics` and `ab_verdict` correctly raised. Switched the e2e **and** the docs owner-smoke (same broken recipe) to **QoS reliability best_effort vs reliable under 20% loss**: QoS keeps the delivered topic `/bench_capacity` across configs, and reliable can never regress completeness vs best_effort — a directional claim robust to runner behavior. Documented the gotcha (A/B compares by topic name; prefer QoS/compression/ffmpeg knobs).

This PR's `e2e-runtime-tools` lane is the first passing CI run of the A/B directional e2e. No auto-merge: merging after confirming that lane is green.