### PR TITLE
Stop the run that exists, not the one the flags describe

### DIFF
--- a/src/rosotacom/cli.py
+++ b/src/rosotacom/cli.py
@@ -2319,6 +2319,30 @@ def _infer_active_ota_smoke_run(
     )
 
 
+def _ota_latest_state_for(
+    runtime: RuntimeConfig, target: InteractiveSmokeTarget, instance_id: str | None
+) -> str | None:
+    """The newest `ota-deployment.yaml` for this target, if one is on disk.
+
+    Instances are laid out `<instances>/<date>/<session>_<time>_<instance-id>/`,
+    so a named instance can be matched by suffix and an unnamed one by
+    modification time. Returns None rather than raising: not finding a state is
+    a normal outcome (nothing was ever started here), and the caller has a
+    command line to fall back to.
+    """
+    root = _session_instances_root(runtime)
+    if not root.is_dir():
+        return None
+    candidates = sorted(
+        (path for path in root.glob("*/*/ota-deployment.yaml")),
+        key=lambda path: path.stat().st_mtime,
+        reverse=True,
+    )
+    if instance_id:
+        candidates = [path for path in candidates if path.parent.name.endswith(f"_{instance_id}")]
+    return str(candidates[0]) if candidates else None
+
+
 def _resolve_ota_smoke_context(
     args: argparse.Namespace,
 ) -> tuple[RuntimeConfig, OtaSmokePlan, InteractiveSmokeTarget]:
@@ -2327,6 +2351,21 @@ def _resolve_ota_smoke_context(
         getattr(args, "target", None), runtime, getattr(args, "target_type", "auto")
     )
     state_file = getattr(args, "state_file", None)
+    if not state_file and getattr(args, "stop", False):
+        # Stopping has to reach the run that exists, and the only record of how
+        # that run was deployed is the state a start wrote. Reconstructing a
+        # plan from the command line instead means guessing the install mode,
+        # and the default guess is `source` — which points the stop at
+        # `/tmp/rosotacom_ota/source/.venv/bin/rosotacom` for peers that were
+        # started from their own checkouts. Observed on 2026-08-11: every peer
+        # stop failed silently (they are best-effort), the containers stayed up,
+        # and the only visible action was a cleanup removing a staging directory
+        # that had never been created. Usually the live tmux session carries the
+        # state path; when it does not — a killed session, a run started from
+        # another terminal — the instance directory still does.
+        state_file = _ota_latest_state_for(runtime, target, getattr(args, "instance_id", None))
+        if state_file:
+            print(f"OTA smoke: stopping the run recorded in {state_file}")
     if state_file:
         plan = _ota_load_state(state_file)
     else:
@@ -3594,6 +3633,17 @@ def _list_ota_smoke(args: argparse.Namespace) -> int:
 
 
 def _ota_cleanup_hosts(plan: OtaSmokePlan, *, dry_run: bool) -> None:
