### PR TITLE
Share the host IPC namespace, so a peer can hear the machine it runs on

### DIFF
--- a/src/rosotacom/cli.py
+++ b/src/rosotacom/cli.py
@@ -4249,13 +4249,40 @@ def _create_scenario_tmux(
     return session_name
 
 
+def _local_ipc_run_args(network_isolated: bool) -> list[str]:
+    """Share the host IPC namespace, unless the run is network-isolated.
+
+    A peer has to exchange local-domain data with application containers on the
+    same machine — a replay, the control centre. With `--network host` but
+    `ipc=private` each container has its own `/dev/shm`, FastDDS sees two
+    participants on one host, negotiates shared memory, and writes into a
+    segment the other side cannot map. Discovery goes over UDP and works;
+    delivery goes over SHM and is dropped without a word.
+
+    The result is the worst shape a failure can take: the link comes up, the
+    heartbeat crosses at 10 Hz with 0% loss, every pipeline reads `pub=1 sub=1`
+    — and no payload ever enters it. Measured on 2026-08-09: 399 messages in
+    eight seconds inside the publisher's container, 0 in the peer's.
+
+    The OTA path never showed it, because the generated unicast profile pins
+    explicit locators and therefore forces UDP.
+
+    Not under `--network-name`. Sharing SHM there would let DDS bypass the very
+    boundary the isolation exists to simulate, and a test that passes through a
+    hole in its own isolation is worse than no test at all.
+    """
+    return [] if network_isolated else ["--ipc", "host"]
+
+
 def _base_extra_run_args(
     runtime: RuntimeConfig,
     session: ResolvedSession,
     cfg: dict[str, Any],
     instance: SessionInstance,
+    *,
+    network_isolated: bool = False,
 ) -> list[str]:
-    args: list[str] = []
+    args: list[str] = _local_ipc_run_args(network_isolated)
     ros2docker_cfg = load_config(runtime.ros2docker_config)
 
     if not ros2docker_cfg.get("mount_ws"):
@@ -4425,7 +4452,7 @@ def start_session(args: argparse.Namespace) -> str:
                 " (or pass --force to replace it, --skip-conflict-check to ignore it).",
             )
     image_name = _scoped_image_name(runtime)
