### PR TITLE
Bump the ros2docker pin to 0.1.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The ROS Communication DevContainer is a Docker-based solution designed to stream
 - Git for configuration management
 - Python 3 with virtual environment support (`python3-venv` on Debian/Ubuntu;
   for versioned Python packages this may be named like `python3.14-venv`)
-- `ros2docker` v0.1.3 or newer. The local installer below installs the pinned
+- `ros2docker` v0.1.4 or newer. The local installer below installs the pinned
   supported range into this checkout's virtual environment.
 - `tmux` for the optional `rosotacom scenario` orchestration commands
 - Machines connected to the same network (VPN or local WLAN)

--- a/install.sh
+++ b/install.sh
@@ -9,13 +9,13 @@ set -euo pipefail
 #
 # Optional env vars:
 #   VENV_DIR=.venv
-#   ROS2DOCKER_SPEC='ros2docker==0.1.3'
+#   ROS2DOCKER_SPEC='ros2docker==0.1.4'
 #   BIN_DIR=~/.local/bin
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$SCRIPT_DIR"
 VENV_DIR="${VENV_DIR:-"$ROOT_DIR/.venv"}"
-ROS2DOCKER_SPEC="${ROS2DOCKER_SPEC:-"ros2docker==0.1.3"}"
+ROS2DOCKER_SPEC="${ROS2DOCKER_SPEC:-"ros2docker==0.1.4"}"
 BIN_DIR="${BIN_DIR:-"$HOME/.local/bin"}"
 
 INSTALL_GLOBAL_SYMLINKS=false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
   "mcap>=1.4,<2",
   "Pillow>=10,<13",
   "PyYAML>=6",
-  "ros2docker>=0.1.3,<0.2",
+  "ros2docker>=0.1.4,<0.2",
 ]
 classifiers = [
   "Development Status :: 3 - Alpha",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-ros2docker==0.1.3
+ros2docker==0.1.4

--- a/src/rosotacom/cli.py
+++ b/src/rosotacom/cli.py
@@ -1631,7 +1631,7 @@ def _ota_packaged_source_bundle(destination: Path) -> Path:
                 'name = "rosotacom"',
                 f'version = "{__version__}"',
                 'requires-python = ">=3.10"',
-                'dependencies = ["argcomplete>=3.6,<4", "PyYAML>=6", "ros2docker>=0.1.3,<0.2"]',
+                'dependencies = ["argcomplete>=3.6,<4", "PyYAML>=6", "ros2docker>=0.1.4,<0.2"]',
                 "",
                 "[project.scripts]",
                 'rosotacom = "rosotacom.cli:main"',


### PR DESCRIPTION
Fixes #192.

`ros2docker` v0.1.4 is published (develNor/ros2docker#164), cut at the same main this project's 0.1.3 pin had been trailing by 15 commits. Machines installing ros2docker from a checkout were getting `0.1.4.dev15` while this repository pinned `0.1.3`; the pin now names the released version again.

Behaviour-neutral here: the only source changes between 0.1.3 and 0.1.4 are an `init`-scaffolding path (`ws/src` -> `ws/ros2src`, which rosotacom does not call) and the removal of an unused private config helper.

## Validation

```
./install.sh
.venv/bin/python -c 'import importlib.metadata as m; print(m.version("ros2docker"))'
# -> 0.1.4
```

Downstream, the FZI harness runs the four-container fleet end-to-end scenario against this checkout; that run is reported on the harness side once this merges.