### PR TITLE
Run the e2e suite as one matrix, and record what each test costs

### DIFF
--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -19,9 +19,25 @@ concurrency:
 
 jobs:
   smoke-e2e:
-    name: smoke-e2e
+    # The same six slices the merge gate and the release run, instead of one
+    # sequential `just test-e2e-smoke` over the whole suite (#198). Keeping the
+    # monolith here was deliberate while the slices were hand-maintained `-k`
+    # expressions that had silently stopped covering three files; #197's
+    # test_e2e_slices_partition_the_whole_suite closed that, so the union is
+    # now guaranteed to be the monolith.
+    #
+    # The gain is diagnosis: a red monolith says "e2e broke", six slices say
+    # which area did. It also removes a load-induced flake. On 2026-08-11 the
+    # nightly failed with nine "Timed out waiting for container readiness"
+    # errors after 1h12m on one runner, while the same tests on the same commit
+    # passed in the merge gate — where they are spread over six.
+    name: smoke-e2e-${{ matrix.slice }}
     runs-on: ubuntu-latest
     timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        slice: [core, transforms, remote-assist, runtime-tools, concurrency, media]
 
     steps:
       - name: Check out repository
@@ -46,14 +62,14 @@ jobs:
       - name: Show Docker environment
         run: docker info
 
-      - name: Run local smoke slice
-        run: just test-e2e-smoke
+      - name: Run E2E slice
+        run: just test-e2e-slice ${{ matrix.slice }}
 
       - name: Upload smoke session artifacts
         if: failure()
         uses: actions/upload-artifact@v7
         with:
-          name: session-instances-smoke
+          name: session-instances-smoke-${{ matrix.slice }}
           path: session-instances/
           if-no-files-found: ignore
 

--- a/.github/workflows/pr-merge-gate.yml
+++ b/.github/workflows/pr-merge-gate.yml
@@ -189,12 +189,24 @@ jobs:
           fi
           echo "All preflight checks passed"
 
-  e2e-core:
-    name: e2e-core
+  e2e:
+    # One matrix job, not six near-identical copies. The copies were how
+    # `e2e-media` ended up listed in ci-success's `needs` with no check on its
+    # result: a failing media slice did not fail the gate. A matrix has one
+    # result for all slices, so that hole cannot be reopened by forgetting a
+    # paragraph. The slice list is the same one release.yml expands, and
+    # tests/contract/test_workflow_contracts.py keeps the three workflows and
+    # the justfile agreeing.
+    name: e2e-${{ matrix.slice }}
     runs-on: ubuntu-latest
     timeout-minutes: 90
     needs: preflight-success
     if: always() && !cancelled() && needs.preflight-success.result == 'success'
+    strategy:
+      fail-fast: false
+      matrix:
+        slice: [core, transforms, remote-assist, runtime-tools, concurrency, media]
+
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
@@ -218,214 +230,14 @@ jobs:
       - name: Show Docker environment
         run: docker info
 
-      - name: Run core E2E tests
-        run: just test-e2e-core
+      - name: Run E2E slice
+        run: just test-e2e-slice ${{ matrix.slice }}
 
       - name: Upload session artifacts
         if: failure()
         uses: actions/upload-artifact@v7
         with:
