### PR TITLE
Document the three processing keys the reference said did not exist

### DIFF
--- a/session-configuration.md
+++ b/session-configuration.md
@@ -417,17 +417,22 @@ message types for `/com/...` topics. For that reason, user-defined topic entries
 The auto-generated heartbeat topic is the only exception because its type is known by the generator.
 
 #### Allowed `processing` keys
-Only these keys are allowed:
+Only these keys are allowed. The list is checked against the generator's
+`KNOWN_PROCESSING_KEYS` by `tests/contract/test_session_configuration_doc.py`,
+so a new knob cannot ship undocumented.
 
 ```yaml
 processing:
   restamp_if: true                # bool OR common bool strings OR "<VAR_NAME>" (template param name)
+  latch: false                    # bool, re-publish on value change only
+  trickle_hz: 1                   # number > 0, receiver-side periodic re-publish
   drop:                           # optional, message drop configuration
     drop_count: 2                 # int >= 0, number of messages to drop
     window_size: 3                # int > 0, window size (drop_count must be < window_size)
   framebridge: local_to_global    # local_to_global | global_to_local
   normalize_on_target: false      # bool
   compress: false                 # bool
+  use_ota_wrapper: false          # bool, wrap the payload for the OTA hop
   throttle_hz: 10                 # int > 0
   pixel_cap_preset: "wsvga"       # scalar, used as suffix only,
   transport:
@@ -435,6 +440,37 @@ processing:
     local_republish: false        # default false
     # plus type-specific params (see below)
 ```
+
+##### `latch` and `trickle_hz`: two answers to "the value did not change"
+
+Both address a topic that publishes rarely, and they sit on opposite ends of
+the link:
+
+- **`latch` is a sender-side filter.** The latch stage forwards a message only
+  when its value differs from the last one, to `<topic>{shared.processing_suffixes.latched}`
+  (default `/latched`). It saves OTA bandwidth on a state topic that repeats
+  itself. Its cost is that a receiver which subscribes *after* the last change
+  gets nothing — what the delivered value is then depends entirely on the OTA
+  QoS for the role (`depth`, `lifespan`, `durability`).
+- **`trickle_hz` is a receiver-side re-publish.** A local timer republishes the
+  last *delivered* value to `<final>/trickle` at that rate, whether or not
+  anything new arrived. Nothing extra crosses the link: the trickle topic is
+  not in the OTA topic lists. It exists for consumers that expect a steady
+  stream — visualization, state diagrams, watchdogs — and would otherwise treat
+  an unchanged value as a dead one.
+
+They compose: `latch: true` with `trickle_hz: 1` sends a message only on change
+and still gives the receiving side a 1 Hz stream.
+
+Because the trickle output is the real delivered topic, it is the monitored
+`native_in` stage rather than the pre-trickle `final` — otherwise the
+re-publish would be an observability blind spot whose rate no `expect` could
+assert. `expect.hz` on such a topic therefore describes the trickle rate plus
+whatever arrives over the link, which is why `examples/sessions/11_trickle`
+asserts `hz: {min: 2, max: 8}` for a 1 Hz source at `trickle_hz: 4`.
+
+`trickle_hz` must be greater than 0. It also sets the expected rate for a topic
+that has no `throttle_hz`.
 
 #### Processing pipeline order (exact)
 Given a base topic like `/tf`, stages are applied in this order:

--- a/src/rosotacom/resources/ws/session/creation/generate_session_files.py
+++ b/src/rosotacom/resources/ws/session/creation/generate_session_files.py
@@ -1574,6 +1574,27 @@ def _render_domain_bridge_yaml(name: str, topics: Dict[str, Dict[str, Any]]) -> 
     return _yaml_canonical_dump(cfg)
 
 
