### PR TITLE
Give the isolation probe a real advertise deadline and honest failures

### DIFF
--- a/src/rosotacom/cli.py
+++ b/src/rosotacom/cli.py
@@ -3198,7 +3198,7 @@ def _ota_verify_isolation(
     published = _ota_run(source, publish, label=f"{source_name}: publish isolation probe", dry_run=dry_run, check=False)
     if published.returncode != 0:
         _ota_print_failure_output(f"{source_name}: publish isolation probe", published)
-        errors.append(f"{source_name}: isolation probe publisher failed")
+        errors.append(f"{source_name}: isolation probe did not advertise (probe-publish output above names the cause)")
         return errors
     _print_completed_output(published)
     check = _ota_rosotacom_command(plan, _ota_probe_check_parts(target, receiver_name, peer_args), receiver)
@@ -6332,8 +6332,17 @@ def _stop_smoke_topic_publishers(containers: dict[str, str], specs: list[SmokeTo
         )
 
 
+# How long the graph may take to report the probe publisher. A loaded graph
+# (e.g. a control centre with hundreds of topics) can take well over the old
+# fixed 10 s to discover a new publisher, and that delay is not a defect.
+_PROBE_ADVERTISE_TIMEOUT_S = 60.0
+# The probe must outlive the advertise wait plus the peer's absence check, or
+# the absence check passes trivially against an already-stopped publisher.
+_PROBE_DURATION_S = 120.0
+
+
 def _publish_isolation_probe(
-    container_name: str, ros_setup: str, topic: str, *, rate: float = 5.0, duration: float = 30.0
+    container_name: str, ros_setup: str, topic: str, *, rate: float = 5.0, duration: float = _PROBE_DURATION_S
 ) -> None:
     """Publish a local-only topic in the container's local application domain,
     detached, for `duration` seconds (self-stops via `timeout`)."""
@@ -6362,6 +6371,45 @@ def _topic_present(container_name: str, ros_setup: str, topic: str) -> bool:
     return topic in names
 
 
+def _isolation_probe_running(container_name: str, topic: str) -> bool:
+    """Whether the probe publisher for `topic` is still alive in the container."""
+    result = subprocess.run(
+        ["docker", "exec", container_name, "pgrep", "-f", f"ros2 topic pub {topic}"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.returncode == 0
+
+
+def _wait_for_probe_advertisement(
+    container_name: str,
+    ros_setup: str,
+    topic: str,
+    *,
+    timeout_s: float,
+    log_line: Callable[[str], None] | None = None,
+) -> str:
+    """Poll until `topic` is reported by the container's local graph.
+
+    Returns "advertised", "publisher-gone" (the probe process exited or never
+    started), or "timeout" (the publisher is alive but the graph did not report
+    the topic within `timeout_s`). Only "publisher-gone" points at a publisher
+    defect; a loaded graph reports late, which is what "timeout" captures.
+    """
+    deadline = time.monotonic() + timeout_s
+    while True:
+        if log_line is not None:
+            log_line(f"Waiting for isolation probe {topic} to advertise in {container_name}")
+        if _topic_present(container_name, ros_setup, topic):
+            return "advertised"
+        if not _isolation_probe_running(container_name, topic):
+            return "publisher-gone"
+        if time.monotonic() >= deadline:
+            return "timeout"
+        time.sleep(1)
+
+
 def _verify_isolation(
     pub_container: str,
     pub_setup: str,
@@ -6376,15 +6424,18 @@ def _verify_isolation(
     log_line(f"Starting isolation probe {topic} in {pub_container}")
     _publish_isolation_probe(pub_container, pub_setup, topic)
     try:
-        live = False
-        for _ in range(8):
-            log_line(f"Waiting for isolation probe {topic} to advertise in {pub_container}")
-            if _topic_present(pub_container, pub_setup, topic):
-                live = True
-                break
-            time.sleep(1)
-        if not live:
-            return [f"isolation check inconclusive: {topic} never advertised in {pub_container}"]
+        outcome = _wait_for_probe_advertisement(
+            pub_container, pub_setup, topic, timeout_s=_PROBE_ADVERTISE_TIMEOUT_S, log_line=log_line
+        )
+        if outcome == "publisher-gone":
+            return [
+                f"isolation check inconclusive: probe publisher for {topic} exited or never started in {pub_container}"
+            ]
+        if outcome == "timeout":
+            return [
+                f"isolation check inconclusive: probe publisher for {topic} is running in {pub_container} "
+                f"but the graph did not report it within {_PROBE_ADVERTISE_TIMEOUT_S:.0f}s"
+            ]
         log_line(f"Checking that isolation probe {topic} is absent in {check_container}")
         if _topic_present(check_container, check_setup, topic):
             return [f"isolation breach: {topic} from {pub_container} leaked to {check_container}"]
@@ -6516,12 +6567,32 @@ def probe_publish_command(args: argparse.Namespace) -> int:
     # Block until the topic is actually advertised so a caller's subsequent
     # absence check on the other peer is meaningful (not a false pass on a
     # publisher that never came up).
-    for _ in range(10):
-        if _topic_present(container, ros_setup, args.topic):
-            print(f"Publishing {args.topic} in {container} (identity {args.identity}); advertised.")
-            return 0
-        time.sleep(1)
-    print(f"ERROR: {args.topic} did not advertise in {container} (identity {args.identity})", file=sys.stderr)
+    started = time.monotonic()
+    outcome = _wait_for_probe_advertisement(container, ros_setup, args.topic, timeout_s=args.advertise_timeout)
+    if outcome == "advertised":
+        print(f"Publishing {args.topic} in {container} (identity {args.identity}); advertised.")
+        return 0
+    if outcome == "publisher-gone":
+        if time.monotonic() - started >= args.duration:
+            print(
+                f"ERROR: probe publisher for {args.topic} in {container} (identity {args.identity}) ran its "
+                f"{args.duration:.0f}s --duration without the graph reporting the topic; keep --duration "
+                f"above --advertise-timeout",
+                file=sys.stderr,
+            )
+        else:
+            print(
+                f"ERROR: probe publisher for {args.topic} exited or never started in {container} "
+                f"(identity {args.identity})",
+                file=sys.stderr,
+            )
+    else:
+        print(
+            f"ERROR: probe publisher for {args.topic} is running in {container} (identity {args.identity}) "
+            f"but the graph did not report it within {args.advertise_timeout:.0f}s; a loaded graph reports "
+            f"late, retry with a larger --advertise-timeout",
+            file=sys.stderr,
+        )
     return 1
 
 
@@ -8957,7 +9028,13 @@ def main(argv: list[str] | None = None) -> int:
     probe_publish_parser.add_argument("--instance-id")
     probe_publish_parser.add_argument("--topic", default=ISOLATION_PROBE_TOPIC)
     probe_publish_parser.add_argument("--rate", type=float, default=5.0)
-    probe_publish_parser.add_argument("--duration", type=float, default=30.0)
+    probe_publish_parser.add_argument("--duration", type=float, default=_PROBE_DURATION_S)
+    probe_publish_parser.add_argument(
+        "--advertise-timeout",
+        type=float,
+        default=_PROBE_ADVERTISE_TIMEOUT_S,
+        help="Seconds to wait for the local graph to report the probe topic before failing.",
+    )
     probe_publish_parser.add_argument(
         "--stop", action="store_true", help="Stop a running probe publisher instead of starting one."
     )

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1539,6 +1539,108 @@ def test_probe_verbs_dispatch_not_wrapped_in_start(monkeypatch: pytest.MonkeyPat
     assert seen[1][1].expect == "absent"
 
 
+def test_probe_publish_parser_advertise_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[argparse.Namespace] = []
+    monkeypatch.setattr(rosotacom, "probe_publish_command", lambda args: calls.append(args) or 0)
+
+    assert rosotacom.main(["probe-publish", "1_heartbeat", "--identity", "a"]) == 0
+    assert calls[0].advertise_timeout == rosotacom._PROBE_ADVERTISE_TIMEOUT_S
+    assert calls[0].duration == rosotacom._PROBE_DURATION_S
+
+    assert rosotacom.main(["probe-publish", "1_heartbeat", "--identity", "a", "--advertise-timeout", "90"]) == 0
+    assert calls[1].advertise_timeout == 90.0
+
+
+def _probe_publish_args(**overrides: object) -> argparse.Namespace:
+    args = argparse.Namespace(
+        identity="center",
+        stop=False,
+        topic="/local_only",
+        rate=5.0,
+        duration=rosotacom._PROBE_DURATION_S,
+        advertise_timeout=rosotacom._PROBE_ADVERTISE_TIMEOUT_S,
+    )
+    for key, value in overrides.items():
+        setattr(args, key, value)
+    return args
+
+
+def test_probe_publish_waits_past_slow_polls_until_advertised(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(rosotacom, "_resolve_running_peer", lambda args, identity: ("box", "setup", {}))
+    monkeypatch.setattr(rosotacom, "_publish_isolation_probe", lambda *a, **k: None)
+    monkeypatch.setattr(rosotacom, "_isolation_probe_running", lambda *a: True)
+    monkeypatch.setattr(rosotacom.time, "sleep", lambda s: None)
+    present = iter([False] * 15 + [True])
+    monkeypatch.setattr(rosotacom, "_topic_present", lambda *a: next(present))
+
+    assert rosotacom.probe_publish_command(_probe_publish_args()) == 0
+    assert "advertised." in capsys.readouterr().out
+
+
+def test_probe_publish_failure_names_slow_graph_not_publisher(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # Publisher alive but the deadline passes: the message must blame graph
+    # discovery, not the publisher (issue #219).
+    monkeypatch.setattr(rosotacom, "_resolve_running_peer", lambda args, identity: ("box", "setup", {}))
+    monkeypatch.setattr(rosotacom, "_publish_isolation_probe", lambda *a, **k: None)
+    monkeypatch.setattr(rosotacom, "_isolation_probe_running", lambda *a: True)
+    monkeypatch.setattr(rosotacom, "_topic_present", lambda *a: False)
+
+    assert rosotacom.probe_publish_command(_probe_publish_args(advertise_timeout=0.0)) == 1
+    err = capsys.readouterr().err
+    assert "is running" in err
+    assert "did not report it within" in err
+    assert "--advertise-timeout" in err
+
+
+def test_probe_publish_failure_names_dead_publisher(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(rosotacom, "_resolve_running_peer", lambda args, identity: ("box", "setup", {}))
+    monkeypatch.setattr(rosotacom, "_publish_isolation_probe", lambda *a, **k: None)
+    monkeypatch.setattr(rosotacom, "_isolation_probe_running", lambda *a: False)
+    monkeypatch.setattr(rosotacom, "_topic_present", lambda *a: False)
+
+    assert rosotacom.probe_publish_command(_probe_publish_args()) == 1
+    assert "exited or never started" in capsys.readouterr().err
+
+
+def test_wait_for_probe_advertisement_outcomes(monkeypatch: pytest.MonkeyPatch) -> None:
+    sleeps: list[float] = []
+    monkeypatch.setattr(rosotacom.time, "sleep", lambda s: sleeps.append(s))
+    monkeypatch.setattr(rosotacom, "_isolation_probe_running", lambda *a: True)
+    present = iter([False, False, True])
+    monkeypatch.setattr(rosotacom, "_topic_present", lambda *a: next(present))
+    assert rosotacom._wait_for_probe_advertisement("box", "setup", "/local_only", timeout_s=60.0) == "advertised"
+    assert len(sleeps) == 2
+
+    monkeypatch.setattr(rosotacom, "_topic_present", lambda *a: False)
+    assert rosotacom._wait_for_probe_advertisement("box", "setup", "/local_only", timeout_s=0.0) == "timeout"
+
+    monkeypatch.setattr(rosotacom, "_isolation_probe_running", lambda *a: False)
+    assert rosotacom._wait_for_probe_advertisement("box", "setup", "/local_only", timeout_s=60.0) == "publisher-gone"
+
+
+def test_verify_isolation_inconclusive_distinguishes_causes(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(rosotacom, "_publish_isolation_probe", lambda *a, **k: None)
+    stopped: list[str] = []
+    monkeypatch.setattr(rosotacom, "_stop_isolation_probe", lambda container, topic: stopped.append(container))
+
+    monkeypatch.setattr(rosotacom, "_wait_for_probe_advertisement", lambda *a, **k: "timeout")
+    errors = rosotacom._verify_isolation("pub", "ps", "chk", "cs", "/local_only", log_line=lambda _: None)
+    assert len(errors) == 1
+    assert "is running in pub" in errors[0]
+    assert "did not report it within" in errors[0]
+
+    monkeypatch.setattr(rosotacom, "_wait_for_probe_advertisement", lambda *a, **k: "publisher-gone")
+    errors = rosotacom._verify_isolation("pub", "ps", "chk", "cs", "/local_only", log_line=lambda _: None)
+    assert errors == ["isolation check inconclusive: probe publisher for /local_only exited or never started in pub"]
+    assert stopped == ["pub", "pub"]
+
+
 def test_expect_from_bag_fragment_passes_rosotacom_test(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],


### PR DESCRIPTION
Closes #219.

`probe-publish` waited a fixed 10x1 s for the probe topic to appear and then printed "did not advertise", regardless of whether the publisher was even running. On a normally loaded control centre (hundreds of topics in the local graph) discovery takes longer than that, so exactly the most realistic runs failed, with a message blaming the publisher.

## Changes

- The advertise wait runs on a monotonic deadline, configurable via `--advertise-timeout` (default 60 s, was a fixed ~10 s poll).
- While waiting, the publisher process is checked: a publisher that exited or never started fails immediately and says so; a publisher that is still running when the deadline passes yields "the graph did not report it in time" with a pointer to `--advertise-timeout`. Only the first is a probe/transport defect.
- Default probe `--duration` raised 30 s -> 120 s so the probe outlives the advertise wait plus the receiver's absence check (which otherwise passes trivially against an already-stopped publisher).
- The local `_verify_isolation` path reuses the same wait and distinguishes the same two inconclusive causes.
- The `ota-smoke` aggregate error no longer claims "isolation probe publisher failed"; it defers to the probe-publish output, which names the cause.

## Validation

- New unit tests: deadline-based wait outcomes (`_wait_for_probe_advertisement`), both failure messages of `probe-publish`, parser wiring of `--advertise-timeout`, and the `_verify_isolation` inconclusive messages.
- Fresh venv (`pip install -c requirements.txt -e .[dev]`): `pytest -q tests/unit tests/contract` -> 601 passed, 10 skipped; `mypy` and `ruff check` / `ruff format --check` clean.
- Commit: 844b01e.