-          name: session-instances-e2e-core
-          path: session-instances/
-          if-no-files-found: ignore
-
-  e2e-transforms:
-    name: e2e-transforms
-    runs-on: ubuntu-latest
-    timeout-minutes: 90
-    needs: preflight-success
-    if: always() && !cancelled() && needs.preflight-success.result == 'success'
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-          cache: pip
-
-      - name: Install just and tmux
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y just tmux
-
-      - name: Set up local environment
-        run: just setup
-
-      - name: Show Docker environment
-        run: docker info
-
-      - name: Run transform E2E tests
-        run: just test-e2e-transforms
-
-      - name: Upload session artifacts
-        if: failure()
-        uses: actions/upload-artifact@v7
-        with:
-          name: session-instances-e2e-transforms
-          path: session-instances/
-          if-no-files-found: ignore
-
-  e2e-remote-assist:
-    name: e2e-remote-assist
-    runs-on: ubuntu-latest
-    timeout-minutes: 90
-    needs: preflight-success
-    if: always() && !cancelled() && needs.preflight-success.result == 'success'
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-          cache: pip
-
-      - name: Install just and tmux
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y just tmux
-
-      - name: Set up local environment
-        run: just setup
-
-      - name: Show Docker environment
-        run: docker info
-
-      - name: Run remote assist E2E tests
-        run: just test-e2e-remote-assist
-
-      - name: Upload session artifacts
-        if: failure()
-        uses: actions/upload-artifact@v7
-        with:
-          name: session-instances-e2e-remote-assist
-          path: session-instances/
-          if-no-files-found: ignore
-
-  e2e-runtime-tools:
-    name: e2e-runtime-tools
-    runs-on: ubuntu-latest
-    timeout-minutes: 90
-    needs: preflight-success
-    if: always() && !cancelled() && needs.preflight-success.result == 'success'
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-          cache: pip
-
-      - name: Install just and tmux
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y just tmux
-
-      - name: Set up local environment
-        run: just setup
-
-      - name: Show Docker environment
-        run: docker info
-
-      - name: Run runtime tools E2E tests
-        run: just test-e2e-runtime-tools
-
-      - name: Upload session artifacts
-        if: failure()
-        uses: actions/upload-artifact@v7
-        with:
-          name: session-instances-e2e-runtime-tools
-          path: session-instances/
-          if-no-files-found: ignore
-
-  e2e-concurrency:
-    name: e2e-concurrency
-    runs-on: ubuntu-latest
-    timeout-minutes: 90
-    needs: preflight-success
-    if: always() && !cancelled() && needs.preflight-success.result == 'success'
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-          cache: pip
-
-      - name: Install just and tmux
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y just tmux
-
-      - name: Set up local environment
-        run: just setup
-
-      - name: Show Docker environment
-        run: docker info
-
-      - name: Run concurrency E2E tests
-        run: just test-e2e-concurrency
-
-      - name: Upload session artifacts
-        if: failure()
-        uses: actions/upload-artifact@v7
-        with:
-          name: session-instances-e2e-concurrency
-          path: session-instances/
-          if-no-files-found: ignore
-
-  e2e-media:
-    name: e2e-media
-    runs-on: ubuntu-latest
-    timeout-minutes: 90
-    needs: preflight-success
-    if: always() && !cancelled() && needs.preflight-success.result == 'success'
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-          cache: pip
-
-      - name: Install just and tmux
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y just tmux
-
-      - name: Set up local environment
-        run: just setup
-
-      - name: Show Docker environment
-        run: docker info
-
-      - name: Run media E2E tests
-        run: just test-e2e-media
-
-      - name: Upload session artifacts
-        if: failure()
-        uses: actions/upload-artifact@v7
-        with:
-          name: session-instances-e2e-media
+          name: session-instances-e2e-${{ matrix.slice }}
           path: session-instances/
           if-no-files-found: ignore
 
@@ -439,12 +251,7 @@ jobs:
       - merge-lightweight
       - package
       - preflight-success
-      - e2e-core
-      - e2e-transforms
-      - e2e-remote-assist
-      - e2e-runtime-tools
-      - e2e-concurrency
-      - e2e-media
+      - e2e
     if: always() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
 
     steps:
@@ -474,24 +281,8 @@ jobs:
             echo "preflight-success failed or was skipped: ${{ needs.preflight-success.result }}"
             exit 1
           fi
