### PR TITLE
benchmark: bag replay as the load for requirements/loss-boundaries (#188)

### DIFF
--- a/README.md
+++ b/README.md
@@ -701,6 +701,23 @@ rosotacom benchmark loss-boundaries --rate-hz 20 --size 18000 --qos-reliability 
 rosotacom benchmark loss-boundaries --rate-hz 20 --size 18000 --qos-reliability best_effort --qos-depth 1 --max-latency-ms 250 --latency-base-ms 30 --downlink-mode lan --bandwidth-low 2.8mbit --bandwidth-high 4mbit --bandwidth-step 0.1mbit --jitter-low-ms 0 --jitter-high-ms 40 --jitter-step-ms 1 --min-duration 20 --min-messages 100 --probe-repeats 1 --netem-seeds 101,102,103,104,105,106,107,108,109,110
 ```
 
+Both `requirements` and `loss-boundaries` also accept a **bag replay as the
+load** instead of the synthetic `sized_publisher` stream: pass `--target
+<session>` (a two-peer replay session such as `15_remote_assist_anonymized_costmap`)
+and, optionally, `--bag <metadata.yaml>` for per-topic completeness ground truth.
+A probe point is then one full replay run under the candidate profile, and the
+oracle judges the **whole contract** — every carried topic must clear the
+loss/latency bound and the `--oracle-min-completeness` floor — aggregated to a
+run verdict that names any failing topics. This answers "which network could
+carry *this bag*?" rather than "…this synthetic stream?". Because a probe now
+costs a full bag loop, keep the iteration budget small. See
+[docs/benchmark-bag-as-load.md](docs/benchmark-bag-as-load.md) for the oracle,
+the local-vs-OTA execution split, and cost guidance:
+
+```bash
+rosotacom benchmark loss-boundaries --target 15_remote_assist_anonymized_costmap --target-type session --axes bandwidth --bandwidth-low 0.5mbit --bandwidth-high 2mbit --bandwidth-step 0.5mbit --rate-hz 10 --min-duration 20 --min-messages 1 --probe-repeats 1 --good-clean-count 1 --bad-lossy-count 1 --max-latency-ms 1000
+```
+
 Use `benchmark ab` when the question is a **tuning** one: "does candidate config
 B beat baseline config A on the same load and profile?" Each `--baseline` and
 `--candidate label=…` is a whole session config (a directory or a

--- a/docs/benchmark-bag-as-load.md
+++ b/docs/benchmark-bag-as-load.md
@@ -1,0 +1,124 @@
+# Bag replay as the benchmark load (`--target` / `--bag`)
+
+`rosotacom benchmark requirements` and `benchmark loss-boundaries` search a
+network profile for a load. Normally that load is the synthetic `sized_publisher`
+stream (a size/rate pattern on `a_to_b`). This mode makes the load a **real
+replay** instead — a whole session/scenario — so the search answers the closed-loop
+vision question:
+
+> *Which network conditions could carry **this bag** loss-free (or ≥95% complete,
+> latency-bounded)?*
+
+instead of the synthetic-stream version of it. The search drivers are unchanged
+(same geometric/linear boundary search, same `result.json`); what changes is
+**what runs at each probe point** and **how the verdict is judged**.
+
+## What varies, what is held constant
+
+| Held constant across every probe | Varied between probes |
+|---|---|
+| the load — the replay `--target` session's own contract publishers (both directions), bag-shaped payloads | the **network profile**: the generated candidate (bandwidth / jitter / latency / loss) the search is testing |
+| the completeness ground truth (`--bag`) and the oracle thresholds | |
+| the RMW and any run-wide QoS override (`--rmw`, `--qos-*`) | |
+
+A probe point = **one full replay run** under the candidate profile. That is the
+whole cost story below.
+
+## The load source (`--target`)
+
+`--target <name> --target-type <session|scenario>` selects the replay, mirroring
+`ota-benchmark`'s target selection. The target's carried topics (across all
+directions) become the **required contract**: the set the run must deliver.
+
+- **Local (Docker) replay** — the default for `benchmark …` with a *session*
+  target. rosotacom starts the target session's two peers on an isolated Docker
+  network and drives every crossed topic with the same synthetic-but-typed
+  publishers the local smoke uses (e.g. a `com_msgs/msg/CompressedData` payload
+  for `/topic5`), shapes the link with the candidate profile, and collects
+  transit records. This is what CI exercises. Local replay needs a two-peer
+  (`a`/`b`) session target.
+- **OTA replay** — `ota-benchmark … --target …` runs the real target
+  session/scenario across deployment peers exactly as `ota-smoke` does, and feeds
+  the same per-topic oracle. Use this for scenario targets, real payloads, and
+  real links.
+
+## The oracle: the whole contract, per topic
+
+Each replay run's transit summary is judged **per topic** and aggregated to a run
+verdict (`rosotacom.benchmark.evaluate_bag_run`, host-tested):
+
+- **loss** — network loss ≤ the driver's loss bound (`requirements --max-loss`;
+  `loss-boundaries` is zero-loss);
+- **latency** — the topic's `p95` OTA-hop ≤ `--max-latency-ms`;
+- **completeness** — when `--bag` supplies a rosbag2 `metadata.yaml`,
+  `delivered / bag-count ≥ --oracle-min-completeness` (default `0.95`). Without a
+  bag the completeness gate is skipped and only loss + latency apply, so the mode
+  still works on a bench session with no bag file.
+
+A run **passes iff every required topic passes**; otherwise the run is a fail and
+the offending topics are listed. A required topic that never arrives counts as
+fully lost. For `loss-boundaries`, an *incomplete* topic makes the run "lossy" —
+so an under-delivered bag is a bad point, exactly as a dropped message would be.
+
+Per-topic verdicts (`passes`, `completeness`, `loss_pct`, `latency_p95_ms`,
+`reason`) are attached to every sample, and the union of failing topics is
+attached to each row.
+
+## Results
+
+`result.json` keeps the normal shape and gains a `result.replay` block recording
+the replay identity so a figure is self-describing:
+
+```json
+"replay": {
+  "target": {"name": "15_remote_assist_anonymized_costmap", "type": "session"},
+  "bag": {"metadata": "…/metadata.yaml", "topics": ["/topic5"]},
+  "required_topics": ["/topic5"],
+  "oracle_min_completeness": 0.95
+}
+```
+
+Rows carry `failing_topics`; each sample carries `per_topic` verdicts. The
+per-topic loss/latency/jitter table (`measurements.points[].samples[].topics`) is
+the full contract, not a single stream.
+
+## Cost guidance
+
+A synthetic probe costs `duration` seconds; a **replay probe costs a full bag
+loop** (the `remote_assist` bag is ~100 s), times `--probe-repeats`, times the
+number of candidates the search visits. So:
+
+- Keep the search budget small: few `--probe-repeats`, a coarse
+  `--bandwidth-step`, one axis at a time (`--axes bandwidth`).
+- The existing prior-knowledge seeding still applies — start near the
+  offered-bandwidth estimate (`--bandwidth-high`/`--bandwidth-low`) and let the
+  target bound exclude conditions that cannot help.
+- Seed policy is unchanged (`--netem-seed` / `--netem-seeds`); on shared CI
+  runners prefer the bandwidth axis (rate-limited, seed-free) over jitter.
+
+## Owner smoke
+
+Run the costmap replay (example 15) through `loss-boundaries` with a one-pair
+budget, on existing packaged material — no new drive needed:
+
+```bash
+rosotacom benchmark loss-boundaries \
+  --target 15_remote_assist_anonymized_costmap --target-type session \
+  --axes bandwidth --bandwidth-low 0.5mbit --bandwidth-high 2mbit --bandwidth-step 0.5mbit \
+  --rate-hz 10 --min-duration 20 --min-messages 1 \
+  --probe-repeats 1 --good-clean-count 1 --bad-lossy-count 1 --max-latency-ms 1000
+```
+
+Expected: the run completes and prints `Benchmark result saved to …/result.json`;
+that file has `genre: "loss-boundaries"`, a `result.replay.target.name` of
+`15_remote_assist_anonymized_costmap`, and per-topic verdicts for `/topic5` on
+every probe row.
+
+## See also
+
+- [Benchmark genres & CI (RFC 0005)](rfcs/0005-benchmark-genres-and-ci.md) — the
+  `requirements` / `loss-boundaries` drivers and their oracle.
+- [A/B tuning experiments](benchmark-ab.md) — the *fix*-step sibling (config A vs
+  B on the same load).
+- [Performance bands & the ratchet](performance-bands.md) — how gated rows assert
+  against committed two-sided bands (RFC 0007).

--- a/docs/rfcs/0005-benchmark-genres-and-ci.md
+++ b/docs/rfcs/0005-benchmark-genres-and-ci.md
@@ -232,6 +232,14 @@ slice and reuses RFC 0003 + 0004.
   reusing the RFC 0007 `Better`/`Verdict` language, repeat-spread + separation
   reporting (`benchmark.ab_verdict`, `cli_benchmark.drive_ab` / `benchmark ab`;
   [../benchmark-ab.md](../benchmark-ab.md)).
+- [x] Let `requirements` / `loss-boundaries` take a **bag replay as the load** (#21):
+  a `--target <session>` probe = one full replay run under the candidate profile,
+  judged by a per-topic whole-contract oracle (loss + latency + optional `--bag`
+  completeness ground truth) aggregated to a run verdict with failing-topic list;
+  local (Docker) execution reuses the smoke contract publishers, OTA reuses the
+  target session/scenario (`benchmark.evaluate_bag_run`,
+  `cli_benchmark._probe_sample_verdict` / `_benchmark_replay_inputs`;
+  [../benchmark-bag-as-load.md](../benchmark-bag-as-load.md)).
 - [ ] Wire the nightly benchmark run as a **monitor** (alerts on budget regression,
   never blocks); the harness wires the actual runner. *(FZI-private — see below.)*
 - [x] Cover the driver oracle, budget compare, and recovery metrics with tests
@@ -317,6 +325,15 @@ reviewed rather than asserted in a blocking test.
   (`test_drive_ab_*`, `test_benchmark_ab_handler_*` in `test_cli_benchmark.py`);
   one Docker-backed slow-lane E2E proves the directional verdict on a `throttle_hz`
   difference (`tests/e2e/test_benchmark_ab.py`, `ROSOTACOM_RUN_E2E=1`). Automatable.
+- [x] **Bag replay as the load** (#21) — host unit tests on the pure per-topic
+  oracle (whole-contract pass/fail, completeness floor, latency bound, absent-topic
+  and order independence: `test_evaluate_bag_run_*` in `test_benchmark.py`) and on
+  both drivers with a stubbed `run_point` consuming multi-topic replay verdicts
+  (`test_loss_boundaries_driver_consumes_replay_verdicts_*`,
+  `test_requirements_driver_consumes_replay_verdicts_*` in `test_cli_benchmark.py`);
+  one Docker-backed slow-lane E2E runs `loss-boundaries` against packaged example 15
+  (costmap) and asserts the replay identity + per-topic verdicts
+  (`tests/e2e/test_benchmark_replay.py`, `ROSOTACOM_RUN_E2E=1`). Automatable.
 - [ ] **Nightly benchmark run wired as a monitor** (alerts on budget regression,
   never blocks) — **operator/harness check**: the public repo defines the genre;
   the actual runner topology is FZI-private, so the wiring is confirmed manually in

--- a/src/rosotacom/benchmark.py
+++ b/src/rosotacom/benchmark.py
@@ -199,6 +199,209 @@ def oracle_passes_topic(topic_summary: dict[str, Any], thresholds: OracleThresho
 
 
 # --------------------------------------------------------------------------- #
+# Bag-as-load oracle: a whole replay contract, judged per topic
+# --------------------------------------------------------------------------- #
+#
+# When the benchmark *load* is a bag replay (a real session/scenario) rather than
+# a single synthetic stream, one probe point delivers many topics at once. The
+# verdict is then per topic — each contract topic must clear the network-loss and
+# latency bound *and* deliver a high-enough share of the bag's known messages
+# (completeness ground truth from ``bag_ground_truth``) — aggregated to a run
+# verdict: the run passes iff every required topic passes, and the failing topics
+# are named. This mirrors ``oracle_passes_topic`` for the loss/latency part and
+# adds the completeness gate the known-source replay makes possible (RFC 0002,
+# "Live vs replay"). It is pure so the search over replay verdicts is host-tested.
+
+
+@dataclass(frozen=True)
+class TopicVerdict:
+    """Per-topic verdict of one replay run against the contract + bag ground truth."""
+
+    topic: str
+    passes: bool
+    expected: int | None  # bag ground-truth count when known, else the run's own expected
+    delivered: int | None
+    lost: int | None
+    reordered: int | None
+    loss_pct: float
+    completeness: float | None  # delivered / bag-count; None when no ground truth
+    latency_p95_ms: float | None
+    jitter_p95_ms: float | None
+    loss_free: bool  # zero network loss AND (when known) complete against the bag
+    latency_ok: bool
+    reason: str  # "ok" or the first failing check, for the failing-topics list
+
+
+@dataclass(frozen=True)
+class BagRunVerdict:
+    """Run verdict aggregated over every required contract topic of one replay."""
+
+    passes: bool
+    loss_free: bool
+    latency_ok: bool
+    topics: tuple[TopicVerdict, ...]
+    failing_topics: tuple[str, ...]
+    representative_topic: str
+    # Row aggregates (summed counts; worst-case rate metrics across topics):
+    expected: int
+    delivered: int
+    lost: int
+    reordered: int
+    loss_pct: float
+    latency_p95_ms: float | None
+    jitter_p95_ms: float | None
+
+
+def summary_topic_name(label: str) -> str:
+    """The bare ROS topic of a ``summarize_transit_records`` label.
+
+    Labels are ``"<source>-><target>:<topic>"`` when directions are known (peer
+    identities carry no ``:``) and just ``"<topic>"`` otherwise; ROS topics never
+    contain ``:``, so the topic is everything after the first ``:``.
+    """
+    if "->" in label and ":" in label:
+        return label.split(":", 1)[1]
+    return label
+
+
+def _topic_data_by_name(summary: dict[str, Any]) -> dict[str, tuple[str, dict[str, Any]]]:
+    """Index a run summary by bare topic name, keeping the richest per-topic row.
+
+    A contract topic flows one direction, but if a name appears under several
+    labels the entry with the most delivered messages is the real stream.
+    """
+    topics = summary.get("topics")
+    if not isinstance(topics, dict):
+        return {}
+    indexed: dict[str, tuple[str, dict[str, Any]]] = {}
+    for label, data in topics.items():
+        if not isinstance(data, dict):
+            continue
+        name = summary_topic_name(str(label))
+        current = indexed.get(name)
+        if current is None or int(data.get("delivered") or 0) > int(current[1].get("delivered") or 0):
+            indexed[name] = (str(label), data)
+    return indexed
+
+
+def evaluate_bag_run(
+    summary: dict[str, Any],
+    *,
+    thresholds: OracleThresholds,
+    ground_truth: dict[str, dict[str, Any]] | None = None,
+    min_completeness: float = 0.95,
+    required_topics: Sequence[str] | None = None,
+) -> BagRunVerdict:
+    """Judge one replay run's transit summary against the whole contract.
+
+    ``required_topics`` is the set the run must deliver (the session's carried
+    topics); when omitted it is taken from ``ground_truth`` if given, else from
+    every topic in the summary. ``ground_truth`` maps ROS topic -> bag facts
+    (``bag_ground_truth``); when a topic has a bag ``count`` the completeness gate
+    (``delivered / count >= min_completeness``) applies on top of the loss/latency
+    oracle. A required topic missing from the summary counts as fully lost.
+    """
+    if not 0.0 < min_completeness <= 1.0:
+        raise ValueError("min_completeness must be within (0, 1].")
+    indexed = _topic_data_by_name(summary)
+    if required_topics is not None:
+        names = [str(name) for name in required_topics]
+    elif ground_truth is not None:
+        names = sorted(name for name in ground_truth if name in indexed) or sorted(indexed)
+    else:
+        names = sorted(indexed)
+
+    quantile = thresholds.latency_quantile
+    verdicts: list[TopicVerdict] = []
+    for name in names:
+        label, data = indexed.get(name, (name, {}))
+        gt = (ground_truth or {}).get(name) or {}
+        gt_count = int(gt.get("count") or 0) if gt else 0
+
+        delivered = data.get("delivered")
+        delivered_n = int(delivered) if delivered is not None else 0
+        lost = data.get("lost")
+        reordered = data.get("reordered")
+        run_expected = data.get("expected")
+        loss_pct = float(data.get("loss_pct", 100.0)) if data else 100.0
+        latency_p95 = (data.get("ota_hop_ms") or {}).get(quantile) if data else None
+        jitter_p95 = (data.get("jitter_ms") or {}).get("p95") if data else None
+        latency_val = None if latency_p95 is None else float(latency_p95)
+
+        expected_out = gt_count if gt_count > 0 else (int(run_expected) if run_expected is not None else None)
+        completeness = (delivered_n / gt_count) if gt_count > 0 else None
+
+        latency_ok = latency_val is not None and latency_val <= thresholds.max_latency_ms
+        loss_ok = loss_pct <= thresholds.max_loss_pct
+        no_network_loss = loss_pct <= 0.0 and int(lost or 0) == 0
+        complete = completeness is None or completeness >= min_completeness
+        passes = bool(data) and loss_ok and latency_ok and complete
+        loss_free = bool(data) and no_network_loss and complete
+
+        if not data:
+            reason = "absent"
+        elif not complete:
+            reason = f"incomplete({completeness:.3f}<{min_completeness:g})"
+        elif not loss_ok:
+            reason = f"loss({loss_pct:.3g}%>{thresholds.max_loss_pct:g}%)"
+        elif not latency_ok:
+            if latency_val is None:
+                reason = "latency(none)"
+            else:
+                reason = f"latency({latency_val:.3g}>{thresholds.max_latency_ms:g}ms)"
+        else:
+            reason = "ok"
+
+        verdicts.append(
+            TopicVerdict(
+                topic=name,
+                passes=passes,
+                expected=expected_out,
+                delivered=delivered_n if data else 0,
+                lost=int(lost) if lost is not None else (expected_out if not data and expected_out else None),
+                reordered=int(reordered) if reordered is not None else None,
+                loss_pct=loss_pct,
+                completeness=round(completeness, 6) if completeness is not None else None,
+                latency_p95_ms=latency_val,
+                jitter_p95_ms=None if jitter_p95 is None else float(jitter_p95),
+                loss_free=loss_free,
+                latency_ok=latency_ok,
+                reason=reason,
+            )
+        )
+
+    failing = tuple(v.topic for v in verdicts if not v.passes)
+    passes = bool(verdicts) and not failing
+    loss_free = bool(verdicts) and all(v.loss_free for v in verdicts)
+    latency_ok = bool(verdicts) and all(v.latency_ok for v in verdicts)
+
+    expected_total = sum(int(v.expected) for v in verdicts if v.expected is not None)
+    delivered_total = sum(int(v.delivered) for v in verdicts if v.delivered is not None)
+    lost_total = sum(int(v.lost) for v in verdicts if v.lost is not None)
+    reordered_total = sum(int(v.reordered) for v in verdicts if v.reordered is not None)
+    loss_values = [v.loss_pct for v in verdicts]
+    latency_values = [v.latency_p95_ms for v in verdicts if v.latency_p95_ms is not None]
+    jitter_values = [v.jitter_p95_ms for v in verdicts if v.jitter_p95_ms is not None]
+    representative = failing[0] if failing else (verdicts[0].topic if verdicts else "")
+
+    return BagRunVerdict(
+        passes=passes,
+        loss_free=loss_free,
+        latency_ok=latency_ok,
+        topics=tuple(verdicts),
+        failing_topics=failing,
+        representative_topic=representative,
+        expected=expected_total,
+        delivered=delivered_total,
+        lost=lost_total,
+        reordered=reordered_total,
+        loss_pct=max(loss_values) if loss_values else 100.0,
+        latency_p95_ms=max(latency_values) if latency_values else None,
+        jitter_p95_ms=max(jitter_values) if jitter_values else None,
+    )
+
+
+# --------------------------------------------------------------------------- #
 # Genre 1 — sweep bounds + shared-link guard
 # --------------------------------------------------------------------------- #
 

--- a/src/rosotacom/cli_benchmark.py
+++ b/src/rosotacom/cli_benchmark.py
@@ -212,6 +212,28 @@ def collect_transit_records(instance_dir: Path) -> list[dict[str, Any]]:
     return join_transit_records(load_transit_records(events_files))
 
 
+def _benchmark_delivery_observed(status_paths: Sequence[Path], *, base: str | None) -> bool:
+    """True once any peer's ``status.json`` reports a delivered message.
+
+    ``base`` restricts the check to one topic (the single synthetic load topic);
+    ``None`` accepts any contract topic — used for replay loads whose topics cross
+    both directions, so the warm-up wait ends as soon as the replay is flowing.
+    """
+    for status_path in status_paths:
+        if not status_path.is_file():
+            continue
+        try:
+            status_data = json.loads(status_path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        for topic_info in status_data.get("topics", []):
+            if base is not None and topic_info.get("base") != base:
+                continue
+            if any(stage.get("messages_total", 0) > 0 for stage in topic_info.get("stages", [])):
+                return True
+    return False
+
+
 # --------------------------------------------------------------------------- #
 # Run-point primitive (the live probe, injected for testing)
 # --------------------------------------------------------------------------- #
@@ -2519,6 +2541,79 @@ def _selected_topic(summary: dict[str, Any], topic: str = "") -> tuple[str, dict
     return first_topic, topic_data if isinstance(topic_data, dict) else {}
 
 
+def _probe_sample_verdict(
+    summary: dict[str, Any],
+    *,
+    thresholds: Any,
+    topic: str,
+    bag_mode: bool,
+    ground_truth: dict[str, dict[str, Any]] | None = None,
+    min_completeness: float = 0.95,
+    required_topics: Sequence[str] | None = None,
+) -> dict[str, Any]:
+    """One probe run's verdict fields, shared by the requirements/boundary drivers.
+
+    In synthetic-load mode (``bag_mode`` false) this reproduces the single-topic
+    oracle the drivers have always used: the selected (or first) topic's loss,
+    latency ``p95`` and jitter ``p95``. In bag-as-load mode it aggregates the whole
+    replay contract with :func:`rosotacom.benchmark.evaluate_bag_run` — every
+    required topic must clear the loss/latency oracle and (when a bag supplies
+    ground truth) the completeness floor — and attaches the per-topic verdicts and
+    the failing-topic list. Both modes return the same keys, so the search loops
+    consume replay verdicts without any change to the boundary/requirements logic.
+    """
+    from .benchmark import oracle_passes_topic
+
+    if not bag_mode:
+        sample_topic, topic_data = _selected_topic(summary, topic)
+        loss_pct = float(topic_data.get("loss_pct", 100.0)) if topic_data else 100.0
+        lost = topic_data.get("lost") if topic_data else None
+        latency_p95 = (topic_data.get("ota_hop_ms") or {}).get("p95") if topic_data else None
+        jitter_p95 = (topic_data.get("jitter_ms") or {}).get("p95") if topic_data else None
+        loss_free = bool(loss_pct <= 0.0 and (lost is None or int(lost) == 0))
+        latency_ok = bool(latency_p95 is not None and float(latency_p95) <= thresholds.max_latency_ms)
+        return {
+            "topic": sample_topic,
+            "expected": topic_data.get("expected") if topic_data else None,
+            "delivered": topic_data.get("delivered") if topic_data else None,
+            "lost": int(lost) if lost is not None else None,
+            "reordered": topic_data.get("reordered") if topic_data else None,
+            "loss_pct": loss_pct,
+            "latency_p95_ms": float(latency_p95) if latency_p95 is not None else None,
+            "jitter_p95_ms": float(jitter_p95) if jitter_p95 is not None else None,
+            "loss_free": loss_free,
+            "latency_ok": latency_ok,
+            "passes": oracle_passes_topic(topic_data, thresholds) if topic_data else False,
+            "per_topic": None,
+            "failing_topics": None,
+        }
+
+    from .benchmark import evaluate_bag_run
+
+    verdict = evaluate_bag_run(
+        summary,
+        thresholds=thresholds,
+        ground_truth=ground_truth,
+        min_completeness=min_completeness,
+        required_topics=required_topics,
+    )
+    return {
+        "topic": verdict.representative_topic,
+        "expected": verdict.expected,
+        "delivered": verdict.delivered,
+        "lost": verdict.lost,
+        "reordered": verdict.reordered,
+        "loss_pct": verdict.loss_pct,
+        "latency_p95_ms": verdict.latency_p95_ms,
+        "jitter_p95_ms": verdict.jitter_p95_ms,
+        "loss_free": verdict.loss_free,
+        "latency_ok": verdict.latency_ok,
+        "passes": verdict.passes,
+        "per_topic": [_jsonable(dataclass_verdict) for dataclass_verdict in verdict.topics],
+        "failing_topics": list(verdict.failing_topics),
+    }
+
+
 def _sensitivity_analysis(rows: Sequence[dict[str, Any]]) -> dict[str, Any]:
     baseline = next((row for row in rows if row.get("axis") == "baseline"), None)
     explicit_reference = next((row for row in rows if row.get("axis") == "reference"), None)
@@ -3182,9 +3277,15 @@ def drive_requirements(
     result_context: dict[str, Any] | None = None,
     generated_profiles_file: Path | None = None,
     profile_prefix: str = "requirements",
+    ground_truth: dict[str, dict[str, Any]] | None = None,
+    oracle_min_completeness: float = 0.95,
+    required_topics: Sequence[str] | None = None,
+    target: dict[str, Any] | None = None,
+    bag: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    from .benchmark import OracleThresholds, oracle_passes_topic
+    from .benchmark import OracleThresholds
 
+    bag_mode = target is not None or ground_truth is not None or required_topics is not None
     if bandwidth_low_bps <= 0.0 or bandwidth_high_bps <= 0.0:
         raise ValueError("Bandwidth bounds must be > 0.")
     if bandwidth_low_bps >= bandwidth_high_bps:
@@ -3322,29 +3423,34 @@ def drive_requirements(
         selected_topic = ""
         for repeat_index in range(1, local_probe_repeats + 1):
             summary = run_point(profile=profile_name, load=load, duration_s=duration_s, out_dir=out_dir)
-            sample_topic, topic_data = _selected_topic(summary, topic)
-            rows_for_print = _topic_rows(summary, topic)
-            if sample_topic and not selected_topic:
-                selected_topic = sample_topic
-            sample_passes = oracle_passes_topic(topic_data, thresholds) if topic_data else False
-            sample_loss_pct = float(topic_data.get("loss_pct", 100.0)) if topic_data else 100.0
-            sample_latency_p95 = (topic_data.get("ota_hop_ms") or {}).get("p95") if topic_data else None
-            sample_jitter_p95 = (topic_data.get("jitter_ms") or {}).get("p95") if topic_data else None
-            sample_lost = topic_data.get("lost") if topic_data else None
-            sample_loss_free = bool(sample_loss_pct <= 0.0 and (sample_lost is None or int(sample_lost) == 0))
+            verdict = _probe_sample_verdict(
+                summary,
+                thresholds=thresholds,
+                topic=topic,
+                bag_mode=bag_mode,
+                ground_truth=ground_truth,
+                min_completeness=oracle_min_completeness,
+                required_topics=required_topics,
+            )
+            rows_for_print = _topic_rows(summary, "" if bag_mode else topic)
+            if verdict["topic"] and not selected_topic:
+                selected_topic = verdict["topic"]
             sample = {
                 "repeat": repeat_index,
-                "passes": sample_passes,
-                "topic": sample_topic,
-                "expected": topic_data.get("expected") if topic_data else None,
-                "delivered": topic_data.get("delivered") if topic_data else None,
-                "lost": sample_lost,
-                "reordered": topic_data.get("reordered") if topic_data else None,
-                "loss_pct": sample_loss_pct,
-                "latency_p95_ms": float(sample_latency_p95) if sample_latency_p95 is not None else None,
-                "jitter_p95_ms": float(sample_jitter_p95) if sample_jitter_p95 is not None else None,
-                "loss_free": sample_loss_free,
+                "passes": verdict["passes"],
+                "topic": verdict["topic"],
+                "expected": verdict["expected"],
+                "delivered": verdict["delivered"],
+                "lost": verdict["lost"],
+                "reordered": verdict["reordered"],
+                "loss_pct": verdict["loss_pct"],
+                "latency_p95_ms": verdict["latency_p95_ms"],
+                "jitter_p95_ms": verdict["jitter_p95_ms"],
+                "loss_free": verdict["loss_free"],
             }
+            if verdict["failing_topics"] is not None:
+                sample["failing_topics"] = verdict["failing_topics"]
+                sample["per_topic"] = verdict["per_topic"]
             sample["target_quality"] = _requirements_target_quality(
                 sample,
                 max_loss_pct=max_loss_pct,
@@ -3429,6 +3535,8 @@ def drive_requirements(
             "repeat": repeat_summary,
             "samples": samples,
         }
+        if bag_mode:
+            row["failing_topics"] = sorted({t for s in samples for t in (s.get("failing_topics") or [])})
         target_quality = _requirements_target_quality(
             row,
             max_loss_pct=max_loss_pct,
@@ -3881,6 +3989,13 @@ def drive_requirements(
         "rows": rows,
         "analysis": analysis,
     }
+    if bag_mode:
+        result["replay"] = {
+            "target": target,
+            "bag": bag,
+            "required_topics": list(required_topics) if required_topics is not None else None,
+            "oracle_min_completeness": oracle_min_completeness,
+        }
     requirements_path = out_dir / "requirements.jsonl"
     requirements_path.write_text(
         "\n".join(json.dumps(row, sort_keys=True) for row in rows) + "\n",
@@ -4040,9 +4155,21 @@ def drive_loss_boundaries(
     result_context: dict[str, Any] | None = None,
     generated_profiles_file: Path | None = None,
     profile_prefix: str = "loss_boundary",
+    ground_truth: dict[str, dict[str, Any]] | None = None,
+    oracle_min_completeness: float = 0.95,
+    required_topics: Sequence[str] | None = None,
+    target: dict[str, Any] | None = None,
+    bag: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Find discrete zero-loss good/bad boundaries for bandwidth and jitter."""
 
+    from .benchmark import OracleThresholds
+
+    bag_mode = target is not None or ground_truth is not None or required_topics is not None
+    # The boundary oracle is zero network loss plus the latency ceiling; in bag
+    # mode the completeness floor rides along inside ``loss_free`` (an incomplete
+    # replay is a lossy run).
+    oracle_thresholds = OracleThresholds(max_loss_pct=0.0, max_latency_ms=max_latency_ms)
     if downlink_mode not in {"mirror", "lan"}:
         raise ValueError("downlink_mode must be 'mirror' or 'lan'.")
     if latency_base_ms < 0.0:
@@ -4212,34 +4339,41 @@ def drive_loss_boundaries(
             )
             write_profiles()
             summary = run_point(profile=profile_name, load=load, duration_s=duration_s, out_dir=out_dir)
-            sample_topic, topic_data = _selected_topic(summary, topic)
-            rows_for_print = _topic_rows(summary, topic)
-            if sample_topic and not selected_topic:
-                selected_topic = sample_topic
-            sample_loss_pct = float(topic_data.get("loss_pct", 100.0)) if topic_data else 100.0
-            sample_lost = int(topic_data.get("lost", 0)) if topic_data and topic_data.get("lost") is not None else None
-            sample_latency_p95 = (topic_data.get("ota_hop_ms") or {}).get("p95") if topic_data else None
-            sample_jitter_p95 = (topic_data.get("jitter_ms") or {}).get("p95") if topic_data else None
-            loss_free = bool(sample_loss_pct <= 0.0 and (sample_lost is None or sample_lost == 0))
-            latency_ok = bool(sample_latency_p95 is not None and float(sample_latency_p95) <= max_latency_ms)
+            verdict = _probe_sample_verdict(
+                summary,
+                thresholds=oracle_thresholds,
+                topic=topic,
+                bag_mode=bag_mode,
+                ground_truth=ground_truth,
+                min_completeness=oracle_min_completeness,
+                required_topics=required_topics,
+            )
+            rows_for_print = _topic_rows(summary, "" if bag_mode else topic)
+            if verdict["topic"] and not selected_topic:
+                selected_topic = verdict["topic"]
+            loss_free = verdict["loss_free"]
+            latency_ok = verdict["latency_ok"]
             good = loss_free and latency_ok
             lossy = not loss_free
             sample = {
                 "sample": sample_index,
                 "seed": sample_seed,
-                "topic": sample_topic,
-                "expected": topic_data.get("expected") if topic_data else None,
-                "delivered": topic_data.get("delivered") if topic_data else None,
-                "lost": sample_lost,
-                "reordered": topic_data.get("reordered") if topic_data else None,
-                "loss_pct": sample_loss_pct,
-                "latency_p95_ms": float(sample_latency_p95) if sample_latency_p95 is not None else None,
-                "jitter_p95_ms": float(sample_jitter_p95) if sample_jitter_p95 is not None else None,
+                "topic": verdict["topic"],
+                "expected": verdict["expected"],
+                "delivered": verdict["delivered"],
+                "lost": verdict["lost"],
+                "reordered": verdict["reordered"],
+                "loss_pct": verdict["loss_pct"],
+                "latency_p95_ms": verdict["latency_p95_ms"],
+                "jitter_p95_ms": verdict["jitter_p95_ms"],
                 "loss_free": loss_free,
                 "latency_ok": latency_ok,
                 "good": good,
                 "lossy": lossy,
             }
+            if verdict["failing_topics"] is not None:
+                sample["failing_topics"] = verdict["failing_topics"]
+                sample["per_topic"] = verdict["per_topic"]
             samples.append(sample)
             sample_measurements.append(
                 {
@@ -4324,6 +4458,8 @@ def drive_loss_boundaries(
             "repeat": repeat_summary,
             "samples": samples,
         }
+        if bag_mode:
+            row["failing_topics"] = sorted({t for s in samples for t in (s.get("failing_topics") or [])})
         rows.append(row)
         measurements.append({"row": row, "samples": sample_measurements})
         row_cache[cache_key] = row
@@ -4501,6 +4637,13 @@ def drive_loss_boundaries(
             }[seed_policy],
         },
     }
+    if bag_mode:
+        result["replay"] = {
+            "target": target,
+            "bag": bag,
+            "required_topics": list(required_topics) if required_topics is not None else None,
+            "oracle_min_completeness": oracle_min_completeness,
+        }
     boundaries_path = out_dir / "loss-boundaries.json"
     boundaries_path.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     _write_benchmark_result(
@@ -4789,6 +4932,25 @@ def _add_benchmark_common_args(parser: argparse.ArgumentParser, *, ota_benchmark
         help="Override benchmark session QoS depth for the whole run.",
     )
     parser.set_defaults(ota_benchmark=ota_benchmark)
+
+
+def _add_benchmark_replay_args(parser: argparse.ArgumentParser) -> None:
+    """Bag-as-load options: a replay ``--target`` (session/scenario, via the shared
+    ``--target``/``--target-type``) plus its per-topic completeness ground truth."""
+    parser.add_argument(
+        "--bag",
+        help=(
+            "rosbag2 metadata.yaml (or bag dir) giving per-topic message-count ground "
+            "truth for the replay --target. Adds the completeness gate (delivered / "
+            "bag-count) on top of the loss/latency oracle."
+        ),
+    )
+    parser.add_argument(
+        "--oracle-min-completeness",
+        type=float,
+        default=0.95,
+        help="Bag-as-load: min delivered/bag-count per topic to pass (default: 0.95).",
+    )
 
 
 def _abort_on_local_benchmark_conflicts(args: argparse.Namespace) -> None:
@@ -5130,27 +5292,36 @@ def _make_live_run_point(args: argparse.Namespace, session_name: str) -> RunPoin
 
                 return run
 
+            # Replay-as-load: the target session's own contract publishers drive
+            # the link (bag-shaped synthetic payloads via `_start_smoke_topic_publishers`,
+            # both directions), instead of a single `sized_publisher` stream. The
+            # container lifecycle, profile shaping, measurement window and transit
+            # collection below are identical to the synthetic path.
+            replay = bool(getattr(args, "_benchmark_replay_target", None))
             ros_setup_a = _smoke_ros_setup(smoke_instance.config_container_dir, cfg, "a")
+            ros_setup_b = _smoke_ros_setup(smoke_instance.config_container_dir, cfg, "b")
             topics_a = cfg.get("topics", {}).get("a_to_b", [])
-            publisher_streams = _publisher_streams_for_topic_specs(topics_a, load)
+            replay_publisher_duration = int(duration_s + 120.0)
             pub_cmds = []
-            for topic_index, topic_spec in enumerate(topics_a):
-                topic_name = topic_spec.get("topic")
-                publisher_args = " ".join(
-                    shlex.quote(str(part))
-                    for part in _sized_publisher_param_args(topic_name, load, streams=publisher_streams)
-                )
-                log_path = (
-                    "${ROSOTACOM_LOGS_DIR}/a/sized_publisher.log"
-                    if len(topics_a) == 1
-                    else f"${{ROSOTACOM_LOGS_DIR}}/a/sized_publisher_{topic_index}.log"
-                )
-                cmd = (
-                    f"{ros_setup_a} && timeout 300 ros2 run com_py sized_publisher --ros-args "
-                    f"{publisher_args} "
-                    f'> "{log_path}" 2>&1'
-                )
-                pub_cmds.append(cmd)
+            if not replay:
+                publisher_streams = _publisher_streams_for_topic_specs(topics_a, load)
+                for topic_index, topic_spec in enumerate(topics_a):
+                    topic_name = topic_spec.get("topic")
+                    publisher_args = " ".join(
+                        shlex.quote(str(part))
+                        for part in _sized_publisher_param_args(topic_name, load, streams=publisher_streams)
+                    )
+                    log_path = (
+                        "${ROSOTACOM_LOGS_DIR}/a/sized_publisher.log"
+                        if len(topics_a) == 1
+                        else f"${{ROSOTACOM_LOGS_DIR}}/a/sized_publisher_{topic_index}.log"
+                    )
+                    cmd = (
+                        f"{ros_setup_a} && timeout 300 ros2 run com_py sized_publisher --ros-args "
+                        f"{publisher_args} "
+                        f'> "{log_path}" 2>&1'
+                    )
+                    pub_cmds.append(cmd)
 
             a_container: str | None = None
             b_container: str | None = None
@@ -5159,13 +5330,15 @@ def _make_live_run_point(args: argparse.Namespace, session_name: str) -> RunPoin
             measurement_window: tuple[float, float] | None = None
 
             def stop_local_publishers() -> None:
-                if not a_container:
-                    return
-                subprocess.run(
-                    ["docker", "exec", a_container, "pkill", "-f", "sized_publisher"],
-                    capture_output=True,
-                    check=False,
-                )
+                for container in (a_container, b_container) if replay else (a_container,):
+                    if not container:
+                        continue
+                    for pattern in ("sized_publisher", "ros2 topic pub"):
+                        subprocess.run(
+                            ["docker", "exec", container, "pkill", "-f", pattern],
+                            capture_output=True,
+                            check=False,
+                        )
 
             try:
                 from .cli import _smoke_network_labels, _smoke_target_key
@@ -5199,49 +5372,55 @@ def _make_live_run_point(args: argparse.Namespace, session_name: str) -> RunPoin
                     container_tc_overrides[b_container] = install_seeded_tc(b_container)
 
                 # 1. Start the publishers
-                for cmd in pub_cmds:
-                    subprocess.run(
-                        ["docker", "exec", "-d", a_container, "bash", "-c", cmd],
-                        capture_output=True,
-                        text=True,
-                        check=False,
-                    )
+                if replay:
+                    from .cli import _start_smoke_topic_publishers
 
-                # 2. Wait for discovery to complete on unshaped network
-                if not getattr(args, "dry_run", False):
-                    topic_name = topics_a[0].get("topic") if topics_a else "/bench_capacity"
-                    # A. Wait for local subscription discovery
-                    info_cmd = f"{ros_setup_a} && ros2 topic info {shlex.quote(topic_name)}"
-                    for _ in range(30):
-                        res = subprocess.run(
-                            ["docker", "exec", a_container, "bash", "-c", info_cmd],
+                    _start_smoke_topic_publishers(
+                        {"a": a_container, "b": b_container},
+                        {"a": ros_setup_a, "b": ros_setup_b},
+                        cfg,
+                        log_line=print,
+                        duration=float(replay_publisher_duration),
+                    )
+                else:
+                    for cmd in pub_cmds:
+                        subprocess.run(
+                            ["docker", "exec", "-d", a_container, "bash", "-c", cmd],
                             capture_output=True,
                             text=True,
                             check=False,
                         )
-                        output = res.stdout or ""
-                        if "Subscription count: 0" not in output and "Subscription count:" in output:
-                            break
-                        time.sleep(0.5)
 
-                    # B. Wait for end-to-end message delivery to Peer B (status.json reports messages_total > 0)
-                    status_json_path = smoke_instance.host_dir / "logs" / "b" / "status" / "status.json"
+                # 2. Wait for discovery to complete on unshaped network
+                if not getattr(args, "dry_run", False):
+                    default_topic = "/bench_capacity"
+                    topic_name = (topics_a[0].get("topic") if topics_a else default_topic) or default_topic
+                    if not replay:
+                        # A. Wait for local subscription discovery of the single load topic.
+                        info_cmd = f"{ros_setup_a} && ros2 topic info {shlex.quote(topic_name)}"
+                        for _ in range(30):
+                            res = subprocess.run(
+                                ["docker", "exec", a_container, "bash", "-c", info_cmd],
+                                capture_output=True,
+                                text=True,
+                                check=False,
+                            )
+                            output = res.stdout or ""
+                            if "Subscription count: 0" not in output and "Subscription count:" in output:
+                                break
+                            time.sleep(0.5)
+
+                    # B. Wait for end-to-end delivery: the load topic to Peer B in
+                    # synthetic mode, or any contract topic reaching either peer in
+                    # replay mode (topics cross both directions).
+                    status_paths = (
+                        [smoke_instance.host_dir / "logs" / peer / "status" / "status.json" for peer in ("a", "b")]
+                        if replay
+                        else [smoke_instance.host_dir / "logs" / "b" / "status" / "status.json"]
+                    )
                     for _ in range(60):
-                        if status_json_path.is_file():
-                            try:
-                                status_data = json.loads(status_json_path.read_text(encoding="utf-8"))
-                                found_msg = False
-                                for topic_info in status_data.get("topics", []):
-                                    if topic_info.get("base") == topic_name:
-                                        if any(
-                                            stage.get("messages_total", 0) > 0 for stage in topic_info.get("stages", [])
-                                        ):
-                                            found_msg = True
-                                            break
-                                if found_msg:
-                                    break
-                            except Exception:
-                                pass
+                        if _benchmark_delivery_observed(status_paths, base=None if replay else topic_name):
+                            break
                         time.sleep(0.5)
                     time.sleep(3.0)
 
@@ -6780,6 +6959,99 @@ def benchmark_matrix(args: argparse.Namespace) -> int:
     return 0
 
 
+def _session_contract_topics(cfg: dict[str, Any]) -> list[str]:
+    """Every topic a session carries, across all directions — the required set."""
+    names: list[str] = []
+    topics = cfg.get("topics")
+    if isinstance(topics, dict):
+        for entries in topics.values():
+            if not isinstance(entries, list):
+                continue
+            for item in entries:
+                name = item.get("topic") if isinstance(item, dict) else None
+                if isinstance(name, str) and name not in names:
+                    names.append(name)
+    return names
+
+
+@dataclass
+class _BenchmarkReplay:
+    """Bag-as-load inputs: which session runs, the required topics, ground truth."""
+
+    session_name: str
+    required_topics: list[str] | None
+    ground_truth: dict[str, dict[str, Any]] | None
+    target: dict[str, Any] | None
+    bag: dict[str, Any] | None
+    lab_replay: bool
+
+
+def _benchmark_replay_inputs(
+    args: argparse.Namespace, runtime: Any, *, genre_session_name: str
+) -> _BenchmarkReplay | None:
+    """Resolve a ``--target``/``--bag`` replay load, or ``None`` for synthetic load.
+
+    A session ``--target`` supplies the required contract topics (both directions)
+    and, when not an OTA run, switches the live probe to run that session's own
+    publishers in the lab (Docker) — a probe point is then one full replay under
+    the candidate profile. ``--bag`` supplies per-topic completeness ground truth.
+    """
+    target = getattr(args, "target", None)
+    target_type = getattr(args, "target_type", None) or "auto"
+    bag_arg = getattr(args, "bag", None)
+    if not target and not bag_arg:
+        return None
+
+    from .cli import _effective_session_config, _resolve_session
+
+    is_ota = _is_ota_benchmark(args)
+    ground_truth: dict[str, dict[str, Any]] | None = None
+    bag_identity: dict[str, Any] | None = None
+    if bag_arg:
+        from .bag_ground_truth import bag_ground_truth
+
+        ground_truth = bag_ground_truth(bag_arg)
+        bag_identity = {"metadata": str(Path(bag_arg)), "topics": sorted(ground_truth)}
+
+    required_topics: list[str] | None = None
+    target_identity: dict[str, Any] | None = None
+    lab_replay = False
+    session_name = genre_session_name
+    if target:
+        target_identity = {"name": str(target), "type": target_type}
+        session_cfg: dict[str, Any] | None = None
+        if target_type in ("session", "auto"):
+            try:
+                session = _resolve_session(str(target), runtime)
+                session_cfg = _effective_session_config(session.host_dir, runtime)
+            except Exception:
+                session_cfg = None
+        if session_cfg is not None:
+            required_topics = _session_contract_topics(session_cfg) or None
+            target_identity["type"] = "session"
+            if not is_ota:
+                lab_replay = True
+                session_name = str(target)
+                args._benchmark_replay_target = str(target)
+        elif not is_ota:
+            raise ValueError(
+                f"--target {target!r} did not resolve to a session for a local replay benchmark. "
+                "Local (Docker) replay supports two-peer session targets; use ota-benchmark "
+                "for scenarios or real hosts."
+            )
+    elif ground_truth is not None:
+        required_topics = sorted(ground_truth)
+
+    return _BenchmarkReplay(
+        session_name=session_name,
+        required_topics=required_topics,
+        ground_truth=ground_truth,
+        target=target_identity,
+        bag=bag_identity,
+        lab_replay=lab_replay,
+    )
+
+
 def benchmark_requirements(args: argparse.Namespace) -> int:
     """Handler for ``rosotacom benchmark requirements``."""
     from .cli import _load_runtime_config
@@ -6806,10 +7078,15 @@ def benchmark_requirements(args: argparse.Namespace) -> int:
         encoding="utf-8",
     )
     args.profiles_file = str(generated_profiles_file)
-    args.qos_reliability = getattr(args, "qos_reliability", None) or "best_effort"
-    args.qos_depth = int(getattr(args, "qos_depth", None) or 1)
+    replay = _benchmark_replay_inputs(args, runtime, genre_session_name=BENCHMARK_SESSIONS_BY_GENRE["requirements"])
+    if replay is None:
+        # Synthetic load pins the benchmark QoS; a replay keeps its session's own.
+        args.qos_reliability = getattr(args, "qos_reliability", None) or "best_effort"
+        args.qos_depth = int(getattr(args, "qos_depth", None) or 1)
+        session_name = BENCHMARK_SESSIONS_BY_GENRE["requirements"]
+    else:
+        session_name = replay.session_name
 
-    session_name = BENCHMARK_SESSIONS_BY_GENRE["requirements"]
     session_context = _prepare_benchmark_session_config(args, session_name, run_dir)
     result_context = _benchmark_result_context(
         args,
@@ -6821,6 +7098,9 @@ def benchmark_requirements(args: argparse.Namespace) -> int:
     result_context["requirements"] = {
         "generated_profiles_file": str(generated_profiles_file),
     }
+    if replay is not None:
+        result_context["requirements"]["replay_target"] = replay.target
+        result_context["requirements"]["bag"] = replay.bag
 
     rate_hz = float(getattr(args, "rate_hz", 20.0))
     size = int(getattr(args, "size", 18_000))
@@ -6854,8 +7134,8 @@ def benchmark_requirements(args: argparse.Namespace) -> int:
             rate_hz=rate_hz,
             size=size,
             streams=streams,
-            qos_reliability=str(args.qos_reliability),
-            qos_depth=int(args.qos_depth),
+            qos_reliability=str(getattr(args, "qos_reliability", None) or "best_effort"),
+            qos_depth=int(getattr(args, "qos_depth", None) or 1),
             topic=getattr(args, "topic", ""),
             out_dir=run_dir,
             bandwidth_high_bps=bandwidth_high_bps,
@@ -6885,6 +7165,11 @@ def benchmark_requirements(args: argparse.Namespace) -> int:
             result_context=result_context,
             generated_profiles_file=generated_profiles_file,
             profile_prefix=str(getattr(args, "profile_prefix", "requirements")),
+            ground_truth=replay.ground_truth if replay else None,
+            required_topics=replay.required_topics if replay else None,
+            target=replay.target if replay else None,
+            bag=replay.bag if replay else None,
+            oracle_min_completeness=float(getattr(args, "oracle_min_completeness", 0.95)),
         )
 
     out_file_name = getattr(args, "out", "requirements.jsonl")
@@ -6928,10 +7213,14 @@ def benchmark_loss_boundaries(args: argparse.Namespace) -> int:
         encoding="utf-8",
     )
     args.profiles_file = str(generated_profiles_file)
-    args.qos_reliability = getattr(args, "qos_reliability", None) or "best_effort"
-    args.qos_depth = int(getattr(args, "qos_depth", None) or 1)
+    replay = _benchmark_replay_inputs(args, runtime, genre_session_name=BENCHMARK_SESSIONS_BY_GENRE["requirements"])
+    if replay is None:
+        args.qos_reliability = getattr(args, "qos_reliability", None) or "best_effort"
+        args.qos_depth = int(getattr(args, "qos_depth", None) or 1)
+        session_name = BENCHMARK_SESSIONS_BY_GENRE["requirements"]
+    else:
+        session_name = replay.session_name
 
-    session_name = BENCHMARK_SESSIONS_BY_GENRE["requirements"]
     session_context = _prepare_benchmark_session_config(args, session_name, run_dir)
     result_context = _benchmark_result_context(
         args,
@@ -6943,6 +7232,9 @@ def benchmark_loss_boundaries(args: argparse.Namespace) -> int:
     result_context["loss_boundaries"] = {
         "generated_profiles_file": str(generated_profiles_file),
     }
+    if replay is not None:
+        result_context["loss_boundaries"]["replay_target"] = replay.target
+        result_context["loss_boundaries"]["bag"] = replay.bag
 
     rate_hz = float(getattr(args, "rate_hz", 20.0))
     size = int(getattr(args, "size", 18_000))
@@ -6971,8 +7263,8 @@ def benchmark_loss_boundaries(args: argparse.Namespace) -> int:
             rate_hz=rate_hz,
             size=size,
             streams=streams,
-            qos_reliability=str(args.qos_reliability),
-            qos_depth=int(args.qos_depth),
+            qos_reliability=str(getattr(args, "qos_reliability", None) or "best_effort"),
+            qos_depth=int(getattr(args, "qos_depth", None) or 1),
             topic=getattr(args, "topic", ""),
             out_dir=run_dir,
             axes=_parse_loss_boundary_axes(getattr(args, "axes", "all")),
@@ -6996,6 +7288,11 @@ def benchmark_loss_boundaries(args: argparse.Namespace) -> int:
             result_context=result_context,
             generated_profiles_file=generated_profiles_file,
             profile_prefix=str(getattr(args, "profile_prefix", "loss_boundary")),
+            ground_truth=replay.ground_truth if replay else None,
+            required_topics=replay.required_topics if replay else None,
+            target=replay.target if replay else None,
+            bag=replay.bag if replay else None,
+            oracle_min_completeness=float(getattr(args, "oracle_min_completeness", 0.95)),
         )
 
     out_file_name = getattr(args, "out", "loss-boundaries.json")
@@ -7421,6 +7718,7 @@ def _register_benchmark_driver_parsers(benchmark_subparsers: Any, *, ota_benchma
         help="Search for a tight network profile that satisfies a ROS 2 stream quality target.",
     )
     _add_benchmark_common_args(requirements_parser, ota_benchmark=ota_benchmark)
+    _add_benchmark_replay_args(requirements_parser)
     requirements_parser.add_argument("--max-loss", type=float, default=5.0, help="Oracle: max ROS 2 loss %%.")
     requirements_parser.add_argument(
         "--max-latency-ms", type=float, default=250.0, help="Oracle: max acceptable p95 latency (ms)."
@@ -7605,6 +7903,7 @@ def _register_benchmark_driver_parsers(benchmark_subparsers: Any, *, ota_benchma
         help="Find discrete zero-loss good/bad boundaries for bandwidth and jitter.",
     )
     _add_benchmark_common_args(loss_boundaries_parser, ota_benchmark=ota_benchmark)
+    _add_benchmark_replay_args(loss_boundaries_parser)
     loss_boundaries_parser.add_argument(
         "--max-latency-ms",
         type=float,

--- a/tests/e2e/test_benchmark_replay.py
+++ b/tests/e2e/test_benchmark_replay.py
@@ -1,0 +1,151 @@
+"""Docker-backed e2e: benchmark search with a bag-replay session as the load.
+
+Exercises the bag-as-load path end to end — a replay ``--target`` session drives
+the link (its own contract publishers, both directions) under generated candidate
+profiles, and the per-topic oracle judges the whole contract. Runs in the slow
+lane only (``ROSOTACOM_RUN_E2E=1``); the search logic and oracle math are covered
+deterministically by the host tests in ``tests/unit``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[2]
+BENCHMARK_TIMEOUT_S = 900
+SMOKE_NETWORK_NAME = "rosotacom-smoke"
+REPLAY_SESSION = "15_remote_assist_anonymized_costmap"
+CONTRACT_TOPIC = "/topic5"
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.skipif(
+        os.environ.get("ROSOTACOM_RUN_E2E") != "1",
+        reason="Docker-backed E2E tests require ROSOTACOM_RUN_E2E=1.",
+    ),
+]
+
+
+def _cleanup_smoke_network() -> None:
+    inspect = subprocess.run(
+        ["docker", "network", "inspect", SMOKE_NETWORK_NAME, "--format", "{{json .Containers}}"],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if inspect.returncode == 0 and inspect.stdout.strip():
+        try:
+            containers = json.loads(inspect.stdout)
+        except json.JSONDecodeError:
+            containers = {}
+        for container_id in containers:
+            subprocess.run(["docker", "rm", "-f", container_id], text=True, capture_output=True, check=False)
+    subprocess.run(["docker", "network", "rm", SMOKE_NETWORK_NAME], text=True, capture_output=True, check=False)
+
+
+def _run(command: list[str], *, timeout: int) -> subprocess.CompletedProcess[str]:
+    try:
+        result = subprocess.run(
+            command,
+            cwd=PACKAGE_ROOT,
+            text=True,
+            capture_output=True,
+            timeout=timeout,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        _cleanup_smoke_network()
+        raise AssertionError(f"Command timed out after {timeout}s: {' '.join(command)}") from exc
+    if result.returncode != 0:
+        raise AssertionError(
+            f"Command failed with {result.returncode}: {' '.join(command)}\n"
+            f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+        )
+    return result
+
+
+def _benchmark_result_path(stdout: str) -> Path:
+    prefix = "Benchmark result saved to "
+    paths = [Path(line.removeprefix(prefix)) for line in stdout.splitlines() if line.startswith(prefix)]
+    if not paths:
+        raise AssertionError(f"Benchmark output did not report a result.json path.\nSTDOUT:\n{stdout}")
+    return paths[-1]
+
+
+@pytest.fixture(scope="module")
+def copied_example_project(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    project = tmp_path_factory.mktemp("rosotacom") / "examples"
+    _run([sys.executable, "-m", "rosotacom", "examples", "create", str(project)], timeout=60)
+    return project
+
+
+def test_loss_boundaries_against_costmap_replay(copied_example_project: Path) -> None:
+    """✅ loss-boundaries with example 15 (costmap replay) as the load completes."""
+    cmd = [
+        sys.executable,
+        "-m",
+        "rosotacom",
+        "benchmark",
+        "loss-boundaries",
+        "--rosotacom-config",
+        str(copied_example_project / "rosotacom.yaml"),
+        "--target",
+        REPLAY_SESSION,
+        "--target-type",
+        "session",
+        # A tiny iteration budget: one bandwidth pair, one sample each side.
+        "--axes",
+        "bandwidth",
+        "--bandwidth-low",
+        "500kbit",
+        "--bandwidth-high",
+        "2mbit",
+        "--bandwidth-step",
+        "500kbit",
+        "--rate-hz",
+        "10",
+        "--min-duration",
+        "8",
+        "--min-messages",
+        "1",
+        "--probe-repeats",
+        "1",
+        "--good-clean-count",
+        "1",
+        "--bad-lossy-count",
+        "1",
+        "--max-latency-ms",
+        "2000",
+        "--oracle-min-completeness",
+        "0.5",
+        "--drain-s",
+        "2",
+        "--rmw",
+        "cyclone",
+    ]
+    result = _run(cmd, timeout=BENCHMARK_TIMEOUT_S)
+
+    result_path = _benchmark_result_path(result.stdout)
+    assert result_path.is_file(), f"Benchmark result file does not exist: {result_path}"
+    doc = json.loads(result_path.read_text(encoding="utf-8"))
+
+    assert doc["genre"] == "loss-boundaries"
+    # The replay load identity is recorded.
+    replay = doc["result"]["replay"]
+    assert replay["target"]["name"] == REPLAY_SESSION
+    assert replay["target"]["type"] == "session"
+    assert CONTRACT_TOPIC in (replay["required_topics"] or [])
+
+    # The whole-contract oracle ran: every classified row carries per-topic
+    # verdicts, and the costmap contract topic was evaluated.
+    rows = doc["result"]["rows"]
+    assert rows, "loss-boundaries produced no probe rows"
+    evaluated_topics = {
+        entry["topic"] for row in rows for sample in row.get("samples", []) for entry in (sample.get("per_topic") or [])
+    }
+    assert CONTRACT_TOPIC in evaluated_topics, f"contract topic not evaluated; saw {sorted(evaluated_topics)}"

--- a/tests/unit/test_benchmark.py
+++ b/tests/unit/test_benchmark.py
@@ -32,6 +32,7 @@ from rosotacom.benchmark import (
     compare_to_band,
     default_ab_tolerance,
     default_better,
+    evaluate_bag_run,
     exclude_probe_warmup,
     expand_size_pattern,
     find_band,
@@ -1038,3 +1039,158 @@ def test_render_ab_markdown_is_self_describing() -> None:
     assert "`cand` vs `baseline`" in markdown
     assert "| topic | metric |" in markdown
     assert "IMPROVED" in markdown
+
+
+# --- bag-as-load oracle (per-topic replay verdict) ------------------------- #
+
+
+def _topic_summary(
+    *,
+    expected: int,
+    delivered: int,
+    latency_p95: float | None = 60.0,
+    jitter_p95: float = 3.0,
+    reordered: int = 0,
+) -> dict[str, object]:
+    lost = expected - delivered
+    return {
+        "expected": expected,
+        "delivered": delivered,
+        "lost": lost,
+        "reordered": reordered,
+        "loss_pct": round(100.0 * lost / expected, 3) if expected else 0.0,
+        "ota_hop_ms": {"p50": (latency_p95 or 0.0) * 0.6, "p95": latency_p95},
+        "jitter_ms": {"p50": jitter_p95 * 0.5, "p95": jitter_p95},
+    }
+
+
+def test_summary_topic_name_strips_direction_label() -> None:
+    from rosotacom.benchmark import summary_topic_name
+
+    assert summary_topic_name("a->b:/topic5") == "/topic5"
+    assert summary_topic_name("/topic5") == "/topic5"
+
+
+def test_evaluate_bag_run_passes_when_every_contract_topic_clears() -> None:
+    summary = {
+        "topics": {
+            "a->b:/topic5": _topic_summary(expected=100, delivered=100, latency_p95=80.0),
+            "b->a:/topic9": _topic_summary(expected=200, delivered=199, latency_p95=120.0),
+        }
+    }
+    ground_truth = {"/topic5": {"count": 100}, "/topic9": {"count": 200}}
+    verdict = evaluate_bag_run(
+        summary,
+        thresholds=OracleThresholds(max_loss_pct=5.0, max_latency_ms=250.0),
+        ground_truth=ground_truth,
+        min_completeness=0.95,
+    )
+    assert verdict.passes is True
+    assert verdict.failing_topics == ()
+    # Row aggregates: worst-case rate metrics, summed counts.
+    assert verdict.expected == 300
+    assert verdict.delivered == 299
+    assert verdict.latency_p95_ms == 120.0
+    by_topic = {t.topic: t for t in verdict.topics}
+    assert by_topic["/topic9"].completeness == 0.995
+
+
+def test_evaluate_bag_run_fails_and_names_incomplete_topic() -> None:
+    # /topic5 delivers only 80/100 of the bag: within the network-loss bound but
+    # below the completeness floor — the whole run fails and names it.
+    summary = {
+        "topics": {
+            "a->b:/topic5": _topic_summary(expected=100, delivered=80, latency_p95=90.0),
+            "b->a:/topic9": _topic_summary(expected=100, delivered=100, latency_p95=90.0),
+        }
+    }
+    ground_truth = {"/topic5": {"count": 100}, "/topic9": {"count": 100}}
+    verdict = evaluate_bag_run(
+        summary,
+        thresholds=OracleThresholds(max_loss_pct=50.0, max_latency_ms=250.0),
+        ground_truth=ground_truth,
+        min_completeness=0.95,
+    )
+    assert verdict.passes is False
+    assert verdict.failing_topics == ("/topic5",)
+    assert verdict.representative_topic == "/topic5"
+    bad = {t.topic: t for t in verdict.topics}["/topic5"]
+    assert bad.completeness == 0.8
+    assert "incomplete" in bad.reason
+    assert verdict.loss_free is False
+
+
+def test_evaluate_bag_run_latency_bound_fails_a_topic() -> None:
+    summary = {
+        "topics": {
+            "a->b:/topic5": _topic_summary(expected=100, delivered=100, latency_p95=900.0),
+        }
+    }
+    verdict = evaluate_bag_run(
+        summary,
+        thresholds=OracleThresholds(max_loss_pct=5.0, max_latency_ms=250.0),
+        ground_truth={"/topic5": {"count": 100}},
+    )
+    assert verdict.passes is False
+    assert verdict.failing_topics == ("/topic5",)
+    assert "latency" in {t.topic: t for t in verdict.topics}["/topic5"].reason
+    # Zero network loss, so the boundary "loss_free" is still true even though the
+    # oracle fails on latency — the two axes stay separable.
+    assert verdict.loss_free is True
+    assert verdict.latency_ok is False
+
+
+def test_evaluate_bag_run_required_topic_absent_counts_as_lost() -> None:
+    # The contract requires /topic5 and /topic9 but the run delivered only /topic5.
+    summary = {"topics": {"a->b:/topic5": _topic_summary(expected=100, delivered=100)}}
+    verdict = evaluate_bag_run(
+        summary,
+        thresholds=OracleThresholds(max_loss_pct=5.0, max_latency_ms=250.0),
+        ground_truth={"/topic5": {"count": 100}, "/topic9": {"count": 100}},
+        required_topics=["/topic5", "/topic9"],
+    )
+    assert verdict.passes is False
+    assert verdict.failing_topics == ("/topic9",)
+    missing = {t.topic: t for t in verdict.topics}["/topic9"]
+    assert missing.reason == "absent"
+    assert missing.delivered == 0
+    assert missing.lost == 100
+
+
+def test_evaluate_bag_run_without_ground_truth_uses_network_loss_only() -> None:
+    # No bag counts: the completeness gate is skipped, so a fully-delivered,
+    # low-latency contract still passes on loss + latency alone.
+    summary = {
+        "topics": {
+            "a->b:/topic5": _topic_summary(expected=100, delivered=100, latency_p95=70.0),
+            "b->a:/topic9": _topic_summary(expected=50, delivered=50, latency_p95=70.0),
+        }
+    }
+    verdict = evaluate_bag_run(
+        summary,
+        thresholds=OracleThresholds(max_loss_pct=0.0, max_latency_ms=250.0),
+    )
+    assert verdict.passes is True
+    assert verdict.loss_free is True
+    assert all(t.completeness is None for t in verdict.topics)
+
+
+def test_evaluate_bag_run_is_order_independent() -> None:
+    thresholds = OracleThresholds(max_loss_pct=5.0, max_latency_ms=250.0)
+    gt = {"/a": {"count": 100}, "/b": {"count": 100}}
+    forward = {
+        "topics": {
+            "x->y:/a": _topic_summary(expected=100, delivered=100),
+            "y->x:/b": _topic_summary(expected=100, delivered=70),
+        }
+    }
+    reverse = {
+        "topics": {
+            "y->x:/b": _topic_summary(expected=100, delivered=70),
+            "x->y:/a": _topic_summary(expected=100, delivered=100),
+        }
+    }
+    a = evaluate_bag_run(forward, thresholds=thresholds, ground_truth=gt)
+    b = evaluate_bag_run(reverse, thresholds=thresholds, ground_truth=gt)
+    assert a.failing_topics == b.failing_topics == ("/b",)
+    assert a.passes == b.passes is False

--- a/tests/unit/test_cli_benchmark.py
+++ b/tests/unit/test_cli_benchmark.py
@@ -1232,6 +1232,183 @@ def test_loss_boundaries_driver_finds_discrete_good_and_bad_cases(tmp_path: Path
     assert result_doc["result"]["analysis"]["seed_policy"] == "seedless"
 
 
+def test_loss_boundaries_driver_consumes_replay_verdicts_across_topics(tmp_path: Path) -> None:
+    # Bag-as-load: the probe returns a whole replay contract (two topics). The
+    # boundary is driven by the hard stream /topic5; the light /topic9 always
+    # clears. The search logic is unchanged — it consumes the aggregated verdict —
+    # and the failing topic is named on the bad rows.
+    from rosotacom.network_profiles import parse_ms, parse_rate_bps
+
+    generated_file = tmp_path / "generated-profiles.yaml"
+    candidate_counts: dict[tuple[int, int], int] = {}
+
+    def probe(*, profile: str | None, load: dict[str, Any], duration_s: float, out_dir: Path) -> dict[str, Any]:
+        assert profile is not None
+        spec = yaml.safe_load(generated_file.read_text(encoding="utf-8"))["profiles"][profile]["uplink"]
+        bandwidth = parse_rate_bps(spec["rate"])
+        jitter = parse_ms(spec.get("jitter", 0), "jitter")
+        key = (int(round(bandwidth / 100_000.0)), int(round(jitter)))
+        sample_index = candidate_counts.get(key, 0) + 1
+        candidate_counts[key] = sample_index
+        if bandwidth < 3_200_000.0:
+            lossy = True
+        elif jitter <= 18.0:
+            lossy = False
+        elif jitter >= 27.0:
+            lossy = True
+        else:
+            lossy = sample_index % 2 == 0
+        lost = 3 if lossy else 0
+        latency_p95 = 35.0 + jitter
+        return {
+            "topics": {
+                "a->b:/topic5": {
+                    "expected": 400,
+                    "delivered": 400 - lost,
+                    "lost": lost,
+                    "loss_pct": lost / 400 * 100.0,
+                    "reordered": 0,
+                    "ota_hop_ms": {"p50": latency_p95 * 0.6, "p95": latency_p95},
+                    "jitter_ms": {"p50": jitter * 0.5, "p95": jitter},
+                },
+                "b->a:/topic9": {
+                    "expected": 200,
+                    "delivered": 200,
+                    "lost": 0,
+                    "loss_pct": 0.0,
+                    "reordered": 0,
+                    "ota_hop_ms": {"p50": 20.0, "p95": 40.0},
+                    "jitter_ms": {"p50": 1.0, "p95": 2.0},
+                },
+            }
+        }
+
+    result = drive_loss_boundaries(
+        probe,
+        max_latency_ms=250.0,
+        rate_hz=20.0,
+        size=18_000,
+        streams=1,
+        qos_reliability="best_effort",
+        qos_depth=1,
+        topic="",
+        out_dir=tmp_path,
+        axes=_parse_loss_boundary_axes("bandwidth"),
+        bandwidth_low_bps=3_000_000.0,
+        bandwidth_high_bps=4_000_000.0,
+        bandwidth_step_bps=100_000.0,
+        latency_base_ms=30.0,
+        jitter_low_ms=0.0,
+        jitter_high_ms=30.0,
+        jitter_step_ms=1.0,
+        min_duration_s=20.0,
+        min_messages=100,
+        distribution="normal",
+        downlink_mode="lan",
+        probe_repeats=10,
+        good_clean_count=10,
+        bad_lossy_count=10,
+        result_context={"test": True},
+        generated_profiles_file=generated_file,
+        ground_truth={"/topic5": {"count": 400}, "/topic9": {"count": 200}},
+        required_topics=["/topic5", "/topic9"],
+        target={"name": "15_remote_assist_anonymized_costmap", "type": "session"},
+        bag={"metadata": "bags/costmap/metadata.yaml"},
+    )
+
+    bandwidth_boundary = result["boundaries"]["bandwidth"]
+    assert bandwidth_boundary["good_boundary"]["candidate"]["bandwidth_bps"] == pytest.approx(3_200_000.0)
+    assert bandwidth_boundary["bad_boundary"]["candidate"]["bandwidth_bps"] == pytest.approx(3_100_000.0)
+    # The whole-contract verdict is driven by the hard topic, named on the bad row.
+    bad_row = next(row for row in result["rows"] if row["classification"] == "bad")
+    assert bad_row["failing_topics"] == ["/topic5"]
+    assert bad_row["samples"][0]["per_topic"][0]["topic"] in {"/topic5", "/topic9"}
+    # Replay identity is recorded in the result.
+    result_doc = json.loads((tmp_path / BENCHMARK_RESULT_FILE).read_text(encoding="utf-8"))
+    assert result_doc["result"]["replay"]["target"]["name"] == "15_remote_assist_anonymized_costmap"
+    assert result_doc["result"]["replay"]["bag"]["metadata"].endswith("metadata.yaml")
+
+
+def test_requirements_driver_consumes_replay_verdicts_with_completeness_floor(tmp_path: Path) -> None:
+    # A tight profile must carry the whole contract: /topic5 needs bandwidth, and
+    # /topic9 is incomplete below 2 Mbit/s. The search reuses the requirements
+    # logic against the aggregated per-topic verdict.
+    from rosotacom.network_profiles import parse_rate_bps
+
+    generated_file = tmp_path / "generated-profiles.yaml"
+
+    def probe(*, profile: str | None, load: dict[str, Any], duration_s: float, out_dir: Path) -> dict[str, Any]:
+        assert profile is not None
+        spec = yaml.safe_load(generated_file.read_text(encoding="utf-8"))["profiles"][profile]["uplink"]
+        bandwidth = parse_rate_bps(spec["rate"])
+        topic5_lost = max(0, int(round((4_000_000.0 - bandwidth) / 1_000_000.0 * 4.0)))
+        topic9_delivered = 200 if bandwidth >= 2_000_000.0 else 150
+        return {
+            "topics": {
+                "a->b:/topic5": {
+                    "expected": 400,
+                    "delivered": 400 - topic5_lost,
+                    "lost": topic5_lost,
+                    "loss_pct": topic5_lost / 400 * 100.0,
+                    "reordered": 0,
+                    "ota_hop_ms": {"p50": 40.0, "p95": 80.0},
+                    "jitter_ms": {"p50": 1.0, "p95": 2.0},
+                },
+                "b->a:/topic9": {
+                    "expected": topic9_delivered,
+                    "delivered": topic9_delivered,
+                    "lost": 0,
+                    "loss_pct": 0.0,
+                    "reordered": 0,
+                    "ota_hop_ms": {"p50": 20.0, "p95": 40.0},
+                    "jitter_ms": {"p50": 1.0, "p95": 2.0},
+                },
+            }
+        }
+
+    result = drive_requirements(
+        probe,
+        max_loss_pct=5.0,
+        max_latency_ms=250.0,
+        rate_hz=20.0,
+        size=18_000,
+        streams=1,
+        qos_reliability="best_effort",
+        qos_depth=1,
+        topic="",
+        out_dir=tmp_path,
+        bandwidth_high_bps=10_000_000.0,
+        bandwidth_low_bps=1_000_000.0,
+        latency_base_ms=0.0,
+        latency_high_ms=300.0,
+        jitter_high_ms=60.0,
+        loss_high_pct=10.0,
+        axes=_parse_requirements_axes("bandwidth"),
+        min_duration_s=20.0,
+        min_messages=100,
+        search_iterations=6,
+        search_rounds=1,
+        distribution="normal",
+        final_refine_iterations=0,
+        loss_coupling="independent",
+        result_context={"test": True},
+        generated_profiles_file=generated_file,
+        ground_truth={"/topic5": {"count": 400}, "/topic9": {"count": 200}},
+        required_topics=["/topic5", "/topic9"],
+        oracle_min_completeness=0.95,
+        target={"name": "15_remote_assist_anonymized_costmap", "type": "session"},
+        bag={"metadata": "bags/costmap/metadata.yaml"},
+    )
+
+    # Passing requires both topics: /topic5 loss-bounded AND /topic9 complete
+    # (>=190/200), so the tight bandwidth sits at/above the 2 Mbit/s completeness knee.
+    assert result["analysis"]["final_passes"] is True
+    assert result["profile"]["candidate"]["bandwidth_bps"] >= 2_000_000.0
+    result_doc = json.loads((tmp_path / BENCHMARK_RESULT_FILE).read_text(encoding="utf-8"))
+    assert result_doc["result"]["replay"]["required_topics"] == ["/topic5", "/topic9"]
+    assert result_doc["result"]["replay"]["oracle_min_completeness"] == 0.95
+
+
 def test_requirements_zero_loss_target_reports_loss_as_limiter() -> None:
     quality = _requirements_target_quality(
         {"loss_pct": 0.25, "latency_p95_ms": 10.0},


### PR DESCRIPTION
Closes #188. Extends the `requirements`/`loss-boundaries` benchmark search
drivers to take a **bag replay** (a real session/scenario) as the load instead
of the synthetic `sized_publisher` stream — answering the closed-loop vision
question *"which network conditions could carry this bag?"*.

## What changed

- **Pure per-topic oracle** — `benchmark.evaluate_bag_run`: each carried contract
  topic must clear the loss + latency bound and, when `--bag` supplies a rosbag2
  `metadata.yaml`, a completeness floor (`delivered / bag-count ≥
  --oracle-min-completeness`). Aggregated to a whole-contract run verdict that
  names the failing topics. Absent required topic = fully lost. Fully host-tested.
- **Driver wiring** — both drivers consume the aggregated verdict through one
  shared helper (`_probe_sample_verdict`); the synthetic single-topic path is
  byte-for-byte unchanged, so existing tests/e2e are untouched. Rows/samples gain
  `per_topic` verdicts + `failing_topics`.
- **Load source / execution** — `--target <session>` selects the replay (reusing
  the existing `--target`/`--target-type`). Local (Docker) runs drive the target
  session's own contract publishers (both directions) via the smoke publisher
  synthesis under each candidate profile; OTA reuses the target session/scenario.
  `--bag` / `--oracle-min-completeness` add the completeness gate.
- **Results** — `result.json` records the replay identity under `result.replay`
  (target + bag + required topics) and per-topic verdicts.
- **Docs** — `docs/benchmark-bag-as-load.md` (linked from the README benchmark
  section); RFC 0005 implementation + validation checklists updated.

## Validation

- `tests/unit/test_benchmark.py::test_evaluate_bag_run_*` — the per-topic oracle
  (whole-contract pass/fail, completeness floor, latency bound, absent topic,
  order independence).
- `tests/unit/test_cli_benchmark.py::test_{loss_boundaries,requirements}_driver_consumes_replay_verdicts_*`
  — both search drivers against a stubbed multi-topic probe runner.
- `tests/e2e/test_benchmark_replay.py` — Docker-backed slow lane
  (`ROSOTACOM_RUN_E2E=1`, runs in nightly `test-e2e-smoke`): `loss-boundaries`
  against packaged example 15 (costmap) completes and writes a result with the
  replay identity + per-topic verdicts for `/topic5`.
- `just test` (562 unit+contract passed), `ruff check`, `ruff format --check`,
  `mypy` all clean locally.

## Owner smoke

Run the costmap replay (example 15) through `loss-boundaries` with a one-pair
budget, on existing packaged material — no new drive needed:

```bash
rosotacom benchmark loss-boundaries \
  --target 15_remote_assist_anonymized_costmap --target-type session \
  --axes bandwidth --bandwidth-low 0.5mbit --bandwidth-high 2mbit --bandwidth-step 0.5mbit \
  --rate-hz 10 --min-duration 20 --min-messages 1 \
  --probe-repeats 1 --good-clean-count 1 --bad-lossy-count 1 --max-latency-ms 1000
```

Expected: prints `Benchmark result saved to …/result.json`; that file has
`genre: "loss-boundaries"`, `result.replay.target.name ==
15_remote_assist_anonymized_costmap`, and per-topic verdicts for `/topic5` on
every probe row.

Tracks harness issue go914/rosotacom_test#21.