+#: Every key a topic's `processing:` mapping may carry. Module level because
+#: `session-configuration.md` claims to list exactly these, and
+#: tests/contract/test_session_configuration_doc.py compares the two: three
+#: keys (`latch`, `trickle_hz`, `use_ota_wrapper`) were live and undocumented,
+#: which is worse than undocumented — the reference says "Only these keys are
+#: allowed", so a reader had no reason to look further.
+KNOWN_PROCESSING_KEYS = {
+    "restamp_if",
+    "latch",
+    "trickle_hz",
+    "drop",
+    "framebridge",
+    "normalize_on_target",
+    "compress",
+    "use_ota_wrapper",
+    "throttle_hz",
+    "pixel_cap_preset",
+    "transport",
+}
+
+
 def _compute_pipeline(
     entry: TopicEntry,
     vars_map: Dict[str, Any],
@@ -1585,20 +1606,7 @@ def _compute_pipeline(
 ) -> Dict[str, Any]:
     proc = entry.processing or {}
 
-    known_keys = {
-        "restamp_if",
-        "latch",
-        "trickle_hz",
-        "drop",
-        "framebridge",
-        "normalize_on_target",
-        "compress",
-        "use_ota_wrapper",
-        "throttle_hz",
-        "pixel_cap_preset",
-        "transport",
-    }
-    unknown = set(proc.keys()) - known_keys
+    unknown = set(proc.keys()) - KNOWN_PROCESSING_KEYS
     if unknown:
         raise ValueError(f"Unknown processing keys for topic '{entry.base}': {sorted(unknown)}")
 

--- a/tests/contract/test_session_configuration_doc.py
+++ b/tests/contract/test_session_configuration_doc.py
@@ -1,0 +1,44 @@
+"""`session-configuration.md` says "Only these keys are allowed". Make it true.
+
+The reference listed eight `processing` keys while the generator accepted
+eleven. `latch`, `trickle_hz` and `use_ota_wrapper` were live, used by real
+sessions, and absent — which is worse than merely undocumented, because the
+sentence above the list tells a reader there is nothing else to find.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from rosotacom.resources.ws.session.creation.generate_session_files import KNOWN_PROCESSING_KEYS
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[2]
+REFERENCE = PACKAGE_ROOT / "session-configuration.md"
+
+#: The fenced block under the "Allowed `processing` keys" heading.
+BLOCK = re.compile(
+    r"#### Allowed `processing` keys.*?```yaml\n(?P<body>.*?)```",
+    re.DOTALL,
+)
+
+#: A top-level key inside that block: two spaces of indent, then `name:`.
+TOP_LEVEL_KEY = re.compile(r"^  ([A-Za-z_][A-Za-z0-9_]*):", re.MULTILINE)
+
+
+def documented_processing_keys() -> set[str]:
+    match = BLOCK.search(REFERENCE.read_text(encoding="utf-8"))
+    assert match, "no fenced `processing` example under the allowed-keys heading"
+    return set(TOP_LEVEL_KEY.findall(match.group("body")))
+
+
+def test_documented_processing_keys_match_the_generator() -> None:
+    documented = documented_processing_keys()
+
+    undocumented = sorted(KNOWN_PROCESSING_KEYS - documented)
+    assert not undocumented, (
+        f"the generator accepts these `processing` keys and {REFERENCE.name} does not list them: {undocumented}"
+    )
+
+    invented = sorted(documented - KNOWN_PROCESSING_KEYS)
+    assert not invented, f"{REFERENCE.name} documents `processing` keys the generator rejects: {invented}"


### PR DESCRIPTION
## Summary

`session-configuration.md`'s allowed-`processing`-key list said eight keys under
the sentence "Only these keys are allowed". The generator accepts eleven:
`latch`, `trickle_hz` and `use_ota_wrapper` were live and unlisted. That is
worse than merely undocumented — the sentence above the list tells a reader
there is nothing else to look for.

- `KNOWN_PROCESSING_KEYS` becomes a module constant in
  `generate_session_files.py` instead of a local variable, so there is one home
  for the list.
- New `tests/contract/test_session_configuration_doc.py` compares the fenced
  example in the reference against that constant in both directions. Verified
  it fails on the pre-change file: deleting the `trickle_hz` line makes it exit
  1 with "the generator accepts these `processing` keys and
  session-configuration.md does not list them: ['trickle_hz']".
- `latch` and `trickle_hz` get prose, because listing them is not the useful
  part. They are the two answers to "the value did not change" and they live at
  opposite ends of the link: `latch` is a sender-side filter that saves OTA
  bandwidth and leaves a late joiner with nothing, `trickle_hz` is a
  receiver-side re-publish that costs no bandwidth. The section covers their
  composition, the `/trickle` suffix, and why the trickle output is the
  monitored `native_in` stage rather than an unassertable blind spot, with
  `examples/sessions/11_trickle` as the worked case.

Requested from harness issue
[go914/rosotacom_test#37](https://ids-git.fzi.de/go914/rosotacom_test/-/issues/37),
which asked for `trickle_hz` alone; the other two are the same defect found
while looking.

## Public Behavior

- [ ] Changes public CLI/config/API/Docker behavior
- [x] Does not change public behavior — documentation plus a constant that moved
      scope; no key was added or removed

## Checks

- [x] `just lint`
- [x] `just typecheck`
- [x] `just test-contract` — 65 passed
- [x] `just docs`
- [x] Negative test: the new contract test fails on the file as it was

## Docs

- [x] Docs updated
- [ ] Docs not needed

## Test Integrity

- [x] Tests/CI were not skipped, weakened, or removed to make this pass

## Merge Mode

- [ ] Draft review PR, auto-merge disabled
- [x] Ready autonomous PR, auto-merge enabled