-    extra_run_args = _base_extra_run_args(runtime, session, cfg, instance)
+    extra_run_args = _base_extra_run_args(runtime, session, cfg, instance, network_isolated=network_isolated)
     run_override: dict[str, object] = {}
     network_name = getattr(args, "network_name", None)
     if network_name:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1888,6 +1888,29 @@ def test_resolve_session_and_base_extra_run_args(tmp_path: Path, monkeypatch: py
     assert f"{runtime.session_configs_dir[0]}:/session/definitions:ro" in args
     assert f"{runtime.session_instances_dir}:/session/instances" in args
     assert "Configured sessions:" in rosotacom._format_available_sessions(runtime)
+    # A peer shares the host IPC namespace, so it can exchange local-domain
+    # data with application containers on the same machine. See
+    # `_local_ipc_run_args` for what happens without it.
+    assert args[:2] == ["--ipc", "host"]
+
+
+def test_a_peer_shares_the_host_ipc_namespace_unless_isolated() -> None:
+    """Without it, a peer receives nothing from a local application container.
+
+    `--network host` with `ipc=private` gives every container its own
+    /dev/shm. FastDDS sees two participants on one host, chooses shared memory,
+    and the reader never maps the writer's segment. Discovery succeeds, delivery
+    does not, and nothing in the output says so: the link comes up, the
+    heartbeat crosses at 10 Hz with 0% loss, and no payload ever enters it.
+
+    Isolated on 2026-08-09 with two containers from one image on one host:
+    `ipc=private` received 0 messages, `--ipc host` received 200.
+    """
+    assert rosotacom._local_ipc_run_args(network_isolated=False) == ["--ipc", "host"]
+    # Under network isolation it must not be shared: SHM would carry data
+    # straight past the boundary the isolation exists to simulate, and a test
+    # that passes through a hole in its own isolation is worse than none.
+    assert rosotacom._local_ipc_run_args(network_isolated=True) == []
 
 
 def test_container_helpers_use_docker_and_ros2docker_stop(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1928,7 +1951,7 @@ def test_start_session_detached_dispatches_ros2docker(monkeypatch: pytest.Monkey
     monkeypatch.setattr(
         rosotacom,
         "_base_extra_run_args",
-        lambda runtime, session, cfg, instance: ["--network", "host"],
+        lambda runtime, session, cfg, instance, **kwargs: ["--network", "host"],
     )
     monkeypatch.setattr(rosotacom, "_resolve_mode", lambda mode: "detached")
     monkeypatch.setattr(rosotacom, "_list_docker_containers", lambda all_states=False: [])
@@ -1972,7 +1995,7 @@ def test_start_session_attach_dispatches_command_run(monkeypatch: pytest.MonkeyP
     monkeypatch.setattr(rosotacom, "_effective_session_config", lambda *args, **kwargs: cfg)
     monkeypatch.setattr(rosotacom, "_auto_identity", lambda *args: "a")
     monkeypatch.setattr(rosotacom, "_scoped_image_name", lambda runtime: "image:id")
-    monkeypatch.setattr(rosotacom, "_base_extra_run_args", lambda runtime, session, cfg, instance: [])
+    monkeypatch.setattr(rosotacom, "_base_extra_run_args", lambda runtime, session, cfg, instance, **kwargs: [])
     monkeypatch.setattr(rosotacom, "_resolve_mode", lambda mode: "attach")
     monkeypatch.setattr(rosotacom, "_list_docker_containers", lambda all_states=False: [])
     monkeypatch.setattr(rosotacom, "_stop_container_name", lambda *args, **kwargs: True)

--- a/tests/unit/test_concurrency.py
+++ b/tests/unit/test_concurrency.py
@@ -143,7 +143,7 @@ def _patch_start_session_collaborators(
     monkeypatch.setattr(rosotacom, "_resolve_session", lambda session_dir, runtime: session)
     monkeypatch.setattr(rosotacom, "_effective_session_config", lambda *args, **kwargs: cfg)
     monkeypatch.setattr(rosotacom, "_scoped_image_name", lambda runtime: "image:id")
-    monkeypatch.setattr(rosotacom, "_base_extra_run_args", lambda runtime, session, cfg, instance: [])
+    monkeypatch.setattr(rosotacom, "_base_extra_run_args", lambda runtime, session, cfg, instance, **kwargs: [])
     monkeypatch.setattr(rosotacom, "_resolve_mode", lambda mode: "detached")
     monkeypatch.setattr(rosotacom, "_container_exists", lambda name: False)
     monkeypatch.setattr(rosotacom, "_wait_for_container_ready", lambda name: None)


### PR DESCRIPTION
Fixes #212

## What

Peer containers now run with `--ipc host`, except under `--network-name`.

## The failure

A peer exchanged **no** data with application containers on the same host.
Measured with a plain rclpy subscriber, no ros2cli involved:

```
inside the publishing container : /can/twist: 399 messages in 8s
inside the peer container       : /can/twist: 0 messages in 8s
```

`--network host` with `ipc=private` gives every container its own `/dev/shm`.
FastDDS sees two participants on one host, negotiates shared memory, and writes
into a segment the other side cannot map. Discovery goes over UDP and works;
delivery goes over SHM and is dropped silently. The two `/dev/shm` directories
held 228 and 14 `fastdds_*` files, disjoint.

Isolated to that one variable, two throwaway containers from the same image,
same host, same ROS domain:

| | received |
|---|---|
| `ipc=private` (today) | 0 messages |
| `--ipc host` | 200 messages |

## Why it stayed hidden

The OTA path uses the generated **unicast** profile, which pins explicit
locators and therefore forces UDP. That path works — on one host and across
two. Only the *local* domain, peer to application container, uses default
transports.

So the failure took the worst available shape: the link comes up, the heartbeat
crosses at 10 Hz with 0% loss, the status overview reads `pub=1 sub=1` at every
stage of every pipeline — and no payload ever enters it. Everything a person
would check says healthy.

`examples/scripts/5_sized_payload/machine_{a,b}` already passed `--ipc host`,
so this was understood once and never reached the peer containers.

## The isolation exception

Not under `--network-name`. Sharing SHM there would let DDS carry data straight
past the boundary the isolation exists to simulate — a test that passes through
a hole in its own isolation is worse than no test. A unit test pins both halves
so the exception cannot be lost later.

## Checks

- [x] 592 unit and contract tests pass
- [x] `just lint`, `just typecheck` clean

## Owner smoke

With a peer and a replay running on one machine:

```bash
docker inspect -f '{{.Name}} {{.HostConfig.IpcMode}}' $(docker ps -q)
```

Expected: `host` for the peer container. Before this change: `private`, and the
peer's `status.txt` shows every payload topic `[STALLED]` while the heartbeat
is `[OK]`.
