### PR TITLE
Run run_session.py through the interpreter, not by its executable bit

### DIFF
--- a/src/rosotacom/cli.py
+++ b/src/rosotacom/cli.py
@@ -98,7 +98,19 @@ SESSION_CONFIG_CONTAINER_DIR = "/session/configs"
 SESSION_DEFINITION_CONTAINER_DIR = "/session/definitions"
 SESSION_INSTANCE_CONTAINER_DIR = "/session/instances"
 EXTERNAL_SESSION_CONTAINER_DIR = "/session/current"
-RUN_SESSION_CONTAINER_PATH = "/ws/session/creation/run_session.py"
+# Run through the interpreter, never as a bare path. `docker exec` on a bare
+# path relies on the file's executable bit, and a wheel does not carry
+# executable bits for package data: the bit is present in a checkout and gone
+# after an install. Every packaged machine therefore failed with
+# `exec: "/ws/session/creation/run_session.py": permission denied` and exit 126,
+# while the development laptop — an editable install over the checkout — worked.
+# That is the one shape no test exercised, and the only shape a control centre,
+# a vehicle or a bench machine ever runs.
+#
+# Not relying on the bit beats making the bit survive packaging: one is a
+# property of this command, the other a property of every tool in the chain.
+# `anonymize_bag.py` two thousand lines below already does it this way.
+RUN_SESSION_CONTAINER_ARGV = ("python3", "/ws/session/creation/run_session.py")
 DEFAULT_SMOKE_SESSION = "1_heartbeat"
 OTA_SUDO_MODES = ("passwordless", "askpass")
 
@@ -4299,7 +4311,7 @@ def _session_command(
     link_trace_modem_command: str | None = None,
 ) -> list[str]:
     parts = [
-        RUN_SESSION_CONTAINER_PATH,
+        *RUN_SESSION_CONTAINER_ARGV,
         "--session-dir",
         session.container_dir,
         "--output-dir",

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1759,6 +1759,7 @@ def test_peer_binding_identity_and_command_helpers(tmp_path: Path, monkeypatch: 
         peer_address_overrides={"a": "10.0.0.1", "b": "10.0.0.2"},
         attach_mode="attach",
     ) == [
+        "python3",
         "/ws/session/creation/run_session.py",
         "--session-dir",
         "/session/current",
@@ -1799,6 +1800,41 @@ def test_peer_binding_identity_and_command_helpers(tmp_path: Path, monkeypatch: 
 
     with pytest.raises(RuntimeError, match="Duplicate"):
         rosotacom._parse_peer_address_overrides(["a=1.1.1.1", "a=2.2.2.2"])
+
+
+def test_container_scripts_run_through_the_interpreter() -> None:
+    """No `docker exec` may depend on a file's executable bit.
+
+    A wheel does not carry executable bits for package data, so a bare script
+    path works from a checkout and fails from an install with
+
+        exec: "/ws/session/creation/run_session.py": permission denied
+
+    and exit 126. That broke `rosotacom start` on every packaged machine —
+    bench, control centre, vehicle — while the development laptop's editable
+    install kept working, which is why it survived to a two-host bring-up on
+    2026-08-09 before anyone saw it.
+
+    Asserted as a property rather than as one literal command, so a second
+    script added later fails here instead of on a machine.
+    """
+    assert rosotacom.RUN_SESSION_CONTAINER_ARGV[0] == "python3"
+    assert rosotacom.RUN_SESSION_CONTAINER_ARGV[1].endswith("/run_session.py")
+
+    # And the same for any container script added later. Comment lines are
+    # dropped first: the explanation above quotes the failing path, and a test
+    # that reads prose as code would fail on the wrong thing.
+    code = "\n".join(
+        line
+        for line in Path(rosotacom.__file__).read_text(encoding="utf-8").splitlines()
+        if not line.lstrip().startswith("#")
+    )
+    for match in re.finditer(r'"(/ws/[^"]*\.py)"', code):
+        preceding = code[max(0, match.start() - 200) : match.start()]
+        assert '"python3"' in preceding, (
+            f"{match.group(1)} is handed to the container without an interpreter; "
+            "a wheel install has no executable bit and this fails with exit 126"
+        )
 
 
 def test_resolve_session_and_base_extra_run_args(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Fixes #208

## What

`docker exec` was handed the bare path `/ws/session/creation/run_session.py`,
which relies on the file's executable bit. A wheel does not carry executable
bits for package data, so `rosotacom start` worked from a checkout and failed
from every install with `permission denied` and exit 126.

## How it was found

Bringing up a two-host link on 2026-08-09 — bench centre `tks-majestic`
(pipx `rosotacom-dev==2.4`) and the vehicle peer on a laptop running the same
pin in a throwaway venv. Both reached exit 126 at the same step, seconds apart,
which is what made it obviously the package and not the machines.

```
-rwxrwxr-x  src/rosotacom/resources/ws/.../run_session.py    checkout
-rw-rw-r--  .../site-packages/rosotacom/.../run_session.py   wheel
```

## The gap behind it

Nothing had ever started a session from a wheel. The development laptop runs an
editable install over the checkout, and the e2e lanes run from the repository.
The packaged artifact is the only shape a control centre, a vehicle or a bench
machine runs, and it was the one shape never exercised end to end.

Worth a follow-up on its own: a lane that installs the built wheel and starts
one session would have caught this before it reached a machine.

## Why the interpreter rather than the bit

Not depending on the executable bit is a property of this command. Making the
bit survive is a property of every packaging tool in the chain — setuptools,
wheel, pip, and whatever replaces them. `anonymize_bag.py` already ran through
`python3`; `run_session.py` was the outlier.

## Verification

- 591 unit and contract tests pass; `just lint` and `just typecheck` clean.
- The new test asserts the property, not one literal command, so a container
  script added later fails here instead of on a machine.
- The test was checked against the defect: reintroducing the bare path makes it
  fail, and reverting makes it pass again. (My first version of it passed in
  both directions — a vacuous regex — which is why this note exists.)

## Owner smoke

On any machine with a wheel install of this branch's dev release:

```bash
cd ~/dev/fleet_mgmt/compositions/fleet_mgmt_demo/a_control_center
./restart_com.sh --peer center=majestic_tks --peer vehicle=lamborghini_tks
```

Expected: the `docker exec … run_session.py` line is followed by a started
session instead of `exit status 126`.
