### PR TITLE
Fix nightly: green the synthetic-camera video-quality e2e

### DIFF
--- a/src/rosotacom/cli.py
+++ b/src/rosotacom/cli.py
@@ -5641,15 +5641,26 @@ def _content_integrity_specs(cfg: dict[str, Any], receiver_peer_key: str) -> lis
 
 
 def _smoke_sensor_image_message() -> str:
+    # A smooth low-frequency gradient stands in for a real camera frame. It
+    # survives the ffmpeg path's rgb8 -> yuv420p chroma subsampling and h264
+    # quantization with a comfortable PSNR/SSIM margin, so the synthetic-camera
+    # quality gate measures a realistic frame -- a high-frequency pattern would
+    # be blurred by the codec below any sane quality bar.
     width = 32
     height = 32
     data: list[str] = []
     for y in range(height):
         for x in range(width):
-            base = (x * 7 + y * 13) % 256
-            data.extend((str(base), str((base + 53) % 256), str((base + 101) % 256)))
+            r = (x * 255) // (width - 1)
+            g = (y * 255) // (height - 1)
+            b = ((x + y) * 255) // (width + height - 2)
+            data.extend((str(r), str(g), str(b)))
+    # `stamp: now` makes `ros2 topic pub` stamp each frame with the current time
+    # (re-evaluated per publish), like a real camera. Without it the stamp is
+    # epoch 0, the monitor guards the absurd age to "no header", and any
+    # latency_ms expect on the ffmpeg-decoded frame is unsatisfiable.
     return (
-        "{header: {frame_id: camera}, "
+        "{header: {stamp: now, frame_id: camera}, "
         f"height: {height}, width: {width}, encoding: rgb8, is_bigendian: false, step: {width * 3}, "
         "data: [" + ", ".join(data) + "]}"
     )

--- a/src/rosotacom/resources/examples/ros2docker.json
+++ b/src/rosotacom/resources/examples/ros2docker.json
@@ -27,7 +27,7 @@
     "BASE_IMAGE": "osrf/ros:kilted-desktop-full-noble",
     "DIGEST": "@sha256:29eb6f48bb06549aba004a7a4b12c00ece23b156731df12cf1f3c1ae1b0fd178",
     "INSTALL_ZENOH":                 "1",
-    "APT_PACKAGES":                  "iputils-ping psmisc net-tools snmp iw nload iftop iproute2 tshark ros-kilted-domain-bridge ros-kilted-rmw-cyclonedds-cpp ros-kilted-rmw-zenoh-cpp ros-kilted-ffmpeg-image-transport-msgs",
+    "APT_PACKAGES":                  "iputils-ping psmisc net-tools snmp iw nload iftop iproute2 tshark ros-kilted-domain-bridge ros-kilted-rmw-cyclonedds-cpp ros-kilted-rmw-zenoh-cpp ros-kilted-ffmpeg-image-transport ros-kilted-ffmpeg-image-transport-msgs",
     "PIP_PACKAGES":                  "numpy>=1.26,<2 lz4 pysnmp speedtest-cli psutil zstandard opencv-python"
   }
 }

--- a/src/rosotacom/resources/ros2docker.json.example
+++ b/src/rosotacom/resources/ros2docker.json.example
@@ -27,7 +27,7 @@
     "BASE_IMAGE":                    "osrf/ros:kilted-desktop-full-noble",
     "DIGEST":                        "@sha256:29eb6f48bb06549aba004a7a4b12c00ece23b156731df12cf1f3c1ae1b0fd178",
     "INSTALL_ZENOH":                 "1",
-    "APT_PACKAGES":                  "iputils-ping psmisc net-tools snmp iw nload iftop iproute2 tshark ros-kilted-domain-bridge ros-kilted-rmw-cyclonedds-cpp ros-kilted-rmw-zenoh-cpp ros-kilted-ffmpeg-image-transport-msgs",
+    "APT_PACKAGES":                  "iputils-ping psmisc net-tools snmp iw nload iftop iproute2 tshark ros-kilted-domain-bridge ros-kilted-rmw-cyclonedds-cpp ros-kilted-rmw-zenoh-cpp ros-kilted-ffmpeg-image-transport ros-kilted-ffmpeg-image-transport-msgs",
     "PIP_PACKAGES":                  "numpy>=1.26,<2 lz4 pysnmp speedtest-cli psutil zstandard opencv-python"
   }
 }

