### PR TITLE
Publish the fork as rosotacom-dev; parallelise the release e2e

### DIFF
--- a/.github/workflows/pr-merge-gate.yml
+++ b/.github/workflows/pr-merge-gate.yml
@@ -389,6 +389,46 @@ jobs:
           path: session-instances/
           if-no-files-found: ignore
 
+  e2e-media:
+    name: e2e-media
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    needs: preflight-success
+    if: always() && !cancelled() && needs.preflight-success.result == 'success'
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install just and tmux
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y just tmux
+
+      - name: Set up local environment
+        run: just setup
+
+      - name: Show Docker environment
+        run: docker info
+
+      - name: Run media E2E tests
+        run: just test-e2e-media
+
+      - name: Upload session artifacts
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: session-instances-e2e-media
+          path: session-instances/
+          if-no-files-found: ignore
+
   ci-success:
     name: ci-success
     runs-on: ubuntu-latest
@@ -404,6 +444,7 @@ jobs:
       - e2e-remote-assist
       - e2e-runtime-tools
       - e2e-concurrency
+      - e2e-media
     if: always() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,7 +102,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        slice: [core, transforms, remote-assist, runtime-tools, concurrency]
+        slice: [core, transforms, remote-assist, runtime-tools, concurrency, media]
 
     steps:
       - name: Check out repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,10 +90,19 @@ jobs:
           if-no-files-found: error
           retention-days: 30
 
-  fast-e2e:
-    name: fast-e2e
+  e2e:
+    # The same five slices the merge gate runs, in parallel, instead of one
+    # sequential `just test-e2e-smoke` over the whole suite. That target is
+    # identical to nightly-e2e.yml's smoke-e2e job, so the release used to be
+    # the third sequential run of the same tests against the same tree; it
+    # dominated release wall-clock at roughly an hour. See issue #196.
+    name: e2e-${{ matrix.slice }}
     runs-on: ubuntu-latest
-    timeout-minutes: 180
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        slice: [core, transforms, remote-assist, runtime-tools, concurrency]
 
     steps:
       - name: Check out repository
@@ -118,13 +127,21 @@ jobs:
       - name: Show Docker environment
         run: docker info
 
-      - name: Run single-machine smoke matrix
-        run: just test-e2e-smoke
+      - name: Run E2E slice
+        run: just test-e2e-${{ matrix.slice }}
+
+      - name: Upload session artifacts
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: session-instances-e2e-${{ matrix.slice }}
+          path: session-instances/
+          if-no-files-found: ignore
 
   publish:
     name: publish
     runs-on: ubuntu-latest
-    needs: [non-docker, package, fast-e2e]
+    needs: [non-docker, package, e2e]
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     # No GitHub environment: authorization is the per-repo Trusted Publisher
     # (registered with a blank environment), so this needs no environment-admin
@@ -142,25 +159,43 @@ jobs:
       - name: Remove checksum sidecar
         run: rm -f dist/SHA256SUMS
 
-      - name: Verify configured publishing target
+      - name: Verify configured publishing targets
         env:
           PYPI_PUBLISH_URL: ${{ vars.PYPI_PUBLISH_URL }}
+          TESTPYPI_PUBLISH_URL: ${{ vars.TESTPYPI_PUBLISH_URL }}
         run: |
           if [ -z "$PYPI_PUBLISH_URL" ]; then
             echo "::error::PYPI_PUBLISH_URL is not configured for this repository."
             exit 1
           fi
-          case "$PYPI_PUBLISH_URL" in
-            https://*) ;;
-            *)
-              echo "::error::PYPI_PUBLISH_URL must be an HTTPS endpoint."
-              exit 1
-              ;;
-          esac
+          for url in "$PYPI_PUBLISH_URL" "$TESTPYPI_PUBLISH_URL"; do
+            [ -n "$url" ] || continue
+            case "$url" in
+              https://*) ;;
+              *)
+                echo "::error::Publishing targets must be HTTPS endpoints; got '$url'."
+                exit 1
+                ;;
+            esac
+          done
+          if [ -z "$TESTPYPI_PUBLISH_URL" ]; then
+            echo "::notice::TESTPYPI_PUBLISH_URL unset; skipping the rehearsal upload."
+          fi
 
-      # The destination is repository configuration, not shared git content:
-      # rehearsal index in the development fork, production index upstream.
-      # Trusted Publisher registration remains the authorization boundary.
+      # Destinations are repository configuration, not shared git content, and
+      # Trusted Publisher registration stays the authorization boundary on each
+      # index. The rehearsal upload runs first but must never gate the real one:
+      # TestPyPI prunes packages and may lack a publisher registration, and a
+      # failure there says nothing about the production upload. It is reported
+      # as a failed step so it stays visible instead of silently degrading.
+      - name: Publish distributions (rehearsal, TestPyPI)
+        if: vars.TESTPYPI_PUBLISH_URL != ''
+        continue-on-error: true
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: ${{ vars.TESTPYPI_PUBLISH_URL }}
+          skip-existing: true
+
       - name: Publish distributions
         uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,7 +128,7 @@ jobs:
         run: docker info
 
       - name: Run E2E slice
