### PR TITLE
Choose the number of e2e slices from the cost model instead of from taste

### DIFF
--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        slice: [core, transforms, remote-assist, runtime-tools, benchmark-capacity, media-concurrency]
+        slice: [heartbeat, chatter, occupancy-grid, sized-payload, remote-assist, remote-assist-streams, runtime-tools, media, concurrency, benchmark-ab, benchmark-replay, benchmark-capacity, benchmark-capacity-cases]
 
     steps:
       - name: Check out repository

--- a/.github/workflows/pr-merge-gate.yml
+++ b/.github/workflows/pr-merge-gate.yml
@@ -201,9 +201,11 @@ jobs:
     # tests/contract/test_workflow_contracts.py keeps the three workflows and
     # the justfile agreeing.
     #
-    # The six slices are balanced by measured cost, not grouped by theme
-    # (#226): themed slices spanned 7m39s to 18m31s, and one test ran in two of
-    # them. Which tests a slice owns and what each costs is E2E_SLICES in
+    # The slices are chosen by measured cost, not grouped by theme (#226):
+    # themed slices spanned 7m39s to 18m31s, and one test ran in two of them.
+    # Thirteen rather than six because the model that predicted the balanced
+    # six within 25s also says twelve reaches the floor and more buys nothing
+    # (#235). Which tests a slice owns and what each costs is E2E_SLICES in
     # tests/e2e/conftest.py — change that, not this line, to move a test.
     name: e2e-${{ matrix.slice }}
     runs-on: ubuntu-latest
@@ -213,7 +215,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        slice: [core, transforms, remote-assist, runtime-tools, benchmark-capacity, media-concurrency]
+        slice: [heartbeat, chatter, occupancy-grid, sized-payload, remote-assist, remote-assist-streams, runtime-tools, media, concurrency, benchmark-ab, benchmark-replay, benchmark-capacity, benchmark-capacity-cases]
 
     steps:
       - name: Check out repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,7 +125,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        slice: [core, transforms, remote-assist, runtime-tools, benchmark-capacity, media-concurrency]
+        slice: [heartbeat, chatter, occupancy-grid, sized-payload, remote-assist, remote-assist-streams, runtime-tools, media, concurrency, benchmark-ab, benchmark-replay, benchmark-capacity, benchmark-capacity-cases]
 
     steps:
       - name: Check out repository

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -43,7 +43,7 @@ check is:
 ci-success
 ```
 
-The merge gate runs workflow lint, dependency/security review, runtime/build asset lint, Python 3.10 through 3.14 non-Docker checks, package validation, and the Docker single-machine smoke matrix (one matrix job per slice, six in parallel):
+The merge gate runs workflow lint, dependency/security review, runtime/build asset lint, Python 3.10 through 3.14 non-Docker checks, package validation, and the Docker single-machine smoke matrix (one matrix job per slice, thirteen in parallel):
 
 Python 3.10–3.14 are supported for the host CLI; Python 3.12 is the reference
 interpreter for packaging and Docker E2E jobs.
@@ -57,12 +57,19 @@ just test-nondocker-cov
 just docs
 just package
 # Parallel E2E lanes, one per slice:
-just test-e2e-slice core
-just test-e2e-slice transforms
+just test-e2e-slice heartbeat
+just test-e2e-slice chatter
+just test-e2e-slice occupancy-grid
+just test-e2e-slice sized-payload
 just test-e2e-slice remote-assist
+just test-e2e-slice remote-assist-streams
 just test-e2e-slice runtime-tools
+just test-e2e-slice media
+just test-e2e-slice concurrency
+just test-e2e-slice benchmark-ab
+just test-e2e-slice benchmark-replay
 just test-e2e-slice benchmark-capacity
-just test-e2e-slice media-concurrency
+just test-e2e-slice benchmark-capacity-cases
 ```
 
 The Python 3.12 leg uploads `coverage.xml` to Codecov with the `nondocker` flag.
@@ -70,9 +77,8 @@ Docker E2E is not collected for coverage.
 
 ## Docker E2E
 
-`just test-e2e-smoke` runs the entire local single-machine smoke matrix through Docker. In the CI merge gate, the same collection runs as six parallel jobs
-(`e2e-core`, `e2e-transforms`, `e2e-remote-assist`, `e2e-runtime-tools`,
-`e2e-benchmark-capacity`, `e2e-media-concurrency`). Each smoke run writes generated
+`just test-e2e-smoke` runs the entire local single-machine smoke matrix through Docker. In the CI merge gate, the same collection runs as thirteen parallel
+jobs, one per slice, named `e2e-<slice>`. Each smoke run writes generated
 config, catmux pane logs, Docker logs when available, and the smoke verification
 log under `session-instances/`; collect that directory as the first debugging
 artifact when an E2E job fails.
