### PR TITLE
Wait for scenario applications before the first verification check

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,7 +394,11 @@ rosotacom ota-smoke 2_native_chatter \
 
 `ota-smoke` accepts sessions and scenarios. It puts rosotacom on each peer,
 stages the active project, runs delivery and isolation checks, collects
-artifacts, stops the run, and removes the remote workdir. Add `--interactive`
+artifacts, stops the run, and removes the remote workdir. For scenario targets
+the checks start only once every declared application container is running
+(bounded at 10 minutes, covering a cold peer's first image build); an
+application that never comes up fails the run by name instead of as missing
+publishers. Add `--interactive`
 for a local control tmux with
 one attachable communication/catmux window per peer with a live status pane below
 each one. Scenario targets also get one native application-container window per

--- a/src/rosotacom/cli.py
+++ b/src/rosotacom/cli.py
@@ -3340,6 +3340,55 @@ def _ota_stop_peers(
         _ota_run(peer, command, label=f"{peer_name}: stop {target.name}", dry_run=dry_run, check=False)
 
 
+# How long verification waits for a scenario application container before it
+# gives up. Covers a first-run image build on a cold peer (observed ~3 min for
+# an apt-get install alone); the communication-container readiness wait uses
+# the same bound.
+OTA_SMOKE_APPLICATION_WAIT_TIMEOUT_S = 600
+
+
+def _ota_wait_for_scenario_applications(
+    target: InteractiveSmokeTarget,
+    plan: OtaSmokePlan,
+    *,
+    dry_run: bool,
+) -> list[str]:
+    """Block until every scenario application container declared for the target
+    is running on its peer. The application windows start their container only
+    after the peer's communication container is up, so on a cold machine the
+    first check would otherwise run against applications that are still being
+    built and report their absence as missing publishers (#218). A session
+    target declares no applications and passes through untouched.
+
+    Running is deliberately the whole bound: whether an application *produces*
+    is exactly what the session's own expectations then check."""
+    definition = target.scenario_definition
+    if definition is None:
+        return []
+    errors: list[str] = []
+    for peer_name in sorted(plan.peers):
+        peer = plan.peers[peer_name]
+        for application in definition.applications.get(peer_name, ()):
+            suffix = _sanitize_docker_name(f"_scenario_{target.name}_{peer_name}_{application.name}")
+            label = f"{peer_name}: wait for application {application.name}"
+            script = _ota_wait_for_running_container_suffix_script(
+                suffix,
+                f"{peer_name}:application:{application.name}",
+                timeout_s=OTA_SMOKE_APPLICATION_WAIT_TIMEOUT_S,
+            )
+            result = _ota_run(peer, script, label=label, dry_run=dry_run, check=False)
+            if result.returncode != 0:
+                _ota_print_failure_output(label, result)
+                errors.append(
+                    f"{peer_name}: application '{application.name}' has no running container after "
+                    f"{OTA_SMOKE_APPLICATION_WAIT_TIMEOUT_S}s; the scenario never came up, so its "
+                    "topics were not checked"
+                )
+            else:
+                _print_completed_output(result)
+    return errors
+
+
 def _ota_verify_only(args: argparse.Namespace) -> int:
     _runtime, plan, target = _resolve_ota_smoke_context(args)
     instance_id = getattr(args, "instance_id", None)
@@ -3347,6 +3396,11 @@ def _ota_verify_only(args: argparse.Namespace) -> int:
         raise RuntimeError("ota-smoke --verify-only requires --instance-id.")
     dry_run = bool(getattr(args, "dry_run", False))
     print(f"OTA smoke verification starting: {target.name} ({target.target_type}), instance={instance_id}")
+    errors = _ota_wait_for_scenario_applications(target, plan, dry_run=dry_run)
+    if errors:
+        for error in errors:
+            print(f"OTA SMOKE ERROR: {error}", file=sys.stderr)
+        return 1
     print("OTA smoke: starting synthetic publishers where needed.")
     _ota_start_session_publishers(target, plan, dry_run=dry_run)
     errors = _ota_verify_delivery(target, plan, instance_id, dry_run=dry_run)
@@ -3359,15 +3413,35 @@ def _ota_verify_only(args: argparse.Namespace) -> int:
     return 0
 
 
-def _ota_wait_for_running_container_suffix_script(suffix: str, label: str) -> str:
+def _ota_wait_for_running_container_suffix_script(suffix: str, label: str, timeout_s: int | None = None) -> str:
     pattern = shlex.quote(f"{re.escape(suffix)}$")
     quoted_label = shlex.quote(label)
-    return (
-        "container=''; "
-        f"until container=$(docker ps --filter status=running --format '{{{{.Names}}}}' "
+    find_container = (
+        f"container=$(docker ps --filter status=running --format '{{{{.Names}}}}' "
         f"| grep -E {pattern} | head -n 1) "
-        '&& [ -n "$container" ]; do '
-        f"echo '[INFO] waiting for running container:' {quoted_label}; "
+        '&& [ -n "$container" ]'
+    )
+    if timeout_s is None:
+        return (
+            "container=''; "
+            f"until {find_container}; do "
+            f"echo '[INFO] waiting for running container:' {quoted_label}; "
+            "sleep 2; "
+            "done; "
+            'echo "[INFO] found running container: $container"'
+        )
+    # Bounded variant for captured (non-interactive) callers: one line up front
+    # instead of a poll-cadence echo, and a hard failure when the bound is hit.
+    attempts = max(1, int(timeout_s) // 2)
+    return (
+        f"echo '[INFO] waiting up to {int(timeout_s)}s for running container:' {quoted_label}; "
+        "container=''; tries=0; "
+        f"until {find_container}; do "
+        "tries=$((tries+1)); "
+        f'if [ "$tries" -ge {attempts} ]; then '
+        f"echo '[ERROR] no running container after {int(timeout_s)}s:' {quoted_label} >&2; "
+        "exit 1; "
+        "fi; "
         "sleep 2; "
         "done; "
         'echo "[INFO] found running container: $container"'
@@ -3773,6 +3847,9 @@ def _start_noninteractive_ota_smoke(args: argparse.Namespace) -> int:
         )
         if not dry_run:
             time.sleep(12)
+        wait_errors = _ota_wait_for_scenario_applications(target, plan, dry_run=dry_run)
+        if wait_errors:
+            raise RuntimeError("OTA smoke verification failed:\n  - " + "\n  - ".join(wait_errors))
         _ota_start_session_publishers(target, plan, dry_run=dry_run)
         errors += _ota_verify_delivery(target, plan, instance.instance_id, dry_run=dry_run, profile=profile_name)
         errors += _ota_verify_isolation(target, plan, dry_run=dry_run)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -978,6 +978,133 @@ def test_ota_collect_logs_extracts_each_peer_into_instance(
     assert not list(host_dir.glob("**/*.tar.gz.b64"))
 
 
+def _wait_script_env(tmp_path: Path, docker_stdout: str) -> dict[str, str]:
+    """PATH with a stub docker that prints `docker_stdout` for any invocation."""
+    stub = tmp_path / "bin" / "docker"
+    stub.parent.mkdir(exist_ok=True)
+    stub.write_text(f"#!/bin/sh\nprintf '%s\\n' {rosotacom.shlex.quote(docker_stdout)}\n", encoding="utf-8")
+    stub.chmod(0o755)
+    return {**os.environ, "PATH": f"{stub.parent}:{os.environ['PATH']}"}
+
+
+def test_ota_wait_script_is_unbounded_without_timeout() -> None:
+    script = rosotacom._ota_wait_for_running_container_suffix_script("_com_to_b", "a:communication")
+
+    assert "exit 1" not in script
+    assert "waiting for running container:" in script
+
+
+def test_ota_bounded_wait_script_fails_clearly_when_the_bound_is_hit(tmp_path: Path) -> None:
+    script = rosotacom._ota_wait_for_running_container_suffix_script(
+        "_scenario_demo_a_local_app", "a:application:local_app", timeout_s=2
+    )
+
+    result = subprocess.run(
+        ["bash", "-c", script], env=_wait_script_env(tmp_path, "unrelated_container"), text=True, capture_output=True
+    )
+
+    assert result.returncode == 1
+    assert "[ERROR] no running container after 2s: a:application:local_app" in result.stderr
+
+
+def test_ota_bounded_wait_script_succeeds_once_the_container_runs(tmp_path: Path) -> None:
+    script = rosotacom._ota_wait_for_running_container_suffix_script(
+        "_scenario_demo_a_local_app", "a:application:local_app", timeout_s=2
+    )
+    runtime, _resolved = _write_test_scenario_project(tmp_path)
+    container = rosotacom._scenario_container_name(runtime, "demo", "a", "local_app", "run1")
+
+    result = subprocess.run(
+        ["bash", "-c", script], env=_wait_script_env(tmp_path, container), text=True, capture_output=True
+    )
+
+    assert result.returncode == 0
+    assert f"[INFO] found running container: {container}" in result.stdout
+
+
+def test_ota_wait_for_scenario_applications_waits_per_declared_application(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime, _resolved = _write_test_scenario_project(tmp_path)
+    target = rosotacom._resolve_interactive_smoke_target("demo", runtime, "scenario")
+    plan = _ota_plan(tmp_path)
+    ran: list[tuple[str, str]] = []
+
+    def fake_ota_run(peer: rosotacom.OtaSmokePeer, script: str, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        ran.append((peer.name, script))
+        return subprocess.CompletedProcess([], 0, "", "")
+
+    monkeypatch.setattr(rosotacom, "_ota_run", fake_ota_run)
+
+    assert rosotacom._ota_wait_for_scenario_applications(target, plan, dry_run=False) == []
+
+    assert [name for name, _script in ran] == ["a", "b"]
+    for identity, script in ran:
+        assert f"_scenario_demo_{identity}_local_app" in script
+        # The bound: verification must not wait forever, unlike the interactive panes.
+        assert "exit 1" in script
+
+
+def test_ota_wait_for_scenario_applications_reports_the_bound_not_the_topics(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime, _resolved = _write_test_scenario_project(tmp_path)
+    target = rosotacom._resolve_interactive_smoke_target("demo", runtime, "scenario")
+    plan = _ota_plan(tmp_path)
+
+    monkeypatch.setattr(
+        rosotacom,
+        "_ota_run",
+        lambda peer, script, **kwargs: subprocess.CompletedProcess([], 0 if peer.name == "a" else 1, "", ""),
+    )
+
+    errors = rosotacom._ota_wait_for_scenario_applications(target, plan, dry_run=False)
+
+    assert len(errors) == 1
+    assert "b: application 'local_app' has no running container" in errors[0]
+    assert "never came up" in errors[0]
+
+
+def test_ota_verify_only_stops_before_checks_when_applications_never_come_up(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime, _resolved = _write_test_scenario_project(tmp_path)
+    target = rosotacom._resolve_interactive_smoke_target("demo", runtime, "scenario")
+    plan = _ota_plan(tmp_path)
+    checks: list[str] = []
+
+    monkeypatch.setattr(rosotacom, "_resolve_ota_smoke_context", lambda args: (runtime, plan, target))
+    monkeypatch.setattr(
+        rosotacom,
+        "_ota_wait_for_scenario_applications",
+        lambda *args, **kwargs: ["b: application 'local_app' has no running container after 600s"],
+    )
+    monkeypatch.setattr(rosotacom, "_ota_start_session_publishers", lambda *args, **kwargs: checks.append("publishers"))
+    monkeypatch.setattr(rosotacom, "_ota_verify_delivery", lambda *args, **kwargs: checks.append("delivery") or [])
+    monkeypatch.setattr(rosotacom, "_ota_verify_isolation", lambda *args, **kwargs: checks.append("isolation") or [])
+
+    rc = rosotacom._ota_verify_only(argparse.Namespace(instance_id="run1", dry_run=False))
+
+    assert rc == 1
+    # The point of #218: no status checks against a scenario that is not up.
+    assert checks == []
+
+
+def test_ota_wait_for_scenario_applications_ignores_session_targets(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime, _resolved = _write_test_scenario_project(tmp_path)
+    target = rosotacom._resolve_interactive_smoke_target("demo", runtime, "session")
+    plan = _ota_plan(tmp_path)
+    monkeypatch.setattr(rosotacom, "_ota_run", lambda *args, **kwargs: pytest.fail("session targets must not wait"))
+
+    assert rosotacom._ota_wait_for_scenario_applications(target, plan, dry_run=False) == []
+
+
 def test_ota_smoke_parser_accepts_stop_without_peer_arguments(monkeypatch: pytest.MonkeyPatch) -> None:
     calls: list[argparse.Namespace] = []
     monkeypatch.setattr(rosotacom, "ota_smoke", lambda args: calls.append(args) or 0)
@@ -1072,6 +1199,9 @@ def test_noninteractive_ota_smoke_lifecycle_uses_generic_runner(
     monkeypatch.setattr(rosotacom, "_ota_preflight", lambda *args, **kwargs: calls.append("preflight"))
     monkeypatch.setattr(rosotacom, "_ota_prepare_hosts", lambda *args, **kwargs: calls.append("prepare"))
     monkeypatch.setattr(rosotacom, "_ota_start_peers", lambda *args, **kwargs: calls.append("start"))
+    monkeypatch.setattr(
+        rosotacom, "_ota_wait_for_scenario_applications", lambda *args, **kwargs: calls.append("wait-apps") or []
+    )
     monkeypatch.setattr(rosotacom, "_ota_start_session_publishers", lambda *args, **kwargs: calls.append("publishers"))
     monkeypatch.setattr(rosotacom, "_ota_verify_delivery", lambda *args, **kwargs: calls.append("test") or [])
     monkeypatch.setattr(rosotacom, "_ota_verify_isolation", lambda *args, **kwargs: calls.append("isolation") or [])
@@ -1100,6 +1230,7 @@ def test_noninteractive_ota_smoke_lifecycle_uses_generic_runner(
         "prepare",
         "start",
         "sleep:12",
+        "wait-apps",
         "publishers",
         "test",
         "isolation",
@@ -1155,6 +1286,8 @@ def test_ota_smoke_dry_run_exercises_generic_remote_flow(
     assert "b: SSH reachable: running remote command" in out
     assert "a: start demo: running remote command" in out
     assert "b: start demo: running remote command" in out
+    assert "a: wait for application local_app: running remote command" in out
+    assert "b: wait for application local_app: running remote command" in out
     assert "a: rosotacom test: running remote command" in out
     assert "a: publish isolation probe: running remote command" in out
     assert "b: check isolation probe absent: running remote command" in out


### PR DESCRIPTION
Fixes #218.

`ota-smoke --interactive` opened the verification window at the same moment as the application windows. The applications wait for their peer's communication container; verification waited for nothing, so on a cold machine it collected its status reports against applications that were still being built and reported every centre-side expectation as "no publisher" — loud, but misattributed to the topics instead of the timing.

Verification now uses the application windows' own primitive (`_ota_wait_for_running_container_suffix_script`) before its first check: per peer, it waits until every scenario application container declared for the target is running. Unlike the interactive panes the wait is bounded (600 s, covering the observed ~3 min cold image build), and hitting the bound fails the run with a message naming the application that never came up. A session target declares no applications and passes through untouched.

The non-interactive runner had the same race hiding behind its 12-second sleep and gets the same wait between starting the peers and checking them.

Decision recorded from the issue: waiting for *running* rather than *producing* is deliberate — whether an application produces is exactly what the session's own expectations then check.

Validation:

```
pytest -q tests/unit    # 548 passed (7 new: bounded/unbounded wait script, per-application wait, ordering)
pytest -q tests/contract
python -m mypy
ruff check / ruff format
```

The bounded wait script is exercised for real in the new tests (stubbed `docker` on PATH, both the timeout and the found path).