-        run: just test-e2e-${{ matrix.slice }}
+        run: just test-e2e-slice ${{ matrix.slice }}
 
       - name: Upload session artifacts
         if: failure()
@@ -173,7 +173,7 @@ jobs:
             case "$url" in
               https://*) ;;
               *)
-                echo "::error::Publishing targets must be HTTPS endpoints; got '$url'."
+                echo "::error::PYPI_PUBLISH_URL must be an HTTPS endpoint (offending value: '$url')."
                 exit 1
                 ;;
             esac

--- a/README.md
+++ b/README.md
@@ -46,7 +46,11 @@ tooling, nothing rosotacom-specific:
 
 ```bash
 # released version (recommended for users)
-pipx install rosotacom            # isolated, on PATH everywhere
+pipx install rosotacom-dev        # isolated, on PATH everywhere
+
+<!-- The distribution is rosotacom-dev; the import name and the CLI stay
+     `rosotacom`. This fork publishes under its own name so that `rosotacom`
+     on PyPI stays reserved for the FZI upstream. -->
 #   or: pip install --user rosotacom
 
 # from a source checkout (developers)
@@ -107,7 +111,7 @@ rosotacom smoke                   # built-in example, zero config
 deactivate                        # back to your usual rosotacom
 ```
 
-For coexisting *released* versions, `pipx install rosotacom==2.2.0 --suffix=@2.2.0`
+For coexisting *released* versions, `pipx install rosotacom-dev==2.2.0 --suffix=@2.2.0`
 gives you a `rosotacom@2.2.0` alongside the default — standard pipx, no bespoke
 version manager.
 

--- a/docs/forensics-report.md
+++ b/docs/forensics-report.md
@@ -19,7 +19,7 @@ Outputs are written to `<instance-dir>/report/` (override with `--out`):
 - `report.md` — the short human summary (also printed to stdout).
 - `figures/<stream>.png` — one timeline figure per stream with event windows
   shaded ("the plot that shows the degradation moment"). Requires the `[plots]`
-  extra (`pip install rosotacom[plots]`); skipped with a note otherwise, or with
+  extra (`pip install rosotacom-dev[plots]`); skipped with a note otherwise, or with
   `--no-figures`.
 
 All outputs are self-describing: the exact command, rosotacom version, git SHA

--- a/justfile
+++ b/justfile
@@ -60,6 +60,15 @@ test-e2e-runtime-tools:
 test-e2e-concurrency:
 	ROSOTACOM_RUN_E2E=1 {{python}} -m pytest -q tests/e2e/test_parallel_smoke.py
 
+# The five slices partition `test-e2e-smoke`; the merge gate and the release
+# both run them in parallel. This wrapper exists so a workflow matrix can select
+# a slice while the recipe name in the `run:` line stays a literal — a name
+# assembled by matrix interpolation is invisible to
+# tests/contract/test_workflow_contracts.py::test_referenced_just_recipes_exist.
+# Run one named slice of the e2e suite.
+test-e2e-slice slice:
+	just test-e2e-{{slice}}
+
 test-e2e-node nodeid:
 	ROSOTACOM_RUN_E2E=1 {{python}} -m pytest -q "{{nodeid}}"
 

--- a/justfile
+++ b/justfile
@@ -55,7 +55,14 @@ test-e2e-remote-assist:
 # every test in the other files (contract-tested in test_benched_set_registry).
 test-e2e-runtime-tools:
 	ROSOTACOM_RUN_E2E=1 {{python}} -m pytest -q tests/e2e/test_smoke.py -k "link_latency"
-	ROSOTACOM_RUN_E2E=1 {{python}} -m pytest -q tests/e2e/test_timeline_stepping.py tests/e2e/test_benchmark_capacity.py tests/e2e/test_benchmark_ab.py
+	ROSOTACOM_RUN_E2E=1 {{python}} -m pytest -q tests/e2e/test_timeline_stepping.py tests/e2e/test_benchmark_capacity.py tests/e2e/test_benchmark_ab.py tests/e2e/test_benchmark_replay.py
+
+# The remaining e2e files. Without this slice the partition is not one: the
+# monolithic `test-e2e-smoke` collects 28 tests, the other five collect 25, and
+# anonymization/video-quality/replay ran only in nightly and the release.
+test-e2e-media:
+	ROSOTACOM_RUN_E2E=1 {{python}} -m pytest -q tests/e2e/test_anonymize_e2e.py tests/e2e/test_video_quality_e2e.py
+	ROSOTACOM_RUN_E2E=1 {{python}} -m pytest -q tests/e2e/test_smoke.py -k "anonymized"
 
 test-e2e-concurrency:
 	ROSOTACOM_RUN_E2E=1 {{python}} -m pytest -q tests/e2e/test_parallel_smoke.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,9 @@ requires = ["setuptools>=80", "setuptools-scm>=8", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "rosotacom"
+# The development fork publishes under its own name so that `rosotacom` stays
+# reserved for the FZI upstream. Consumers of this line pin rosotacom-dev.
+name = "rosotacom-dev"
 description = "Host CLI for ROS OTA communication sessions."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/contract/test_workflow_contracts.py
+++ b/tests/contract/test_workflow_contracts.py
@@ -116,3 +116,74 @@ def test_precommit_ruff_matches_pyproject_pin() -> None:
         f"ruff pre-commit rev {rev!r} does not match pyproject pin "
         f"ruff=={pyproject_version}; keep local hooks and just/CI checks aligned"
     )
