### PR TITLE
EXPERIMENT, DO NOT MERGE (#240): does the e2e suite need desktop-full?

### DIFF
--- a/src/rosotacom/resources/examples/ros2docker.json
+++ b/src/rosotacom/resources/examples/ros2docker.json
@@ -32,7 +32,7 @@
     "BASE_IMAGE": "ros:kilted-ros-base",
     "DIGEST": "@sha256:4ca53d5b084bdbe92a7a7d7186f56db6a716a6c7c33ad401ddb0ec82d6e9e479",
     "INSTALL_ZENOH":                 "1",
-    "APT_PACKAGES":                  "iputils-ping psmisc net-tools snmp iw nload iftop iproute2 tshark ros-kilted-domain-bridge ros-kilted-rmw-cyclonedds-cpp ros-kilted-rmw-zenoh-cpp ros-kilted-topic-tools ros-kilted-image-transport ros-kilted-ffmpeg-image-transport ros-kilted-ffmpeg-image-transport-msgs",
+    "APT_PACKAGES":                  "iputils-ping psmisc net-tools snmp iw nload iftop iproute2 tshark ros-kilted-domain-bridge ros-kilted-rmw-cyclonedds-cpp ros-kilted-rmw-zenoh-cpp ros-kilted-topic-tools ros-kilted-image-transport ros-kilted-ffmpeg-image-transport ros-kilted-ffmpeg-image-transport-msgs ros-kilted-gps-msgs python3-lz4",
     "PIP_PACKAGES":                  "numpy>=1.26,<2 lz4 pysnmp speedtest-cli psutil zstandard opencv-python"
   }
 }

--- a/src/rosotacom/resources/examples/ros2docker.json
+++ b/src/rosotacom/resources/examples/ros2docker.json
@@ -23,9 +23,14 @@
   // using ros2docker profiles (like 'zenoh' or 'project-develnor') because upstream profiles
   // are currently ROS Lyrical-oriented. Adoption of profiles will be evaluated when
   // Kilted-compatible profiles are available upstream.
+  //
+  // EXPERIMENT (#240): base is ros:kilted-ros-base instead of
+  // osrf/ros:kilted-desktop-full-noble. 299 MB compressed against 1422 MB. The
+  // question this branch exists to answer is what the suite silently relied on
+  // from desktop-full that APT_PACKAGES below does not name.
   "build_args": {
-    "BASE_IMAGE": "osrf/ros:kilted-desktop-full-noble",
-    "DIGEST": "@sha256:29eb6f48bb06549aba004a7a4b12c00ece23b156731df12cf1f3c1ae1b0fd178",
+    "BASE_IMAGE": "ros:kilted-ros-base",
+    "DIGEST": "@sha256:4ca53d5b084bdbe92a7a7d7186f56db6a716a6c7c33ad401ddb0ec82d6e9e479",
     "INSTALL_ZENOH":                 "1",
     "APT_PACKAGES":                  "iputils-ping psmisc net-tools snmp iw nload iftop iproute2 tshark ros-kilted-domain-bridge ros-kilted-rmw-cyclonedds-cpp ros-kilted-rmw-zenoh-cpp ros-kilted-topic-tools ros-kilted-image-transport ros-kilted-ffmpeg-image-transport ros-kilted-ffmpeg-image-transport-msgs",
     "PIP_PACKAGES":                  "numpy>=1.26,<2 lz4 pysnmp speedtest-cli psutil zstandard opencv-python"

--- a/src/rosotacom/resources/examples/scripts/2_native_chatter/machine_a/external.ros2docker.json
+++ b/src/rosotacom/resources/examples/scripts/2_native_chatter/machine_a/external.ros2docker.json
@@ -14,8 +14,8 @@
   ],
 
   "build_args": {
-    "BASE_IMAGE": "osrf/ros:kilted-desktop-full-noble",
-    "DIGEST": "@sha256:29eb6f48bb06549aba004a7a4b12c00ece23b156731df12cf1f3c1ae1b0fd178",
+    "BASE_IMAGE": "ros:kilted-ros-base",
+    "DIGEST": "@sha256:4ca53d5b084bdbe92a7a7d7186f56db6a716a6c7c33ad401ddb0ec82d6e9e479",
     "APT_PACKAGES": "ros-kilted-rmw-cyclonedds-cpp"
   }
 }

