### PR TITLE
Balance the e2e slices by measured cost, and make the partition a partition

### DIFF
--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        slice: [core, transforms, remote-assist, runtime-tools, concurrency, media]
+        slice: [core, transforms, remote-assist, runtime-tools, benchmark-capacity, media-concurrency]
 
     steps:
       - name: Check out repository

--- a/.github/workflows/pr-merge-gate.yml
+++ b/.github/workflows/pr-merge-gate.yml
@@ -197,6 +197,11 @@ jobs:
     # paragraph. The slice list is the same one release.yml expands, and
     # tests/contract/test_workflow_contracts.py keeps the three workflows and
     # the justfile agreeing.
+    #
+    # The six slices are balanced by measured cost, not grouped by theme
+    # (#226): themed slices spanned 7m39s to 18m31s, and one test ran in two of
+    # them. Which tests a slice owns and what each costs is E2E_SLICES in
+    # tests/e2e/conftest.py — change that, not this line, to move a test.
     name: e2e-${{ matrix.slice }}
     runs-on: ubuntu-latest
     timeout-minutes: 90
@@ -205,7 +210,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        slice: [core, transforms, remote-assist, runtime-tools, concurrency, media]
+        slice: [core, transforms, remote-assist, runtime-tools, benchmark-capacity, media-concurrency]
 
     steps:
       - name: Check out repository

--- a/.github/workflows/pr-merge-gate.yml
+++ b/.github/workflows/pr-merge-gate.yml
@@ -27,7 +27,10 @@ jobs:
           ACTIONLINT_VERSION="1.7.12"
           CHECKSUM="8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8"
           URL="https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
-          curl -sSL -o actionlint.tar.gz "$URL"
+          # --fail, or a transient HTTP error body is saved as the tarball and
+          # reported as "computed checksum did NOT match" — which reads like a
+          # tampered release. That cost this PR a full gate run.
+          curl -sSLf --retry 3 --retry-all-errors -o actionlint.tar.gz "$URL"
           echo "${CHECKSUM}  actionlint.tar.gz" | sha256sum --check
           tar -xzf actionlint.tar.gz actionlint
           sudo mv actionlint /usr/local/bin/actionlint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,7 +125,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        slice: [core, transforms, remote-assist, runtime-tools, concurrency, media]
+        slice: [core, transforms, remote-assist, runtime-tools, benchmark-capacity, media-concurrency]
 
     steps:
       - name: Check out repository

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -43,7 +43,7 @@ check is:
 ci-success
 ```
 
-The merge gate runs workflow lint, dependency/security review, runtime/build asset lint, Python 3.10 through 3.14 non-Docker checks, package validation, and the Docker single-machine smoke matrix (divided into 5 parallel lanes):
+The merge gate runs workflow lint, dependency/security review, runtime/build asset lint, Python 3.10 through 3.14 non-Docker checks, package validation, and the Docker single-machine smoke matrix (one matrix job per slice, six in parallel):
 
 Python 3.10–3.14 are supported for the host CLI; Python 3.12 is the reference
 interpreter for packaging and Docker E2E jobs.
@@ -56,12 +56,13 @@ just typecheck
 just test-nondocker-cov
 just docs
 just package
-# Parallel E2E lanes:
-just test-e2e-core
-just test-e2e-transforms
-just test-e2e-remote-assist
-just test-e2e-runtime-tools
-just test-e2e-concurrency
+# Parallel E2E lanes, one per slice:
+just test-e2e-slice core
+just test-e2e-slice transforms
+just test-e2e-slice remote-assist
+just test-e2e-slice runtime-tools
+just test-e2e-slice benchmark-capacity
+just test-e2e-slice media-concurrency
 ```
 
 The Python 3.12 leg uploads `coverage.xml` to Codecov with the `nondocker` flag.
@@ -69,10 +70,43 @@ Docker E2E is not collected for coverage.
 
 ## Docker E2E
 
-`just test-e2e-smoke` runs the entire local single-machine smoke matrix through Docker. In the CI merge gate, E2E testing is divided into parallel jobs (`e2e-core`, `e2e-transforms`, `e2e-remote-assist`, `e2e-runtime-tools`, `e2e-concurrency`) which run concurrently to minimize wall-clock time. Each smoke run writes generated
+`just test-e2e-smoke` runs the entire local single-machine smoke matrix through Docker. In the CI merge gate, the same collection runs as six parallel jobs
+(`e2e-core`, `e2e-transforms`, `e2e-remote-assist`, `e2e-runtime-tools`,
+`e2e-benchmark-capacity`, `e2e-media-concurrency`). Each smoke run writes generated
 config, catmux pane logs, Docker logs when available, and the smoke verification
 log under `session-instances/`; collect that directory as the first debugging
 artifact when an E2E job fails.