-          if [[ "${{ needs.e2e-core.result }}" != "success" ]]; then
-            echo "e2e-core failed or was skipped: ${{ needs.e2e-core.result }}"
-            exit 1
-          fi
-          if [[ "${{ needs.e2e-transforms.result }}" != "success" ]]; then
-            echo "e2e-transforms failed or was skipped: ${{ needs.e2e-transforms.result }}"
-            exit 1
-          fi
-          if [[ "${{ needs.e2e-remote-assist.result }}" != "success" ]]; then
-            echo "e2e-remote-assist failed or was skipped: ${{ needs.e2e-remote-assist.result }}"
-            exit 1
-          fi
-          if [[ "${{ needs.e2e-runtime-tools.result }}" != "success" ]]; then
-            echo "e2e-runtime-tools failed or was skipped: ${{ needs.e2e-runtime-tools.result }}"
-            exit 1
-          fi
-          if [[ "${{ needs.e2e-concurrency.result }}" != "success" ]]; then
-            echo "e2e-concurrency failed or was skipped: ${{ needs.e2e-concurrency.result }}"
+          if [[ "${{ needs.e2e.result }}" != "success" ]]; then
+            echo "one or more e2e slices failed or were skipped: ${{ needs.e2e.result }}"
             exit 1
           fi
           echo "ci-success passed"

--- a/justfile
+++ b/justfile
@@ -38,34 +38,34 @@ test-nondocker-cov:
 	{{python}} -m pytest -q tests/unit tests/contract --cov=rosotacom --cov-report=term-missing --cov-report=xml:coverage.xml
 
 test-e2e-smoke:
-	ROSOTACOM_RUN_E2E=1 {{python}} -m pytest -q tests/e2e/ -m e2e
+	ROSOTACOM_RUN_E2E=1 {{python}} -m pytest -q --durations=0 tests/e2e/ -m e2e
 
 test-e2e-fast: test-e2e-smoke
 
 test-e2e-core:
-	ROSOTACOM_RUN_E2E=1 {{python}} -m pytest -q tests/e2e/test_smoke.py -k "heartbeat or chatter"
+	ROSOTACOM_RUN_E2E=1 {{python}} -m pytest -q --durations=0 tests/e2e/test_smoke.py -k "heartbeat or chatter"
 
 test-e2e-transforms:
-	ROSOTACOM_RUN_E2E=1 {{python}} -m pytest -q tests/e2e/test_smoke.py -k "occupancy_grid or sized_payload"
+	ROSOTACOM_RUN_E2E=1 {{python}} -m pytest -q --durations=0 tests/e2e/test_smoke.py -k "occupancy_grid or sized_payload"
 
 test-e2e-remote-assist:
-	ROSOTACOM_RUN_E2E=1 {{python}} -m pytest -q tests/e2e/test_smoke.py -k "remote_assist"
+	ROSOTACOM_RUN_E2E=1 {{python}} -m pytest -q --durations=0 tests/e2e/test_smoke.py -k "remote_assist"
 
 # Two invocations on purpose: a shared `-k` filter would silently deselect
 # every test in the other files (contract-tested in test_benched_set_registry).
 test-e2e-runtime-tools:
-	ROSOTACOM_RUN_E2E=1 {{python}} -m pytest -q tests/e2e/test_smoke.py -k "link_latency"
-	ROSOTACOM_RUN_E2E=1 {{python}} -m pytest -q tests/e2e/test_timeline_stepping.py tests/e2e/test_benchmark_capacity.py tests/e2e/test_benchmark_ab.py tests/e2e/test_benchmark_replay.py
+	ROSOTACOM_RUN_E2E=1 {{python}} -m pytest -q --durations=0 tests/e2e/test_smoke.py -k "link_latency"
+	ROSOTACOM_RUN_E2E=1 {{python}} -m pytest -q --durations=0 tests/e2e/test_timeline_stepping.py tests/e2e/test_benchmark_capacity.py tests/e2e/test_benchmark_ab.py tests/e2e/test_benchmark_replay.py
 
 # The remaining e2e files. Without this slice the partition is not one: the
 # monolithic `test-e2e-smoke` collects 28 tests, the other five collect 25, and
 # anonymization/video-quality/replay ran only in nightly and the release.
 test-e2e-media:
