### PR TITLE
Refuse a run that declares vs_bag_ratio and supplies no bag

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -75,6 +75,16 @@ planned decimation is not counted as OTA loss. The default `--min-ratio 0.9`
 leaves a safety margin for a healthy link; tune it per gate instead of
 committing a brittle 100% threshold.
 
+**`vs_bag_ratio` is replay-only, and the run refuses to pretend otherwise.** It
+compares the delivered rate to the source's native rate, which only the bag
+knows, so `rosotacom test` needs `--bag <dir>` to evaluate it. Until #214 a run
+without one skipped those assertions silently and still printed `TEST OK` — a
+session could declare completeness on every topic and have none of it checked.
+`test` now exits non-zero naming the topics instead. If a session genuinely is
+not replay-driven, drop the assertion rather than running without the bag: a
+skipped check reads as coverage, which is the failure mode these contracts
+exist to catch.
+
 Transient-local or explicitly latched topics become `mode: latched`, because the
 contract is that the held value arrives, not that the topic keeps ticking.
 Sparse volatile topics become `mode: existence`; the current expect model has no

--- a/src/rosotacom/cli.py
+++ b/src/rosotacom/cli.py
@@ -6540,6 +6540,26 @@ def test_command(args: argparse.Namespace) -> int:
         from . import bag_ground_truth
 
         ground_truth = bag_ground_truth.bag_ground_truth(bag)
+    elif not getattr(args, "suggest", False):
+        # A `vs_bag_ratio` needs the bag's native rate, and without one it is
+        # skipped rather than failed -- so the run would print TEST OK having
+        # checked nothing about completeness. Refuse instead: the declaration
+        # is the statement of intent, and honouring it or failing loudly is
+        # this command's job.
+        needs_bag = status_eval.topics_requiring_bag(expect_by_topic, profile)
+        if needs_bag:
+            listed = "\n".join(f"    {base}" for base in needs_bag)
+            print(
+                f"rosotacom test: {len(needs_bag)} topic(s) declare "
+                f"`completeness.vs_bag_ratio`, which compares the delivered rate "
+                f"to the source's native rate and can only be evaluated against "
+                f"the replay bag:\n{listed}\n"
+                f"Pass `--bag <dir>`, or drop the assertion from a session that "
+                f"is not replay-driven. Without a bag it would be skipped in "
+                f"silence and this run would report success.",
+                file=sys.stderr,
+            )
+            return 1
     reports: dict[str, Any] = {}
     failures: list[str] = []
 

--- a/src/rosotacom/status_eval.py
+++ b/src/rosotacom/status_eval.py
@@ -105,6 +105,27 @@ def resolve_expect_for_profile(expect: dict[str, Any], profile: str | None) -> d
     return resolved
 
 
+def topics_requiring_bag(expect_by_topic: dict[str, dict[str, Any]], profile: str | None = None) -> list[str]:
+    """Topics whose expectations can only be evaluated against a replay bag.
+
+    `completeness.vs_bag_ratio` compares the delivered rate to the *source's*
+    native rate, which only a bag knows. `_check_bag_completeness` returns
+    early when no ground truth was supplied, so without `--bag` such an
+    expectation is skipped in silence and the run still prints `TEST OK`.
+
+    A skipped assertion reads as coverage, which is worse than no assertion at
+    all: it is the exact shape of the defect these contracts exist to catch.
+    The caller uses this to refuse the run instead.
+    """
+    required = []
+    for base, raw in sorted((expect_by_topic or {}).items()):
+        expect = resolve_expect_for_profile(raw or {}, profile)
+        completeness = expect.get("completeness") or {}
+        if isinstance(completeness, dict) and completeness.get("vs_bag_ratio") is not None:
+            required.append(base)
+    return required
+
+
 def expectations_from_cfg(cfg: dict[str, Any]) -> dict[str, dict[str, Any]]:
     """Map a topic's base name -> its `expect` block, from a session config."""
     out: dict[str, dict[str, Any]] = {}

