### PR TITLE
Say that the dev channel needs its own Trusted Publisher

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -42,8 +42,13 @@ jobs:
     if: >-
       github.event.workflow_run.conclusion == 'success'
       && github.event.workflow_run.event == 'push'
-    # Same authorization as release.yml: the per-repo Trusted Publisher,
-    # registered with a blank environment. No token, no environment admin.
+    # Authorized by a Trusted Publisher registered with a blank environment. No
+    # token, no environment admin.
+    #
+    # PyPI matches the OIDC claims of the *workflow file*, so this needs its own
+    # registration for `dev-release.yml`; release.yml's does not cover it. Until
+    # that exists the build succeeds and the upload fails with
+    # `invalid-publisher`. See docs/github-repository-settings.md.
     permissions:
       id-token: write
 

--- a/docs/github-repository-settings.md
+++ b/docs/github-repository-settings.md
@@ -29,6 +29,41 @@ gh api "repos/$REPO/code-scanning/default-setup"
 gh variable get PYPI_PUBLISH_URL --repo "$REPO"
 ```
 
+`gh ruleset check` reports which rules apply, not which status checks they
+require. A ruleset can be named for CI and still carry no
+`required_status_checks` rule, in which case auto-merge will merge a pull
+request whose checks are red. Read the rule types out directly:
+
+```bash
+gh api "repos/$REPO/rulesets" --jq '.[].id' \
+  | xargs -I{} gh api "repos/$REPO/rulesets/{}" \
+      --jq '{name, rules: [.rules[] | select(.type=="required_status_checks")
+             | .parameters.required_status_checks[].context]}'
+```
+
+Expected output names `ci-success`. An empty list is the drift this section
+exists to catch.
+
+## Trusted Publishers
+
+PyPI authorizes an upload by matching the OIDC claims of the *workflow file*
+that requests it, so a publisher registration is per filename, not per
+repository. This codebase publishes from two:
+
+| Workflow | Publishes | Registration |
+|---|---|---|
+| `release.yml` | stable `vX.Y.Z` tags | required |
+| `dev-release.yml` | `X.Y.devN` from the development branch | required for the development channel |
+
+A missing registration fails at upload with `invalid-publisher: valid token, but
+no corresponding publisher`, after a completely successful build. The message
+prints the claims it presented; `workflow_ref` is the filename to register.
+
+Register on PyPI under the project's *Publishing* settings: owner, repository,
+the workflow filename, and an empty environment (this codebase deliberately uses
+no GitHub environment, so that no repository sharing it needs environment-admin
+rights).
+
 ## Repository Metadata
 
 Expected topics include `ros2`, `docker`, `robotics`, `teleoperation`, and

--- a/docs/release.md
+++ b/docs/release.md
@@ -86,11 +86,17 @@ distribution, and `SHA256SUMS`. Manual workflow dispatch validates and builds
 artifacts but does not publish; publishing a stable version requires a
 deliberate `vX.Y.Z` tag.
 
-Development-channel uploads use the same Trusted Publisher and the same
-`PYPI_PUBLISH_URL`. They are triggered by the CI workflow *completing
-successfully* on `develop`, not by the push itself, so a commit whose checks
-failed is never published. They skip the TestPyPI rehearsal: the dev channel is
-already the rehearsal.
+Development-channel uploads use the same `PYPI_PUBLISH_URL`. They are triggered
+by the CI workflow *completing successfully* on `develop`, not by the push
+itself, so a commit whose checks failed is never published. They skip the
+TestPyPI rehearsal: the dev channel is already the rehearsal.
+
+They need their **own** Trusted Publisher, because PyPI matches the OIDC claims
+of the workflow file and this one is `dev-release.yml`. Registering it is a
+one-time step, listed with the other out-of-git settings in
+[github-repository-settings.md](github-repository-settings.md). Without it the
+build succeeds and the upload fails with `invalid-publisher` — which reads like
+a code problem and is not one.
 
 The target index is set per repository by the `PYPI_PUBLISH_URL` Actions
 variable, and authorization is granted by the Trusted Publisher registered for


### PR DESCRIPTION
Refs #204.

The dev channel built correctly and failed at upload with `invalid-publisher`, because PyPI matches OIDC claims per workflow *file* and `dev-release.yml` has no registration of its own. That registration is an owner action and stays in #204; this makes the requirement discoverable instead of a surprise.

Also fixes a verification gap found while writing it up: `gh ruleset check` reports which rules apply, not which status checks they require. The documented contract says the required check is `ci-success`; the live ruleset has no `required_status_checks` rule at all, so auto-merge would merge a red PR. The added query is what surfaces that.

Docs only — no code, no workflow behaviour change.

## Validation

- `actionlint .github/workflows/dev-release.yml` — clean
- `just docs` subset (markdown links, README examples, workflow contracts) — 14 passed