--- a/src/rosotacom/video_quality.py
+++ b/src/rosotacom/video_quality.py
@@ -1,8 +1,9 @@
 """Offline image-quality metrics for decoded camera frames.
 
-The command layer accepts rosbag2 stage bags and simple JSON frame manifests.
-Metric math is intentionally independent of ROS so unit tests can cover the
-alignment and loss semantics without a runtime container.
+The command layer accepts rosbag2 stage bags (including a bare or unfinalized
+`.mcap` a killed recorder leaves behind) and simple JSON frame manifests. Metric
+math is intentionally independent of ROS so unit tests can cover the alignment
+and loss semantics without a runtime container.
 """
 
 from __future__ import annotations
@@ -284,16 +285,23 @@ def _topic_type(metadata: dict[str, Any], topic: str) -> str | None:
     return None
 
 
-def _require_supported_image_topic(metadata: dict[str, Any], topic: str) -> str:
-    msg_type = _topic_type(metadata, topic)
+def _require_supported_image_type(msg_type: str | None, topic: str, *, absent: str) -> str:
     if msg_type is None:
-        raise ValueError(f"topic {topic!r} is not present in bag metadata")
+        raise ValueError(absent)
     if msg_type not in SUPPORTED_IMAGE_TOPIC_TYPES:
         raise ValueError(
             f"topic {topic!r} has type {msg_type!r}; PSNR/SSIM requires {SENSOR_IMAGE_TYPE} "
             f"or JPEG/PNG {SENSOR_COMPRESSED_IMAGE_TYPE} frames"
         )
     return msg_type
