### PR TITLE
Stop the TestPyPI rehearsal from blocking the PyPI upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -196,6 +196,15 @@ jobs:
           repository-url: ${{ vars.TESTPYPI_PUBLISH_URL }}
           skip-existing: true
 
+      # The rehearsal writes <dist>.publish.attestation next to each artifact,
+      # and it does so even when the upload itself then fails. Both publish
+      # steps share one dist/, so the second refuses to start: "distributions
+      # already have publish attestations". Clearing them makes the production
+      # upload independent of whether the rehearsal ran, succeeded, or failed.
+      - name: Clear rehearsal attestations
+        if: always()
+        run: rm -f dist/*.publish.attestation
+
       - name: Publish distributions
         uses: pypa/gh-action-pypi-publish@release/v1
         with:


### PR DESCRIPTION
The v2.2 release run failed at `publish` with:

```
Attestation generation failure: The following distributions already have publish attestations:
* dist/rosotacom_dev-2.2-py3-none-any.whl -> dist/rosotacom_dev-2.2-py3-none-any.whl.publish.attestation
```

The production step never attempted an upload. Both publish steps share one `dist/`, and the rehearsal writes an attestation next to each artifact — also when its own upload fails, which it did (TestPyPI returned 400 for a project-name mismatch in the pending publisher).

A `rm -f dist/*.publish.attestation` between the steps, with `if: always()` so a failed rehearsal cannot skip it, makes the production upload independent of the rehearsal's outcome. Defect in the dual-target publish from #197.