### PR TITLE
Stop tracking .agents, and make the pattern that missed it cover a symlink

### DIFF
--- a/.agents
+++ b/.agents
@@ -1,1 +1,0 @@
-/home/go914/dev/rosotacom_test/ros_communication_devcontainer/.agents

--- a/.gitignore
+++ b/.gitignore
@@ -33,4 +33,10 @@ CLAUDE.md
 
 # The dedicated agent account's credential lives here and must never reach a
 # commit. See docs/github-repository-settings.md, "Identities".
-.agents/
+#
+# No trailing slash, deliberately: `.agents/` matches a directory only, so a
+# `.agents` *symlink* — the shape a worktree gets when it points at the main
+# checkout's credential — slipped past it and was committed (#238). Without the
+# slash the pattern covers file, directory and symlink alike, and
+# tests/contract/test_packaged_resources.py fails if one is ever tracked again.
+.agents

--- a/tests/contract/test_packaged_resources.py
+++ b/tests/contract/test_packaged_resources.py
@@ -284,3 +284,67 @@ def test_named_resources_point_at_real_packaged_directories() -> None:
     assert (com_msgs / "package.xml").is_file()
     assert (com_msgs / "CMakeLists.txt").is_file()
     assert list(com_msgs.glob("msg/*.msg"))
+
+
+def _tracked_entries() -> list[tuple[str, str, str]]:
+    """``(mode, sha, path)`` for every tracked file, or skip outside a checkout."""
+    listing = subprocess.run(
+        ["git", "ls-files", "-s", "-z"],
+        cwd=PACKAGE_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if listing.returncode != 0:
+        pytest.skip("not a git checkout — nothing to say about tracked files")
+    entries = []
+    for record in listing.stdout.split("\0"):
+        if not record:
+            continue
+        meta, _, path = record.partition("\t")
+        mode, sha, _stage = meta.split()
+        entries.append((mode, sha, path))
+    return entries
+
+
+def test_no_credential_path_is_tracked_and_no_symlink_escapes_the_repository() -> None:
+    """`.agents/` carries a repository-scoped write credential, and a tracked
+    symlink is checked out over whatever already sits at that path.
+
+    Both halves are the same defect (#238). `.gitignore` said `.agents/`, which
+    matches a directory only, so a `.agents` *symlink* — the shape a worktree
+    takes when it points at the main checkout's credential — was not ignored,
+    was committed, and on the next pull replaced a real credential directory
+    (git overwrites ignored files silently). Any tracked symlink pointing
+    outside the tree can do that to any path on any machine that has it, and
+    setuptools_scm puts every tracked file into the sdist, so it ships too.
+    """
+    credentials: list[str] = []
+    escaping: list[str] = []
+    for mode, sha, path in _tracked_entries():
+        if ".agents" in Path(path).parts:
+            credentials.append(path)
+        if mode != "120000":
+            continue
+        # A symlink's blob *is* its target, so this reads the same bytes a
+        # checkout would write — no dependence on the working tree.
+        target = subprocess.run(
+            ["git", "cat-file", "blob", sha],
+            cwd=PACKAGE_ROOT,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+        resolved = Path(os.path.normpath((PACKAGE_ROOT / path).parent / target))
+        if os.path.isabs(target) or not resolved.is_relative_to(PACKAGE_ROOT):
+            escaping.append(f"{path} -> {target}")
+
+    assert not credentials, (
+        f"agent credential paths are tracked: {credentials}. They must stay local to a checkout "
+        "(.gitignore covers `.agents`); a tracked one is published and overwrites the real "
+        "credential directory of anyone who pulls it."
+    )
+    assert not escaping, (
+        f"tracked symlinks point outside the repository: {escaping}. Checking one out overwrites "
+        "whatever is at that path, and it is shipped in the sdist."
+    )


### PR DESCRIPTION
Closes #238. `develop` tracks a symlink at the repository root, added by #233:

```
120000 .agents -> /home/go914/dev/rosotacom_test/ros_communication_devcontainer/.agents
```

## How it got past `.gitignore`

Line 36 was `.agents/`. The trailing slash matches a **directory**, so the real directory in a normal checkout is ignored — but a worktree that points at the main checkout's credential has `.agents` as a *symlink*, which is a file, which the pattern does not match. `git add -A` staged it, and it reviewed as a one-line addition nobody looked twice at.

## Why it is not cosmetic

A tracked symlink is checked out **over** whatever already occupies that path, and git overwrites ignored files without warning. Pulling this commit onto the machine named in the target replaced a real `.agents/` directory with a link to itself and deleted its contents. On any machine holding that path, a fresh clone's `.agents` also resolves into a *different* checkout's credential directory — the inverse of the rule that a write credential belongs to exactly one checkout.

No secret was committed at any point: the symlink's target is a path, not a file.

## The fix

- Untrack `.agents`.
- `.gitignore`: `.agents/` → `.agents`, so the pattern covers file, directory and symlink alike.
- `tests/contract/test_packaged_resources.py::test_no_credential_path_is_tracked_and_no_symlink_escapes_the_repository` — the general form of the rule, not just this instance: no tracked path may be named `.agents`, and no tracked symlink may point outside the repository. It reads each symlink's *blob* rather than the working tree, so it judges what a checkout would write, on any machine.

## Correcting the issue on one point

#238 claims the entry ships in the sdist. It does not, and I should have checked before writing it. The published `2.5.dev20` sdist — built from a post-#233 commit — has no `.agents` entry, while root files like `justfile` and `budgets.jsonl` are present, so root files are included in general. The symlink is dangling on the runner (its target does not exist there) and the sdist builder skips it. The exposure was therefore environment-dependent rather than universal, which is a weaker claim than the issue makes.

## Validation

`just check` green (665 unit + contract tests, up from 664).

The guard was proved against the exact bad state rather than only against the fixed one: re-adding the symlink with `git add -f` fails the new test with

```
AssertionError: agent credential paths are tracked: ['.agents'].
```

and `git check-ignore -v .agents` now reports `.gitignore:42:.agents` for a symlink, which the old pattern did not match.
