### PR TITLE
Pin the ros2docker release that makes PIP_PACKAGES reach the nodes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
   "mcap>=1.4,<2",
   "Pillow>=10,<13",
   "PyYAML>=6",
-  "ros2docker>=0.1.4,<0.2",
+  "ros2docker>=0.1.5.dev8,<0.2",
 ]
 classifiers = [
   "Development Status :: 3 - Alpha",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-ros2docker==0.1.4
+ros2docker==0.1.5.dev8


### PR DESCRIPTION
Closes #242. Consumes develNor/ros2docker#175.

## What was wrong

A module declared in `PIP_PACKAGES` was not importable from a node started by
`ros2 run`. `colcon` on `PATH` is the apt executable from the ROS base image, so
its own shebang pins it to `/usr/bin/python3` whatever `PATH` says; setuptools
stamps that interpreter into every generated console script, and `ros2 run`
execs the script. The node therefore ran outside the venv that `PIP_PACKAGES`
installs into.

Measured on a minimal image with the same layering (full detail in #242):

| workspace built with | generated shebang | `import lz4` in the node |
|---|---|---|
| `colcon build` | `#!/usr/bin/python3` | **FAILED** |
| `python3 -m colcon build` | `#!/opt/ros_venv/bin/python3` | **OK** |

Fixed upstream, where `entrypoint.sh` lives, and released as
`ros2docker 0.1.5.dev8`. Verified in this branch's venv:
`site-packages/ros2docker/resources/build/entrypoint.sh` carries
`python3 -m colcon build`.

## What this changes here, and what it does not

Nothing observable on the current base image. `osrf/ros:kilted-desktop-full-noble`
ships `python3-lz4` system-wide, which is exactly why the defect stayed
invisible: the import resolved against the accidental copy while the declared
one sat unused in the venv. What changes is that the declaration is now true
rather than shadowed, and the venv interpreter sees strictly *more* than the
system one did (`--system-site-packages`), not less. The gate is expected to
stay green; if it does not, the failure is the interesting part and gets
reported rather than worked around.

It also unblocks #240: the `ros-base` experiment currently needs `python3-lz4`
in `APT_PACKAGES` as a crutch, and that crutch exists only because of this bug.

## Two things worth flagging

**pyproject moves with requirements.txt on purpose.** pip does not resolve a
range to a pre-release, so `>=0.1.4,<0.2` and a `==0.1.5.dev8` constraint have
no intersection at all — `just setup` fails with `ResolutionImpossible`. Naming
the pre-release as the lower bound is what makes it resolvable.

**This is the first pre-release ros2docker pin here.** 0.1.3 and 0.1.4 were both
stable. The cost propagates: `rosotacom-dev` now declares a pre-release
dependency, so anything installing it resolves one too. Deliberate, and it
should go back to a stable pin when ros2docker cuts 0.1.5.

## Validation

`just check` green: lint, workflow lint, build lint, typecheck, 665 non-Docker
tests, docs, package. The 13 e2e slices on this PR are the real check — they run
against images built by the new entrypoint.
