### PR TITLE
Install the packages the session templates invoke

### DIFF
--- a/src/rosotacom/resources/examples/ros2docker.json
+++ b/src/rosotacom/resources/examples/ros2docker.json
@@ -27,7 +27,7 @@
     "BASE_IMAGE": "osrf/ros:kilted-desktop-full-noble",
     "DIGEST": "@sha256:29eb6f48bb06549aba004a7a4b12c00ece23b156731df12cf1f3c1ae1b0fd178",
     "INSTALL_ZENOH":                 "1",
-    "APT_PACKAGES":                  "iputils-ping psmisc net-tools snmp iw nload iftop iproute2 tshark ros-kilted-domain-bridge ros-kilted-rmw-cyclonedds-cpp ros-kilted-rmw-zenoh-cpp ros-kilted-ffmpeg-image-transport ros-kilted-ffmpeg-image-transport-msgs",
+    "APT_PACKAGES":                  "iputils-ping psmisc net-tools snmp iw nload iftop iproute2 tshark ros-kilted-domain-bridge ros-kilted-rmw-cyclonedds-cpp ros-kilted-rmw-zenoh-cpp ros-kilted-topic-tools ros-kilted-image-transport ros-kilted-ffmpeg-image-transport ros-kilted-ffmpeg-image-transport-msgs",
     "PIP_PACKAGES":                  "numpy>=1.26,<2 lz4 pysnmp speedtest-cli psutil zstandard opencv-python"
   }
 }

--- a/src/rosotacom/resources/ros2docker.json.example
+++ b/src/rosotacom/resources/ros2docker.json.example
@@ -27,7 +27,7 @@
     "BASE_IMAGE":                    "osrf/ros:kilted-desktop-full-noble",
     "DIGEST":                        "@sha256:29eb6f48bb06549aba004a7a4b12c00ece23b156731df12cf1f3c1ae1b0fd178",
     "INSTALL_ZENOH":                 "1",
-    "APT_PACKAGES":                  "iputils-ping psmisc net-tools snmp iw nload iftop iproute2 tshark ros-kilted-domain-bridge ros-kilted-rmw-cyclonedds-cpp ros-kilted-rmw-zenoh-cpp ros-kilted-ffmpeg-image-transport ros-kilted-ffmpeg-image-transport-msgs",
+    "APT_PACKAGES":                  "iputils-ping psmisc net-tools snmp iw nload iftop iproute2 tshark ros-kilted-domain-bridge ros-kilted-rmw-cyclonedds-cpp ros-kilted-rmw-zenoh-cpp ros-kilted-topic-tools ros-kilted-image-transport ros-kilted-ffmpeg-image-transport ros-kilted-ffmpeg-image-transport-msgs",
     "PIP_PACKAGES":                  "numpy>=1.26,<2 lz4 pysnmp speedtest-cli psutil zstandard opencv-python"
   }
 }

--- a/tests/contract/test_profile_covers_generated_commands.py
+++ b/tests/contract/test_profile_covers_generated_commands.py
@@ -1,0 +1,78 @@
+"""The packaged image profile must install every ROS package the sessions invoke.
+
+The session templates emit concrete commands — `ros2 run topic_tools throttle`,
+`ros2 run domain_bridge domain_bridge`, and so on. If the packaged image profile
+does not install the package behind one of them, the stage dies with
+"Package '<name>' not found" and the pipeline stops there.
+
+That failure is quiet where it matters. The producing side reports the topic as
+present at its native stage; only the *next* stage is missing, so a receiver
+simply never sees the processed topic and waits for something that will never
+arrive. Reviewing a diff does not catch it, because the command and the package
+list live in different files and neither mentions the other.
+
+So the coupling is asserted here instead of trusted: every package name the
+session templates run has to appear in the profile that builds the image those
+templates run in.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from ros2docker.config import load_config
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RESOURCES = REPO_ROOT / "src" / "rosotacom" / "resources"
+SESSION_CONTENT = RESOURCES / "ws" / "session" / "content"
+PROFILE = RESOURCES / "examples" / "ros2docker.json"
+
+#: `ros2 run <package> <executable>` in a template.
+ROS2_RUN = re.compile(r"\bros2\s+run\s+([A-Za-z_][A-Za-z0-9_]*)\b")
+
+#: Packages that ship with the base ROS image rather than through APT_PACKAGES.
+#: Keep this list short and justified: every entry is a package the profile does
+#: NOT install, so an entry added carelessly re-opens the hole this test closes.
+BASE_IMAGE_PACKAGES = {
+    # rosotacom's own workspace package, built into the image from source.
+    "com_py",
+    # ros2cli and friends are part of every ROS 2 base image.
+    "ros2cli",
+}
+
+
+def _invoked_packages() -> dict[str, set[str]]:
+    """Every package name run by a session template, mapped to where it appears."""
+    found: dict[str, set[str]] = {}
+    for template in sorted(SESSION_CONTENT.rglob("*.yaml")):
+        for package in ROS2_RUN.findall(template.read_text(encoding="utf-8")):
+            found.setdefault(package, set()).add(str(template.relative_to(RESOURCES)))
+    return found
+
+
+def test_profile_installs_every_package_the_sessions_run() -> None:
+    # Read it through ros2docker itself, so the test sees exactly what the
+    # tool that builds the image sees rather than a second parser's idea of it.
+    installed = str(load_config(PROFILE)["build_args"]["APT_PACKAGES"]).split()
+    # `ros-<distro>-topic-tools` installs the `topic_tools` package; compare on
+    # the ROS package name rather than the apt name so a distro bump does not
+    # silently turn this test green.
+    installed_ros_packages = {
+        name.split("-", 2)[2].replace("-", "_")
+        for name in installed
+        if name.startswith("ros-") and name.count("-") >= 2
+    }
+
+    missing = {
+        package: sorted(where)
+        for package, where in _invoked_packages().items()
+        if package not in installed_ros_packages and package not in BASE_IMAGE_PACKAGES
+    }
+
+    assert not missing, (
+        "session templates run packages the example image profile does not "
+        "install; the stage will fail with \"Package '<name>' not found\" and "
+        "the topic will stop at its previous stage:\n"
+        + "\n".join(f"  {package}: invoked in {', '.join(where)}" for package, where in sorted(missing.items()))
+    )


### PR DESCRIPTION
Fixes #194.

`session_plugin_base.yaml` runs `topic_tools` and `image_transport`; the packaged profile installed neither. `topic_tools` was carried incidentally by base images and `image_transport` came in transitively via the ffmpeg plugin, so it only surfaced on the first rebuild that had neither — as `Package 'topic_tools' not found`, with the throttled topics stopping at their native stage and a downstream consumer hanging on one uninitialised input.

Both are declared now, and `tests/contract/test_profile_covers_generated_commands.py` asserts the coupling so it cannot come back. It found `image_transport` on its own while I was fixing `topic_tools`.

## Validation

```
.venv/bin/python -m pytest tests/contract/test_profile_covers_generated_commands.py -q
# 1 passed
```

Negative check: removing `ros-kilted-topic-tools` from the profile turns it red with `topic_tools: invoked in ws/session/content/base/session_plugin_base.yaml`.

Downstream the FZI harness runs the four-container fleet scenario against this; that run is reported on the harness side once this merges.