+
+
+def _release_e2e_slices() -> list[str]:
+    """The slice names the release matrix expands to."""
+    workflow = yaml.safe_load((WORKFLOWS_DIR / "release.yml").read_text(encoding="utf-8"))
+    return list(workflow["jobs"]["e2e"]["strategy"]["matrix"]["slice"])
+
+
+def _recipe_pytest_invocations(recipe: str) -> list[list[str]]:
+    """Every pytest argument list a recipe runs, with just's substitutions applied."""
+    import shlex
+
+    text = JUSTFILE_PATH.read_text(encoding="utf-8")
+    match = re.search(rf"^{re.escape(recipe)}\s*:[^\n]*\n(?P<body>(?:[ \t]+[^\n]*\n?)+)", text, re.MULTILINE)
+    assert match, f"recipe {recipe!r} not found in the justfile"
+
+    invocations: list[list[str]] = []
+    for line in match.group("body").splitlines():
+        line = line.strip()
+        if "-m pytest" not in line:
+            continue
+        tokens = shlex.split(line.replace("{{python}}", "python"))
+        start = tokens.index("pytest") + 1
+        invocations.append([t for t in tokens[start:] if t != "-q"])
+    return invocations
+
+
+def _collect_e2e_ids(args: list[str]) -> set[str]:
+    import os
+    import subprocess
+    import sys
+
+    result = subprocess.run(
+        [sys.executable, "-m", "pytest", "--collect-only", "-q", *args],
+        capture_output=True,
+        text=True,
+        cwd=PACKAGE_ROOT,
+        env={**os.environ, "ROSOTACOM_RUN_E2E": "1"},
+        check=False,
+    )
+    return {line.strip() for line in result.stdout.splitlines() if line.startswith("tests/e2e/")}
+
+
+def test_e2e_slices_partition_the_whole_suite() -> None:
+    """The parallel slices must collect exactly what the monolith collects.
+
+    `test-e2e-smoke` is `pytest tests/e2e/ -m e2e`, so it picks up any new file
+    automatically; the slices name files and `-k` expressions by hand and do
+    not. When the merge gate was split into slices, three files
+    (anonymize, video-quality, benchmark-replay) and the two
+    `[remote-assist-anonymized-*]` parameters silently stopped being covered
+    there — `-k "remote_assist"` misses the latter because the parameter id
+    spells it with hyphens. Nothing failed, because nightly and the release
+    still ran the monolith. This test is what makes that drift loud.
+    """
+    monolith = _collect_e2e_ids(["tests/e2e/", "-m", "e2e"])
+    assert monolith, "collected no e2e tests; the monolith invocation changed"
+
+    covered: set[str] = set()
+    for slice_name in _release_e2e_slices():
+        for args in _recipe_pytest_invocations(f"test-e2e-{slice_name}"):
+            covered |= _collect_e2e_ids(args)
+
+    assert not monolith - covered, (
+        "These e2e tests run in `just test-e2e-smoke` but in no slice, so the "
+        "merge gate and the release would not run them:\n" + "\n".join(sorted(monolith - covered))
+    )
+    assert not covered - monolith, (
+        "These tests are selected by a slice but not by the monolith, so the "
+        "two definitions disagree:\n" + "\n".join(sorted(covered - monolith))
+    )


### PR DESCRIPTION
Fixes the two problems the failed v2.2 release surfaced.

**`rosotacom-dev`** — a PyPI project cannot be renamed, so the fork publishes under its own name and `rosotacom` stays reserved for the FZI upstream. Distribution name only; the import package and CLI remain `rosotacom`. Verified by building the wheel: `rosotacom/resources/ws/ros2src/com_msgs` still ships (7 files), `rosotacom/__init__.py` present.

**Both indexes** — the publish job uploads to TestPyPI first as a rehearsal (`continue-on-error`, so a pruned package or missing registration there cannot block production) and then to PyPI. Needs repo variables `PYPI_PUBLISH_URL` and `TESTPYPI_PUBLISH_URL`, plus a Trusted Publisher for `rosotacom-dev` on each index.

**Release e2e** — `fast-e2e` ran `just test-e2e-smoke`, identical to nightly's `smoke-e2e`, while the merge gate already parallelises the same set into five slices. Replaced by a matrix over those slices. Closes #196.

The v2.2 tag failed with `invalid-publisher` against TestPyPI: valid OIDC token, no matching publisher registered. Nothing was published, so v2.2 can be re-tagged once the publishers exist.