+
+
+def _require_supported_image_topic(metadata: dict[str, Any], topic: str) -> str:
+    return _require_supported_image_type(
+        _topic_type(metadata, topic),
+        topic,
+        absent=f"topic {topic!r} is not present in bag metadata",
+    )
 
 
 def _parse_image_frame_cdr(
@@ -369,6 +377,70 @@ def read_rosbag_frames(path: str | Path, topic: str) -> list[VideoFrame]:
     if storage_id == "mcap":
         return _read_mcap_bag(bag_path, metadata, topic)
     raise ValueError(f"unsupported rosbag2 storage_identifier {storage_id!r}; expected sqlite3 or mcap")
+
+
+def _stage_mcap_files(path: Path) -> list[Path]:
+    """The `.mcap` split(s) of a metric stage bag, addressed as a bare file or a
+    directory that lacks a finalized `metadata.yaml` (e.g. a recorder killed at
+    session teardown)."""
+    if path.is_file() and path.suffix == ".mcap":
+        return [path]
+    if path.is_dir():
+        return sorted(p for p in path.glob("*.mcap") if p.is_file())
+    return []
+
+
+def read_mcap_stage_frames(path: str | Path, topic: str) -> list[VideoFrame]:
+    """Read image frames from a metric stage `.mcap` that has no rosbag2
+    `metadata.yaml`. rosbag2 writes `metadata.yaml` and the mcap summary/footer
+    only on clean shutdown; the metric recorder runs inside a container that is
+    torn down abruptly, so stage bags routinely arrive truncated. mcap is
+    self-describing, so the message type comes from the file's own Schema records
+    and a truncated tail is tolerated (the recorded prefix is kept)."""
+    try:
+        from mcap.exceptions import McapError
+        from mcap.records import Channel, Message, Schema
+        from mcap.stream_reader import StreamReader
+    except ImportError:
+        raise RuntimeError(
+            "mcap support requires the Python package `mcap`; reinstall rosotacom or install mcap"
+        ) from None
+
+    stage_path = Path(path)
+    schemas: dict[int, str] = {}
+    channels: dict[int, tuple[str, int]] = {}
+    rows: list[tuple[int, int, bytes]] = []
+    for mcap_path in _stage_mcap_files(stage_path):
+        with mcap_path.open("rb") as fp:
+            records = iter(StreamReader(fp).records)
+            while True:
+                try:
+                    record = next(records)
+                except StopIteration:
+                    break
+                except (struct.error, EOFError, McapError):
+                    # Unfinalized tail: keep what was decoded before the cut.
+                    break
+                if isinstance(record, Schema):
+                    schemas[record.id] = record.name
+                elif isinstance(record, Channel):
+                    channels[record.id] = (record.topic, record.schema_id)
+                elif isinstance(record, Message):
+                    channel = channels.get(record.channel_id)
+                    if channel is not None and channel[0] == topic:
+                        rows.append((int(record.log_time), channel[1], bytes(record.data)))
+    if not rows:
+        raise ValueError(f"topic {topic!r} has no messages in mcap stage bag {stage_path}")
+    msg_type = _require_supported_image_type(
+        schemas.get(rows[0][1]),
+        topic,
+        absent=f"topic {topic!r} has no schema in mcap stage bag {stage_path}",
+    )
+    rows.sort(key=lambda row: row[0])
+    return [
+        _parse_image_frame_cdr(msg_type, data, index=index, recorded_time_ns=timestamp, source=f"{stage_path}:{topic}")
+        for index, (timestamp, _schema_id, data) in enumerate(rows)
+    ]
 
 
 def _read_pnm(path: Path) -> tuple[int, int, str, int, bytes]:
@@ -463,6 +535,10 @@ def load_frames(path: str | Path, *, topic: str | None = None) -> list[VideoFram
         if not topic:
             raise ValueError("--topic is required when reading rosbag2 inputs")
         return read_rosbag_frames(frame_path, topic)
+    if _stage_mcap_files(frame_path):
+        if not topic:
+            raise ValueError("--topic is required when reading .mcap stage bags")
+        return read_mcap_stage_frames(frame_path, topic)
     return read_frame_manifest(frame_path)
 
 

--- a/tests/contract/test_packaged_resources.py
+++ b/tests/contract/test_packaged_resources.py
@@ -91,6 +91,10 @@ def test_default_ros2docker_config_pins_supported_kilted_noble_image() -> None:
         assert "ros-kilted-domain-bridge" in apt_packages
         assert "ros-kilted-rmw-cyclonedds-cpp" in apt_packages
         assert "ros-kilted-rmw-zenoh-cpp" in apt_packages
+        # The ffmpeg encoder plugin (image_transport/ffmpeg_pub) is what the
+        # synthetic-camera-quality session needs to produce /camera/image/ffmpeg;
+        # the -msgs package alone only provides FFMPEGPacket definitions.
+        assert "ros-kilted-ffmpeg-image-transport" in apt_packages
         assert "ros-kilted-ffmpeg-image-transport-msgs" in apt_packages
 
 

--- a/tests/unit/test_video_quality.py
+++ b/tests/unit/test_video_quality.py
@@ -12,10 +12,12 @@ import yaml
 from rosotacom.video_quality import (
     VideoFrame,
     compare_frame_sequences,
+    load_frames,
     parse_sensor_compressed_image_cdr,
     parse_sensor_image_cdr,
     psnr_db,
     read_frame_manifest,
+    read_mcap_stage_frames,
     read_rosbag_frames,
     ssim,
     threshold_failures,
@@ -283,6 +285,57 @@ def test_sqlite_rosbag_reader_loads_compressed_image_topic(tmp_path: Path) -> No
     assert frames[0].encoding == "rgb8"
     assert frames[0].data == pixels
     assert frames[0].recorded_time_ns == 456
+
+
+def _write_stage_mcap(path: Path, topic: str, cdrs: list[bytes], *, finalize: bool = True) -> None:
+    """Write a metric-stage `.mcap` the way `ros2 bag record -s mcap` does. With
+    finalize=False the summary/footer are omitted -- the shape a recorder killed
+    at session teardown leaves behind."""
+    from mcap.writer import Writer
+
+    with path.open("wb") as handle:
+        writer = Writer(handle, use_chunking=False)
+        writer.start()
+        schema_id = writer.register_schema(name="sensor_msgs/msg/Image", encoding="ros2msg", data=b"")
+        channel_id = writer.register_channel(topic=topic, message_encoding="cdr", schema_id=schema_id)
+        for index, cdr in enumerate(cdrs):
+            writer.add_message(channel_id=channel_id, log_time=1000 + index, data=cdr, publish_time=1000 + index)
+        if finalize:
+            writer.finish()
+
+
+def test_mcap_stage_reader_reads_bare_file_and_directory(tmp_path: Path) -> None:
+    cdrs = [_image_cdr(width=2, height=2, encoding="mono8", data=bytes([i, i + 1, i + 2, i + 3])) for i in range(3)]
+    mcap_path = tmp_path / "stages_x" / "stages_x_0.mcap"
+    mcap_path.parent.mkdir()
+    _write_stage_mcap(mcap_path, "/camera/image", cdrs)
+
+    # A bare .mcap path and the enclosing rosbag2 directory (no metadata.yaml)
+    # both resolve, and `load_frames` dispatches to the stage reader for each.
+    for target in (mcap_path, mcap_path.parent):
+        frames = read_mcap_stage_frames(target, "/camera/image")
+        assert [f.data for f in frames] == [bytes([i, i + 1, i + 2, i + 3]) for i in range(3)]
+        assert [f.recorded_time_ns for f in frames] == [1000, 1001, 1002]
+        assert load_frames(target, topic="/camera/image") == frames
+
+
+def test_mcap_stage_reader_tolerates_unfinalized_tail(tmp_path: Path) -> None:
+    cdrs = [_image_cdr(width=2, height=2, encoding="mono8", data=bytes([i, i, i, i])) for i in range(4)]
+    mcap_path = tmp_path / "stages_x_0.mcap"
+    _write_stage_mcap(mcap_path, "/camera/image", cdrs, finalize=False)
+
+    # No summary/footer, so the index-based rosbag reader cannot open it; the
+    # streaming stage reader still recovers the recorded frames.
+    frames = read_mcap_stage_frames(mcap_path, "/camera/image")
+    assert [bytes(f.data) for f in frames] == [bytes([i, i, i, i]) for i in range(4)]
+
+
+def test_mcap_stage_reader_rejects_unknown_topic(tmp_path: Path) -> None:
+    mcap_path = tmp_path / "stages_x_0.mcap"
+    _write_stage_mcap(mcap_path, "/camera/image", [_image_cdr(width=2, height=2, encoding="mono8", data=bytes(4))])
+
+    with pytest.raises(ValueError, match="no messages"):
+        read_mcap_stage_frames(mcap_path, "/camera/image/missing")
 
 
 def test_frame_manifest_and_synthetic_pair_are_comparable(tmp_path: Path) -> None:


### PR DESCRIPTION
## Problem

The Nightly E2E `smoke-e2e` lane has failed since 2026-07-08 (e.g. [run 28998730863](https://github.com/develNor/ros_communication_devcontainer/actions/runs/28998730863)). The failing test is `test_video_quality_e2e.py::test_synthetic_camera_pipeline_records_quality_metrics` (session `17_synthetic_camera_quality`), which landed 2026-07-08 and **never** passed a nightly — the video-quality e2e runs only in the nightly, so its PR gate never exercised it, and it was merged with four stacked defects.

Fixes #190.

## Root causes and fixes

1. **ffmpeg encoder plugin missing.** The ffmpeg `republish` node on peer `b` crashed with `pluginlib::LibraryLoadException` — `image_transport/ffmpeg_pub` does not exist. The image installed only `ros-kilted-ffmpeg-image-transport-msgs` (message defs), not the plugin. → add `ros-kilted-ffmpeg-image-transport` to `APT_PACKAGES` (example + template configs), asserted by the packaged-resources contract so the PR gate catches a regression, not just the nightly.

2. **Synthetic frame stamp = epoch 0.** `/camera/image` was published with `header.stamp` unset, so the monitor guarded the absurd age to "no header" and the session's `latency_ms:{max:1000}` expect could never pass. → publish `stamp: now` so `ros2 topic pub` re-stamps each frame like a real camera.

3. **Unreadable metric stage bags.** The stage bags are `ros2 bag record -s mcap` recordings inside a container torn down abruptly, so they arrive with no `metadata.yaml`/mcap summary; `videoquality` treated the directory as a JSON manifest (`Is a directory`). → add a tolerant streaming reader that reads a bare/unfinalized stage `.mcap`, taking the type from the file's own Schema records and keeping the recorded prefix past a truncated tail. Covered by new offline unit tests.

4. **PSNR below the gate.** The old high-frequency pattern decoded at ~18 dB (< 20 dB bar). → use a smooth gradient that survives rgb8→yuv420p + h264 with margin.

## Validation

- `just test-e2e-smoke` session 17 now passes end-to-end locally: `VIDEOQUALITY OK`, **mean PSNR ~39 dB, SSIM ~0.999, loss ~17%** (budget 30%).
- Plugin package verified to install and declare `ffmpeg_pub` in the pinned base image `osrf/ros:kilted-desktop-full-noble`.
- `just test-unit` / `test-contract` green (565 passed), incl. new stage-bag reader tests; ruff + mypy clean.

## Owner smoke

Run the failing lane on existing material and watch it go green:

```
just setup && just test-e2e-smoke
```

Expected: `test_synthetic_camera_pipeline_records_quality_metrics` passes and the run prints `VIDEOQUALITY OK` with mean PSNR well above 20 dB.