-	ROSOTACOM_RUN_E2E=1 {{python}} -m pytest -q tests/e2e/test_anonymize_e2e.py tests/e2e/test_video_quality_e2e.py
-	ROSOTACOM_RUN_E2E=1 {{python}} -m pytest -q tests/e2e/test_smoke.py -k "anonymized"
+	ROSOTACOM_RUN_E2E=1 {{python}} -m pytest -q --durations=0 tests/e2e/test_anonymize_e2e.py tests/e2e/test_video_quality_e2e.py
+	ROSOTACOM_RUN_E2E=1 {{python}} -m pytest -q --durations=0 tests/e2e/test_smoke.py -k "anonymized"
 
 test-e2e-concurrency:
-	ROSOTACOM_RUN_E2E=1 {{python}} -m pytest -q tests/e2e/test_parallel_smoke.py
+	ROSOTACOM_RUN_E2E=1 {{python}} -m pytest -q --durations=0 tests/e2e/test_parallel_smoke.py
 
 # The five slices partition `test-e2e-smoke`; the merge gate and the release
 # both run them in parallel. This wrapper exists so a workflow matrix can select
@@ -77,7 +77,7 @@ test-e2e-slice slice:
 	just test-e2e-{{slice}}
 
 test-e2e-node nodeid:
-	ROSOTACOM_RUN_E2E=1 {{python}} -m pytest -q "{{nodeid}}"
+	ROSOTACOM_RUN_E2E=1 {{python}} -m pytest -q --durations=0 "{{nodeid}}"
 
 test-e2e-rmw session:
 	ROSOTACOM_RUN_E2E=1 ROSOTACOM_RUN_FULL_E2E=1 {{python}} -m pytest -q "tests/e2e/test_smoke.py::test_full_rmw_heartbeat_smoke_matrix[{{session}}]"

--- a/tests/contract/test_security_maintenance_config.py
+++ b/tests/contract/test_security_maintenance_config.py
@@ -46,15 +46,26 @@ def test_image_scan_is_advisory_and_not_a_pr_check() -> None:
 
 def test_merge_gate_requires_non_docker_package_and_docker_smoke() -> None:
     merge_gate = MERGE_GATE_PATH.read_text(encoding="utf-8")
+    jobs = yaml.safe_load(merge_gate)["jobs"]
 
     assert "ci-success" in merge_gate
     assert "just test-nondocker-cov" in merge_gate
     assert "just package" in merge_gate
-    assert "just test-e2e-core" in merge_gate
-    assert "just test-e2e-transforms" in merge_gate
-    assert "just test-e2e-remote-assist" in merge_gate
-    assert "just test-e2e-runtime-tools" in merge_gate
-    assert "just test-e2e-concurrency" in merge_gate
+
+    # The gate runs the e2e suite as one matrix over named slices rather than
+    # six copy-pasted jobs, so the slice names live in the matrix and the
+    # recipe name in the `run:` line is `test-e2e-slice`. Which slices those
+    # are, and that they add up to the whole suite, is
+    # tests/contract/test_workflow_contracts.py's job.
+    assert "just test-e2e-slice" in merge_gate
+    assert set(jobs["e2e"]["strategy"]["matrix"]["slice"]) >= {
+        "core",
+        "transforms",
+        "remote-assist",
+        "runtime-tools",
+        "concurrency",
+        "media",
+    }
 
 
 def test_merge_gate_requires_new_ci_jobs_and_no_masking() -> None:
@@ -62,7 +73,6 @@ def test_merge_gate_requires_new_ci_jobs_and_no_masking() -> None:
     data = yaml.safe_load(content)
     jobs = data["jobs"]
 