--- a/tests/unit/test_status_eval.py
+++ b/tests/unit/test_status_eval.py
@@ -7,6 +7,7 @@ from rosotacom.status_eval import (
     evaluate_reports,
     expectations_from_cfg,
     resolve_expect_for_profile,
+    topics_requiring_bag,
 )
 
 
@@ -350,11 +351,37 @@ def test_bag_completeness_above_ratio_passes() -> None:
 
 
 def test_bag_completeness_skipped_without_ground_truth() -> None:
+    # `evaluate_report` itself still skips -- it has no bag to compare against.
+    # That silence is exactly why the CLI must refuse the run one level up; see
+    # the `topics_requiring_bag` tests below (#214).
     topic = {"base": "/tf", "direction": "inbound", "overall": "OK", "stages": [_counted2("app_in", 1.0, 100)]}
     assert (
         evaluate_report({"peer": "a", "topics": [topic]}, {"/tf": {"completeness": {"vs_bag_ratio": 0.9}}}, None, None)
         == []
     )
+
+
+def test_topics_requiring_bag_lists_only_replay_only_expectations() -> None:
+    expect = {
+        "/tf": {"completeness": {"vs_bag_ratio": 0.1}},
+        "/costmap": {"completeness": {"vs_bag_ratio": 0.85}},
+        "/plain": {"hz": {"min": 5}},
+        "/within_peer_only": {"completeness": {"min_ratio": 0.7}},
+    }
+    assert topics_requiring_bag(expect) == ["/costmap", "/tf"]
+
+
+def test_topics_requiring_bag_is_empty_without_any_declaration() -> None:
+    assert topics_requiring_bag({"/plain": {"hz": {"min": 5}}}) == []
+    assert topics_requiring_bag({}) == []
+
+
+def test_topics_requiring_bag_sees_a_per_profile_declaration() -> None:
+    # RFC 0004: the conditional block can come from a profile override, so a
+    # profiled run must be inspected through the same resolution the evaluator
+    # uses -- otherwise the requirement is invisible under `--profile`.
+    expect = {"/tf": {"per_profile": {"lossy": {"completeness": {"vs_bag_ratio": 0.5}}}}}
+    assert topics_requiring_bag(expect, profile="lossy") == ["/tf"]
 
 
 def test_suggest_stream_topic_emits_hz_band() -> None:


### PR DESCRIPTION
Fixes #214.

`completeness.vs_bag_ratio` was skipped rather than failed when `rosotacom test` had no `--bag`, so a session could declare it on every topic and the run would still print `TEST OK`. `test` now exits non-zero and names the topics.

## Owner smoke

Against fleet_mgmt's `ccng_remote_assist`, which now declares eight of them:

```bash
cd ~/dev/rosotacom_test
export ROSOTACOM_COM_MSGS="$(rosotacom resources path com_msgs)"
rosotacom test ccng_remote_assist --project fzi_projects/remote_assist/rosotacom.yaml --timeout 1
```

Expected — exit 1, before any status evaluation:

```
rosotacom test: 8 topic(s) declare `completeness.vs_bag_ratio`, which compares the
delivered rate to the source's native rate and can only be evaluated against the
replay bag:
    /can/steering_angle
    /can/twist
    /costmap/costmap
    /mission/progress
    /tf
    /visualization/maneuver/announcements_barriers
    /visualization/map/sliding_driving_area
    /visualization/planning/pso/submitted_visualization
```

Adding `--bag ~/dev/fleet_mgmt/center/ws/full_center_side_recordings/ccng_r2_mission01_vehicle_native` proceeds to normal evaluation. Both verified.

## Validation

- `tests/unit/test_status_eval.py`: three new cases — only replay-only expectations are listed, an empty/plain contract requires nothing, and a declaration that exists only under `per_profile` is seen with `--profile`. 54 pass.
- `docs/testing.md` states the assertion is replay-only and why skipping was removed.