### PR TITLE
Make the package boundary cheap to consume: dev channel, honest OTA install, real version

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -1,0 +1,152 @@
+name: Dev release
+
+# Every commit that lands on develop becomes an installable pre-release.
+#
+# Consuming this package should not mean consuming something days old. Without
+# this, a downstream repository could only pin a version after someone decided
+# to cut a release, so "always consume the package, never the checkout" cost a
+# human decision per iteration — and the cheap way out was to stop consuming the
+# package.
+#
+# setuptools-scm already derives X.Y.devN from the history; those wheels were
+# built by CI and thrown away. This publishes them.
+#
+# `pip` does not resolve pre-releases unless asked, so the stable line is
+# unaffected: nobody gets a dev version by accident, and anybody who wants one
+# pins it exactly. Cutting a stable vX.Y stays a deliberate, human decision in
+# release.yml.
+#
+# It runs on workflow_run rather than on push, so a commit whose CI failed is
+# never published. workflow_run resolves this file from the default branch,
+# which is develop — the branch it watches.
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches: [develop]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_sha }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: publish
+    runs-on: ubuntu-latest
+    # `event == 'push'` keeps pull-request CI runs out: only what actually
+    # landed on develop is published.
+    if: >-
+      github.event.workflow_run.conclusion == 'success'
+      && github.event.workflow_run.event == 'push'
+    # Same authorization as release.yml: the per-repo Trusted Publisher,
+    # registered with a blank environment. No token, no environment admin.
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Check out the commit CI validated
+        uses: actions/checkout@v6
+        with:
+          # Pin to the validated commit: develop may have moved on since, and
+          # publishing a different tree than the one that passed would make the
+          # version meaningless.
+          ref: ${{ github.event.workflow_run.head_sha }}
+          # setuptools-scm needs the full history and the tags to derive the
+          # version; a shallow clone silently yields 0.1.dev1.
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install just
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y just
+
+      - name: Set up local environment
+        run: just setup
+
+      - name: Build and validate distributions
+        run: just package
+
+      - name: Require a pre-release version
+        id: version
+        run: |
+          set -euo pipefail
+          # A wheel filename is name-version-pytag-abitag-plattag.whl.
+          shopt -s nullglob
+          wheels=(dist/*.whl)
+          if [ "${#wheels[@]}" -ne 1 ]; then
+            echo "::error::expected exactly one wheel in dist/, found ${#wheels[@]}"
+            exit 1
+          fi
+          base="$(basename "${wheels[0]}" .whl)"
+          name="${base%%-*}"
+          rest="${base#*-}"
+          version="${rest%%-*}"
+          echo "distribution=${name//_/-}" >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Built ${name//_/-} $version"
+          # A clean X.Y here means develop points at a tagged commit. That
+          # version belongs to the stable line and release.yml owns it, so skip
+          # rather than race it onto the index under a second identity.
+          if [ "${version#*.dev}" = "$version" ]; then
+            echo "::notice::$version is not a pre-release; the stable tag path owns it. Skipping."
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Remove checksum sidecar
+        if: steps.version.outputs.publish == 'true'
+        run: rm -f dist/SHA256SUMS
+
+      - name: Verify configured publishing target
+        if: steps.version.outputs.publish == 'true'
+        env:
+          PYPI_PUBLISH_URL: ${{ vars.PYPI_PUBLISH_URL }}
+        run: |
+          if [ -z "$PYPI_PUBLISH_URL" ]; then
+            echo "::error::PYPI_PUBLISH_URL is not configured for this repository."
+            exit 1
+          fi
+          case "$PYPI_PUBLISH_URL" in
+            https://*) ;;
+            *)
+              echo "::error::PYPI_PUBLISH_URL must be an HTTPS endpoint (offending value: '$PYPI_PUBLISH_URL')."
+              exit 1
+              ;;
+          esac
+
+      # No TestPyPI rehearsal here. The dev channel *is* the rehearsal, and a
+      # second upload per commit would double the noise for no extra signal.
+      - name: Publish pre-release
+        if: steps.version.outputs.publish == 'true'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: ${{ vars.PYPI_PUBLISH_URL }}
+          skip-existing: true
+
+      - name: Summarise
+        if: steps.version.outputs.publish == 'true'
+        env:
+          DISTRIBUTION: ${{ steps.version.outputs.distribution }}
+          VERSION: ${{ steps.version.outputs.version }}
+          COMMIT: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          # Markdown code block by indentation: no backticks, which shellcheck
+          # would read as command substitution.
+          {
+            echo "Published $VERSION from $COMMIT."
+            echo
+            echo "Consume it with:"
+            echo
+            echo "    pipx install \"$DISTRIBUTION==$VERSION\""
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,6 +77,29 @@ jobs:
       - name: Build and validate distributions
         run: just package
 
+      # The mirror of the dev channel's guard. A tag build must produce the
+      # clean version the tag names; a pre-release here means the tag is not on
+      # the commit being built (a dirty tree, or a tag pushed from the wrong
+      # place), and the release would silently publish something else.
+      - name: Require a stable version
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          wheels=(dist/*.whl)
+          if [ "${#wheels[@]}" -ne 1 ]; then
+            echo "::error::expected exactly one wheel in dist/, found ${#wheels[@]}"
+            exit 1
+          fi
+          base="$(basename "${wheels[0]}" .whl)"
+          rest="${base#*-}"
+          version="${rest%%-*}"
+          expected="${GITHUB_REF_NAME#v}"
+          if [ "$version" != "$expected" ]; then
+            echo "::error::tag $GITHUB_REF_NAME builds version $version, not $expected."
+            exit 1
+          fi
+
       - name: Generate checksums
         run: |
           cd dist

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,21 @@ Shared workflow:
   is unavailable, record why in the PR and final status.
 - Keep the PR description current with the issue link, validation commands,
   important SHAs, CI status, and any dependency on another PR or harness MR.
+
+Release autonomy — where the human decision actually is:
+
+- Agents run a change to the end: branch, PR, CI, auto-merge. Merging publishes
+  a `X.Y.devN` pre-release automatically (`.github/workflows/dev-release.yml`),
+  so a downstream repository can pin the result immediately. Nothing about that
+  needs a human, and a merged change that nobody can consume is not finished.
+- Cutting a stable `vX.Y.Z` tag is the one release step that is a decision, not
+  a consequence: the version is a promise to consumers and cannot be taken back
+  once it is on the index. Cut one only when the task says so.
+- A stable tag needs `docs/release-notes/vX.Y.Z.md` **in the tagged commit**.
+  Add it in the PR that will be tagged; adding it afterwards leaves the release
+  job failing on a tag that cannot be moved.
+- Never reuse or move a published version. If a release is wrong, supersede it
+  with the next one and say so in its notes.
 - Before reporting completion, check the remote PR state and CI results with
   `gh pr view` / `gh pr checks`; report the actual status, not just that a
   branch was pushed.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,17 +112,30 @@ repository settings that live outside git.
 
 ## Release Workflow
 
-Releases are built from tags in the form `vX.Y.Z`. Release PRs must include
-`docs/release-notes/vX.Y.Z.md`, copied from
-[docs/release-notes/TEMPLATE.md](docs/release-notes/TEMPLATE.md).
+Two channels, described in full in [docs/release.md](docs/release.md).
 
-After the release PR has merged to `main`, verify the exact commit and then:
+**Development channel.** Every commit that lands on the development branch with
+green CI is published automatically as `X.Y.devN`. There is nothing to do and
+nothing to decide: merging *is* releasing on this channel. Consume such a
+version with an exact pin, which is how a downstream repository tracks work in
+progress without reaching past the package boundary:
 
 ```bash
-git switch main
+pipx install "rosotacom-dev==2.4.dev3"
+```
+
+**Stable release.** Built from tags in the form `vX.Y.Z`. Release PRs must
+include `docs/release-notes/vX.Y.Z.md`, copied from
+[docs/release-notes/TEMPLATE.md](docs/release-notes/TEMPLATE.md) — the tagged
+commit has to contain its own notes, so the notes land in the PR, not after it.
+
+After the release PR has merged, verify the exact commit and then:
+
+```bash
+git switch develop
 git fetch --prune
 git pull --ff-only
-git tag vX.Y.Z
+git tag -a vX.Y.Z -m "rosotacom vX.Y.Z"
 git push origin vX.Y.Z
 ```
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ pipx install rosotacom-dev        # isolated, on PATH everywhere
      on PyPI stays reserved for the FZI upstream. -->
 #   or: pip install --user rosotacom
 
+# a specific development build (for consumers tracking work in progress)
+pipx install "rosotacom-dev==2.4.dev3"
+
 # from a source checkout (developers)
 cd /path/to/ros_communication_devcontainer
 ./install.sh                      # builds a checkout-local .venv
@@ -63,6 +66,12 @@ rosotacom --version
 python -m rosotacom --version
 rosotacom doctor
 ```
+
+Every commit that lands on the development branch with green CI is published as
+a `X.Y.devN` pre-release, so a consumer never has to wait for a release decision
+or reach past the package to a checkout. `pip` ignores pre-releases unless you
+pin one exactly, so this cannot reach you by accident. See
+[docs/release.md](docs/release.md).
 
 For a source checkout, that single `source .venv/bin/activate` command also
 enables completion. Nothing needs to be added to your shell configuration.
@@ -383,10 +392,10 @@ rosotacom ota-smoke 2_native_chatter \
   --peer b=robot
 ```
 
-`ota-smoke` accepts sessions and scenarios. It automatically stages and
-installs the currently selected rosotacom version, stages the active project,
-runs delivery and isolation checks, collects artifacts, stops the run, and
-removes the remote workdir. Add `--interactive` for a local control tmux with
+`ota-smoke` accepts sessions and scenarios. It puts rosotacom on each peer,
+stages the active project, runs delivery and isolation checks, collects
+artifacts, stops the run, and removes the remote workdir. Add `--interactive`
+for a local control tmux with
 one attachable communication/catmux window per peer with a live status pane below
 each one. Scenario targets also get one native application-container window per
 scenario app. Stop an interactive run with `rosotacom ota-smoke TARGET
@@ -394,6 +403,29 @@ scenario app. Stop an interactive run with `rosotacom ota-smoke TARGET
 metadata is not available. Use `--keep-running` to leave components up,
 `--keep-workdir` to retain staged files, or `--reuse` to reuse an existing
 installation.
+
+#### What the peers run: `--install-mode`
+
+```bash
+# default: stage and install what you are running, uncommitted changes included
+rosotacom ota-smoke 2_native_chatter --peer a=workstation --peer b=robot
+
+# rehearse a deployment: the peers install the published artefact
+rosotacom ota-smoke 2_native_chatter --peer a=workstation --peer b=robot \
+  --install-mode pin                # defaults to your own version
+rosotacom ota-smoke 2_native_chatter --peer a=workstation --peer b=robot \
+  --install-mode pin --install-pin 2.4
+```
+
+`source` is right while iterating on rosotacom itself — the peers run the code
+in front of you. `pin` is right when the run is meant to stand in for a real
+deployment: the peers install from the index, so a packaging defect (a file
+missing from the wheel, an undeclared dependency) fails in the rehearsal instead
+of on the target machine. `source` cannot catch that class of defect by
+construction, because it never builds the artefact that ships.
+
+The run manifest records which mode and which version the peers ran, so a result
+can be attributed to an artefact rather than to a working copy.
 
 ### Live status / debugging overview
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -11,10 +11,14 @@ but one stable release line:
 
 - topic PRs are gated into the repository's active development branch by the
   GitHub checks below;
-- **`main`** is the stable release line;
+- every commit that lands there with green CI is published as a `X.Y.devN`
+  pre-release, so any commit is consumable without a release decision;
+- **`main`** is the stable line a repository synchronises upstream from;
 - moving development work to `main` is a deliberate maintainer operation and
   may require an external OTA gate;
-- releases are tags `vX.Y.Z` cut from `main` (see [release.md](release.md)).
+- releases are tags `vX.Y.Z` cut from a validated commit on the release line —
+  in this repository `develop`, its default branch (see
+  [release.md](release.md)).
 
 The OTA tier is not part of this repository's public CI. An operator-supplied
 external runner provides it as a manual promotion gate, as described generically

--- a/docs/release-notes/v2.3.md
+++ b/docs/release-notes/v2.3.md
@@ -1,0 +1,34 @@
+# v2.3
+
+## Summary
+
+- Add `rosotacom resources path <name>`: report the host path of a packaged
+  resource (`ws`, `com_msgs`) for tooling outside the installation. rosotacom
+  installs into an isolated environment (pipx, or a project venv), so a consumer
+  cannot `import rosotacom` to compute such a path; this command is the
+  supported lookup.
+
+## Compatibility And Migration
+
+- No breaking changes. Consumers that hardcoded a path into a rosotacom checkout
+  should switch to `rosotacom resources path com_msgs`.
+
+## Known Issues
+
+- An installed `rosotacom-dev` reports its version as `0+unknown`: the package
+  looked up the distribution name `rosotacom`, which the fork no longer uses.
+  A version check against a pin therefore never matches, and
+  `ota-smoke --install-mode source` started from an installation writes that
+  string into the source bundle it builds on each peer, where it is not a valid
+  PEP 440 version and the remote build fails. Fixed in 2.4; this release cannot
+  be replaced because a published version is immutable.
+
+## Validation
+
+- `just lint`
+- `just typecheck`
+- `just test-unit`
+- `just test-contract`
+- `just docs`
+- `just package`
+- `just test-e2e-smoke`

--- a/docs/release-notes/v2.4.md
+++ b/docs/release-notes/v2.4.md
@@ -1,0 +1,46 @@
+# v2.4
+
+## Summary
+
+- **Fix the reported version.** An installed distribution is now looked up
+  rather than assumed, so `rosotacom --version` reports the real version under
+  both published names (`rosotacom-dev` from this fork, `rosotacom` upstream).
+  Up to 2.3 every installed `rosotacom-dev` reported `0+unknown`, which made a
+  version check against a pin impossible and produced an unbuildable OTA source
+  bundle.
+- **Publish a development channel.** Every commit that lands on the development
+  branch with green CI is published as a `X.Y.devN` pre-release. Consuming this
+  package no longer means waiting for a release decision. `pip` ignores
+  pre-releases unless one is pinned exactly, so the stable line is unaffected.
+- **Stop duplicating packaging metadata.** The source bundle `ota-smoke` builds
+  when it runs from an installation derives its name, version, dependencies and
+  entry points from the installed distribution. The hand-written copy it used
+  before had drifted: `mcap` and `Pillow` were missing, so a peer prepared this
+  way imported fine and then failed inside the first MCAP or image code path.
+- **`ota-smoke --install-mode pin`.** Install a published release on each peer
+  instead of staging a source tree, so the rehearsal runs the artefact that
+  ships and can catch a packaging defect before a target machine does. The run
+  manifest records the mode and version the peers ran.
+- **`rosotacom resources path` covers `package` and `examples`**, which is how
+  pin mode remaps project config roots onto the peer's installation.
+
+## Compatibility And Migration
+
+- `ota-smoke` behaves as before unless `--install-mode pin` is passed.
+- The OTA deployment state file (`ota-deployment.yaml`) is now `schema_version:
+  2` and carries the install mode. State files written by an older version are
+  rejected; they are per-run artifacts, so start a new run.
+- Consumers pinning `rosotacom-dev==2.3` should move to `2.4` to get a usable
+  `--version`.
+
+## Validation
+
+- `just lint`
+- `just typecheck`
+- `just test-unit`
+- `just test-contract`
+- `just docs`
+- `just package`
+- `just test-e2e-smoke`
+- `tests/contract/test_ota_source_bundle.py` fails if the bundle metadata ever
+  diverges from `pyproject.toml` again.

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,11 +1,39 @@
 # Release
 
-Releases are built by `.github/workflows/release.yml`.
+This project publishes on two channels, and the difference between them is who
+decides, not how much is tested. Both build from the same commit and the same
+`just package`.
+
+| | Development channel | Stable release |
+|---|---|---|
+| Trigger | every commit that lands on `develop` with green CI | a `vX.Y.Z` tag |
+| Version | `X.Y.devN` (PEP 440 pre-release) | `X.Y.Z` |
+| Built by | `.github/workflows/dev-release.yml` | `.github/workflows/release.yml` |
+| Decided by | nobody — it follows the branch | a maintainer |
+| Reached by | an exact pin, or `--pre` | a normal install |
+
+The point of the development channel is that consuming this package should never
+be more expensive than consuming a checkout. Downstream repositories pin an
+exact version; without a continuous channel their only alternatives are to wait
+for a release decision or to bypass the package boundary, and the second one
+always wins in practice.
+
+`pip` does not resolve pre-releases unless asked, so a dev version can never
+reach a consumer by accident.
 
 ## Version Source
 
 Package versions come from Git tags through `setuptools-scm`. The project does
 not keep a static version in `pyproject.toml` or `src/rosotacom/__init__.py`.
+
+After `v2.3`, commits on `develop` therefore build as `2.4.devN`: a
+pre-release *of the next* stable version, ordered before `2.4` itself.
+
+The distribution name is never hardcoded in the source. This code publishes as
+`rosotacom-dev` from the development fork and as `rosotacom` upstream, and
+`rosotacom/__init__.py` looks its own distribution up rather than assuming a
+name. Assuming one is what made every installed `rosotacom-dev` up to 2.3 report
+its version as `0+unknown`.
 
 ## Tags
 
@@ -15,10 +43,16 @@ Stable releases use tags in this form:
 vX.Y.Z
 ```
 
-Tags are cut from a deliberately selected and validated `main` commit (see
-[ci.md](ci.md) for the branch model). Before promoting a candidate to `main`, a
-maintainer should record the manual full-suite gate result described in
-[testing.md](testing.md). Push the tag from that exact commit.
+Tags are cut from a validated commit on the release line — in this repository
+`develop`, which is also its default branch (see [ci.md](ci.md) for the branch
+model). Before cutting one, a maintainer should record the manual full-suite
+gate result described in [testing.md](testing.md). Push the tag from that exact
+commit.
+
+The tag build asserts that the version it produces is the version the tag names,
+and the development channel asserts the mirror image: it refuses to publish
+anything that is not a pre-release. Neither channel can publish under the
+other's identity.
 
 ## Release Notes
 
@@ -37,7 +71,14 @@ dependency, compatibility, and migration changes.
 Tag pushes validate, publish through the repository's configured Trusted
 Publisher, and create a GitHub Release with the release notes, wheel, source
 distribution, and `SHA256SUMS`. Manual workflow dispatch validates and builds
-artifacts but does not publish; publishing requires a deliberate `vX.Y.Z` tag.
+artifacts but does not publish; publishing a stable version requires a
+deliberate `vX.Y.Z` tag.
+
+Development-channel uploads use the same Trusted Publisher and the same
+`PYPI_PUBLISH_URL`. They are triggered by the CI workflow *completing
+successfully* on `develop`, not by the push itself, so a commit whose checks
+failed is never published. They skip the TestPyPI rehearsal: the dev channel is
+already the rehearsal.
 
 The target index is set per repository by the `PYPI_PUBLISH_URL` Actions
 variable, and authorization is granted by the Trusted Publisher registered for

--- a/docs/release.md
+++ b/docs/release.md
@@ -35,6 +35,18 @@ The distribution name is never hardcoded in the source. This code publishes as
 name. Assuming one is what made every installed `rosotacom-dev` up to 2.3 report
 its version as `0+unknown`.
 
+The two "dev" in `rosotacom-dev==2.4.dev3` are not the same word, and only one
+of them is about maturity:
+
+- `-dev` in the **distribution name** says which line publishes it — the
+  development fork, as opposed to the FZI upstream that publishes as
+  `rosotacom`. It is part of every version of this package, stable ones
+  included: `rosotacom-dev==2.4` is a stable release.
+- `.dev3` in the **version** says how far along that particular artefact is
+  within this line: the third commit after `v2.3`, on the way to `2.4`.
+
+So `rosotacom-dev` alone tells you nothing about maturity. The version does.
+
 ## Tags
 
 Stable releases use tags in this form:

--- a/src/rosotacom/__init__.py
+++ b/src/rosotacom/__init__.py
@@ -2,17 +2,27 @@
 
 from __future__ import annotations
 
-from importlib.metadata import PackageNotFoundError, version
+from importlib.metadata import PackageNotFoundError, packages_distributions, version
 from typing import Any
-
-_DISTRIBUTION_NAME = "rosotacom"
 
 
 def _package_version() -> str:
-    try:
-        return version(_DISTRIBUTION_NAME)
-    except PackageNotFoundError:
-        return "0+unknown"
+    """Version of the distribution that ships this package.
+
+    The distribution name is looked up, not hardcoded. This source is published
+    as `rosotacom-dev` from the development fork and as `rosotacom` upstream, so
+    a hardcoded name resolves under one of them and silently degrades to
+    "0+unknown" under the other — which is what happened up to 2.3: every
+    installed `rosotacom-dev` misreported its own version, so `--version` could
+    not be compared against a pin, and the OTA source bundle wrote an invalid
+    PEP 440 version into its generated metadata.
+    """
+    for distribution in packages_distributions().get(__name__, ()):
+        try:
+            return version(distribution)
+        except PackageNotFoundError:
+            continue
+    return "0+unknown"
 
 
 __version__ = _package_version()

--- a/src/rosotacom/cli.py
+++ b/src/rosotacom/cli.py
@@ -2580,19 +2580,55 @@ def _ota_install_pin_script(plan: OtaSmokePlan) -> str:
     )
 
 
+def _ota_project_uses_packaged_configs(runtime: RuntimeConfig) -> bool:
+    """Whether any project config root points inside the installed rosotacom.
+
+    Most projects keep their session and scenario configs next to their own
+    `rosotacom.yaml`; only a project reusing rosotacom's packaged examples
+    reaches into the package. Asking this first keeps pin mode from querying the
+    peer for a path it would not use — which also keeps it working against
+    versions older than the `resources path package` lookup.
+    """
+    if not runtime.rosotacom_config:
+        return False
+    raw = _load_yaml_file(runtime.rosotacom_config)
+    for key in ("session_configs_dir", "scenario_configs_dir"):
+        if raw.get(key) is None:
+            continue
+        for value in _path_values(raw[key], key):
+            path = Path(os.path.expandvars(os.path.expanduser(str(value))))
+            if path.is_absolute() and _relative_to(path.resolve(), PACKAGE_DIR) is not None:
+                return True
+    return False
+
+
 def _ota_remote_package_dir(peer: OtaSmokePeer, plan: OtaSmokePlan, *, dry_run: bool) -> str | None:
     """Ask the peer's own installation where its packaged resources live.
 
-    Only pin mode needs this: no source tree is staged, so a project config that
-    points into rosotacom's packaged examples has to be remapped onto the path
-    the peer's venv actually installed them at. The peer answers through the same
-    `resources path` interface every other external consumer uses.
+    Only pin mode needs this, and only for a project that reuses rosotacom's
+    packaged configs: no source tree is staged, so such a root has to be remapped
+    onto the path the peer's venv actually installed it at. The peer answers
+    through the same `resources path` interface every other external consumer
+    uses.
     """
     if dry_run:
         return f"{plan.workdir}/venv/<site-packages>/rosotacom"
     command = _ota_quote_cmd([f"{plan.workdir}/{plan.rosotacom}", "resources", "path", "package"])
-    result = _ota_run(peer, command, label=f"{peer.name}: locate packaged resources", dry_run=False)
-    return (result.stdout or "").strip() or None
+    result = _ota_run(
+        peer,
+        command,
+        label=f"{peer.name}: locate packaged resources",
+        dry_run=False,
+        check=False,
+    )
+    located = (result.stdout or "").strip()
+    if result.returncode != 0 or not located:
+        raise RuntimeError(
+            f"{peer.name}: rosotacom {plan.install_pin} cannot report its packaged resource paths, and this "
+            "project addresses configs inside the package. `resources path package` needs 2.4 or newer; "
+            "pin a newer version, or move the config roots into the project."
+        )
+    return located
 
 
 def _ota_prepare_hosts(args: argparse.Namespace, runtime: RuntimeConfig, plan: OtaSmokePlan) -> None:
@@ -2646,7 +2682,11 @@ def _ota_prepare_hosts(args: argparse.Namespace, runtime: RuntimeConfig, plan: O
 
             if from_pin:
                 local_root: Path | None = PACKAGE_DIR
-                remote_root = _ota_remote_package_dir(peer, plan, dry_run=dry_run)
+                remote_root = (
+                    _ota_remote_package_dir(peer, plan, dry_run=dry_run)
+                    if _ota_project_uses_packaged_configs(runtime)
+                    else None
+                )
             else:
                 local_root = source_checkout
                 remote_root = f"{plan.workdir}/source"

--- a/src/rosotacom/cli.py
+++ b/src/rosotacom/cli.py
@@ -89,8 +89,10 @@ EXAMPLE_PROJECT_DIR = RESOURCE_DIR / "examples"
 # is the supported lookup. Names are part of the CLI contract, the layout behind
 # them is not — ask for "com_msgs", not for "ws/ros2src/com_msgs".
 NAMED_RESOURCES = {
+    "package": PACKAGE_DIR,
     "ws": WS_DIR,
     "com_msgs": WS_DIR / "ros2src" / "com_msgs",
+    "examples": EXAMPLE_PROJECT_DIR,
 }
 SESSION_CONFIG_CONTAINER_DIR = "/session/configs"
 SESSION_DEFINITION_CONTAINER_DIR = "/session/definitions"
@@ -99,6 +101,19 @@ EXTERNAL_SESSION_CONTAINER_DIR = "/session/current"
 RUN_SESSION_CONTAINER_PATH = "/ws/session/creation/run_session.py"
 DEFAULT_SMOKE_SESSION = "1_heartbeat"
 OTA_SUDO_MODES = ("passwordless", "askpass")
+
+# How ota-smoke puts rosotacom on each peer.
+#
+# `source` stages whatever the caller is running and installs it from source.
+# That is right while iterating on rosotacom itself: the peers run the code in
+# front of you, including uncommitted changes.
+#
+# `pin` installs a published version from the index and stages no source at all.
+# That is right when rehearsing a deployment: the peers then run the artefact
+# that ships, so a packaging defect — a file missing from the wheel, an
+# undeclared dependency — fails here rather than on a Versuchsträger. `source`
+# cannot catch that class of bug by construction.
+OTA_INSTALL_MODES = ("source", "pin")
 OTA_DEFAULT_SUDO_MODE = "passwordless"
 
 ws_creation_dir = WS_DIR / "session" / "creation"
@@ -194,6 +209,8 @@ class OtaSmokePlan:
     rosotacom: str
     project: str
     peers: dict[str, OtaSmokePeer]
+    install_mode: str = "source"
+    install_pin: str | None = None
 
 
 @dataclass(frozen=True)
@@ -1461,27 +1478,62 @@ def _infer_active_interactive_smoke_run(
     )
 
 
-def _ota_plan_from_bindings(bindings: dict[str, PeerBinding], *, workdir: str) -> OtaSmokePlan:
+def _ota_validate_install_mode(install_mode: str) -> str:
+    if install_mode not in OTA_INSTALL_MODES:
+        raise RuntimeError(
+            f"Unsupported OTA install mode {install_mode!r}; expected one of {', '.join(OTA_INSTALL_MODES)}."
+        )
+    return install_mode
+
+
+def _ota_rosotacom_path(install_mode: str) -> str:
+    """Where the peer's rosotacom executable lands, relative to the workdir."""
+    return "venv/bin/rosotacom" if install_mode == "pin" else "source/.venv/bin/rosotacom"
+
+
+def _ota_plan_from_bindings(
+    bindings: dict[str, PeerBinding],
+    *,
+    workdir: str,
+    install_mode: str = "source",
+    install_pin: str | None = None,
+) -> OtaSmokePlan:
     _ota_validate_prepare_workdir(workdir)
+    _ota_validate_install_mode(install_mode)
+    if install_mode == "pin":
+        # Defaulting to the caller's own version makes `--install-mode pin`
+        # mean "rehearse what I am running, as it ships" without a second flag.
+        install_pin = install_pin or __version__
+        if "+" in install_pin or install_pin == "0+unknown":
+            raise RuntimeError(
+                f"Cannot pin OTA peers to version {install_pin!r}: it is a local build, not something an "
+                "index can serve. Pass --install-pin with a published version, or use --install-mode source."
+            )
+    elif install_pin is not None:
+        raise RuntimeError("--install-pin only applies to --install-mode pin.")
     peers = {
         name: OtaSmokePeer(name=name, ssh=binding.ssh, address=binding.address) for name, binding in bindings.items()
     }
     return OtaSmokePlan(
         state_path=None,
         workdir=workdir,
-        rosotacom="source/.venv/bin/rosotacom",
+        rosotacom=_ota_rosotacom_path(install_mode),
         project="project/rosotacom.yaml",
         peers=peers,
+        install_mode=install_mode,
+        install_pin=install_pin,
     )
 
 
 def _ota_write_state(instance: SessionInstance, plan: OtaSmokePlan) -> OtaSmokePlan:
     path = instance.host_dir / "ota-deployment.yaml"
     payload = {
-        "schema_version": 1,
+        "schema_version": 2,
         "workdir": plan.workdir,
         "rosotacom": plan.rosotacom,
         "project": plan.project,
+        "install_mode": plan.install_mode,
+        "install_pin": plan.install_pin,
         "peers": {name: {"address": peer.address, "ssh": peer.ssh} for name, peer in sorted(plan.peers.items())},
     }
     path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
@@ -1491,7 +1543,7 @@ def _ota_write_state(instance: SessionInstance, plan: OtaSmokePlan) -> OtaSmokeP
 def _ota_load_state(path_arg: str) -> OtaSmokePlan:
     path = Path(path_arg).expanduser().resolve()
     raw = _load_yaml_file(path)
-    if raw.get("schema_version") != 1:
+    if raw.get("schema_version") != 2:
         raise RuntimeError(f"Unsupported OTA deployment state: {path}")
     peers_raw = raw.get("peers")
     if not isinstance(peers_raw, dict) or len(peers_raw) != 2:
@@ -1505,12 +1557,15 @@ def _ota_load_state(path_arg: str) -> OtaSmokePlan:
             address=str(peer_raw["address"]),
             ssh=str(peer_raw["ssh"]) if peer_raw.get("ssh") else None,
         )
+    install_pin = raw.get("install_pin")
     return OtaSmokePlan(
         state_path=path,
         workdir=str(raw["workdir"]),
         rosotacom=str(raw["rosotacom"]),
         project=str(raw["project"]),
         peers=peers,
+        install_mode=_ota_validate_install_mode(str(raw["install_mode"])),
+        install_pin=str(install_pin) if install_pin else None,
     )
 
 
@@ -1625,11 +1680,124 @@ def _ota_source_checkout() -> Path | None:
     return None
 
 
+def _ota_requirement_is_optional(requirement: str) -> bool:
+    """Whether a Requires-Dist entry only applies to an extra.
+
+    `packaging` is not a runtime dependency, so the marker is inspected
+    textually. An extra-guarded requirement always carries `extra ==` in its
+    marker, which is enough to separate `pytest>=8.3; extra == "dev"` from a
+    runtime entry with an environment marker such as `tomli; python_version <
+    "3.11"`.
+    """
+    _, separator, marker = requirement.partition(";")
+    return bool(separator) and "extra" in marker and "==" in marker
+
+
+def _ota_installed_distribution() -> importlib.metadata.Distribution | None:
+    """The installed distribution that provides the running rosotacom package.
+
+    Deduplicated and order-preserving: a machine migrated from `rosotacom` to
+    `rosotacom-dev` can carry both dist-info directories in one environment, and
+    the first resolvable one is the one `__version__` reports.
+    """
+    candidates = importlib.metadata.packages_distributions().get(PACKAGE_DIR.name, ())
+    for candidate in dict.fromkeys(candidates):
+        try:
+            return importlib.metadata.distribution(candidate)
+        except importlib.metadata.PackageNotFoundError:
+            continue
+    return None
+
+
+@dataclass(frozen=True)
+class OtaBundleMetadata:
+    """Packaging metadata of the rosotacom distribution that is running."""
+
+    name: str
+    version: str
+    requires_python: str
+    dependencies: tuple[str, ...]
+    console_scripts: tuple[tuple[str, str], ...]
+
+
+def _ota_bundle_metadata() -> OtaBundleMetadata:
+    """Read the running distribution's metadata for the OTA source bundle.
+
+    This used to be a literal in `_ota_packaged_source_bundle`, i.e. a second
+    copy of `pyproject.toml` maintained by hand. The copies drifted: `mcap` and
+    `Pillow` were added to the project and never to the literal, so a peer
+    prepared from an installed rosotacom got an environment that imported fine
+    and then failed inside the first MCAP or image code path — remotely only,
+    and only for OTA runs started from an install. Derive it instead, so there
+    is exactly one source of truth. `tests/contract/test_ota_source_bundle.py`
+    fails if this stops matching the distribution.
+    """
+    distribution = _ota_installed_distribution()
+    if distribution is None:
+        raise RuntimeError(
+            f"Cannot read the packaging metadata of the installed {PACKAGE_DIR.name!r} distribution, so "
+            "the OTA source bundle cannot be built. Run ota-smoke from a rosotacom checkout, or from an "
+            "installation made with pip/pipx rather than a bare copy of the package directory."
+        )
+    scripts = tuple(
+        (entry.name, entry.value)
+        for entry in sorted(distribution.entry_points, key=lambda entry: entry.name)
+        if entry.group == "console_scripts"
+    )
+    return OtaBundleMetadata(
+        name=distribution.metadata["Name"],
+        version=distribution.version,
+        requires_python=distribution.metadata.get("Requires-Python") or ">=3.10",
+        dependencies=tuple(
+            requirement
+            for requirement in (distribution.requires or ())
+            if not _ota_requirement_is_optional(requirement)
+        ),
+        console_scripts=scripts,
+    )
+
+
+def _ota_distribution_name() -> str:
+    """Name of the distribution that publishes this source.
+
+    Derived, never assumed: this source ships as `rosotacom-dev` from the
+    development fork and as `rosotacom` upstream, and pin mode has to ask the
+    index for the right one.
+    """
+    distribution = _ota_installed_distribution()
+    if distribution is not None:
+        return str(distribution.metadata["Name"])
+    checkout = _ota_source_checkout()
+    if checkout is not None:
+        # A checkout that was never installed still declares its own name. Read
+        # it textually: `tomllib` does not exist on the supported 3.10 floor.
+        match = re.search(
+            r"^\s*name\s*=\s*[\"']([^\"']+)[\"']",
+            (checkout / "pyproject.toml").read_text(encoding="utf-8"),
+            re.MULTILINE,
+        )
+        if match:
+            return match.group(1)
+    raise RuntimeError(
+        "Cannot determine which distribution publishes this rosotacom, so --install-mode pin cannot "
+        "name a package to install. Run from an installed rosotacom or from a checkout with a "
+        "readable pyproject.toml."
+    )
+
+
+def _ota_toml_string(value: str) -> str:
+    """Encode a string as a TOML basic string (JSON escaping is compatible)."""
+    return json.dumps(value)
+
+
 def _ota_packaged_source_bundle(destination: Path) -> Path:
+    metadata = _ota_bundle_metadata()
     source_root = destination / "rosotacom-source"
     package_target = source_root / "src" / "rosotacom"
     package_target.parent.mkdir(parents=True)
     shutil.copytree(PACKAGE_DIR, package_target)
+    dependencies = ", ".join(_ota_toml_string(item) for item in metadata.dependencies)
+    scripts = [f"{name} = {_ota_toml_string(target)}" for name, target in metadata.console_scripts]
     (source_root / "pyproject.toml").write_text(
         "\n".join(
             [
@@ -1638,15 +1806,13 @@ def _ota_packaged_source_bundle(destination: Path) -> Path:
                 'build-backend = "setuptools.build_meta"',
                 "",
                 "[project]",
-                'name = "rosotacom"',
-                f'version = "{__version__}"',
-                'requires-python = ">=3.10"',
-                'dependencies = ["argcomplete>=3.6,<4", "PyYAML>=6", "ros2docker>=0.1.4,<0.2"]',
+                f"name = {_ota_toml_string(metadata.name)}",
+                f"version = {_ota_toml_string(metadata.version)}",
+                f"requires-python = {_ota_toml_string(metadata.requires_python)}",
+                f"dependencies = [{dependencies}]",
                 "",
                 "[project.scripts]",
-                'rosotacom = "rosotacom.cli:main"',
-                'start_rosotacom = "rosotacom.cli:start_compat_main"',
-                'stop_rosotacom = "rosotacom.cli:stop_compat_main"',
+                *scripts,
                 "",
                 "[tool.setuptools]",
                 'package-dir = {"" = "src"}',
@@ -1922,6 +2088,10 @@ def _ota_write_manifest(
             "deployment_state": str(plan.state_path) if plan.state_path else None,
             "workdir": plan.workdir,
             "project": plan.project,
+            # What the peers actually ran, so a result can be attributed to an
+            # artefact rather than to "whatever was on the laptop that day".
+            "install_mode": plan.install_mode,
+            "install_pin": plan.install_pin,
             "peers": {
                 name: {"ssh_configured": bool(peer.ssh), "address": peer.address} for name, peer in plan.peers.items()
             },
@@ -2069,6 +2239,8 @@ def _resolve_ota_smoke_context(
         plan = _ota_plan_from_bindings(
             bindings,
             workdir=str(getattr(args, "workdir", None) or "/tmp/rosotacom_ota"),
+            install_mode=str(getattr(args, "install_mode", None) or "source"),
+            install_pin=getattr(args, "install_pin", None),
         )
     plan_peers = set(plan.peers)
     target_peers = set(_peer_keys_from_cfg(target.cfg))
@@ -2343,14 +2515,15 @@ def _ota_stage_text(peer: OtaSmokePeer, text: str, destination: str, *, dry_run:
 
 
 def _ota_remap_config_roots(
-    raw: Any, key: str, project_root: Path, source_checkout: Path | None, staged_source: str
+    raw: Any, key: str, project_root: Path, rosotacom_root: Path | None, remote_rosotacom_root: str | None
 ) -> Any:
-    """Rewrite config-root paths so they resolve on the remote staged tree.
+    """Rewrite config-root paths so they resolve on the remote.
 
     - relative roots resolve under the staged project, so keep them verbatim;
     - absolute roots inside the project become relative (staged with the project);
-    - absolute roots inside the staged rosotacom source point at the remote source
-      path (``{workdir}/source/...``), since the examples are staged there;
+    - absolute roots inside the local rosotacom tree point at wherever that tree
+      lives on the peer: the staged source (``{workdir}/source/...``) in source
+      mode, and the installed package directory in pin mode;
     - anything else is left untouched (it cannot be staged automatically and will
       surface as a clear "Path does not exist" on the remote).
     """
@@ -2367,9 +2540,9 @@ def _ota_remap_config_roots(
         if rel_to_project is not None:
             remapped.append(rel_to_project.as_posix())
             continue
-        rel_to_source = _relative_to(path, source_checkout) if source_checkout else None
-        if rel_to_source is not None:
-            remapped.append(f"{staged_source}/{rel_to_source.as_posix()}")
+        rel_to_source = _relative_to(path, rosotacom_root) if rosotacom_root else None
+        if rel_to_source is not None and remote_rosotacom_root:
+            remapped.append(f"{remote_rosotacom_root}/{rel_to_source.as_posix()}")
             continue
         remapped.append(str(value))
     if scalar:
@@ -2377,7 +2550,11 @@ def _ota_remap_config_roots(
     return remapped
 
 
-def _ota_remote_project_config(runtime: RuntimeConfig, plan: OtaSmokePlan, source_checkout: Path | None) -> str:
+def _ota_remote_project_config(
+    runtime: RuntimeConfig,
+    rosotacom_root: Path | None,
+    remote_rosotacom_root: str | None,
+) -> str:
     if not runtime.rosotacom_config:
         raise RuntimeError("ota-smoke requires an active rosotacom.yaml project.")
     raw = _load_yaml_file(runtime.rosotacom_config)
@@ -2386,26 +2563,69 @@ def _ota_remote_project_config(runtime: RuntimeConfig, plan: OtaSmokePlan, sourc
         raw["deployment"] = ".rosotacom/deployment.yaml"
     if runtime.profiles_file and _relative_to(runtime.profiles_file, project_root) is None:
         raw["profiles"] = ".rosotacom/profiles.yaml"
-    staged_source = f"{plan.workdir}/source"
     for key in ("session_configs_dir", "scenario_configs_dir"):
         if raw.get(key) is not None:
-            raw[key] = _ota_remap_config_roots(raw[key], key, project_root, source_checkout, staged_source)
+            raw[key] = _ota_remap_config_roots(raw[key], key, project_root, rosotacom_root, remote_rosotacom_root)
     return yaml.safe_dump(raw, sort_keys=False)
+
+
+def _ota_install_pin_script(plan: OtaSmokePlan) -> str:
+    """Create a venv on the peer and install the pinned release into it."""
+    venv = shlex.quote(f"{plan.workdir}/venv")
+    requirement = shlex.quote(f"{_ota_distribution_name()}=={plan.install_pin}")
+    return (
+        f"rm -rf {venv} && python3 -m venv {venv} && "
+        f"{venv}/bin/python -m pip install --upgrade pip && "
+        f"{venv}/bin/python -m pip install {requirement}"
+    )
+
+
+def _ota_remote_package_dir(peer: OtaSmokePeer, plan: OtaSmokePlan, *, dry_run: bool) -> str | None:
+    """Ask the peer's own installation where its packaged resources live.
+
+    Only pin mode needs this: no source tree is staged, so a project config that
+    points into rosotacom's packaged examples has to be remapped onto the path
+    the peer's venv actually installed them at. The peer answers through the same
+    `resources path` interface every other external consumer uses.
+    """
+    if dry_run:
+        return f"{plan.workdir}/venv/<site-packages>/rosotacom"
+    command = _ota_quote_cmd([f"{plan.workdir}/{plan.rosotacom}", "resources", "path", "package"])
+    result = _ota_run(peer, command, label=f"{peer.name}: locate packaged resources", dry_run=False)
+    return (result.stdout or "").strip() or None
 
 
 def _ota_prepare_hosts(args: argparse.Namespace, runtime: RuntimeConfig, plan: OtaSmokePlan) -> None:
     if not runtime.rosotacom_config:
         raise RuntimeError("ota-smoke requires an active rosotacom.yaml project.")
     dry_run = bool(getattr(args, "dry_run", False))
-    source_checkout = _ota_source_checkout()
+    from_pin = plan.install_mode == "pin"
+    source_checkout: Path | None = None
     temporary_bundle: Path | None = None
-    if source_checkout is None:
-        temporary_bundle = Path(tempfile.mkdtemp(prefix="rosotacom-ota-source-"))
-        source_checkout = _ota_packaged_source_bundle(temporary_bundle)
+    if not from_pin:
+        source_checkout = _ota_source_checkout()
+        if source_checkout is None:
+            temporary_bundle = Path(tempfile.mkdtemp(prefix="rosotacom-ota-source-"))
+            source_checkout = _ota_packaged_source_bundle(temporary_bundle)
     reuse = bool(getattr(args, "reuse", False))
     try:
         for peer in plan.peers.values():
-            if not reuse:
+            if reuse:
+                _ota_run(
+                    peer,
+                    f"test -x {shlex.quote(plan.workdir + '/' + plan.rosotacom)}",
+                    label=f"{peer.name}: reuse rosotacom",
+                    dry_run=dry_run,
+                )
+            elif from_pin:
+                _ota_run(
+                    peer,
+                    _ota_install_pin_script(plan),
+                    label=f"{peer.name}: install rosotacom {plan.install_pin} from the index",
+                    dry_run=dry_run,
+                )
+            else:
+                assert source_checkout is not None
                 _ota_stage_tree(
                     peer,
                     source_checkout,
@@ -2423,13 +2643,13 @@ def _ota_prepare_hosts(args: argparse.Namespace, runtime: RuntimeConfig, plan: O
                         ".venv/bin/python -m pip install -e ."
                     )
                 _ota_run(peer, install, label=f"{peer.name}: install rosotacom", dry_run=dry_run)
+
+            if from_pin:
+                local_root: Path | None = PACKAGE_DIR
+                remote_root = _ota_remote_package_dir(peer, plan, dry_run=dry_run)
             else:
-                _ota_run(
-                    peer,
-                    f"test -x {shlex.quote(plan.workdir + '/' + plan.rosotacom)}",
-                    label=f"{peer.name}: reuse rosotacom",
-                    dry_run=dry_run,
-                )
+                local_root = source_checkout
+                remote_root = f"{plan.workdir}/source"
 
             project_root = runtime.rosotacom_config.parent
             _ota_stage_tree(
@@ -2441,7 +2661,7 @@ def _ota_prepare_hosts(args: argparse.Namespace, runtime: RuntimeConfig, plan: O
             )
             _ota_stage_text(
                 peer,
-                _ota_remote_project_config(runtime, plan, source_checkout),
+                _ota_remote_project_config(runtime, local_root, remote_root),
                 f"{plan.workdir}/{plan.project}",
                 dry_run=dry_run,
                 label=f"{peer.name}: write staged project config",
@@ -7962,6 +8182,20 @@ def main(argv: list[str] | None = None) -> int:
         "--reuse",
         action="store_true",
         help="Reuse an already installed rosotacom source tree in the workdir.",
+    )
+    ota_smoke_parser.add_argument(
+        "--install-mode",
+        choices=list(OTA_INSTALL_MODES),
+        default="source",
+        help=(
+            "How the peers get rosotacom. 'source' (default) stages and installs what you are running — "
+            "right while iterating on rosotacom. 'pin' installs a published release from the index, so the "
+            "peers run the artefact that ships — right when rehearsing a deployment."
+        ),
+    )
+    ota_smoke_parser.add_argument(
+        "--install-pin",
+        help="Version for --install-mode pin (default: the version of the rosotacom you are running).",
     )
     ota_smoke_parser.add_argument(
         "--keep-workdir",

--- a/tests/contract/test_ota_source_bundle.py
+++ b/tests/contract/test_ota_source_bundle.py
@@ -1,0 +1,120 @@
+"""The OTA source bundle must not restate packaging metadata.
+
+`ota-smoke --install-mode source` stages a source tree to each peer. When it is
+invoked from an installed rosotacom there is no checkout to stage, so the bundle
+is reconstructed from the installed package and given a generated
+`pyproject.toml`.
+
+That generated file used to carry a hand-written copy of the project's
+dependencies, name and entry points. The copies drifted: `mcap` and `Pillow`
+were added to the project and never to the literal, and the name still said
+`rosotacom` after the fork was renamed to `rosotacom-dev`. A peer prepared from
+an installed rosotacom therefore got an environment that imported fine and then
+failed inside the first MCAP or image code path — remotely only, under OTA only,
+and only when the run started from an install rather than a checkout.
+
+These tests pin the metadata to a single source of truth.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+import rosotacom.cli as cli
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[2]
+PYPROJECT_PATH = PACKAGE_ROOT / "pyproject.toml"
+
+# PEP 440 public version, optionally with a local segment. "0+unknown" — what an
+# unresolvable distribution name degrades to — deliberately does not match.
+VERSION_RE = re.compile(r"^\d+(\.\d+)*((a|b|rc|\.post|\.dev)\d+)*(\+[a-zA-Z0-9.]+)?$")
+
+
+def _project_dependency_names() -> set[str]:
+    """Runtime dependency names declared in pyproject.toml's [project] table."""
+    text = PYPROJECT_PATH.read_text(encoding="utf-8")
+    block = re.search(r"^dependencies = \[(.*?)^\]", text, re.MULTILINE | re.DOTALL)
+    assert block is not None, "pyproject.toml has no [project] dependencies array"
+    return {_normalise(item) for item in re.findall(r"\"([^\"]+)\"", block.group(1))}
+
+
+def _normalise(requirement: str) -> str:
+    """Distribution name of a requirement, lowercased with separators unified."""
+    name = re.split(r"[<>=!~;\[\s]", requirement.strip(), maxsplit=1)[0]
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+@pytest.fixture(scope="module")
+def metadata() -> cli.OtaBundleMetadata:
+    distribution = cli._ota_installed_distribution()
+    if distribution is None:
+        pytest.skip("rosotacom is not installed in this environment; the bundle cannot be derived")
+    return cli._ota_bundle_metadata()
+
+
+def test_bundle_dependencies_cover_every_runtime_dependency(metadata: cli.OtaBundleMetadata) -> None:
+    """The regression: mcap and Pillow were declared but never bundled."""
+    bundled = {_normalise(item) for item in metadata.dependencies}
+
+    assert _project_dependency_names() <= bundled
+
+
+def test_bundle_excludes_optional_dependencies(metadata: cli.OtaBundleMetadata) -> None:
+    """Peers need the runtime stack, not the dev toolchain."""
+    bundled = {_normalise(item) for item in metadata.dependencies}
+
+    assert "pytest" not in bundled
+    assert "ruff" not in bundled
+    assert "matplotlib" not in bundled
+
+
+def test_bundle_name_matches_the_published_distribution(metadata: cli.OtaBundleMetadata) -> None:
+    text = PYPROJECT_PATH.read_text(encoding="utf-8")
+    declared = re.search(r"^name = \"([^\"]+)\"", text, re.MULTILINE)
+    assert declared is not None
+
+    assert _normalise(metadata.name) == _normalise(declared.group(1))
+
+
+def test_bundle_version_is_installable(metadata: cli.OtaBundleMetadata) -> None:
+    """`0+unknown` in the generated pyproject makes the remote build fail."""
+    assert metadata.version != "0+unknown"
+    assert VERSION_RE.match(metadata.version), f"not a PEP 440 version: {metadata.version!r}"
+
+
+def test_bundle_console_scripts_match_the_project(metadata: cli.OtaBundleMetadata) -> None:
+    text = PYPROJECT_PATH.read_text(encoding="utf-8")
+    block = re.search(r"^\[project\.scripts\](.*?)^\[", text, re.MULTILINE | re.DOTALL)
+    assert block is not None
+    declared = dict(re.findall(r"^(\S+) = \"([^\"]+)\"", block.group(1), re.MULTILINE))
+
+    assert dict(metadata.console_scripts) == declared
+
+
+def test_generated_pyproject_declares_the_derived_metadata(metadata: cli.OtaBundleMetadata, tmp_path: Path) -> None:
+    """End to end: the file the peer builds from carries the derived values."""
+    generated = (cli._ota_packaged_source_bundle(tmp_path) / "pyproject.toml").read_text(encoding="utf-8")
+
+    assert f'name = "{metadata.name}"' in generated
+    assert f'version = "{metadata.version}"' in generated
+    for requirement in metadata.dependencies:
+        assert f'"{requirement}"' in generated
+
+
+def test_the_historical_literal_would_fail_this_guard() -> None:
+    """Proof that the guard bites: the hand-written list that shipped up to 2.3."""
+    shipped_until_2_3 = ("argcomplete>=3.6,<4", "PyYAML>=6", "ros2docker>=0.1.4,<0.2")
+    bundled = {_normalise(item) for item in shipped_until_2_3}
+
+    assert not _project_dependency_names() <= bundled
+
+
+def test_requirement_extras_are_recognised() -> None:
+    assert cli._ota_requirement_is_optional('pytest>=8.3; extra == "dev"')
+    assert cli._ota_requirement_is_optional('matplotlib>=3.8; extra == "plots"')
+    assert not cli._ota_requirement_is_optional("PyYAML>=6")
+    # An environment marker is not an extra: the peer needs this one.
+    assert not cli._ota_requirement_is_optional('tomli; python_version < "3.11"')

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -18,6 +18,7 @@ import pytest
 import yaml
 
 import rosotacom.cli as rosotacom
+from rosotacom.deployment import PeerBinding
 
 
 @pytest.fixture(autouse=True)
@@ -2784,3 +2785,98 @@ def test_resources_path_reports_an_incomplete_installation(monkeypatch: pytest.M
     monkeypatch.setitem(rosotacom.NAMED_RESOURCES, "ws", tmp_path / "gone")
     with pytest.raises(RuntimeError, match="missing from this rosotacom installation"):
         rosotacom.resources_path_command(argparse.Namespace(name="ws"))
+
+
+def _ota_bindings() -> dict[str, PeerBinding]:
+    return {
+        "a": PeerBinding("a", "10.0.0.10", None, "workstation"),
+        "b": PeerBinding("b", "10.0.0.11", "robot-b", "robot"),
+    }
+
+
+def test_ota_source_mode_stages_a_checkout_and_owns_the_default() -> None:
+    plan = rosotacom._ota_plan_from_bindings(_ota_bindings(), workdir="/tmp/rosotacom_ota")
+
+    assert plan.install_mode == "source"
+    assert plan.install_pin is None
+    assert plan.rosotacom == "source/.venv/bin/rosotacom"
+
+
+def test_ota_pin_mode_defaults_to_the_running_version() -> None:
+    # `--install-mode pin` alone means "rehearse what I am running, as it
+    # ships", so it must not need a second flag to be useful.
+    plan = rosotacom._ota_plan_from_bindings(_ota_bindings(), workdir="/tmp/rosotacom_ota", install_mode="pin")
+
+    assert plan.install_pin == rosotacom.__version__
+    assert plan.rosotacom == "venv/bin/rosotacom"
+
+
+def test_ota_pin_mode_installs_the_published_distribution() -> None:
+    plan = rosotacom._ota_plan_from_bindings(
+        _ota_bindings(), workdir="/tmp/rosotacom_ota", install_mode="pin", install_pin="2.4"
+    )
+
+    script = rosotacom._ota_install_pin_script(plan)
+
+    assert "python3 -m venv /tmp/rosotacom_ota/venv" in script
+    assert f"pip install {rosotacom._ota_distribution_name()}==2.4" in script
+    # Nothing is staged in pin mode: the peer pulls the artefact from the index.
+    assert "source" not in script
+
+
+def test_ota_pin_mode_rejects_a_version_no_index_can_serve() -> None:
+    # A local build ("0+unknown", or anything with a local segment) would make
+    # the peers install some *other* version while the manifest claims this one.
+    for unusable in ("0+unknown", "2.4.dev3+g1234567"):
+        with pytest.raises(RuntimeError, match="not something an index can serve"):
+            rosotacom._ota_plan_from_bindings(
+                _ota_bindings(), workdir="/tmp/rosotacom_ota", install_mode="pin", install_pin=unusable
+            )
+
+
+def test_ota_install_pin_requires_pin_mode() -> None:
+    with pytest.raises(RuntimeError, match="only applies to --install-mode pin"):
+        rosotacom._ota_plan_from_bindings(
+            _ota_bindings(), workdir="/tmp/rosotacom_ota", install_mode="source", install_pin="2.4"
+        )
+
+
+def test_ota_rejects_an_unknown_install_mode() -> None:
+    with pytest.raises(RuntimeError, match="Unsupported OTA install mode"):
+        rosotacom._ota_plan_from_bindings(_ota_bindings(), workdir="/tmp/rosotacom_ota", install_mode="wheel")
+
+
+def test_ota_state_round_trips_the_install_mode(tmp_path: Path) -> None:
+    runtime, _resolved = _write_test_scenario_project(tmp_path)
+    plan = rosotacom._ota_plan_from_bindings(
+        _ota_bindings(), workdir="/tmp/rosotacom_ota", install_mode="pin", install_pin="2.4"
+    )
+    target = rosotacom._resolve_interactive_smoke_target("demo", runtime, "auto")
+    instance = rosotacom._resolve_session_instance(runtime, target.session, "ota")
+
+    plan = rosotacom._ota_write_state(instance, plan)
+
+    # A stop or a --state-file resume must reach the same executable the start
+    # installed; losing the mode here would look for a source tree that is
+    # not there.
+    assert rosotacom._ota_load_state(str(plan.state_path)) == plan
+
+
+def test_ota_manifest_records_what_the_peers_ran(tmp_path: Path) -> None:
+    runtime, _resolved = _write_test_scenario_project(tmp_path)
+    plan = rosotacom._ota_plan_from_bindings(
+        _ota_bindings(), workdir="/tmp/rosotacom_ota", install_mode="pin", install_pin="2.4"
+    )
+    target = rosotacom._resolve_interactive_smoke_target("demo", runtime, "auto")
+    instance = rosotacom._resolve_session_instance(runtime, target.session, "ota")
+    plan = rosotacom._ota_write_state(instance, plan)
+
+    rosotacom._ota_write_manifest(
+        instance, target, runtime, plan, tmux_session=None, interactive=False, phase="running"
+    )
+
+    manifest = yaml.safe_load((instance.host_dir / "manifest.yaml").read_text(encoding="utf-8"))
+    run = manifest["ota_smoke_runs"]["scenario:demo"]
+
+    assert run["install_mode"] == "pin"
+    assert run["install_pin"] == "2.4"

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -2880,3 +2880,22 @@ def test_ota_manifest_records_what_the_peers_ran(tmp_path: Path) -> None:
 
     assert run["install_mode"] == "pin"
     assert run["install_pin"] == "2.4"
+
+
+def test_pin_mode_does_not_query_a_self_contained_project(tmp_path: Path) -> None:
+    # The peer lookup exists only for projects that reuse rosotacom's packaged
+    # configs. Running it unconditionally would make pin mode depend on a
+    # command that older pinned versions do not have, for an answer it would
+    # then discard.
+    runtime, _resolved = _write_test_scenario_project(tmp_path)
+
+    assert rosotacom._ota_project_uses_packaged_configs(runtime) is False
+
+
+def test_pin_mode_queries_a_project_reusing_packaged_configs(tmp_path: Path) -> None:
+    runtime, _resolved = _write_test_scenario_project(tmp_path)
+    config = rosotacom._load_yaml_file(runtime.rosotacom_config)
+    config["session_configs_dir"] = str(rosotacom.EXAMPLE_PROJECT_DIR / "sessions")
+    runtime.rosotacom_config.write_text(yaml.safe_dump(config), encoding="utf-8")
+
+    assert rosotacom._ota_project_uses_packaged_configs(runtime) is True


### PR DESCRIPTION
Closes #202.

Consumers of this package should only ever see the installed interface, never a
checkout. `resources path` (#201) closed the last hole in that boundary; this
makes the boundary cheap enough that nobody is tempted to route around it.

## A release-blocking bug found on the way

An installed `rosotacom-dev` reports its version as `0+unknown`. The package
looked up the distribution name `rosotacom`, which the fork stopped using when
it was renamed. Verified against a clean install of the 2.3 wheel:

```
$ pip install rosotacom_dev-2.3-py3-none-any.whl && rosotacom --version
rosotacom 0+unknown
```

Two consequences, both silent:

- a consumer cannot compare `--version` against its pin, so a version check
  either always warns or is quietly useless;
- `ota-smoke` started from an installation writes that string into the
  `pyproject.toml` it generates for each peer, where it is not a valid PEP 440
  version and the remote build fails outright.

The name is derived now, so the same source is correct as `rosotacom-dev` here
and as `rosotacom` upstream. 2.3 cannot be replaced — a published version is
immutable — so its release notes record the defect and point at 2.4.

## Development channel

`setuptools-scm` already derived `X.Y.devN`; CI built those wheels and threw
them away, so pinning this package meant waiting for a release decision. The
cheap way out of that wait is to stop consuming the package at all, which is
exactly the failure this boundary work is meant to prevent.

`dev-release.yml` publishes them. It triggers on `workflow_run` (CI completing
successfully on `develop`), not on `push`, so a commit whose checks failed is
never published, and it pins the checkout to the validated SHA rather than the
branch tip. It refuses any version that is not a pre-release; `release.yml` now
asserts the mirror image, so neither channel can publish under the other's
identity.

`pip` does not resolve pre-releases unless asked, so the stable line is
unaffected.

## Metadata duplication, and where it had already drifted

`_ota_packaged_source_bundle` restated the project's name, dependencies and
entry points as a literal — a second copy of `pyproject.toml` maintained by
hand. The copies no longer agreed: `mcap` and `Pillow` were declared in the
project and missing from the literal, and the name still said `rosotacom`.

The imports are lazy, so the CLI started fine and then failed inside the first
MCAP or image code path — on the peer only, under OTA only, and only when the
run started from an install. Derived from the installed distribution now;
`tests/contract/test_ota_source_bundle.py` fails on any future divergence, and
includes a test proving the guard bites against the literal that shipped.

## `ota-smoke --install-mode pin`

The rehearsal always installed from source, so it never exercised the wheel that
ships and could not catch a packaging defect — the class of bug it exists to
catch before a target machine sees it.

`pin` installs a published version on each peer instead, defaulting to the
caller's own version so `--install-mode pin` alone means "rehearse what I am
running, as it ships". Project config roots pointing into rosotacom are remapped
onto the peer's installation by asking it through `resources path`, which gains
`package` and `examples` for that. The manifest records the mode and version, so
a result can be attributed to an artefact.

`source` is unchanged and stays the default.

## Also

`docs/ci.md` and `docs/release.md` claimed tags are cut from `main`. Every tag
from v2.1 on was cut from `develop`, which is this repository's default branch;
corrected while adding the channel.

## Validation

- `just lint`, `just typecheck`, `just docs` — clean
- `just test-unit`, `just test-contract` — 588 passed (16 new)
- `actionlint` on both workflows — clean
- clean-venv install of the built wheel, confirming the version fix end to end

## Owner smoke

```bash
pipx install "rosotacom-dev==2.4" && rosotacom --version
```

Expected: `rosotacom 2.4` — not `0+unknown`.