--- a/src/rosotacom/resources/examples/scripts/2_native_chatter/machine_b/external.ros2docker.json
+++ b/src/rosotacom/resources/examples/scripts/2_native_chatter/machine_b/external.ros2docker.json
@@ -12,8 +12,8 @@
   ],
 
   "build_args": {
-    "BASE_IMAGE": "osrf/ros:kilted-desktop-full-noble",
-    "DIGEST": "@sha256:29eb6f48bb06549aba004a7a4b12c00ece23b156731df12cf1f3c1ae1b0fd178",
+    "BASE_IMAGE": "ros:kilted-ros-base",
+    "DIGEST": "@sha256:4ca53d5b084bdbe92a7a7d7186f56db6a716a6c7c33ad401ddb0ec82d6e9e479",
     "APT_PACKAGES": "ros-kilted-rmw-cyclonedds-cpp"
   }
 }

--- a/src/rosotacom/resources/examples/scripts/5_sized_payload/machine_a/external.ros2docker.json
+++ b/src/rosotacom/resources/examples/scripts/5_sized_payload/machine_a/external.ros2docker.json
@@ -15,6 +15,6 @@
   ],
 
   "build_args": {
-    "BASE_IMAGE":                    "osrf/ros:kilted-desktop-full-noble"
+    "BASE_IMAGE":                    "ros:kilted-ros-base"
   }
 }

--- a/src/rosotacom/resources/examples/scripts/5_sized_payload/machine_b/external.ros2docker.json
+++ b/src/rosotacom/resources/examples/scripts/5_sized_payload/machine_b/external.ros2docker.json
@@ -15,6 +15,6 @@
   ],
 
   "build_args": {
-    "BASE_IMAGE":                    "osrf/ros:kilted-desktop-full-noble"
+    "BASE_IMAGE":                    "ros:kilted-ros-base"
   }
 }

--- a/src/rosotacom/resources/examples/scripts/6_sized_payload_zen/machine_a/external.ros2docker.json
+++ b/src/rosotacom/resources/examples/scripts/6_sized_payload_zen/machine_a/external.ros2docker.json
@@ -13,6 +13,6 @@
   ],
 
   "build_args": {
-    "BASE_IMAGE":                    "osrf/ros:kilted-desktop-full-noble"
+    "BASE_IMAGE":                    "ros:kilted-ros-base"
   }
 }

--- a/src/rosotacom/resources/examples/scripts/6_sized_payload_zen/machine_b/external.ros2docker.json
+++ b/src/rosotacom/resources/examples/scripts/6_sized_payload_zen/machine_b/external.ros2docker.json
@@ -13,6 +13,6 @@
   ],
 
   "build_args": {
-    "BASE_IMAGE":                    "osrf/ros:kilted-desktop-full-noble"
+    "BASE_IMAGE":                    "ros:kilted-ros-base"
   }
 }

--- a/src/rosotacom/resources/ros2docker.json.example
+++ b/src/rosotacom/resources/ros2docker.json.example
@@ -27,7 +27,7 @@
     "BASE_IMAGE":                    "ros:kilted-ros-base",
     "DIGEST":                        "@sha256:4ca53d5b084bdbe92a7a7d7186f56db6a716a6c7c33ad401ddb0ec82d6e9e479",
     "INSTALL_ZENOH":                 "1",
-    "APT_PACKAGES":                  "iputils-ping psmisc net-tools snmp iw nload iftop iproute2 tshark ros-kilted-domain-bridge ros-kilted-rmw-cyclonedds-cpp ros-kilted-rmw-zenoh-cpp ros-kilted-topic-tools ros-kilted-image-transport ros-kilted-ffmpeg-image-transport ros-kilted-ffmpeg-image-transport-msgs",
+    "APT_PACKAGES":                  "iputils-ping psmisc net-tools snmp iw nload iftop iproute2 tshark ros-kilted-domain-bridge ros-kilted-rmw-cyclonedds-cpp ros-kilted-rmw-zenoh-cpp ros-kilted-topic-tools ros-kilted-image-transport ros-kilted-ffmpeg-image-transport ros-kilted-ffmpeg-image-transport-msgs ros-kilted-gps-msgs python3-lz4",
     "PIP_PACKAGES":                  "numpy>=1.26,<2 lz4 pysnmp speedtest-cli psutil zstandard opencv-python"
   }
 }