-    # 1. ci-success depends on the new required jobs
     ci_success = jobs["ci-success"]
     needs = ci_success["needs"]
     expected_jobs = {
@@ -72,29 +82,19 @@ def test_merge_gate_requires_new_ci_jobs_and_no_masking() -> None:
         "merge-lightweight",
         "package",
         "preflight-success",
-        "e2e-core",
-        "e2e-transforms",
-        "e2e-remote-assist",
-        "e2e-runtime-tools",
-        "e2e-concurrency",
-    }
-    e2e_jobs = {
-        "e2e-core",
-        "e2e-transforms",
-        "e2e-remote-assist",
-        "e2e-runtime-tools",
-        "e2e-concurrency",
+        "e2e",
     }
     assert expected_jobs.issubset(set(needs))
 
-    for job in e2e_jobs:
-        assert jobs[job]["needs"] == "preflight-success"
-        assert jobs[job]["if"] == "always() && !cancelled() && needs.preflight-success.result == 'success'"
+    assert jobs["e2e"]["needs"] == "preflight-success"
+    assert jobs["e2e"]["if"] == "always() && !cancelled() && needs.preflight-success.result == 'success'"
 
-    # Check that required jobs are validated in the bash step of ci-success
+    # Every needed job's result must be turned into an exit code by hand,
+    # because ci-success runs with `if: always()`. This used to list the e2e
+    # jobs one by one and missed `e2e-media` entirely.
     check_step = next(step for step in ci_success["steps"] if step.get("name") == "Check required jobs")
     run_script = check_step["run"]
-    for job in expected_jobs:
+    for job in needs:
         if job == "dependency-review":
             assert f"needs.{job}.result" in run_script
         else:
@@ -107,7 +107,6 @@ def test_merge_gate_requires_new_ci_jobs_and_no_masking() -> None:
         for step in job.get("steps", []):
             assert step.get("continue-on-error", False) is False
             run_cmd = step.get("run", "")
-            # Ensure no masking with || true or || exit 0
             assert "|| true" not in run_cmd
             assert "|| exit 0" not in run_cmd
 

--- a/tests/contract/test_workflow_contracts.py
+++ b/tests/contract/test_workflow_contracts.py
@@ -118,10 +118,59 @@ def test_precommit_ruff_matches_pyproject_pin() -> None:
     )
 
 
+#: Every workflow that runs the e2e suite, and the job whose matrix names the
+#: slices. All three must expand to the same list: the merge gate decides what
+#: may land, the release decides what ships, and nightly is the only one that
+#: runs against a tree nobody is watching.
+E2E_SLICE_MATRICES = {
+    "release.yml": "e2e",
+    "pr-merge-gate.yml": "e2e",
+    "nightly-e2e.yml": "smoke-e2e",
+}
+
+
+def _e2e_slices(workflow_name: str, job: str) -> list[str]:
+    workflow = yaml.safe_load((WORKFLOWS_DIR / workflow_name).read_text(encoding="utf-8"))
+    return list(workflow["jobs"][job]["strategy"]["matrix"]["slice"])
+
+
 def _release_e2e_slices() -> list[str]:
     """The slice names the release matrix expands to."""
