### PR TITLE
Export the packaged resource paths rosotacom already owns

### DIFF
--- a/src/rosotacom/cli.py
+++ b/src/rosotacom/cli.py
@@ -8659,8 +8659,34 @@ TOP_LEVEL_COMMANDS = {
 }
 
 
+def _export_named_resource_paths() -> None:
+    """Put the packaged resource paths in the environment for ros2docker.
+
+    A ros2docker config driven by rosotacom may need to bake a package that
+    lives *inside* the rosotacom install — `com_msgs` above all, since both
+    sides of a link must agree on the message definitions. The install is
+    isolated by design, so the config cannot compute the path and writes
+    `${ROSOTACOM_COM_MSGS}` instead. Something has to put it there, and until
+    now that was every caller's job: a shell snippet each project carried,
+    sourced before every start and stop script.
+
+    That works until the caller is not a shell on the same machine. A two-host
+    OTA run reached the control-centre application on the far side and died with
+    `Could not expand environment variables in host path:
+    '${ROSOTACOM_COM_MSGS}'` — while the identical single-host run passed,
+    because there the peer inherited the variable from the orchestrator's
+    environment. The single-host run could not have caught it by construction.
+
+    rosotacom owns the resource, so rosotacom exports it. `setdefault`, so a
+    caller that deliberately points somewhere else still wins.
+    """
+    for name, path in NAMED_RESOURCES.items():
+        os.environ.setdefault(f"ROSOTACOM_{name.upper()}", str(path))
+
+
 def main(argv: list[str] | None = None) -> int:
     argv = list(sys.argv[1:] if argv is None else argv)
+    _export_named_resource_paths()
     if not argv:
         argv = ["start"]
     elif argv[0] not in TOP_LEVEL_COMMANDS and not argv[0].startswith("-"):

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -3364,6 +3364,37 @@ def _ota_exec_plan(project_config: Path, command: str = "remote-rosotacom majest
     )
 
 
+def test_named_resources_reach_ros2docker_through_the_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A ros2docker config cannot compute a path into an isolated install, so it
+    # writes ${ROSOTACOM_COM_MSGS}. Until this, every caller had to export that
+    # itself -- which works right up to the point where the caller is not a
+    # shell on the same machine. A two-host run died on the far side with
+    # "Could not expand environment variables in host path" while the identical
+    # single-host run passed, because there the peer inherited the variable from
+    # the orchestrator. The single-host run could not have caught it.
+    for name in rosotacom.NAMED_RESOURCES:
+        monkeypatch.delenv(f"ROSOTACOM_{name.upper()}", raising=False)
+
+    rosotacom._export_named_resource_paths()
+
+    assert os.environ["ROSOTACOM_COM_MSGS"] == str(rosotacom.NAMED_RESOURCES["com_msgs"])
+    assert Path(os.environ["ROSOTACOM_COM_MSGS"]).name == "com_msgs"
+
+
+def test_an_explicit_resource_path_is_not_overridden(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # setdefault, not assignment: a caller pointing somewhere else on purpose --
+    # a checkout under development, say -- still wins.
+    monkeypatch.setenv("ROSOTACOM_COM_MSGS", "/somewhere/else")
+
+    rosotacom._export_named_resource_paths()
+
+    assert os.environ["ROSOTACOM_COM_MSGS"] == "/somewhere/else"
+
+
 def test_ota_peer_exec_replaces_the_ssh_client(tmp_path: Path) -> None:
     # The point of the flag: a peer can be reached by something that is not a
     # shell. The script arrives as the final argument, which is the contract


### PR DESCRIPTION
A ros2docker config driven by rosotacom may need to bake a package that lives *inside* the rosotacom install — `com_msgs` above all, since both sides of a link must agree on the message definitions. The install is isolated by design, so the config cannot compute the path and writes `\${ROSOTACOM_COM_MSGS}` instead. Until now something else had to put that in the environment: a shell snippet each project carried and sourced before every start and stop script.

That holds until the caller is not a shell on the same machine.

## How it surfaced

A two-host OTA run (fleet_mgmt, `--install-mode checkout`, centre on a second machine) reached the control-centre application on the far side and died:

```
rosotacom: error: Could not expand environment variables in host path: '\${ROSOTACOM_COM_MSGS}'
```

The identical single-host run passes, because there the peer inherits the variable from the orchestrator's own environment. **The single-host run could not have caught this by construction** — which is exactly what the two-host rung exists for.

## The fix

rosotacom owns the resource, so rosotacom exports it, at CLI entry, for every name in `NAMED_RESOURCES` rather than only the one that happened to bite. `setdefault`, so a caller pointing somewhere else on purpose — a checkout under development — still wins.

`just check`: 630 unit + 14 contract + 13 tests, ruff, mypy — green.