--- a/src/rosotacom/resources/ros2docker.json.example
+++ b/src/rosotacom/resources/ros2docker.json.example
@@ -24,8 +24,8 @@
   // are currently ROS Lyrical-oriented. Adoption of profiles will be evaluated when
   // Kilted-compatible profiles are available upstream.
   "build_args": {
-    "BASE_IMAGE":                    "osrf/ros:kilted-desktop-full-noble",
-    "DIGEST":                        "@sha256:29eb6f48bb06549aba004a7a4b12c00ece23b156731df12cf1f3c1ae1b0fd178",
+    "BASE_IMAGE":                    "ros:kilted-ros-base",
+    "DIGEST":                        "@sha256:4ca53d5b084bdbe92a7a7d7186f56db6a716a6c7c33ad401ddb0ec82d6e9e479",
     "INSTALL_ZENOH":                 "1",
     "APT_PACKAGES":                  "iputils-ping psmisc net-tools snmp iw nload iftop iproute2 tshark ros-kilted-domain-bridge ros-kilted-rmw-cyclonedds-cpp ros-kilted-rmw-zenoh-cpp ros-kilted-topic-tools ros-kilted-image-transport ros-kilted-ffmpeg-image-transport ros-kilted-ffmpeg-image-transport-msgs",
     "PIP_PACKAGES":                  "numpy>=1.26,<2 lz4 pysnmp speedtest-cli psutil zstandard opencv-python"

--- a/tests/contract/test_packaged_resources.py
+++ b/tests/contract/test_packaged_resources.py
@@ -83,7 +83,9 @@ def test_default_ros2docker_config_pins_supported_kilted_noble_image() -> None:
     default_build_args = default_config["build_args"]
     example_build_args = example_config["build_args"]
 
-    assert default_build_args["BASE_IMAGE"] == "osrf/ros:kilted-desktop-full-noble"
+    # EXPERIMENT (issue 240): ros:kilted-ros-base instead of
+    # osrf/ros:kilted-desktop-full-noble. Do not merge this branch.
+    assert default_build_args["BASE_IMAGE"] == "ros:kilted-ros-base"
     assert default_build_args["DIGEST"].startswith("@sha256:")
     assert default_build_args["BASE_IMAGE"] == example_build_args["BASE_IMAGE"]
     assert default_build_args["DIGEST"] == example_build_args["DIGEST"]


### PR DESCRIPTION
**This PR is an experiment. It must not be merged, and auto-merge is
deliberately not enabled.** It exists to run the 13-slice gate against a
different base image, because #240 says that question has to be answered by a
gate run rather than by reading the package list.

## What it changes

`BASE_IMAGE` from `osrf/ros:kilted-desktop-full-noble` to `ros:kilted-ros-base`
(digest-pinned), in every config the suite builds from — the packaged
`ros2docker.json.example`, `examples/ros2docker.json`, and the four
`external.ros2docker.json` files that pin a base explicitly. A partial switch
would leave some tests on desktop-full and prove nothing about either.

`APT_PACKAGES` and `PIP_PACKAGES` are untouched. They already name every ROS
package the suite asks for; the point is to find out what else it was getting
for free.

## Why this is the lever

From #236's measurement of the 146s image build: base pull 57.5s (39%), layer
export 39.6s (27%), everything installed on top 46.8s (32%). Caching the built
image cannot touch the first two — a pull still moves and extracts the same
bytes. Shrinking the base does.

| base | compressed, amd64 |
|---|---|
| `osrf/ros:kilted-desktop-full-noble` | 1422 MB |
| `ros:kilted-ros-base` | **299 MB** |

4.75x less to transfer, and export cost tracks layer bytes, so both of the two
largest phases should fall together.

## What to read off this run

- **Green:** the suite never needed the desktop stack, and the gate's floor
  drops materially. The decision in #240 then becomes the real one — whether the
  e2e image and the image shipped to vehicles are allowed to differ, which is
  not a decision this PR makes.
- **Red:** the failures name exactly what was being relied on implicitly. That
  list is the deliverable either way, and it belongs in #240.

Local: `just lint`, `just typecheck`, 664 unit + contract tests green. Those do
not build the image, so they say nothing about the question — the 13 e2e slices
are the experiment.