+    if plan.state_path is None:
+        # No recorded state means this plan came from the command line, so its
+        # install mode is a default rather than a fact about the run. Removing a
+        # workdir on that basis is a destructive act taken on a guess: it is how
+        # a stop that reached no peer still reported doing something. Say what
+        # is missing instead.
+        print(
+            "OTA smoke: skipping cleanup — no deployment state for this run, so its install mode is unknown. "
+            "Pass --state-file if a workdir really needs removing."
+        )
+        return
     if plan.install_mode == "checkout":
         # The workdir is the user's repository here. `rm -rf` on it would delete
         # a checkout with its untracked work — bags, instance artefacts, local

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -12,6 +12,7 @@ import sys
 import tarfile
 import zlib
 from collections.abc import Callable
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
@@ -3083,7 +3084,7 @@ def test_ota_cleanup_never_removes_a_checkout(tmp_path: Path, capsys: pytest.Cap
     # `--cleanup` exists to undo staging. In checkout mode the workdir is the
     # user's repository, so the same `rm -rf` would delete a checkout — with
     # its bags and untracked work — to remove files that were never created.
-    plan = _ota_checkout_plan(_write_checkout_project(tmp_path))
+    plan = replace(_ota_checkout_plan(_write_checkout_project(tmp_path)), state_path=tmp_path / "state.yaml")
     calls: list[str] = []
 
     original = rosotacom._ota_run
@@ -3108,3 +3109,38 @@ def test_ota_checkout_state_round_trips_the_peer_checkouts(tmp_path: Path) -> No
     # A --stop or --state-file resume must reach the same checkout the start
     # used; losing it would run the stop in the staging directory instead.
     assert rosotacom._ota_load_state(str(plan.state_path)) == plan
+
+
+def test_ota_stop_recovers_the_recorded_plan_instead_of_guessing(tmp_path: Path) -> None:
+    # A stop that reconstructs its plan from the command line guesses the
+    # install mode, and the default guess points at a staged interpreter that a
+    # checkout-mode run never installed: every peer stop then fails silently
+    # (they are best-effort) while the containers stay up.
+    runtime, _resolved = _write_test_scenario_project(tmp_path)
+    plan = _ota_checkout_plan(_write_checkout_project(tmp_path))
+    target = rosotacom._resolve_interactive_smoke_target("demo", runtime, "auto")
+    instance = rosotacom._resolve_session_instance(runtime, target.session, "ota")
+    written = rosotacom._ota_write_state(instance, plan)
+
+    found = rosotacom._ota_latest_state_for(runtime, target, "ota")
+
+    assert found == str(written.state_path)
+    assert rosotacom._ota_load_state(found).install_mode == "checkout"
+    assert rosotacom._ota_latest_state_for(runtime, target, "no-such-instance") is None
+
+
+def test_ota_cleanup_refuses_to_act_on_a_guessed_plan(capsys: pytest.CaptureFixture[str]) -> None:
+    # Without recorded state the install mode is a default, not a fact. Removing
+    # a workdir on that basis is a destructive act taken on a guess.
+    plan = rosotacom._ota_plan_from_bindings(_ota_bindings(), workdir="/tmp/rosotacom_ota")
+    calls: list[str] = []
+
+    original = rosotacom._ota_run
+    try:
+        rosotacom._ota_run = lambda *args, **kwargs: calls.append(str(args))  # type: ignore[assignment]
+        rosotacom._ota_cleanup_hosts(plan, dry_run=False)
+    finally:
+        rosotacom._ota_run = original  # type: ignore[assignment]
+
+    assert calls == []
+    assert "no deployment state" in capsys.readouterr().out


### PR DESCRIPTION
Found by the first `--install-mode checkout` run on real containers, which is
exactly the failure that mode makes possible: the install mode is now a fact
about a run rather than a detail all runs shared.

`ota-smoke --stop` rebuilt its plan from the command line whenever no
`--state-file` was passed. That means guessing how the run was deployed, and
the default guess is `source`, so a stop aimed at peers running from their own
checkouts looked for `/tmp/rosotacom_ota/source/.venv/bin/rosotacom`. Peer stops
are best-effort, so every one of them failed silently. Observed:

```
+ center: remove OTA workdir: running remote command
+ vehicle: remove OTA workdir: running remote command
OTA smoke cleanup attempted for: rung3_two_host (scenario)
$ docker ps --format '{{.Names}}'
rosotacom_..._scenario_rung3_two_host_vehicle_replay_ella
rosotacom_..._com_to_center
rosotacom_..._com_to_ella
```

Three containers still running, and the only action the command actually took
was removing a staging directory the run had never created. Passing
`--state-file <the run's ota-deployment.yaml>` stopped it correctly.

## Changes

- A stop with no state file looks for the run's own `ota-deployment.yaml` under
  the project's instances, newest first, filtered by `--instance-id` when given,
  and prints which one it used. The live tmux session usually carries that path;
  this covers a killed session, a run started from another terminal, or a
  machine rebooted in between.
- `_ota_cleanup_hosts` refuses to act on a reconstructed plan. Without recorded
  state its install mode is a default rather than a fact, and `rm -rf` on a
  directory chosen by a default is a destructive act taken on a guess. It now
  says what is missing.

## Validation

`just check` passes. Two new unit tests: the state lookup finds the run and its
recorded mode (and returns None for an instance id that does not exist), and
cleanup on a plan without state issues no remote command.

Owner smoke, single machine, no second host:

```bash
cd ~/dev/fleet_mgmt && tools/run_two_host.sh --pair local --depth 1
# then, from another terminal, without any peer/checkout flags:
. tools/rosotacom_env.sh && rosotacom ota-smoke rung3_two_host \
  --project session/rosotacom.yaml --target-type scenario --interactive --stop
docker ps    # expected: no rosotacom containers
```

Before this change the same stop left all three containers running.