-    workflow = yaml.safe_load((WORKFLOWS_DIR / "release.yml").read_text(encoding="utf-8"))
-    return list(workflow["jobs"]["e2e"]["strategy"]["matrix"]["slice"])
+    return _e2e_slices("release.yml", E2E_SLICE_MATRICES["release.yml"])
+
+
+def test_every_e2e_workflow_runs_the_same_slices() -> None:
+    """One slice list, three workflows.
+
+    Before this, the six e2e jobs in the merge gate were copy-pasted rather
+    than a matrix, and `ci-success` listed `e2e-media` in `needs` while
+    checking the results of only the other five — a failing media slice did not
+    fail the gate. A matrix cannot lose a slice that way, and this keeps the
+    three matrices from drifting apart instead.
+    """
+    lists = {name: _e2e_slices(name, job) for name, job in sorted(E2E_SLICE_MATRICES.items())}
+    reference = lists["release.yml"]
+    mismatched = {name: value for name, value in lists.items() if value != reference}
+    assert not mismatched, f"e2e slice lists disagree; release.yml has {reference} but: " + "; ".join(
+        f"{name} has {value}" for name, value in sorted(mismatched.items())
+    )
+
+
+def test_ci_success_checks_every_job_it_waits_for() -> None:
+    """A job in `needs` that nothing checks is a gate that does not gate.
+
+    `ci-success` runs with `if: always()`, so every needed job's failure has to
+    be turned into an exit code by hand. `e2e-media` sat in `needs` for a
+    release cycle with no matching check.
+    """
+    workflow = yaml.safe_load((WORKFLOWS_DIR / "pr-merge-gate.yml").read_text(encoding="utf-8"))
+    job = workflow["jobs"]["ci-success"]
+    script = "\n".join(_workflow_run_blocks(job))
+    unchecked = [name for name in job["needs"] if f"needs.{name}.result" not in script]
+    assert not unchecked, (
+        "ci-success waits for these jobs but never inspects their result, so "
+        "their failure does not fail the gate: " + ", ".join(unchecked)
+    )
 
 
 def _recipe_pytest_invocations(recipe: str) -> list[list[str]]:


### PR DESCRIPTION
## Summary

- `pr-merge-gate.yml`: six copy-pasted e2e jobs become one matrix over the same
  six slices `release.yml` already expands.
- `ci-success`: waits on `e2e` and checks its result. It previously listed
  `e2e-media` in `needs` and never checked `needs.e2e-media.result`, so a
  failing media slice did not fail the gate.
- `nightly-e2e.yml`: `smoke-e2e` runs the slice matrix instead of the
  monolithic `just test-e2e-smoke` (#198).
- `justfile`: `--durations=0` on every e2e invocation.
- Two new contract tests: all three workflows expand the same slice list, and
  `ci-success` inspects the result of every job it waits for.

Fixes #198. Refs #226 (the rebalance this measurement feeds).

## Why nightly can be sliced now

Keeping the monolith there was deliberate: the slices are hand-maintained `-k`
expressions that had silently stopped covering three files, and nightly was the
only place those still ran. #197 closed that with
`test_e2e_slices_partition_the_whole_suite`, which fails if the union and the
monolith ever diverge again.

Beyond diagnosis, this removes a load-induced flake. Run
[31457253750](https://github.com/develNor/ros_communication_devcontainer/actions/runs/31457253750)
failed with **nine** `Timed out waiting for container readiness` errors after
1h12m on one runner — the same tests on the same commit pass in the merge gate,
where they are spread over six runners. The readiness wait is 240s; a runner
seventy minutes into building and tearing down containers does not always make
it.

## Public Behavior

- [ ] Changes public CLI/config/API/Docker behavior
- [x] Does not change public behavior

## Checks

- [x] `just lint`
- [x] `just lint-workflows` (actionlint)
- [x] `just lint-build`
- [x] `just typecheck`
- [x] `just test-contract` — 66 passed
- [x] `just docs`
- [ ] `just test-e2e-*` — this PR's own gate run is the check, since the change
      is the gate

## Docs

- [ ] Docs updated
- [x] Docs not needed — the change is workflow shape; the reasoning is in the
      workflow comments and in #226

## Test Integrity

- [x] Tests/CI were not skipped, weakened, or removed to make this pass.
      `test_security_maintenance_config` was updated because it asserted the
      six-job shape by name; the replacement asserts more than it did (it
      checks every needed job, where the old one enumerated five of six).

## Merge Mode

- [ ] Draft review PR, auto-merge disabled
- [x] Ready autonomous PR, auto-merge enabled