@@ -94,19 +100,35 @@ twice a run. A partition can do neither: an unowned test fails every slice job
 with a usage error, and a test owned twice fails
 `test_e2e_slices_partition_the_whole_suite`.
 
-The costs are warm pytest `call` durations — medians over six merge-gate runs
+The costs are warm pytest `call` durations — medians over seven merge-gate runs
 of 2026-08-11/12. On top of them each job pays a fixed
-`RUNNER_SETUP_SECONDS + IMAGE_BUILD_SECONDS` (~3m30s: runner setup, then the
+`RUNNER_SETUP_SECONDS + IMAGE_BUILD_SECONDS` (3m29s: 55s of runner setup, then the
 project image built inside whichever test runs first). Because that constant is
-per job and not per test, balancing warm costs balances wall clock, and adding
-slices buys less than the arithmetic suggests: six balanced slices are
-predicted at ~13m30s against ~10m for twelve, at twice the runner minutes.
+per job and not per test, balancing warm costs balances wall clock.
+
+### How many slices
+
+`floor_seconds()` is `fixed + slowest single test` — the fastest any partition
+of this suite could be, because one job has to run that test and pays the fixed
+cost like every other. It is currently **7m56s**, of which 2m34s is the image
+build (#236 is about removing it).
+
+Thirteen slices sit at 8m38s, 1.09x the floor. That is the point of choosing N
+from the numbers rather than from taste: six balanced slices were 13m37s,
+twelve reach the floor, and past twelve every extra job is pure cost. The
+contract test asserts distance to the floor rather than the spread between
+slices — spread is compressed toward 1.0 by the fixed cost as N grows, so it
+keeps reading fine while the gate stops improving.
+
+Runner minutes are not the constraint here (this repository is public, so
+standard GitHub-hosted runners are free); the concurrent-job cap is, and
+thirteen stays under it.
 
 To refresh the numbers, read a merge-gate run: every e2e invocation runs
 `--durations=0`, so each job prints the cost of every test it ran. A test that
 ran first in its job carries the image build and needs `IMAGE_BUILD_SECONDS`
-subtracted. `tests/contract/test_workflow_contracts.py::test_e2e_slices_stay_balanced`
-fails when the recorded spread passes 1.5x.
+subtracted. `tests/contract/test_workflow_contracts.py::test_e2e_slices_stay_close_to_the_floor`
+fails when the slowest slice passes 1.25x the floor.
 
 ## Performance Regression Gate
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -125,17 +125,24 @@ from one-host smoke.
 
 `just test-e2e-smoke` runs the entire set of local-checkable curated examples. In CI and for local convenience, you can run specific E2E test slices or nodes:
 
-- `just test-e2e-slice core`: heartbeat and native chatter.
-- `just test-e2e-slice transforms`: transport transforms (compression, payload sizes).
-- `just test-e2e-slice remote-assist`: the anonymized remote-assist rig and its two single-stream cuts.
-- `just test-e2e-slice runtime-tools`: link latency, live timeline stepping, and the two benchmark verdicts.
-- `just test-e2e-slice benchmark-capacity`: the band-asserted capacity probes.
-- `just test-e2e-slice media-concurrency`: anonymization, video quality, and the concurrency/isolation gate.
+- `just test-e2e-slice heartbeat`: the heartbeat matrix (and the opt-in RMW matrix).
+- `just test-e2e-slice chatter`: the native chatter scenario, smoke, and debug rig.
+- `just test-e2e-slice occupancy-grid`: compressed occupancy grid over both transports.
+- `just test-e2e-slice sized-payload`: sized payload over both transports.
+- `just test-e2e-slice remote-assist`: the full anonymized remote-assist rig.
+- `just test-e2e-slice remote-assist-streams`: its costmap and camera single-stream cuts.
+- `just test-e2e-slice runtime-tools`: link latency and live timeline stepping.
+- `just test-e2e-slice media`: anonymization and video quality.
+- `just test-e2e-slice concurrency`: the concurrency/isolation gate.
+- `just test-e2e-slice benchmark-ab`: the A/B reliability verdict.
+- `just test-e2e-slice benchmark-replay`: loss boundaries against costmap replay.
+- `just test-e2e-slice benchmark-capacity`: the band-asserted capacity rows.
+- `just test-e2e-slice benchmark-capacity-cases`: the capacity good/bad-case verdicts.
 - `just test-e2e-node <nodeid>`: Reruns a specific pytest node ID directly.
 - `just e2e-slice-costs`: prints what each slice costs and how balanced the six are.
 
-The slices are balanced by measured cost rather than grouped by theme, which is
-why two of them carry a compound name. `E2E_SLICES` in `tests/e2e/conftest.py`
+The slices are chosen by measured cost, and split where the tests already
+differ so a red job names an area. `E2E_SLICES` in `tests/e2e/conftest.py`
 decides which slice owns which test; see
 [ci.md](ci.md#balancing-the-e2e-slices) before moving one.
 

--- a/tests/contract/test_security_maintenance_config.py
+++ b/tests/contract/test_security_maintenance_config.py
@@ -58,13 +58,24 @@ def test_merge_gate_requires_non_docker_package_and_docker_smoke() -> None:
     # are, and that they add up to the whole suite, is
     # tests/contract/test_workflow_contracts.py's job.
     assert "just test-e2e-slice" in merge_gate
+    # Named individually rather than compared to E2E_SLICES, so that dropping a
+    # slice from the manifest and the matrix together still fails here. Which
+    # slices exist is a balance decision (#226, #235); that the gate runs the
+    # Docker smoke suite at all is what this file is about.
     assert set(jobs["e2e"]["strategy"]["matrix"]["slice"]) >= {
-        "core",
-        "transforms",
+        "heartbeat",
+        "chatter",
+        "occupancy-grid",
+        "sized-payload",
         "remote-assist",
+        "remote-assist-streams",
         "runtime-tools",
+        "media",
+        "concurrency",
+        "benchmark-ab",
+        "benchmark-replay",
         "benchmark-capacity",
-        "media-concurrency",
+        "benchmark-capacity-cases",
     }
 
 

--- a/tests/contract/test_workflow_contracts.py
+++ b/tests/contract/test_workflow_contracts.py
@@ -278,31 +278,52 @@ def test_workflow_matrices_expand_the_slices_that_exist() -> None:
     )
 
 
-def test_e2e_slices_stay_balanced() -> None:
+def test_e2e_slices_stay_close_to_the_floor() -> None:
     """Balance is a number now, so it can be kept rather than rediscovered.
 
     Themed slices drifted to a 2.4x spread (7m39s against 18m31s) with nobody
     noticing, because the only place a per-test cost existed was a `pytest -q`
-    total that nothing compared. The recorded costs make the next imbalance a
-    red contract test instead of a hand-diff of job durations.
+    total that nothing compared.
 
-    The wall-clock ceiling is a tripwire, not the target: a suite that grows
-    past it wants either a rebalance or more slices, and the fixed
-    RUNNER_SETUP_SECONDS + IMAGE_BUILD_SECONDS per job is what makes that a
-    trade rather than a free win.
+    Measured against the floor rather than the spread, which is what this test
+    asserted at six slices and what stopped meaning anything at thirteen. The
+    fixed cost per job compresses spread toward 1.0 as N grows, so a suite could
+    go badly wrong while spread still read 1.1; and past N=12 the spread is set
+    by tests too small to split rather than by imbalance. Distance to
+    `floor_seconds()` says the one thing worth asserting at any N — the gate is
+    near the fastest it could possibly be — and needs no retuning when a test is
+    added.
+
+    1.25x, not 1.0x, because the floor assumes tests can be divided arbitrarily
+    and they cannot. At thirteen slices the partition sits at 1.09x.
     """
     module = _e2e_conftest()
     predicted = {name: module.predicted_slice_seconds(name) for name in module.E2E_SLICES}
-    slowest, fastest = max(predicted.values()), min(predicted.values())
+    slowest = max(predicted.values())
+    floor = module.floor_seconds()
 
-    assert slowest / fastest < 1.5, (
-        f"e2e slices are unbalanced ({slowest / fastest:.2f}x spread); move tests "
-        f"between slices in tests/e2e/conftest.py:\n{module.slice_cost_report()}"
+    assert slowest <= 1.25 * floor, (
+        f"the slowest e2e slice is predicted at {slowest / 60:.2f}m against a "
+        f"{floor / 60:.2f}m floor ({slowest / floor:.2f}x). Move tests between slices, "
+        f"or split the slowest one, in tests/e2e/conftest.py:\n{module.slice_cost_report()}"
     )
-    assert slowest <= 15 * 60, (
-        f"the slowest e2e slice is predicted at {slowest / 60:.1f} minutes; rebalance "
-        f"or add a slice:\n{module.slice_cost_report()}"
-    )
+
+
+def test_the_floor_is_a_single_test_not_a_slice() -> None:
+    """`floor_seconds()` has to stay the *suite's* floor, not the current
+    partition's. It reads the slowest single test out of E2E_SLICES, so it
+    would silently follow a bad partition if it summed a slice instead — and
+    then the test above would be comparing the gate against itself.
+    """
+    module = _e2e_conftest()
+    slowest_test = max(cost for tests in module.E2E_SLICES.values() for cost in tests.values())
+    expected = module.RUNNER_SETUP_SECONDS + module.IMAGE_BUILD_SECONDS + slowest_test
+
+    assert module.floor_seconds() == expected
+    # The floor bounds the critical path, not every slice: a slice that does not
+    # own the slowest test is free to be quicker than it.
+    slowest_slice = max(module.predicted_slice_seconds(name) for name in module.E2E_SLICES)
+    assert module.floor_seconds() <= slowest_slice, "the floor is above the critical path, so it is not a floor"
 
 
 def test_slice_recipe_selects_by_slice_not_by_k() -> None:

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,23 +1,23 @@
 """Collection rules for the Docker-backed e2e suite, and the CI slice partition.
 
 `just test-e2e-smoke` runs the whole suite in one process; CI runs the same
-collection as six parallel slices, selected with `--e2e-slice=<name>`. A slice
-is a deselection of one shared collection, not a separate pytest invocation
-with its own file list — which is what it used to be, and that shape got two
-things wrong that a partition cannot get wrong:
+collection as thirteen parallel slices, selected with `--e2e-slice=<name>`. A
+slice is a deselection of one shared collection, not a separate pytest
+invocation with its own file list — which is what it used to be, and that shape
+got two things wrong that a partition cannot get wrong:
 
 - `-k "remote_assist"` missed the `[remote-assist-anonymized-*]` parameters,
   because the parameter id spells it with hyphens (#198 found and fixed that);
 - `-k "remote_assist"` and `-k "anonymized"` both matched
   `test_local_remote_assist_anonymized_smoke_from_copied_example_project`, so
-  the gate ran that test in two slices every run. The contract test compared a
-  *union* of the slices against the monolith, and a union hides an overlap.
+  the gate ran that test in two slices every run (#226). The contract test
+  compared a *union* of the slices against the monolith, and a union hides an
+  overlap.
 
-The number next to each test is what it costs, which is the other half of
-#226: slices were grouped by theme and nothing recorded a per-test cost, so
-the imbalance (2.4x between the fastest and slowest job) was invisible unless
-somebody diffed job durations by hand. Balance is now a reviewable number, and
-`tests/contract/test_workflow_contracts.py` fails when it drifts.
+The number next to each test is what it costs. #226 balanced six themed slices
+on those numbers and the run came back within 25s of every prediction, so #235
+used the same model to choose N instead of guessing it: thirteen slices, split
+where the tests already differ, is 1.09x the fastest any partition could be.
 """
 
 from __future__ import annotations
@@ -27,89 +27,110 @@ import os
 import pytest
 
 #: Seconds a job spends before pytest starts: checkout, Python, `just setup`,
-#: `docker info`. Measured across the six e2e jobs of merge-gate run
-#: 31597657446 (43-60s).
+#: `docker info`. Measured across the e2e jobs of merge-gate runs 31597657446
+#: and 31634604888 (43-60s).
 RUNNER_SETUP_SECONDS = 55.0
 
 #: Seconds the first test in a job pays to build the rosotacom project image.
-#: Every job pays this exactly once, whichever test happens to run first, so it
-#: is a constant that balancing cannot remove — only running fewer, larger
-#: slices can. Measured as the gap between the two invocations of the one test
-#: that used to run in two slices: median 419s as its job's first test against
-#: median 262s as a later one, over the six runs of 2026-08-11/12.
-IMAGE_BUILD_SECONDS = 155.0
-
-#: Every e2e test, the slice that owns it, and its *warm* pytest `call`
-#: duration in seconds — the median over those six runs of a run where the
-#: project image already existed. Warm is the right unit because
-#: IMAGE_BUILD_SECONDS is charged once per job on top; balancing warm costs is
-#: therefore the same thing as balancing wall clock.
+#: Every job pays it exactly once, whichever test runs first, so it is a
+#: constant no partition can remove — see #236, which is about removing it.
+#: Because it is per job and not per test, it is also what makes more slices
+#: cost more: at thirteen, 33 minutes of every gate run is this.
 #:
-#: `derived` marks a test that has only ever run as its job's first test, so
-#: its warm cost is the measured value minus IMAGE_BUILD_SECONDS. Two sibling
-#: parameters check that arithmetic: `[1-heartbeat]` derives to 128.6s against
-#: a measured 123.1s for `[status]`, and `[compressed-occupancy-grid]` derives
-#: to 159.9s against a measured 150.4s for its zenoh twin.
+#: Measured over 21 cold/warm pairs across seven runs: median 153.7s. A pair is
+#: one test's duration as its job's first test against its median duration when
+#: something else went first. Run 31634604888 supplied five of them at once,
+#: because rebalancing changed which test each slice starts with.
+IMAGE_BUILD_SECONDS = 154.0
+
+#: Every e2e test, the slice that owns it, and its *warm* pytest `call` duration
+#: in seconds — the median over seven runs of the invocations where the project
+#: image already existed. Warm is the right unit because IMAGE_BUILD_SECONDS is
+#: charged once per job on top; balancing warm costs balances wall clock.
+#:
+#: `derived` marks the three tests that have only ever run first in their job,
+#: so their warm cost is the measured value minus IMAGE_BUILD_SECONDS. That
+#: arithmetic is not a guess any more: #226 recorded five derived costs, #235's
+#: rebalance moved two of them out of first position, and both came back within
+#: 3s of the derivation (`link-latency` 146.9 derived / 145.0 measured,
+#: `independent...in_parallel` 143.9 / 146.6).
 #:
 #: To refresh: every e2e invocation runs `--durations=0`, so a merge-gate run
-#: prints every number here. See docs/ci.md, "Balancing the e2e slices".
+#: prints every number here, and each slice's first test prints one more
+#: measurement of IMAGE_BUILD_SECONDS. See docs/ci.md, "Balancing the e2e
+#: slices".
 E2E_SLICES: dict[str, dict[str, float]] = {
-    # Heartbeat and chatter: the smallest thing that has to work.
-    "core": {
-        "tests/e2e/test_smoke.py::test_local_heartbeat_smoke_matrix_from_copied_example_project[1-heartbeat]": 128.6,  # derived
-        "tests/e2e/test_smoke.py::test_local_heartbeat_smoke_matrix_from_copied_example_project[status]": 123.1,
-        "tests/e2e/test_smoke.py::test_native_chatter_scenario_starts_apps_and_communication_together": 104.1,
-        "tests/e2e/test_smoke.py::test_local_native_chatter_smoke_from_copied_example_project[native-chatter]": 85.3,
-        "tests/e2e/test_smoke.py::test_interactive_native_chatter_smoke_starts_full_local_debug_rig": 73.8,
-        # Skipped unless ROSOTACOM_RUN_FULL_E2E=1; nightly runs them one per
-        # job through `just test-e2e-rmw`, so they cost this slice nothing.
+    # The smallest thing that has to work, split from `core` because two
+    # heartbeat parameters and three chatter tests are two jobs' worth.
+    "heartbeat": {
+        "tests/e2e/test_smoke.py::test_local_heartbeat_smoke_matrix_from_copied_example_project[1-heartbeat]": 128.4,  # derived
+        "tests/e2e/test_smoke.py::test_local_heartbeat_smoke_matrix_from_copied_example_project[status]": 120.8,
+        # Skipped unless ROSOTACOM_RUN_FULL_E2E=1; nightly runs them one per job
+        # through `just test-e2e-rmw`, so they cost this slice nothing.
         "tests/e2e/test_smoke.py::test_full_rmw_heartbeat_smoke_matrix[cyclone-local-zenoh-ros2dds-ota]": 0.0,
         "tests/e2e/test_smoke.py::test_full_rmw_heartbeat_smoke_matrix[cyclone-ota]": 0.0,
         "tests/e2e/test_smoke.py::test_full_rmw_heartbeat_smoke_matrix[fastdds]": 0.0,
         "tests/e2e/test_smoke.py::test_full_rmw_heartbeat_smoke_matrix[zen-endpoints]": 0.0,
     },
-    # What the transport does to a payload: compression and size, each over
-    # both RMW paths.
-    "transforms": {
-        "tests/e2e/test_smoke.py::test_local_zenoh_sized_payload_smoke_from_copied_example_project[sized-payload-zenoh]": 172.3,
-        "tests/e2e/test_smoke.py::test_local_compressed_occupancy_grid_smoke_from_copied_example_project[compressed-occupancy-grid]": 159.9,  # derived
+    "chatter": {
+        "tests/e2e/test_smoke.py::test_native_chatter_scenario_starts_apps_and_communication_together": 103.3,
+        "tests/e2e/test_smoke.py::test_local_native_chatter_smoke_from_copied_example_project[native-chatter]": 85.3,
+        "tests/e2e/test_smoke.py::test_interactive_native_chatter_smoke_starts_full_local_debug_rig": 74.4,
+    },
+    # `transforms` was one slice over two unrelated questions. Compression and
+    # payload size each keep their RMW pair together, because the pair is the
+    # comparison: a red job here means "this transform, both transports" or
+    # "this transform, one transport", which is the first thing you ask.
+    "occupancy-grid": {
+        "tests/e2e/test_smoke.py::test_local_compressed_occupancy_grid_smoke_from_copied_example_project[compressed-occupancy-grid]": 158.3,  # derived
         "tests/e2e/test_smoke.py::test_local_zenoh_compressed_occupancy_grid_smoke_from_copied_example_project[compressed-occupancy-grid-zenoh]": 150.4,
-        "tests/e2e/test_smoke.py::test_local_wrapped_sized_payload_smoke_from_copied_example_project[sized-payload-fastdds]": 117.3,
     },
-    # All three anonymized remote-assist scenarios. The full rig and its two
-    # single-stream cuts belong together: they share a trace and a failure
-    # mode, and splitting them across slices is how one of them ended up
-    # running twice.
+    "sized-payload": {
+        "tests/e2e/test_smoke.py::test_local_zenoh_sized_payload_smoke_from_copied_example_project[sized-payload-zenoh]": 172.5,
+        "tests/e2e/test_smoke.py::test_local_wrapped_sized_payload_smoke_from_copied_example_project[sized-payload-fastdds]": 117.4,
+    },
+    # The full anonymized rig, alone: at 267s warm it is the slowest single test
+    # in the suite and therefore sets the floor every other slice is measured
+    # against. Nothing can share a job with it and stay under that floor.
     "remote-assist": {
-        "tests/e2e/test_smoke.py::test_local_remote_assist_anonymized_smoke_from_copied_example_project[remote-assist-anonymized]": 262.0,
-        "tests/e2e/test_smoke.py::test_local_single_stream_anonymized_smoke_from_copied_example_project[remote-assist-anonymized-costmap]": 147.8,
-        "tests/e2e/test_smoke.py::test_local_single_stream_anonymized_smoke_from_copied_example_project[remote-assist-anonymized-camera]": 146.3,
+        "tests/e2e/test_smoke.py::test_local_remote_assist_anonymized_smoke_from_copied_example_project[remote-assist-anonymized]": 267.0,
     },
-    # Everything built on top of a running session: the latency probe, live
-    # timeline shaping, and the two benchmark verdicts.
+    # Its two single-stream cuts, which share a trace with the rig above.
+    "remote-assist-streams": {
+        "tests/e2e/test_smoke.py::test_local_single_stream_anonymized_smoke_from_copied_example_project[remote-assist-anonymized-costmap]": 145.2,
+        "tests/e2e/test_smoke.py::test_local_single_stream_anonymized_smoke_from_copied_example_project[remote-assist-anonymized-camera]": 145.1,
+    },
+    # What a live session exposes and what can be changed under it.
     "runtime-tools": {
-        "tests/e2e/test_benchmark_ab.py::test_benchmark_ab_reliability_verdict": 202.5,
-        "tests/e2e/test_benchmark_replay.py::test_loss_boundaries_against_costmap_replay": 174.2,
-        "tests/e2e/test_smoke.py::test_local_link_latency_smoke_exposes_metric_backbone[link-latency]": 146.9,  # derived
+        "tests/e2e/test_smoke.py::test_local_link_latency_smoke_exposes_metric_backbone[link-latency]": 145.0,
         "tests/e2e/test_timeline_stepping.py::test_timeline_steps_change_the_qdisc_tree_in_place": 1.4,
     },
-    # The band-asserted capacity probes, split out of `runtime-tools`: they
-    # were two thirds of the slowest slice and they gate on committed bands
-    # (docs/performance-bands.md), so a red job here means one thing.
-    "benchmark-capacity": {
-        "tests/e2e/test_benchmark_capacity.py::test_merge_gate_row_is_band_asserted[probe-loss-gop-tight-cyclone]": 142.0,
-        "tests/e2e/test_benchmark_capacity.py::test_benchmark_capacity_good_case": 93.1,
-        "tests/e2e/test_benchmark_capacity.py::test_benchmark_capacity_bad_case": 91.6,
-        "tests/e2e/test_benchmark_capacity.py::test_benchmark_probe_camera_load": 88.4,
+    "media": {
+        "tests/e2e/test_video_quality_e2e.py::test_synthetic_camera_pipeline_records_quality_metrics": 161.8,
+        "tests/e2e/test_anonymize_e2e.py::test_anonymize_headless_end_to_end_preserves_keyframe_structure": 10.4,  # derived
     },
-    # Two themes in one slice, because at 177s and 265s neither fills a job and
-    # a job costs 210s before it runs a test. The name says so rather than
-    # hiding it under one of the two.
-    "media-concurrency": {
-        "tests/e2e/test_video_quality_e2e.py::test_synthetic_camera_pipeline_records_quality_metrics": 164.3,
-        "tests/e2e/test_parallel_smoke.py::test_independent_local_smoke_tests_run_in_parallel": 143.9,  # derived
-        "tests/e2e/test_parallel_smoke.py::test_second_same_target_smoke_aborts_and_leaves_first_intact": 120.8,
-        "tests/e2e/test_anonymize_e2e.py::test_anonymize_headless_end_to_end_preserves_keyframe_structure": 12.3,  # derived
+    "concurrency": {
+        "tests/e2e/test_parallel_smoke.py::test_independent_local_smoke_tests_run_in_parallel": 146.6,
+        "tests/e2e/test_parallel_smoke.py::test_second_same_target_smoke_aborts_and_leaves_first_intact": 125.0,
+    },
+    # The two benchmark verdicts, one job each: at 202s and 174s neither fits
+    # anywhere without becoming the slowest slice.
+    "benchmark-ab": {
+        "tests/e2e/test_benchmark_ab.py::test_benchmark_ab_reliability_verdict": 202.5,
+    },
+    "benchmark-replay": {
+        "tests/e2e/test_benchmark_replay.py::test_loss_boundaries_against_costmap_replay": 174.3,
+    },
+    # The band-asserted rows, which gate against committed bands
+    # (docs/performance-bands.md), separated from the good/bad-case pair that
+    # only checks the verdict logic. Different failures, different jobs.
+    "benchmark-capacity": {
+        "tests/e2e/test_benchmark_capacity.py::test_merge_gate_row_is_band_asserted[probe-loss-gop-tight-cyclone]": 141.6,
+        "tests/e2e/test_benchmark_capacity.py::test_benchmark_probe_camera_load": 87.4,
+    },
+    "benchmark-capacity-cases": {
+        "tests/e2e/test_benchmark_capacity.py::test_benchmark_capacity_good_case": 93.1,
+        "tests/e2e/test_benchmark_capacity.py::test_benchmark_capacity_bad_case": 91.4,
     },
 }
 
@@ -124,16 +145,35 @@ def predicted_slice_seconds(name: str) -> float:
     return RUNNER_SETUP_SECONDS + IMAGE_BUILD_SECONDS + sum(E2E_SLICES[name].values())
 
 
+def floor_seconds() -> float:
+    """The fastest any partition of this suite could possibly be.
+
+    One job has to run the slowest single test, and it pays the fixed cost like
+    every other job. No number of slices gets below this, which is why "how
+    close to the floor" is the honest way to judge a partition and "spread" is
+    not: spread is compressed toward 1.0 by the fixed cost as N grows, so it
+    keeps looking fine while the gate stops improving.
+    """
+    return (
+        RUNNER_SETUP_SECONDS
+        + IMAGE_BUILD_SECONDS
+        + max(cost for tests in E2E_SLICES.values() for cost in tests.values())
+    )
+
+
 def slice_cost_report() -> str:
     """The balance table, for a failure message or `just e2e-slice-costs`."""
-    lines = [f"{'slice':<20} {'tests':>5} {'pytest':>8} {'job':>8}"]
+    lines = [f"{'slice':<26} {'tests':>5} {'pytest':>8} {'job':>8}"]
     for name in sorted(E2E_SLICES, key=predicted_slice_seconds, reverse=True):
         job = predicted_slice_seconds(name)
         tests = E2E_SLICES[name]
-        lines.append(f"{name:<20} {len(tests):5d} {sum(tests.values()):7.0f}s {job / 60:7.1f}m")
+        lines.append(f"{name:<26} {len(tests):5d} {sum(tests.values()):7.0f}s {job / 60:7.2f}m")
     slowest = max(map(predicted_slice_seconds, E2E_SLICES))
-    fastest = min(map(predicted_slice_seconds, E2E_SLICES))
-    lines.append(f"critical path {slowest / 60:.1f}m, spread {slowest / fastest:.2f}x, {len(E2E_SLICES)} jobs")
+    floor = floor_seconds()
+    lines.append(
+        f"critical path {slowest / 60:.2f}m over {len(E2E_SLICES)} jobs, "
+        f"{slowest / floor:.2f}x the {floor / 60:.2f}m floor"
+    )
     return "\n".join(lines)
 
 


### PR DESCRIPTION
Closes #235. Follows #234, which did steps 1-3 of #226 and left N at six.

## The measurement this rests on

Run [31634604888](https://github.com/develNor/ros_communication_devcontainer/actions/runs/31634604888) was the first with balanced slices, and it is what makes choosing N a
calculation rather than a preference:

| slice | predicted | measured |
|---|---|---|
| `transforms` | 13m30s | **13m37s** |
| `remote-assist` | 12m46s | 12m33s |
| `core` | 12m05s | 12m26s |
| `runtime-tools` | 12m15s | 12m15s |
| `media-concurrency` | 10m51s | 10m58s |
| `benchmark-capacity` | 10m25s | 10m14s |

It also improved the inputs, because rebalancing changed which test starts each
slice:

- **The image build is 154s**, now from 21 cold/warm pairs over seven runs.
  #226 had one pair (the duplicated test) and inferred 155s from it; five more
  arrived at once in this run, at 154-164s.
- **Two of the five derived warm costs became measurable and confirmed the
  method.** `link-latency` was derived at 146.9s and measured warm at 145.0s;
  `independent_local_smoke_tests_run_in_parallel` derived at 143.9s, measured at
  146.6s. Three tests are still derived; all costs are now warm-only medians
  over seven runs rather than six.

## The floor, and why it decides N

`floor_seconds()` = fixed cost + slowest single test = **7m56s**. One job has to
run the 267s remote-assist rig and pays the 3m29s fixed cost like every other,
so no partition beats it.

| N | critical path | runner-min |
|---|---|---|
| 6 (today) | 13m37s measured | 72 |
| 8 | 10m09s | 79 |
| 12 | 8m01s | 93 |
| 16 | 7m52s | 107 |
| 24 (one per test) | 7m52s | 135 |

Twelve reaches the floor. Past it, each extra job repays 3m29s of setup and
image build to buy nothing — one job per test is *slower* than twelve. And the
runner-min column is not the constraint it looks like: this repository is
public, so standard GitHub-hosted runners are free; the 20-concurrent-job cap is
the real ceiling, and thirteen stays under it.

## Thirteen slices, split along test identity

Not cost buckets — split where the tests already differ, so the name gets more
precise instead of becoming `e2e-07`:

| slice | tests | predicted |
|---|---|---|
| `occupancy-grid` | 2 | 8m38s |
| `remote-assist-streams` | 2 | 8m19s |
| `sized-payload` | 2 | 8m19s |
| `concurrency` | 2 | 8m01s |
| `remote-assist` | 1 | 7m56s |
| `chatter` | 3 | 7m52s |
| `heartbeat` | 2 (+4 skipped) | 7m38s |
| `benchmark-capacity` | 2 | 7m18s |
| `benchmark-ab` | 1 | 6m52s |
| `benchmark-capacity-cases` | 2 | 6m34s |
| `benchmark-replay` | 1 | 6m23s |
| `media` | 2 | 6m21s |
| `runtime-tools` | 2 | 5m55s |

**8m38s, 1.09x the floor**, from 13m37s. Thirteen and not twelve because every
thematic twelve forces a merge of two ~150-175s slices, and that merge lands at
8m52s — slower than thirteen.

Each split is a real seam: `core` was heartbeat and chatter; `transforms` was
compression and payload size (each keeping its RMW pair, because the pair *is*
the comparison); `remote-assist` separates the full rig from its two
single-stream cuts; the capacity probes separate the band-asserted rows from the
good/bad-case verdicts, which fail for different reasons.

## The balance check had to change

`test_e2e_slices_stay_balanced` asserted spread < 1.5x. That was right at six
and says nothing at thirteen — the fixed per-job cost compresses spread toward
1.0 as N grows, so it keeps reading fine while the gate stops improving, and
past twelve it is set by tests too small to split rather than by imbalance.

Replaced by `test_e2e_slices_stay_close_to_the_floor`: `max(job) <= 1.25 *
floor_seconds()`. It asserts the one thing worth asserting at any N — the gate
is near the fastest it could possibly be — and needs no retuning when a test is
added. 1.25x rather than 1.0x because the floor assumes tests divide arbitrarily
and they do not. `test_the_floor_is_a_single_test_not_a_slice` guards the guard:
if `floor_seconds()` ever summed a slice instead of taking the slowest test, the
gate would be measured against itself.

## Validation

- `just check` — 651 non-Docker tests, lint, workflow lint, typecheck, docs,
  package. Green.
- The 13 e2e jobs on this PR are the check that matters, and they re-measure
  again: nine slices have a first test that has never been measured cold, so the
  run adds nine independent readings of `IMAGE_BUILD_SECONDS` and either
  confirms the three remaining derived costs or corrects them.

## Follow-up

#236 is the floor itself: 2m34s of the 7m56s is the image build, done
identically 13 times per run. It is deliberately a measure-first issue — the
image is a multi-GB ROS desktop-full build, so caching the built image may swap
one large transfer for another, and nobody has yet broken those 154s into base
pull vs apt/pip vs export.