+
+### Balancing the e2e slices
+
+A slice is not its own pytest invocation. `just test-e2e-slice <name>` runs the
+monolith's collection with `--e2e-slice=<name>`, and everything the named slice
+does not own is deselected. Which tests a slice owns, and what each one costs,
+is `E2E_SLICES` in `tests/e2e/conftest.py`; `just e2e-slice-costs` prints the
+resulting balance. Moving a test between slices is one line there — the
+workflow matrices only name slices.
+
+That shape exists because the previous one, per-slice file lists and `-k`
+filters, could not say what it ran. `-k "remote_assist"` silently missed the
+`[remote-assist-anonymized-*]` parameters, and `-k "remote_assist"` and
+`-k "anonymized"` silently *shared* one 262s test, which the gate therefore ran
+twice a run. A partition can do neither: an unowned test fails every slice job
+with a usage error, and a test owned twice fails
+`test_e2e_slices_partition_the_whole_suite`.
+
+The costs are warm pytest `call` durations — medians over six merge-gate runs
+of 2026-08-11/12. On top of them each job pays a fixed
+`RUNNER_SETUP_SECONDS + IMAGE_BUILD_SECONDS` (~3m30s: runner setup, then the
+project image built inside whichever test runs first). Because that constant is
+per job and not per test, balancing warm costs balances wall clock, and adding
+slices buys less than the arithmetic suggests: six balanced slices are
+predicted at ~13m30s against ~10m for twelve, at twice the runner minutes.
+
+To refresh the numbers, read a merge-gate run: every e2e invocation runs
+`--durations=0`, so each job prints the cost of every test it ran. A test that
+ran first in its job carries the image build and needs `IMAGE_BUILD_SECONDS`
+subtracted. `tests/contract/test_workflow_contracts.py::test_e2e_slices_stay_balanced`
+fails when the recorded spread passes 1.5x.
 
 ## Performance Regression Gate
 
@@ -80,7 +114,7 @@ The deterministic benchmark rows gate against committed two-sided bands
 ([performance-bands.md](performance-bands.md), RFC 0007):
 
 - the `merge-gate` rows of the benched-set registry run inside the
-  `e2e-runtime-tools` lane (band-asserted benchmark-capacity E2E);
+  `e2e-benchmark-capacity` lane (band-asserted benchmark-capacity E2E);
 - `.github/workflows/benchmark-gate.yml` runs the `nightly` rows on schedule
   and on manual dispatch. Its matrix comes from
   `rosotacom benchmark rows --format ids`; each row uploads `result.json` plus

--- a/docs/performance-bands.md
+++ b/docs/performance-bands.md
@@ -103,8 +103,8 @@ Lanes (RFC 0007 §4):
 
 - **merge gate** — the `merge-gate` rows run inside the benchmark-capacity E2E
   (`tests/e2e/test_benchmark_capacity.py::test_merge_gate_row_is_band_asserted`,
-  lane `just test-e2e-runtime-tools`): minutes-scale, default RMW, one
-  rate-limited profile.
+  lane `just test-e2e-slice benchmark-capacity`): minutes-scale, default RMW,
+  one rate-limited profile.
 - **nightly** — `.github/workflows/benchmark-gate.yml` runs every `nightly`
   row on schedule (and on dispatch), uploads per-row verdicts plus the
   aggregated `benchmark-gate-summary` artifact (`benchmark gate-summary`), and

--- a/docs/rfcs/0007-regression-gate.md
+++ b/docs/rfcs/0007-regression-gate.md
@@ -303,7 +303,8 @@ slices these into issues.
 - [x] **Merge-gate row** — exercised by the merge gate itself (band-asserted
   benchmark-capacity E2E), runtime bounded by the workflow timeout.
   *(`test_benchmark_capacity.py::test_merge_gate_row_is_band_asserted` in the
-  `e2e-runtime-tools` lane of `pr-merge-gate.yml`; a 60 s probe window plus
+  `e2e-benchmark-capacity` lane of `pr-merge-gate.yml` — the `e2e-runtime-tools`
+  lane until #226 split the capacity probes out of it; a 60 s probe window plus
   session setup keeps it minutes-scale.)*
 - [x] **Nightly matrix** — one deliberately injected regression (canary
   branch) turns the lane red end-to-end; documented one-off exercise.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -125,12 +125,19 @@ from one-host smoke.
 
 `just test-e2e-smoke` runs the entire set of local-checkable curated examples. In CI and for local convenience, you can run specific E2E test slices or nodes:
 
-- `just test-e2e-core`: Runs core communication smoke tests.
-- `just test-e2e-transforms`: Runs transport transforms (compression, payload sizes).
-- `just test-e2e-remote-assist`: Runs anonymized remote assist streams.
-- `just test-e2e-runtime-tools`: Runs runtime utility/metrics E2E checks.
-- `just test-e2e-concurrency`: Runs concurrency/isolation gate checks.
+- `just test-e2e-slice core`: heartbeat and native chatter.
+- `just test-e2e-slice transforms`: transport transforms (compression, payload sizes).
+- `just test-e2e-slice remote-assist`: the anonymized remote-assist rig and its two single-stream cuts.
+- `just test-e2e-slice runtime-tools`: link latency, live timeline stepping, and the two benchmark verdicts.
+- `just test-e2e-slice benchmark-capacity`: the band-asserted capacity probes.
+- `just test-e2e-slice media-concurrency`: anonymization, video quality, and the concurrency/isolation gate.
 - `just test-e2e-node <nodeid>`: Reruns a specific pytest node ID directly.
+- `just e2e-slice-costs`: prints what each slice costs and how balanced the six are.
+
+The slices are balanced by measured cost rather than grouped by theme, which is
+why two of them carry a compound name. `E2E_SLICES` in `tests/e2e/conftest.py`
+decides which slice owns which test; see
+[ci.md](ci.md#balancing-the-e2e-slices) before moving one.
 
 The generated RMW matrix is available as an opt-in full local slice:
 

--- a/justfile
+++ b/justfile
@@ -42,39 +42,16 @@ test-e2e-smoke:
 
 test-e2e-fast: test-e2e-smoke
 
-test-e2e-core:
-	ROSOTACOM_RUN_E2E=1 {{python}} -m pytest -q --durations=0 tests/e2e/test_smoke.py -k "heartbeat or chatter"
-
-test-e2e-transforms:
-	ROSOTACOM_RUN_E2E=1 {{python}} -m pytest -q --durations=0 tests/e2e/test_smoke.py -k "occupancy_grid or sized_payload"
-
-test-e2e-remote-assist:
-	ROSOTACOM_RUN_E2E=1 {{python}} -m pytest -q --durations=0 tests/e2e/test_smoke.py -k "remote_assist"
-
-# Two invocations on purpose: a shared `-k` filter would silently deselect
-# every test in the other files (contract-tested in test_benched_set_registry).
-test-e2e-runtime-tools:
-	ROSOTACOM_RUN_E2E=1 {{python}} -m pytest -q --durations=0 tests/e2e/test_smoke.py -k "link_latency"
-	ROSOTACOM_RUN_E2E=1 {{python}} -m pytest -q --durations=0 tests/e2e/test_timeline_stepping.py tests/e2e/test_benchmark_capacity.py tests/e2e/test_benchmark_ab.py tests/e2e/test_benchmark_replay.py
-
-# The remaining e2e files. Without this slice the partition is not one: the
-# monolithic `test-e2e-smoke` collects 28 tests, the other five collect 25, and
-# anonymization/video-quality/replay ran only in nightly and the release.
-test-e2e-media:
-	ROSOTACOM_RUN_E2E=1 {{python}} -m pytest -q --durations=0 tests/e2e/test_anonymize_e2e.py tests/e2e/test_video_quality_e2e.py
-	ROSOTACOM_RUN_E2E=1 {{python}} -m pytest -q --durations=0 tests/e2e/test_smoke.py -k "anonymized"
-
-test-e2e-concurrency:
-	ROSOTACOM_RUN_E2E=1 {{python}} -m pytest -q --durations=0 tests/e2e/test_parallel_smoke.py
-
-# The five slices partition `test-e2e-smoke`; the merge gate and the release
-# both run them in parallel. This wrapper exists so a workflow matrix can select
-# a slice while the recipe name in the `run:` line stays a literal — a name
-# assembled by matrix interpolation is invisible to
-# tests/contract/test_workflow_contracts.py::test_referenced_just_recipes_exist.
-# Run one named slice of the e2e suite.
+# Run one named slice of the e2e suite. Same collection as `test-e2e-smoke`,
+# with everything the slice does not own deselected — so a slice cannot miss a
+# test or run one twice, which per-slice file lists and `-k` filters both did.
+# Which tests a slice owns, and what each costs, is E2E_SLICES in
+# tests/e2e/conftest.py; `just e2e-slice-costs` prints the balance.
 test-e2e-slice slice:
-	just test-e2e-{{slice}}
+	ROSOTACOM_RUN_E2E=1 {{python}} -m pytest -q --durations=0 tests/e2e/ -m e2e --e2e-slice={{slice}}
+
+e2e-slice-costs:
+	{{python}} tests/e2e/conftest.py
 
 test-e2e-node nodeid:
 	ROSOTACOM_RUN_E2E=1 {{python}} -m pytest -q --durations=0 "{{nodeid}}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,12 @@ select = ["B", "E", "F", "I", "UP"]
 [tool.ruff.lint.isort]
 known-first-party = ["rosotacom"]
 
+[tool.ruff.lint.per-file-ignores]
+# The e2e slice partition is a table of pytest node ids, which have to be
+# verbatim to select anything and run past 120 characters on their own. Folding
+# them would make the table neither readable nor greppable.
+"tests/e2e/conftest.py" = ["E501"]
+
 [tool.mypy]
 python_version = "3.12"
 mypy_path = "src"

--- a/tests/contract/test_benched_set_registry.py
+++ b/tests/contract/test_benched_set_registry.py
@@ -25,6 +25,19 @@ CALIBRATE_WORKFLOW = WORKFLOWS_DIR / "benchmark-calibrate.yml"
 JUSTFILE = PACKAGE_ROOT / "justfile"
 
 
+def _e2e_slices() -> dict[str, dict[str, float]]:
+    """E2E_SLICES, loaded from tests/e2e/conftest.py by path (not importable)."""
+    import importlib.util
+
+    path = PACKAGE_ROOT / "tests" / "e2e" / "conftest.py"
+    spec = importlib.util.spec_from_file_location("rosotacom_e2e_conftest", path)
+    assert spec and spec.loader, f"cannot load {path}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    slices: dict[str, dict[str, float]] = module.E2E_SLICES
+    return slices
+
+
 @pytest.fixture(scope="module")
 def rows() -> list[GateRow]:
     return load_registry()
@@ -174,19 +187,26 @@ def test_gate_workflows_exist_and_consume_the_registry(rows: list[GateRow]) -> N
 
 
 def test_merge_gate_lane_actually_selects_the_benchmark_e2e() -> None:
-    """Regression contract for the silent deselection this work found: the
-    runtime-tools recipe must run both benchmark E2E files
-    (tests/e2e/test_benchmark_capacity.py and tests/e2e/test_benchmark_ab.py) in a
-    pytest invocation that carries no `-k` filter (a `-k` from another file's
-    selection would deselect every benchmark test without failing)."""
-    recipe = re.search(
-        r"^test-e2e-runtime-tools:\n((?:\t.*\n?)+)",
+    """Regression contract for the silent deselection this work found: a
+    `-k` filter meant for one file used to deselect every test in another, so
+    the benchmark E2E could vanish from the gate without failing anything.
+
+    The slice runner carries no `-k` at all now — it deselects by node id
+    against E2E_SLICES — so the contract is that both benchmark E2E files are
+    owned by a slice. Which slice is a balance decision (#226 split the
+    capacity probes out of `runtime-tools`); that they run at all is not.
+    """
+    slice_recipe = re.search(
+        r"^test-e2e-slice[^\n:]*:\n((?:\t.*\n?)+)",
         JUSTFILE.read_text(encoding="utf-8"),
         re.MULTILINE,
     )
-    assert recipe, "justfile recipe test-e2e-runtime-tools is missing"
+    assert slice_recipe, "justfile recipe test-e2e-slice is missing"
+    poisoned = [line for line in slice_recipe.group(1).splitlines() if re.search(r"\s-k\s", line)]
+    assert not poisoned, f"a -k filter would silently deselect tests from a slice: {poisoned}"
+
+    owned = {nodeid for tests in _e2e_slices().values() for nodeid in tests}
     for e2e_file in ("test_benchmark_capacity.py", "test_benchmark_ab.py"):
-        benchmark_lines = [line for line in recipe.group(1).splitlines() if e2e_file in line]
-        assert benchmark_lines, f"test-e2e-runtime-tools no longer runs tests/e2e/{e2e_file}"
-        poisoned = [line for line in benchmark_lines if re.search(r"\s-k\s", line)]
-        assert not poisoned, f"a -k filter would silently deselect the benchmark E2E {e2e_file}: {poisoned}"
+        assert any(nodeid.startswith(f"tests/e2e/{e2e_file}::") for nodeid in owned), (
+            f"no e2e slice owns tests/e2e/{e2e_file}, so no merge-gate lane runs it"
+        )

--- a/tests/contract/test_security_maintenance_config.py
+++ b/tests/contract/test_security_maintenance_config.py
@@ -63,8 +63,8 @@ def test_merge_gate_requires_non_docker_package_and_docker_smoke() -> None:
         "transforms",
         "remote-assist",
         "runtime-tools",
-        "concurrency",
-        "media",
+        "benchmark-capacity",
+        "media-concurrency",
     }
 
 

--- a/tests/contract/test_workflow_contracts.py
+++ b/tests/contract/test_workflow_contracts.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import importlib.util
 import re
 from collections.abc import Iterator
 from pathlib import Path
+from types import ModuleType
 
+import pytest
 import yaml
 
 PACKAGE_ROOT = Path(__file__).resolve().parents[2]
@@ -178,7 +181,8 @@ def _recipe_pytest_invocations(recipe: str) -> list[list[str]]:
     import shlex
 
     text = JUSTFILE_PATH.read_text(encoding="utf-8")
-    match = re.search(rf"^{re.escape(recipe)}\s*:[^\n]*\n(?P<body>(?:[ \t]+[^\n]*\n?)+)", text, re.MULTILINE)
+    # `[^\n:]*` so a parameterised recipe (`test-e2e-slice slice:`) matches too.
+    match = re.search(rf"^{re.escape(recipe)}[^\n:]*:[^\n]*\n(?P<body>(?:[ \t]+[^\n]*\n?)+)", text, re.MULTILINE)
     assert match, f"recipe {recipe!r} not found in the justfile"
 
     invocations: list[list[str]] = []
@@ -208,31 +212,161 @@ def _collect_e2e_ids(args: list[str]) -> set[str]:
     return {line.strip() for line in result.stdout.splitlines() if line.startswith("tests/e2e/")}
 
 
+def _e2e_conftest() -> ModuleType:
+    """The slice manifest, loaded from tests/e2e/conftest.py by path.
+
+    By path because `tests` is not an importable package and only pytest's own
+    collection puts `tests/e2e` on `sys.path`; a contract test in a sibling
+    directory cannot rely on that.
+    """
+    path = PACKAGE_ROOT / "tests" / "e2e" / "conftest.py"
+    spec = importlib.util.spec_from_file_location("rosotacom_e2e_conftest", path)
+    assert spec and spec.loader, f"cannot load {path}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
 def test_e2e_slices_partition_the_whole_suite() -> None:
-    """The parallel slices must collect exactly what the monolith collects.
+    """The slices must own exactly what the monolith collects, once each.
 
     `test-e2e-smoke` is `pytest tests/e2e/ -m e2e`, so it picks up any new file
-    automatically; the slices name files and `-k` expressions by hand and do
-    not. When the merge gate was split into slices, three files
-    (anonymize, video-quality, benchmark-replay) and the two
-    `[remote-assist-anonymized-*]` parameters silently stopped being covered
-    there — `-k "remote_assist"` misses the latter because the parameter id
-    spells it with hyphens. Nothing failed, because nightly and the release
-    still ran the monolith. This test is what makes that drift loud.
+    automatically; E2E_SLICES names node ids by hand and does not. Both halves
+    have failed in production. Three files (anonymize, video-quality,
+    benchmark-replay) and the two `[remote-assist-anonymized-*]` parameters
+    once ran in no slice at all, because `-k "remote_assist"` misses a
+    parameter id that spells it with hyphens. And
+    `test_local_remote_assist_anonymized_smoke_from_copied_example_project` ran
+    in *two* slices for as long as slices existed, because `-k "remote_assist"`
+    and `-k "anonymized"` both match it — 262s of duplicated work per run that
+    the old version of this test could not see, since it compared a union of
+    the slices against the monolith and a union hides an overlap.
     """
     monolith = _collect_e2e_ids(["tests/e2e/", "-m", "e2e"])
     assert monolith, "collected no e2e tests; the monolith invocation changed"
 
-    covered: set[str] = set()
-    for slice_name in _release_e2e_slices():
-        for args in _recipe_pytest_invocations(f"test-e2e-{slice_name}"):
-            covered |= _collect_e2e_ids(args)
+    slices = _e2e_conftest().E2E_SLICES
+    owned: set[str] = set()
+    duplicated: dict[str, list[str]] = {}
+    for name, tests in slices.items():
+        for nodeid in tests:
+            if nodeid in owned:
+                duplicated.setdefault(nodeid, []).append(name)
+            owned.add(nodeid)
 
-    assert not monolith - covered, (
+    assert not duplicated, (
+        "These e2e tests are owned by more than one slice, so the gate runs "
+        "them twice:\n" + "\n".join(f"{nodeid} -> {names}" for nodeid, names in sorted(duplicated.items()))
+    )
+    assert not monolith - owned, (
         "These e2e tests run in `just test-e2e-smoke` but in no slice, so the "
-        "merge gate and the release would not run them:\n" + "\n".join(sorted(monolith - covered))
+        "merge gate and the release would not run them:\n" + "\n".join(sorted(monolith - owned))
     )
-    assert not covered - monolith, (
-        "These tests are selected by a slice but not by the monolith, so the "
-        "two definitions disagree:\n" + "\n".join(sorted(covered - monolith))
+    assert not owned - monolith, (
+        "These tests are owned by a slice but not collected by the monolith, "
+        "so the two definitions disagree:\n" + "\n".join(sorted(owned - monolith))
     )
+
+
+def test_workflow_matrices_expand_the_slices_that_exist() -> None:
+    """The matrix names slices; E2E_SLICES defines them. A name in one and not
+    the other is either a job that fails on an unknown `--e2e-slice` value or a
+    set of tests nothing runs."""
+    module = _e2e_conftest()
+    assert sorted(_release_e2e_slices()) == sorted(module.E2E_SLICES), (
+        f"the release matrix expands {sorted(_release_e2e_slices())} but E2E_SLICES defines {sorted(module.E2E_SLICES)}"
+    )
+
+
+def test_e2e_slices_stay_balanced() -> None:
+    """Balance is a number now, so it can be kept rather than rediscovered.
+
+    Themed slices drifted to a 2.4x spread (7m39s against 18m31s) with nobody
+    noticing, because the only place a per-test cost existed was a `pytest -q`
+    total that nothing compared. The recorded costs make the next imbalance a
+    red contract test instead of a hand-diff of job durations.
+
+    The wall-clock ceiling is a tripwire, not the target: a suite that grows
+    past it wants either a rebalance or more slices, and the fixed
+    RUNNER_SETUP_SECONDS + IMAGE_BUILD_SECONDS per job is what makes that a
+    trade rather than a free win.
+    """
+    module = _e2e_conftest()
+    predicted = {name: module.predicted_slice_seconds(name) for name in module.E2E_SLICES}
+    slowest, fastest = max(predicted.values()), min(predicted.values())
+
+    assert slowest / fastest < 1.5, (
+        f"e2e slices are unbalanced ({slowest / fastest:.2f}x spread); move tests "
+        f"between slices in tests/e2e/conftest.py:\n{module.slice_cost_report()}"
+    )
+    assert slowest <= 15 * 60, (
+        f"the slowest e2e slice is predicted at {slowest / 60:.1f} minutes; rebalance "
+        f"or add a slice:\n{module.slice_cost_report()}"
+    )
+
+
+def test_slice_recipe_selects_by_slice_not_by_k() -> None:
+    """One invocation, no `-k`. Every slice-shaped bug this repository has had
+    came from a filter that was not the collection: a `-k` that missed a
+    hyphenated parameter id, a `-k` that matched two slices' tests, and a `-k`
+    from one file's selection deselecting every test in another file."""
+    invocations = _recipe_pytest_invocations("test-e2e-slice")
+    assert len(invocations) == 1, f"test-e2e-slice should run pytest once, runs {len(invocations)} times"
+    args = invocations[0]
+    assert "-k" not in args, f"test-e2e-slice must not filter with -k: {args}"
+    assert "--e2e-slice={{slice}}" in args, f"test-e2e-slice must pass the slice through: {args}"
+
+
+def test_each_slice_collects_exactly_what_it_owns() -> None:
+    """The manifest is the intent; this is what pytest actually selects.
+
+    Checked per slice rather than as a union, because a union is precisely what
+    could not see one test being collected by two slices.
+    """
+    slices = _e2e_conftest().E2E_SLICES
+    for name, tests in slices.items():
+        collected = _collect_e2e_ids(["tests/e2e/", "-m", "e2e", f"--e2e-slice={name}"])
+        assert collected == set(tests), f"slice {name!r} collects {sorted(collected)} but owns {sorted(tests)}"
+
+
+class _FakeItem:
+    """Enough of a pytest item for the collection hook."""
+
+    def __init__(self, nodeid: str) -> None:
+        self.nodeid = nodeid
+        self.keywords = {"e2e"}
+
+    def add_marker(self, marker: object) -> None:
+        pass
+
+
+class _FakeConfig:
+    def __init__(self, slice_name: str) -> None:
+        self._slice_name = slice_name
+        self.deselected: list[object] = []
+        self.hook = self
+
+    def getoption(self, name: str) -> str:
+        assert name == "--e2e-slice"
+        return self._slice_name
+
+    def pytest_deselected(self, items: list[object]) -> None:
+        self.deselected.extend(items)
+
+
+def test_an_unowned_e2e_test_fails_every_slice_job() -> None:
+    """An e2e test in no slice must stop the run, not quietly not run.
+
+    Three e2e files once sat outside every slice for a release cycle and
+    nothing went red, because the gate only ran what the slices named. Failing
+    here means all six jobs say so on the first PR that adds a test.
+    """
+    module = _e2e_conftest()
+    config = _FakeConfig("core")
+    items = [_FakeItem("tests/e2e/test_smoke.py::test_a_test_nobody_assigned")]
+
+    with pytest.raises(pytest.UsageError) as excinfo:
+        module.pytest_collection_modifyitems(config, items)
+
+    assert "test_a_test_nobody_assigned" in str(excinfo.value)
+    assert "E2E_SLICES" in str(excinfo.value)

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,8 +1,149 @@
+"""Collection rules for the Docker-backed e2e suite, and the CI slice partition.
+
+`just test-e2e-smoke` runs the whole suite in one process; CI runs the same
+collection as six parallel slices, selected with `--e2e-slice=<name>`. A slice
+is a deselection of one shared collection, not a separate pytest invocation
+with its own file list — which is what it used to be, and that shape got two
+things wrong that a partition cannot get wrong:
+
+- `-k "remote_assist"` missed the `[remote-assist-anonymized-*]` parameters,
+  because the parameter id spells it with hyphens (#198 found and fixed that);
+- `-k "remote_assist"` and `-k "anonymized"` both matched
+  `test_local_remote_assist_anonymized_smoke_from_copied_example_project`, so
+  the gate ran that test in two slices every run. The contract test compared a
+  *union* of the slices against the monolith, and a union hides an overlap.
+
+The number next to each test is what it costs, which is the other half of
+#226: slices were grouped by theme and nothing recorded a per-test cost, so
+the imbalance (2.4x between the fastest and slowest job) was invisible unless
+somebody diffed job durations by hand. Balance is now a reviewable number, and
+`tests/contract/test_workflow_contracts.py` fails when it drifts.
+"""
+
 from __future__ import annotations
 
 import os
 
 import pytest
+
+#: Seconds a job spends before pytest starts: checkout, Python, `just setup`,
+#: `docker info`. Measured across the six e2e jobs of merge-gate run
+#: 31597657446 (43-60s).
+RUNNER_SETUP_SECONDS = 55.0
+
+#: Seconds the first test in a job pays to build the rosotacom project image.
+#: Every job pays this exactly once, whichever test happens to run first, so it
+#: is a constant that balancing cannot remove — only running fewer, larger
+#: slices can. Measured as the gap between the two invocations of the one test
+#: that used to run in two slices: median 419s as its job's first test against
+#: median 262s as a later one, over the six runs of 2026-08-11/12.
+IMAGE_BUILD_SECONDS = 155.0
+
+#: Every e2e test, the slice that owns it, and its *warm* pytest `call`
+#: duration in seconds — the median over those six runs of a run where the
+#: project image already existed. Warm is the right unit because
+#: IMAGE_BUILD_SECONDS is charged once per job on top; balancing warm costs is
+#: therefore the same thing as balancing wall clock.
+#:
+#: `derived` marks a test that has only ever run as its job's first test, so
+#: its warm cost is the measured value minus IMAGE_BUILD_SECONDS. Two sibling
+#: parameters check that arithmetic: `[1-heartbeat]` derives to 128.6s against
+#: a measured 123.1s for `[status]`, and `[compressed-occupancy-grid]` derives
+#: to 159.9s against a measured 150.4s for its zenoh twin.
+#:
+#: To refresh: every e2e invocation runs `--durations=0`, so a merge-gate run
+#: prints every number here. See docs/ci.md, "Balancing the e2e slices".
+E2E_SLICES: dict[str, dict[str, float]] = {
+    # Heartbeat and chatter: the smallest thing that has to work.
+    "core": {
+        "tests/e2e/test_smoke.py::test_local_heartbeat_smoke_matrix_from_copied_example_project[1-heartbeat]": 128.6,  # derived
+        "tests/e2e/test_smoke.py::test_local_heartbeat_smoke_matrix_from_copied_example_project[status]": 123.1,
+        "tests/e2e/test_smoke.py::test_native_chatter_scenario_starts_apps_and_communication_together": 104.1,
+        "tests/e2e/test_smoke.py::test_local_native_chatter_smoke_from_copied_example_project[native-chatter]": 85.3,
+        "tests/e2e/test_smoke.py::test_interactive_native_chatter_smoke_starts_full_local_debug_rig": 73.8,
+        # Skipped unless ROSOTACOM_RUN_FULL_E2E=1; nightly runs them one per
+        # job through `just test-e2e-rmw`, so they cost this slice nothing.
+        "tests/e2e/test_smoke.py::test_full_rmw_heartbeat_smoke_matrix[cyclone-local-zenoh-ros2dds-ota]": 0.0,
+        "tests/e2e/test_smoke.py::test_full_rmw_heartbeat_smoke_matrix[cyclone-ota]": 0.0,
+        "tests/e2e/test_smoke.py::test_full_rmw_heartbeat_smoke_matrix[fastdds]": 0.0,
+        "tests/e2e/test_smoke.py::test_full_rmw_heartbeat_smoke_matrix[zen-endpoints]": 0.0,
+    },
+    # What the transport does to a payload: compression and size, each over
+    # both RMW paths.
+    "transforms": {
+        "tests/e2e/test_smoke.py::test_local_zenoh_sized_payload_smoke_from_copied_example_project[sized-payload-zenoh]": 172.3,
+        "tests/e2e/test_smoke.py::test_local_compressed_occupancy_grid_smoke_from_copied_example_project[compressed-occupancy-grid]": 159.9,  # derived
+        "tests/e2e/test_smoke.py::test_local_zenoh_compressed_occupancy_grid_smoke_from_copied_example_project[compressed-occupancy-grid-zenoh]": 150.4,
+        "tests/e2e/test_smoke.py::test_local_wrapped_sized_payload_smoke_from_copied_example_project[sized-payload-fastdds]": 117.3,
+    },
+    # All three anonymized remote-assist scenarios. The full rig and its two
+    # single-stream cuts belong together: they share a trace and a failure
+    # mode, and splitting them across slices is how one of them ended up
+    # running twice.
+    "remote-assist": {
+        "tests/e2e/test_smoke.py::test_local_remote_assist_anonymized_smoke_from_copied_example_project[remote-assist-anonymized]": 262.0,
+        "tests/e2e/test_smoke.py::test_local_single_stream_anonymized_smoke_from_copied_example_project[remote-assist-anonymized-costmap]": 147.8,
+        "tests/e2e/test_smoke.py::test_local_single_stream_anonymized_smoke_from_copied_example_project[remote-assist-anonymized-camera]": 146.3,
+    },
+    # Everything built on top of a running session: the latency probe, live
+    # timeline shaping, and the two benchmark verdicts.
+    "runtime-tools": {
+        "tests/e2e/test_benchmark_ab.py::test_benchmark_ab_reliability_verdict": 202.5,
+        "tests/e2e/test_benchmark_replay.py::test_loss_boundaries_against_costmap_replay": 174.2,
+        "tests/e2e/test_smoke.py::test_local_link_latency_smoke_exposes_metric_backbone[link-latency]": 146.9,  # derived
+        "tests/e2e/test_timeline_stepping.py::test_timeline_steps_change_the_qdisc_tree_in_place": 1.4,
+    },
+    # The band-asserted capacity probes, split out of `runtime-tools`: they
+    # were two thirds of the slowest slice and they gate on committed bands
+    # (docs/performance-bands.md), so a red job here means one thing.
+    "benchmark-capacity": {
+        "tests/e2e/test_benchmark_capacity.py::test_merge_gate_row_is_band_asserted[probe-loss-gop-tight-cyclone]": 142.0,
+        "tests/e2e/test_benchmark_capacity.py::test_benchmark_capacity_good_case": 93.1,
+        "tests/e2e/test_benchmark_capacity.py::test_benchmark_capacity_bad_case": 91.6,
+        "tests/e2e/test_benchmark_capacity.py::test_benchmark_probe_camera_load": 88.4,
+    },
+    # Two themes in one slice, because at 177s and 265s neither fills a job and
+    # a job costs 210s before it runs a test. The name says so rather than
+    # hiding it under one of the two.
+    "media-concurrency": {
+        "tests/e2e/test_video_quality_e2e.py::test_synthetic_camera_pipeline_records_quality_metrics": 164.3,
+        "tests/e2e/test_parallel_smoke.py::test_independent_local_smoke_tests_run_in_parallel": 143.9,  # derived
+        "tests/e2e/test_parallel_smoke.py::test_second_same_target_smoke_aborts_and_leaves_first_intact": 120.8,
+        "tests/e2e/test_anonymize_e2e.py::test_anonymize_headless_end_to_end_preserves_keyframe_structure": 12.3,  # derived
+    },
+}
+
+
+def slice_owners() -> dict[str, str]:
+    """Node id -> the slice that runs it."""
+    return {nodeid: name for name, tests in E2E_SLICES.items() for nodeid in tests}
+
+
+def predicted_slice_seconds(name: str) -> float:
+    """Wall clock a slice's CI job should take, setup and image build included."""
+    return RUNNER_SETUP_SECONDS + IMAGE_BUILD_SECONDS + sum(E2E_SLICES[name].values())
+
+
+def slice_cost_report() -> str:
+    """The balance table, for a failure message or `just e2e-slice-costs`."""
+    lines = [f"{'slice':<20} {'tests':>5} {'pytest':>8} {'job':>8}"]
+    for name in sorted(E2E_SLICES, key=predicted_slice_seconds, reverse=True):
+        job = predicted_slice_seconds(name)
+        tests = E2E_SLICES[name]
+        lines.append(f"{name:<20} {len(tests):5d} {sum(tests.values()):7.0f}s {job / 60:7.1f}m")
+    slowest = max(map(predicted_slice_seconds, E2E_SLICES))
+    fastest = min(map(predicted_slice_seconds, E2E_SLICES))
+    lines.append(f"critical path {slowest / 60:.1f}m, spread {slowest / fastest:.2f}x, {len(E2E_SLICES)} jobs")
+    return "\n".join(lines)
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    parser.addoption(
+        "--e2e-slice",
+        default=None,
+        choices=sorted(E2E_SLICES),
+        help="Run only the e2e tests this CI slice owns; see E2E_SLICES in tests/e2e/conftest.py.",
+    )
 
 
 def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
@@ -12,3 +153,33 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item
     for item in items:
         if "e2e" in item.keywords and not run_e2e:
             item.add_marker(skip_e2e)
+
+    slice_name = config.getoption("--e2e-slice")
+    if slice_name is None:
+        return
+
+    owners = slice_owners()
+    e2e_items = [item for item in items if "e2e" in item.keywords]
+
+    unassigned = sorted(item.nodeid for item in e2e_items if item.nodeid not in owners)
+    if unassigned:
+        # Loud on purpose, and in every slice at once. An e2e test that belongs
+        # to no slice is a test the merge gate does not run, which is how three
+        # files and two parameters went unchecked for a release cycle.
+        raise pytest.UsageError(
+            "These e2e tests belong to no slice, so no CI job would run them:\n"
+            + "\n".join(unassigned)
+            + "\n\nAdd each to E2E_SLICES in tests/e2e/conftest.py with its `--durations=0`"
+            + " cost. Current balance:\n"
+            + slice_cost_report()
+        )
+
+    deselected = [item for item in e2e_items if owners[item.nodeid] != slice_name]
+    if deselected:
+        config.hook.pytest_deselected(items=deselected)
+        dropped = {id(item) for item in deselected}
+        items[:] = [item for item in items if id(item) not in dropped]
+
+
+if __name__ == "__main__":  # `just e2e-slice-costs`
+    print(slice_cost_report())


### PR DESCRIPTION
Closes #226.

## What the numbers said

`--durations=0` (added by #227) over six merge-gate runs, 2026-08-11/12. Two
things came out of it that the issue could not know yet:

**One test ran in two slices, every run.** `-k "remote_assist"` and
`-k "anonymized"` both match
`test_local_remote_assist_anonymized_smoke_from_copied_example_project`, so
`e2e-remote-assist` and `e2e-media` each ran it — 262s of duplicated work per
run, for as long as slices have existed. `test_e2e_slices_partition_the_whole_suite`
could not see it: it compared a *union* of the slices against the monolith, and
a union hides an overlap. So the suite is 24 distinct tests, not 25.

**Roughly 210s of every job is fixed, and it is not where the issue put it.**
~55s is runner setup before pytest starts; the rest is the project image, built
inside whichever test runs first. Measured directly, because the duplicated
test gave us the same test warm and cold in the same run: median 419s as its
job's first test against 262s as a later one, six runs, Δ155s. Two sibling
parameters confirm the constant independently — `[1-heartbeat]` derives to
128.6s warm against a measured 123.1s for `[status]`, and
`[compressed-occupancy-grid]` to 159.9s against 150.4s for its zenoh twin.

That matters for step 4 of the issue: the fixed cost is per *job*, so it is
re-paid by every slice added. Total warm work is 3042s.

| N | predicted critical path | runner-minutes |
|---|---|---|
| 6 (this PR) | 13m30s | ~72 |
| 8 | 9m52s | ~79 |
| 12 | 7m46s | ~93 |
| 24 (one per test) | 7m52s | ~146 |

One job per test is not the floor — it is *slower* than twelve, because the
slowest single test (262s warm) plus 210s fixed is already 7m52s. The issue
called that; the measured floor is just harder than it estimated.

## What changed

**A slice is a deselection, not its own invocation.** `just test-e2e-slice
<name>` runs the monolith's collection with `--e2e-slice=<name>`; `E2E_SLICES`
in `tests/e2e/conftest.py` maps every node id to its slice and its cost. Six
recipes with eight pytest invocations become one recipe with one. Both slice
bugs this repository has had were `-k` bugs — the hyphenated parameter id #198
found, and the overlap above — and neither is expressible now: a test owned by
nobody fails all six jobs with a usage error naming it, a test owned twice
fails a contract test.

**Rebalanced on the measured costs**, keeping matched pairs together:

| slice | tests | pytest | predicted job | was |
|---|---|---|---|---|
| `transforms` | 4 | 600s | 13m30s | 12m31s |
| `remote-assist` | 3 | 556s | 12m46s | 7m39s (one test, and it was a duplicate) |
| `runtime-tools` | 4 | 525s | 12m15s | 18m31s |
| `core` | 5 + 4 skipped | 515s | 12m05s | 12m01s |
| `media-concurrency` | 4 | 441s | 10m51s | 15m51s + 7m49s |
| `benchmark-capacity` | 4 | 415s | 10m25s | (was inside `runtime-tools`) |

Critical path 18m31s → 13m30s, spread 2.38x → 1.30x, at slightly fewer
runner-minutes because the duplicate is gone. `runtime-tools` splits: the
capacity probes were two thirds of the slowest slice and they gate on committed
bands, so a red job there means one thing. `remote-assist` takes all three
remote-assist scenarios rather than sharing one with `media`. `media` and
`concurrency` merge and say so in the name — at 177s and 265s neither fills a
job that costs 210s before it runs a test.

**Balance is now checked.** `test_e2e_slices_stay_balanced` fails past 1.5x
spread or 15 minutes on the slowest slice, and prints the table. That is the
part the issue asked for that a one-time rebalance does not give: the last
imbalance grew to 2.4x because nothing compared job durations.

## Validation

- `just check` (lint, workflow lint, build lint, typecheck, 650 non-Docker
  tests, docs, package) — passes.
- New: `test_each_slice_collects_exactly_what_it_owns` collects each of the six
  slices for real and asserts it equals what the manifest says, per slice
  rather than as a union. `test_an_unowned_e2e_test_fails_every_slice_job`
  drives the collection hook with an unassigned test and asserts the
  `UsageError`. `test_e2e_slices_partition_the_whole_suite` now also rejects an
  overlap.
- The six slice jobs on this PR are the real check, and they re-measure: every
  slice now has a different first test, so the run either confirms the five
  derived warm costs or corrects them.

## Notes

- Image caching across jobs is still out of scope (#226 non-goals) — it would
  move the 210s floor, which is the only thing that makes N > 12 interesting.
- Two derived numbers to watch in this PR's run: `anonymize` derives to 12.3s
  warm (it was only ever measured as its job's first test, at 167.3s), and
  `link-latency` to 146.9s. If they land far off, `media-concurrency` and
  `runtime-tools` want a small correction — a one-line edit each.
