### PR TITLE
Publish the e2e image once instead of rebuilding it thirteen times (#236)

### DIFF
--- a/.github/workflows/pr-merge-gate.yml
+++ b/.github/workflows/pr-merge-gate.yml
@@ -192,6 +192,96 @@ jobs:
           fi
           echo "All preflight checks passed"
 
+  image:
+    # Publish the images the e2e suite builds, once per set of build inputs,
+    # instead of rebuilding them in each of thirteen jobs. #236 measured that
+    # build at 154s per job: 57s pulling the multi-GB ROS base from Docker Hub,
+    # 40s exporting layers, 47s of apt and pip. A pull from GHCR — co-located
+    # with the runners, no Hub rate limit, one transfer instead of a transfer
+    # plus a build — replaces all of it, and takes twelve of the thirteen Hub
+    # pulls off the merge gate's critical path.
+    #
+    # The tag is a hash of everything that decides the image (base digest,
+    # package lists, Dockerfile, entrypoint, ros2docker version, build UID):
+    # `rosotacom image references` derives it, nothing here chooses it. A
+    # build-input change is therefore a different tag, so "the published image
+    # is stale" is not a state this can reach — which is the objection #226
+    # raised against caching the image inline.
+    #
+    # Runs beside preflight rather than after it: on a hit it inspects two
+    # manifests and stops, so it is never on the critical path.
+    name: image
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      repository: ${{ steps.publish.outputs.repository }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install just
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y just
+
+      - name: Set up local environment
+        run: just setup
+
+      - name: Log in to GHCR
+        run: echo '${{ secrets.GITHUB_TOKEN }}' | docker login ghcr.io -u '${{ github.actor }}' --password-stdin
+
+      - name: Publish every image the e2e suite builds
+        id: publish
+        run: |
+          set -euo pipefail
+          repository="ghcr.io/$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')/rosotacom-e2e"
+          # The packaged example project, because that is the one the e2e tests
+          # copy. The repository's own rosotacom.yaml points at profiles and
+          # artifacts that live beside the checkout in the private harness, so it
+          # does not resolve here.
+          project="$(.venv/bin/rosotacom resources path examples)/rosotacom.yaml"
+          .venv/bin/rosotacom image references --project "$project" --repository "$repository" > references.txt
+          cat references.txt
+
+          while read -r reference; do
+            if docker manifest inspect "$reference" >/dev/null 2>&1; then
+              echo "present: $reference"
+              continue
+            fi
+            echo "missing, building: $reference"
+            .venv/bin/rosotacom image build --project "$project" --reference "$reference"
+            docker push "$reference" || echo "::warning::could not push $reference"
+          done < references.txt
+
+          # Report the repository only when every reference resolves. A
+          # read-only GITHUB_TOKEN (a fork PR, Dependabot) can log in and pull
+          # but not push, and the slices must then build as they always did
+          # rather than fail on a pull that was never going to work. Probed
+          # rather than predicted from the event, so it stays right when
+          # GitHub's token rules change.
+          available=true
+          while read -r reference; do
+            docker manifest inspect "$reference" >/dev/null 2>&1 || available=false
+          done < references.txt
+
+          if [[ "$available" == "true" ]]; then
+            echo "repository=$repository" >> "$GITHUB_OUTPUT"
+          else
+            echo "repository=" >> "$GITHUB_OUTPUT"
+            echo "::warning::published images unavailable; each e2e slice will build its own"
+          fi
+
   e2e:
     # One matrix job, not six near-identical copies. The copies were how
     # `e2e-media` ended up listed in ci-success's `needs` with no check on its
@@ -210,8 +300,11 @@ jobs:
     name: e2e-${{ matrix.slice }}
     runs-on: ubuntu-latest
     timeout-minutes: 90
-    needs: preflight-success
-    if: always() && !cancelled() && needs.preflight-success.result == 'success'
+    needs: [preflight-success, image]
+    if: always() && !cancelled() && needs.preflight-success.result == 'success' && needs.image.result == 'success'
+    permissions:
+      contents: read
+      packages: read
     strategy:
       fail-fast: false
       matrix:
@@ -240,7 +333,18 @@ jobs:
       - name: Show Docker environment
         run: docker info
 
+      - name: Log in to GHCR
+        if: needs.image.outputs.repository != ''
+        run: echo '${{ secrets.GITHUB_TOKEN }}' | docker login ghcr.io -u '${{ github.actor }}' --password-stdin
+
       - name: Run E2E slice
+        env:
+          # Empty when the `image` job could not publish, and then rosotacom
+          # builds exactly as before. Set, and each image build becomes a pull
+          # of the tag this tree's own build inputs hash to — rosotacom derives
+          # that tag itself and never accepts one, so it cannot be pointed at an
+          # image built from something else.
+          ROSOTACOM_IMAGE_CACHE: ${{ needs.image.outputs.repository }}
         run: just test-e2e-slice ${{ matrix.slice }}
 
       - name: Upload session artifacts
@@ -261,6 +365,7 @@ jobs:
       - merge-lightweight
       - package
       - preflight-success
+      - image
       - e2e
     if: always() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
 
@@ -289,6 +394,10 @@ jobs:
           fi
           if [[ "${{ needs.preflight-success.result }}" != "success" ]]; then
             echo "preflight-success failed or was skipped: ${{ needs.preflight-success.result }}"
+            exit 1
+          fi
+          if [[ "${{ needs.image.result }}" != "success" ]]; then
+            echo "image failed or was skipped: ${{ needs.image.result }}"
             exit 1
           fi
           if [[ "${{ needs.e2e.result }}" != "success" ]]; then

--- a/README.md
+++ b/README.md
@@ -199,6 +199,32 @@ example to bake `com_msgs` into its own container image. Ask for the resource by
 name rather than reconstructing a path: the names are part of the CLI contract,
 the layout behind them is not.
 
+### Reusing an image instead of rebuilding it
+
+Somewhere that starts many rosotacom sessions from the same tree — CI above all
+— can build each image once, publish it, and have every later run pull it:
+
+```bash
+# What this project's images are called: <repository>:<hash of the build inputs>
+rosotacom image references --repository ghcr.io/owner/rosotacom-e2e
+
+# Build the one a reference names, then push it
+rosotacom image build --reference ghcr.io/owner/rosotacom-e2e:<hash>
+docker push ghcr.io/owner/rosotacom-e2e:<hash>
+
+# Adopt published images anywhere rosotacom would otherwise build
+export ROSOTACOM_IMAGE_CACHE=ghcr.io/owner/rosotacom-e2e
+```
+
+The tag is a hash of everything that decides the image — base image and its
+pinned digest, apt and pip packages, the Dockerfile and entrypoint ros2docker
+stages, the build UID — so a build-input change is a different tag and a
+published image can never be stale for the tree that adopts it. Nothing accepts
+a reference: rosotacom derives the one its own inputs allow and pulls exactly
+that, and fails rather than quietly rebuilding if it is not there. With
+`ROSOTACOM_IMAGE_CACHE` unset, nothing changes. See
+[docs/ci.md](docs/ci.md) for how the merge gate uses this.
+
 See the [example project README](src/rosotacom/resources/examples/README.md)
 for the copyable example layout, the
 [session configuration reference](session-configuration.md) for the session

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -93,7 +93,9 @@ runner time and thirteen Hub pulls on the critical path of every merge gate.
 The `image` job now publishes those images to
 `ghcr.io/<owner>/rosotacom-e2e` and each slice pulls instead of building. GHCR
 is co-located with the runners and has no Hub rate limit, so this is one
-transfer where there used to be a transfer plus a build.
+transfer where there used to be a transfer plus a build. Measured on run
+31678648935: **154s → 70s per job**, and the slowest slice's pytest run fell
+from 8m19s to 6m50s.
 
 The tag is the whole safety argument. It is a SHA-256 of everything that decides
 what the image contains — the `docker build` command ros2docker renders from a
@@ -157,18 +159,24 @@ with a usage error, and a test owned twice fails
 
 The costs are warm pytest `call` durations — medians over seven merge-gate runs
 of 2026-08-11/12. On top of them each job pays a fixed
-`RUNNER_SETUP_SECONDS + IMAGE_BUILD_SECONDS` (3m29s: 55s of runner setup, then the
-project image built inside whichever test runs first). Because that constant is
-per job and not per test, balancing warm costs balances wall clock.
+`RUNNER_SETUP_SECONDS + IMAGE_BUILD_SECONDS` (2m05s: 55s of runner setup, then
+the project image obtained inside whichever test runs first). Because that
+constant is per job and not per test, balancing warm costs balances wall clock.
+
+`IMAGE_BUILD_SECONDS` models the merge gate, where that image is pulled rather
+than built (see above); the release and nightly lanes still build and pay the
+older 154s. One slice does not currently reproduce its recorded split: `media`
+spends about 24s more than its two costs predict, and it is the critical path,
+so it is the first thing to remeasure.
 
 ### How many slices
 
 `floor_seconds()` is `fixed + slowest single test` — the fastest any partition
 of this suite could be, because one job has to run that test and pays the fixed
-cost like every other. It is currently **7m56s**, of which 2m34s is the image
-build (#236 is about removing it).
+cost like every other. It is currently **6m32s**, of which 1m10s is the image
+(7m56s before #236 published it instead of rebuilding it per job).
 
-Thirteen slices sit at 8m38s, 1.09x the floor. That is the point of choosing N
+Thirteen slices sit at 7m14s, 1.11x the floor. That is the point of choosing N
 from the numbers rather than from taste: six balanced slices were 13m37s,
 twelve reach the floor, and past twelve every extra job is pure cost. The
 contract test asserts distance to the floor rather than the spread between

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -83,6 +83,61 @@ config, catmux pane logs, Docker logs when available, and the smoke verification
 log under `session-instances/`; collect that directory as the first debugging
 artifact when an E2E job fails.
 
+### The e2e image is published once, not rebuilt per job
+
+Every e2e job used to build the project image from scratch. #236 measured that
+at 154s per job — 57s pulling the multi-GB ROS base from Docker Hub, 40s
+exporting layers, 47s of apt and pip — which at thirteen slices is 33 minutes of
+runner time and thirteen Hub pulls on the critical path of every merge gate.
+
+The `image` job now publishes those images to
+`ghcr.io/<owner>/rosotacom-e2e` and each slice pulls instead of building. GHCR
+is co-located with the runners and has no Hub rate limit, so this is one
+transfer where there used to be a transfer plus a build.
+
+The tag is the whole safety argument. It is a SHA-256 of everything that decides
+what the image contains — the `docker build` command ros2docker renders from a
+config (base image and its pinned digest, `APT_PACKAGES`, `PIP_PACKAGES`, the
+build UID) and every file in the context it stages (Dockerfile, entrypoint, any
+baked packages). Change any of them and the name changes, so "the published
+image is stale" is not a state this can reach, which is the objection #226
+raised against caching the image inline.
+
+Nothing ever *accepts* a reference. `rosotacom image references` derives them;
+the publisher builds and pushes only what is missing, and only under the name
+its own inputs hash to (`rosotacom image build --reference`). A consumer is told
+a repository, in `ROSOTACOM_IMAGE_CACHE`, and derives the tag itself:
+
+```bash
+# What this project's build inputs are called
+rosotacom image references --repository ghcr.io/owner/rosotacom-e2e
+
+# Adopt them instead of building, anywhere rosotacom would build
+ROSOTACOM_IMAGE_CACHE=ghcr.io/owner/rosotacom-e2e just test-e2e-slice heartbeat
+```
+
+With the variable unset, nothing changes: rosotacom builds as it always did. Set
+and the image absent, the job fails rather than falling back — a miss means the
+publisher did not run or did not agree with this tree, and a silent rebuild
+would hide both while costing exactly what this removes. The one place that
+decision is made is the `image` job, which reports its repository only after
+confirming every reference resolves; a read-only `GITHUB_TOKEN` (a fork PR,
+Dependabot) therefore leaves the slices building as before.
+
+Two properties are worth keeping in mind when changing this:
+
+- **Publisher and consumer read one list.** `2_native_chatter` builds a second
+  image from a different package list, so `rosotacom image references` walks the
+  project config *and* every scenario application. Publishing only the project
+  image would leave that slice adopting something nobody published.
+- **The release and nightly lanes still build from scratch**, as does the
+  nightly `image-scan`. That is deliberate: they are what would notice if a
+  published image and a fresh build ever stopped agreeing.
+
+Content-addressed tags accumulate in the GHCR package — one per distinct set of
+build inputs, so roughly one per change to the base digest or package lists.
+Nothing prunes them yet.
+
 ### Balancing the e2e slices
 
 A slice is not its own pytest invocation. `just test-e2e-slice <name>` runs the

--- a/src/rosotacom/cli.py
+++ b/src/rosotacom/cli.py
@@ -55,6 +55,15 @@ from .deployment import (
     parse_assignments,
     resolve_peer_bindings,
 )
+from .image_cache import (
+    IMAGE_CACHE_ENV,
+    ImageCacheError,
+    adopt_cached_image,
+    cache_repository,
+    cached_reference,
+    image_fingerprint,
+    reference_tag,
+)
 
 anonymize_lib = importlib.import_module("rosotacom.anonymize")
 
@@ -595,6 +604,53 @@ def _scoped_image_name_from_base(base: str, suffix: str) -> str:
         prefix, tag = base.rsplit(":", 1)
         return f"{prefix}-{suffix}:{tag}"
     return f"{base}-{suffix}"
+
+
+def _build_image(config_file: Path, override: Mapping[str, object]) -> None:
+    """Build the image these inputs describe, or adopt the published one.
+
+    With ``ROSOTACOM_IMAGE_CACHE`` unset this is exactly ``ros2docker build``.
+    With it set, the build is replaced by a pull of ``<repository>:<hash of
+    these build inputs>`` — see `rosotacom.image_cache` for why that name is
+    the whole safety argument.
+
+    The fingerprint deliberately ignores ``override``: it carries the container
+    name, the scoped image name, and sometimes isolated-network run args, none
+    of which reach ``docker build``. Feeding them in would give the same image
+    a different name per session.
+    """
+    repository = cache_repository()
+    if repository is None:
+        ros2docker_build(config_file=config_file, override=override)
+        return
+
+    image_name = str(override["image_name"])
+    reference = cached_reference(repository, image_fingerprint(config_file))
+    print(f"Adopting published image {reference} as {image_name} (build skipped)")
+    adopt_cached_image(reference, image_name)
+
+
+def _project_build_inputs(runtime: RuntimeConfig) -> list[tuple[str, Path]]:
+    """Every ``(label, ros2docker config)`` this project can build an image from.
+
+    The project image is one of several: each scenario application names its own
+    config, and `2_native_chatter` builds a second image from a different
+    package list. Publishing only the project image would leave the adopt path
+    strict about an image nobody published, so the publisher and the consumer
+    read the same list.
+    """
+    inputs: list[tuple[str, Path]] = [("project", runtime.ros2docker_config)]
+    seen = {runtime.ros2docker_config.resolve()}
+    for scenario_name in _scenario_names(runtime):
+        definition = _load_scenario_definition(_resolve_scenario(scenario_name, runtime))
+        for identity, applications in sorted(definition.applications.items()):
+            for application in applications:
+                config = application.ros2docker_config.resolve()
+                if config in seen:
+                    continue
+                seen.add(config)
+                inputs.append((f"{scenario_name}/{identity}/{application.name}", config))
+    return inputs
 
 
 def _instance_name_token(instance_id: str) -> str:
@@ -4911,7 +4967,7 @@ def start_session(args: argparse.Namespace) -> str:
 
     common_override = {"container_name": container_name, "image_name": image_name}
     if mode == "detached":
-        ros2docker_build(config_file=runtime.ros2docker_config, override=common_override)
+        _build_image(runtime.ros2docker_config, common_override)
         ros2docker_run(
             config_file=runtime.ros2docker_config,
             override={**common_override, "run_type": "up", **run_override},
@@ -4926,7 +4982,7 @@ def start_session(args: argparse.Namespace) -> str:
         )
         _write_docker_log(container_name, instance, identity)
     else:
-        ros2docker_build(config_file=runtime.ros2docker_config, override=common_override)
+        _build_image(runtime.ros2docker_config, common_override)
         ros2docker_run(
             config_file=runtime.ros2docker_config,
             override={
@@ -5258,7 +5314,7 @@ def run_scenario_application(args: argparse.Namespace) -> int:
             network_name,
             getattr(args, "network_ip", None),
         )
-    ros2docker_build(config_file=application.ros2docker_config, override=override)
+    _build_image(application.ros2docker_config, override)
     ros2docker_run(config_file=application.ros2docker_config, override=override)
     return 0
 
@@ -5330,6 +5386,55 @@ def examples_create_command(args: argparse.Namespace) -> int:
     print(f"Use it by entering the directory (auto-discovered):  cd {shlex.quote(str(target))}")
     print(f"Or pin it everywhere:  rosotacom config set project {shlex.quote(str(target / 'rosotacom.yaml'))} --global")
     return 0
+
+
+def image_references_command(args: argparse.Namespace) -> int:
+    """Print the content-addressed reference of every image this project builds.
+
+    The publisher's whole job is this list: build and push what is missing. It
+    never chooses a tag, so it cannot publish an image under a name that
+    describes different inputs.
+    """
+    _require_ros2docker()
+    runtime = _load_runtime_config(args)
+    repository = args.repository or cache_repository()
+    if not repository:
+        raise RuntimeError(f"Pass --repository or set {IMAGE_CACHE_ENV} to the repository that holds published images.")
+
+    printed: set[str] = set()
+    for _label, config in _project_build_inputs(runtime):
+        reference = cached_reference(repository, image_fingerprint(config))
+        # Two scenario applications with the same build inputs are one image.
+        if reference in printed:
+            continue
+        printed.add(reference)
+        print(reference)
+    return 0
+
+
+def image_build_command(args: argparse.Namespace) -> int:
+    """Build the image whose build inputs hash to the tag in ``--reference``.
+
+    Taking a reference rather than a config keeps the publisher honest: the only
+    thing it can push is an image whose inputs actually hash to the name it is
+    pushing under.
+    """
+    _require_ros2docker()
+    runtime = _load_runtime_config(args)
+    reference = args.reference
+    wanted = reference_tag(reference)
+
+    for label, config in _project_build_inputs(runtime):
+        if image_fingerprint(config) != wanted:
+            continue
+        print(f"Building {label} ({config}) as {reference}")
+        ros2docker_build(config_file=config, override={"image_name": reference})
+        return 0
+
+    raise ImageCacheError(
+        f"No image this project builds has the fingerprint {wanted}. Take the reference from "
+        f"`rosotacom image references`; it changes whenever the build inputs do."
+    )
 
 
 def resources_path_command(args: argparse.Namespace) -> int:
@@ -8648,6 +8753,7 @@ TOP_LEVEL_COMMANDS = {
     "list-sessions",
     "scenario",
     "examples",
+    "image",
     "resources",
     "config",
     "bundle",
@@ -9375,6 +9481,30 @@ def main(argv: list[str] | None = None) -> int:
     examples_create_parser.add_argument("target", help="Directory to create.")
     examples_create_parser.add_argument("--force", action="store_true", help="Replace the target if it exists.")
     examples_create_parser.set_defaults(func=examples_create_command)
+
+    image_parser = subparsers.add_parser("image", help="Publish and consume the project's container images.")
+    image_subparsers = image_parser.add_subparsers(dest="image_action", required=True)
+
+    image_references_parser = image_subparsers.add_parser(
+        "references", help="Print the content-addressed reference of every image this project builds."
+    )
+    _add_common_config_args(image_references_parser)
+    image_references_parser.add_argument(
+        "--repository",
+        help=f"Repository holding published images, e.g. ghcr.io/owner/name. Defaults to {IMAGE_CACHE_ENV}.",
+    )
+    image_references_parser.set_defaults(func=image_references_command)
+
+    image_build_parser = image_subparsers.add_parser(
+        "build", help="Build the image whose build inputs hash to the tag in --reference."
+    )
+    _add_common_config_args(image_build_parser)
+    image_build_parser.add_argument(
+        "--reference",
+        required=True,
+        help="Full reference from `rosotacom image references`. Its tag decides which image is built.",
+    )
+    image_build_parser.set_defaults(func=image_build_command)
 
     resources_parser = subparsers.add_parser("resources", help="Locate resources packaged with rosotacom.")
     resources_subparsers = resources_parser.add_subparsers(dest="resources_action", required=True)

--- a/src/rosotacom/image_cache.py
+++ b/src/rosotacom/image_cache.py
@@ -1,0 +1,169 @@
+"""Content-addressed names for the images this project builds.
+
+Every e2e job rebuilds the same project image from scratch, and #236 measured
+what that costs: 154s per job, thirteen jobs per merge-gate run. Publishing the
+built image once and adopting it in each job removes the build — but only if
+"adopt" can never mean "adopt something else". A cached image that no longer
+matches its build inputs is a silent wrong-result machine, which is why #226
+declined to do this inline.
+
+So the name of a published image is a hash of everything that determines it:
+the ``docker build`` command ros2docker renders from a config, and the build
+context it stages. Nothing else decides what the image contains. A changed base
+digest, apt package, pip package, Dockerfile, entrypoint, or ros2docker version
+is a different hash and therefore a different name, so "the published image is
+stale" is not a state this can be in rather than a state it is unlikely to be
+in. A consumer never receives a reference to trust; it derives the one name its
+own inputs allow and pulls exactly that.
+
+The image name itself is deliberately excluded from the hash. It says what the
+caller wants the result called, not what is in it, and rosotacom scopes it per
+install (``ros-communication-<install_id>``), so including it would give two
+checkouts of the same tree two different hashes for one image.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import subprocess
+import time
+from collections.abc import Mapping
+from pathlib import Path
+
+#: Docker repository holding published images, e.g.
+#: ``ghcr.io/develnor/rosotacom-e2e``. Set it and every build this project would
+#: run is replaced by a pull of the content-addressed tag; leave it unset and
+#: nothing changes.
+IMAGE_CACHE_ENV = "ROSOTACOM_IMAGE_CACHE"
+
+_FINGERPRINT_IMAGE_NAME = "rosotacom-image-fingerprint"
+
+_PULL_ATTEMPTS = 3
+_PULL_RETRY_SECONDS = 5.0
+
+
+class ImageCacheError(RuntimeError):
+    """A published image could not be resolved, pulled, or adopted."""
+
+
+def cache_repository(env: Mapping[str, str] | None = None) -> str | None:
+    """The configured publish repository, or ``None`` when there is none."""
+    source = os.environ if env is None else env
+    value = source.get(IMAGE_CACHE_ENV, "").strip()
+    return value or None
+
+
+def image_fingerprint(
+    config_file: str | os.PathLike[str] | None = None,
+    override: Mapping[str, object] | None = None,
+) -> str:
+    """Hash everything that decides what ``ros2docker build`` would produce.
+
+    Both halves are taken from ros2docker rather than re-derived here: the
+    rendered command carries the build args (``BASE_IMAGE``, its ``DIGEST``,
+    ``APT_PACKAGES``, ``PIP_PACKAGES``, ``USER_UID``/``USER_GID``) and the
+    staged context carries the Dockerfile, the entrypoint, and any baked
+    packages. Hashing what ros2docker actually produces means a change in
+    ros2docker itself — a new build arg, a changed Dockerfile — moves the hash
+    without anything here knowing it happened.
+    """
+    from ros2docker.api import build_context
+    from ros2docker.commands import make_build_command
+
+    fingerprint_override: dict[str, object] = dict(override or {})
+    fingerprint_override["image_name"] = _FINGERPRINT_IMAGE_NAME
+
+    digest = hashlib.sha256()
+    with build_context(config_file, fingerprint_override) as context_dir:
+        command = make_build_command(config_file, fingerprint_override, context_dir=context_dir)
+        # The final token is the context path, a temporary directory whose name
+        # differs every run. What is *in* it is hashed below instead.
+        for token in command[:-1]:
+            _feed(digest, token.encode("utf-8"))
+        _feed_tree(digest, Path(context_dir))
+    return digest.hexdigest()
+
+
+def cached_reference(repository: str, fingerprint: str) -> str:
+    """``<repository>:<fingerprint>`` — the only name these inputs may be published under."""
+    repository = repository.strip().rstrip("/")
+    if not repository:
+        raise ImageCacheError(f"{IMAGE_CACHE_ENV} is set to an empty repository.")
+    if ":" in repository.rsplit("/", 1)[-1]:
+        raise ImageCacheError(
+            f"{IMAGE_CACHE_ENV} must name a repository without a tag, got {repository!r}. "
+            "The tag is the content hash and is never chosen by the caller."
+        )
+    return f"{repository}:{fingerprint}"
+
+
+def reference_tag(reference: str) -> str:
+    """The tag part of a full image reference."""
+    name = reference.rsplit("/", 1)[-1]
+    if ":" not in name:
+        raise ImageCacheError(f"Image reference {reference!r} carries no tag.")
+    return name.rsplit(":", 1)[1]
+
+
+def adopt_cached_image(reference: str, image_name: str, *, attempts: int = _PULL_ATTEMPTS) -> None:
+    """Make ``image_name`` resolve to the published image, pulling it if needed.
+
+    Failure is an error rather than a fallback to building. The reference was
+    derived from this machine's own build inputs, so a miss means the publish
+    step did not run or did not agree with this tree — both worth a red job,
+    and neither worth hiding behind a build that silently costs what this
+    change exists to remove.
+    """
+    if not image_present(reference):
+        _pull(reference, attempts=attempts)
+    result = _docker(["tag", reference, image_name])
+    if result.returncode != 0:
+        raise ImageCacheError(f"Could not tag {reference} as {image_name}: {_message(result)}")
+
+
+def image_present(reference: str) -> bool:
+    """Whether the local Docker daemon already holds this image."""
+    return _docker(["image", "inspect", reference], quiet=True).returncode == 0
+
+
+def _pull(reference: str, *, attempts: int) -> None:
+    last = ""
+    for attempt in range(1, attempts + 1):
+        result = _docker(["pull", reference])
+        if result.returncode == 0:
+            return
+        last = _message(result)
+        if attempt < attempts:
+            time.sleep(_PULL_RETRY_SECONDS)
+    raise ImageCacheError(f"Could not pull the published image {reference} after {attempts} attempts: {last}")
+
+
+def _docker(args: list[str], *, quiet: bool = False) -> subprocess.CompletedProcess[str]:
+    if quiet:
+        return subprocess.run(
+            ["docker", *args],
+            text=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        )
+    return subprocess.run(["docker", *args], text=True, capture_output=True, check=False)
+
+
+def _message(result: subprocess.CompletedProcess[str]) -> str:
+    return ((result.stderr or "") + (result.stdout or "")).strip()
+
+
+def _feed(digest: hashlib._Hash, payload: bytes) -> None:
+    digest.update(payload)
+    digest.update(b"\0")
+
+
+def _feed_tree(digest: hashlib._Hash, root: Path) -> None:
+    for path in sorted(entry for entry in root.rglob("*") if entry.is_file()):
+        _feed(digest, str(path.relative_to(root)).encode("utf-8"))
+        # The executable bit is part of the context: an entrypoint that loses it
+        # builds an image that cannot start.
+        _feed(digest, b"x" if path.stat().st_mode & 0o111 else b"-")
+        _feed(digest, hashlib.sha256(path.read_bytes()).digest())

--- a/tests/contract/test_security_maintenance_config.py
+++ b/tests/contract/test_security_maintenance_config.py
@@ -93,12 +93,18 @@ def test_merge_gate_requires_new_ci_jobs_and_no_masking() -> None:
         "merge-lightweight",
         "package",
         "preflight-success",
+        "image",
         "e2e",
     }
     assert expected_jobs.issubset(set(needs))
 
-    assert jobs["e2e"]["needs"] == "preflight-success"
-    assert jobs["e2e"]["if"] == "always() && !cancelled() && needs.preflight-success.result == 'success'"
+    # Both gates the e2e slices wait on have to be green before any slice runs,
+    # and the `if` has to say so job by job: `needs` alone does not stop a
+    # dependency's failure from reaching a job that runs with `always()`.
+    assert set(jobs["e2e"]["needs"]) == {"preflight-success", "image"}
+    assert jobs["e2e"]["if"] == (
+        "always() && !cancelled() && needs.preflight-success.result == 'success' && needs.image.result == 'success'"
+    )
 
     # Every needed job's result must be turned into an exit code by hand,
     # because ci-success runs with `if: always()`. This used to list the e2e

--- a/tests/contract/test_workflow_contracts.py
+++ b/tests/contract/test_workflow_contracts.py
@@ -176,6 +176,29 @@ def test_ci_success_checks_every_job_it_waits_for() -> None:
     )
 
 
+def test_e2e_slices_take_the_image_repository_from_the_publisher() -> None:
+    """A slice may only consume images the `image` job confirmed are there.
+
+    That job publishes what is missing and then reports its repository *only*
+    if every content-addressed reference resolves, so a read-only
+    `GITHUB_TOKEN` leaves the value empty and the slices build as they always
+    did. Writing the repository into the e2e job directly would skip that
+    probe: the slices would then fail on a pull that was never going to work,
+    which is worse than the build this replaces.
+    """
+    workflow = yaml.safe_load((WORKFLOWS_DIR / "pr-merge-gate.yml").read_text(encoding="utf-8"))
+    e2e = workflow["jobs"]["e2e"]
+
+    assert "image" in e2e["needs"], "the e2e slices must wait for the image job"
+
+    steps = [step for step in e2e["steps"] if "ROSOTACOM_IMAGE_CACHE" in (step.get("env") or {})]
+    assert len(steps) == 1, "exactly one e2e step consumes the published images"
+    assert steps[0]["env"]["ROSOTACOM_IMAGE_CACHE"] == "${{ needs.image.outputs.repository }}", (
+        "ROSOTACOM_IMAGE_CACHE must come from the image job's output, not from a literal repository"
+    )
+    assert workflow["jobs"]["image"]["outputs"]["repository"], "the image job must publish its repository as an output"
+
+
 def _recipe_pytest_invocations(recipe: str) -> list[list[str]]:
     """Every pytest argument list a recipe runs, with just's substitutions applied."""
     import shlex

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -31,17 +31,31 @@ import pytest
 #: and 31634604888 (43-60s).
 RUNNER_SETUP_SECONDS = 55.0
 
-#: Seconds the first test in a job pays to build the rosotacom project image.
+#: Seconds the first test in a job pays to get the rosotacom project image.
 #: Every job pays it exactly once, whichever test runs first, so it is a
-#: constant no partition can remove — see #236, which is about removing it.
-#: Because it is per job and not per test, it is also what makes more slices
-#: cost more: at thirteen, 33 minutes of every gate run is this.
+#: constant no partition can remove. Because it is per job and not per test, it
+#: is also what makes more slices cost more.
 #:
-#: Measured over 21 cold/warm pairs across seven runs: median 153.7s. A pair is
-#: one test's duration as its job's first test against its median duration when
-#: something else went first. Run 31634604888 supplied five of them at once,
-#: because rebalancing changed which test each slice starts with.
-IMAGE_BUILD_SECONDS = 154.0
+#: It was 154.0 — a `docker build`, measured over 21 cold/warm pairs across
+#: seven runs (median 153.7s). #236 replaced that build with a pull of a
+#: content-addressed image the merge gate's `image` job publishes, and this is
+#: what the pull costs instead. So the number models the *merge gate*: the
+#: release and nightly lanes still build from scratch, deliberately, as the
+#: check that a published image and a fresh build still agree.
+#:
+#: 70.0 from run 31678648935, two estimators agreeing. Per slice, (sum of
+#: measured `call` durations − sum of the warm costs below) has a median of
+#: 67.2s over the twelve slices that behaved (43.8–77.8s). Per test, the twelve
+#: tests that run first in their job each dropped 74–119s against their median
+#: over three earlier runs, median −84s, i.e. 154 − 84 = 70.
+#:
+#: `media` is the thirteenth and did not behave: it got 57s *slower*, all of it
+#: in `test_synthetic_camera_pipeline_records_quality_metrics` (+72s) while its
+#: sibling moved +2s. Its two recorded costs below do not reproduce either —
+#: they sum ~24s short of what the job actually spends — so that slice needs a
+#: measurement of its own rather than a number derived from one anomalous run.
+#: It is currently the critical path.
+IMAGE_BUILD_SECONDS = 70.0
 
 #: Every e2e test, the slice that owns it, and its *warm* pytest `call` duration
 #: in seconds — the median over seven runs of the invocations where the project

--- a/tests/unit/test_image_cache.py
+++ b/tests/unit/test_image_cache.py
@@ -1,0 +1,262 @@
+"""The content-addressed image name, and the build it replaces.
+
+The whole safety argument for skipping a build is that the name of a published
+image is derived from its build inputs and never accepted from a caller. These
+tests are that argument: identical inputs agree wherever they are evaluated, any
+input change moves the name, and a build only turns into an adoption when a
+repository is configured.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+import subprocess
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+import rosotacom.cli as rosotacom
+from rosotacom import image_cache
+
+
+@pytest.fixture(autouse=True)
+def no_ambient_cache(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(image_cache.IMAGE_CACHE_ENV, raising=False)
+
+
+def _project(tmp_path: Path, name: str, build_args: dict[str, str]) -> Path:
+    """A minimal rosotacom project whose ros2docker config carries build_args."""
+    root = tmp_path / name
+    root.mkdir()
+    (root / "ros2docker.json").write_text(
+        json.dumps({"image_name": "ros-communication", "build_args": build_args}),
+        encoding="utf-8",
+    )
+    (root / "rosotacom.yaml").write_text("ros2docker_config: ros2docker.json\n", encoding="utf-8")
+    return root
+
+
+_BUILD_ARGS = {"BASE_IMAGE": "osrf/ros:kilted-desktop-full-noble", "APT_PACKAGES": "iputils-ping"}
+
+
+def test_fingerprint_ignores_where_the_project_lives(tmp_path: Path) -> None:
+    """A copied project is the same image.
+
+    Not a detail: every e2e test runs against its own copy of the packaged
+    example, and the publisher runs against the packaged original. If the path
+    reached the hash, the two would never agree and nothing would ever be
+    adopted.
+    """
+    here = _project(tmp_path, "here", _BUILD_ARGS)
+    there = _project(tmp_path, "there", _BUILD_ARGS)
+
+    assert image_cache.image_fingerprint(here / "ros2docker.json") == image_cache.image_fingerprint(
+        there / "ros2docker.json"
+    )
+
+
+def test_fingerprint_ignores_the_image_name(tmp_path: Path) -> None:
+    """rosotacom scopes the image name per install; the contents do not change with it."""
+    project = _project(tmp_path, "scoped", _BUILD_ARGS)
+    config = project / "ros2docker.json"
+
+    assert image_cache.image_fingerprint(config) == image_cache.image_fingerprint(
+        config, {"image_name": "ros-communication-deadbeef", "container_name": "whatever"}
+    )
+
+
+@pytest.mark.parametrize(
+    ("key", "value"),
+    [
+        ("BASE_IMAGE", "ros:kilted-ros-base"),
+        ("DIGEST", "@sha256:0000000000000000000000000000000000000000000000000000000000000000"),
+        ("APT_PACKAGES", "iputils-ping curl"),
+        ("PIP_PACKAGES", "numpy"),
+    ],
+)
+def test_fingerprint_moves_with_every_build_input(tmp_path: Path, key: str, value: str) -> None:
+    baseline = image_cache.image_fingerprint(_project(tmp_path, "base", _BUILD_ARGS) / "ros2docker.json")
+    changed = _project(tmp_path, f"changed-{key}", {**_BUILD_ARGS, key: value})
+
+    assert image_cache.image_fingerprint(changed / "ros2docker.json") != baseline
+
+
+def test_fingerprint_moves_with_the_build_context(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The Dockerfile and entrypoint ros2docker stages are inputs too.
+
+    They come from the installed ros2docker rather than from this repository, so
+    a ros2docker release that changes either one has to change the name — that is
+    what keeps the published image from outliving the package that built it.
+    """
+    import ros2docker.api
+
+    config = _project(tmp_path, "context", _BUILD_ARGS) / "ros2docker.json"
+    baseline = image_cache.image_fingerprint(config)
+    original = ros2docker.api.build_context
+
+    @contextlib.contextmanager
+    def with_a_changed_entrypoint(*args: object, **kwargs: object) -> Iterator[Path]:
+        with original(*args, **kwargs) as context_dir:  # type: ignore[arg-type]
+            entrypoint = Path(context_dir) / "entrypoint.sh"
+            entrypoint.write_text(entrypoint.read_text(encoding="utf-8") + "# changed\n", encoding="utf-8")
+            yield Path(context_dir)
+
+    monkeypatch.setattr(ros2docker.api, "build_context", with_a_changed_entrypoint)
+
+    assert image_cache.image_fingerprint(config) != baseline
+
+
+def test_reference_is_repository_plus_fingerprint() -> None:
+    assert image_cache.cached_reference("ghcr.io/owner/name", "abc123") == "ghcr.io/owner/name:abc123"
+    assert image_cache.reference_tag("ghcr.io/owner/name:abc123") == "abc123"
+
+
+def test_repository_may_not_carry_a_tag() -> None:
+    """The tag is the content hash. A caller that picks one has defeated the point."""
+    with pytest.raises(image_cache.ImageCacheError, match="without a tag"):
+        image_cache.cached_reference("ghcr.io/owner/name:latest", "abc123")
+
+
+def test_cache_repository_reads_the_environment() -> None:
+    assert image_cache.cache_repository({image_cache.IMAGE_CACHE_ENV: " ghcr.io/owner/name "}) == "ghcr.io/owner/name"
+    assert image_cache.cache_repository({image_cache.IMAGE_CACHE_ENV: "  "}) is None
+    assert image_cache.cache_repository({}) is None
+
+
+def test_adopt_pulls_only_when_the_image_is_absent(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(command: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+        calls.append(command)
+        present = command[1:3] == ["image", "inspect"]
+        return subprocess.CompletedProcess(command, 0 if not present else 1, "", "")
+
+    monkeypatch.setattr(image_cache.subprocess, "run", fake_run)
+    image_cache.adopt_cached_image("ghcr.io/owner/name:abc", "ros-communication-1234")
+
+    assert calls == [
+        ["docker", "image", "inspect", "ghcr.io/owner/name:abc"],
+        ["docker", "pull", "ghcr.io/owner/name:abc"],
+        ["docker", "tag", "ghcr.io/owner/name:abc", "ros-communication-1234"],
+    ]
+
+
+def test_adopt_fails_loudly_when_the_image_is_not_published(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No silent fallback to building.
+
+    A miss means the publisher never ran, or ran against a different tree. Both
+    are worth a red job: falling back would quietly restore the 154s per job
+    this exists to remove, and it would do so invisibly.
+    """
+    monkeypatch.setattr(
+        image_cache.subprocess,
+        "run",
+        lambda command, **_: subprocess.CompletedProcess(command, 1, "", "manifest unknown"),
+    )
+    monkeypatch.setattr(image_cache.time, "sleep", lambda _seconds: None)
+
+    with pytest.raises(image_cache.ImageCacheError, match="Could not pull"):
+        image_cache.adopt_cached_image("ghcr.io/owner/name:abc", "ros-communication-1234", attempts=2)
+
+
+def test_build_runs_ros2docker_when_no_repository_is_configured(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config = _project(tmp_path, "plain", _BUILD_ARGS) / "ros2docker.json"
+    built: list[object] = []
+    monkeypatch.setattr(rosotacom, "ros2docker_build", lambda **kwargs: built.append(kwargs))
+
+    rosotacom._build_image(config, {"image_name": "ros-communication-1234"})
+
+    assert built == [{"config_file": config, "override": {"image_name": "ros-communication-1234"}}]
+
+
+def test_build_adopts_the_published_image_when_a_repository_is_configured(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config = _project(tmp_path, "cached", _BUILD_ARGS) / "ros2docker.json"
+    monkeypatch.setenv(image_cache.IMAGE_CACHE_ENV, "ghcr.io/owner/name")
+    monkeypatch.setattr(
+        rosotacom,
+        "ros2docker_build",
+        lambda **_: pytest.fail("a configured repository must replace the build, not add to it"),
+    )
+    adopted: list[tuple[str, str]] = []
+    monkeypatch.setattr(rosotacom, "adopt_cached_image", lambda ref, name: adopted.append((ref, name)))
+
+    rosotacom._build_image(config, {"image_name": "ros-communication-1234"})
+
+    expected = f"ghcr.io/owner/name:{image_cache.image_fingerprint(config)}"
+    assert adopted == [(expected, "ros-communication-1234")]
+
+
+def test_references_lists_every_image_the_project_builds(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Publisher and consumer read one list.
+
+    `2_native_chatter` builds a second image from a different package list. If
+    the publisher only knew about the project image, the chatter slice would
+    reach a strict adopt path for something nobody published.
+    """
+    project = _example_project(tmp_path, monkeypatch)
+    capsys.readouterr()
+
+    rosotacom.image_references_command(
+        argparse.Namespace(rosotacom_config=str(project / "rosotacom.yaml"), repository="ghcr.io/owner/name")
+    )
+
+    references = capsys.readouterr().out.split()
+    assert len(references) == 2, references
+    assert len(set(references)) == 2, "two different package lists must not share one name"
+    assert all(reference.startswith("ghcr.io/owner/name:") for reference in references)
+
+
+def test_build_refuses_a_reference_no_input_hashes_to(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The publisher may push only what its own inputs produced."""
+    project = _example_project(tmp_path, monkeypatch)
+    monkeypatch.setattr(
+        rosotacom,
+        "ros2docker_build",
+        lambda **_: pytest.fail("nothing may be built under a name that describes other inputs"),
+    )
+
+    with pytest.raises(image_cache.ImageCacheError, match="No image this project builds"):
+        rosotacom.image_build_command(
+            argparse.Namespace(
+                rosotacom_config=str(project / "rosotacom.yaml"),
+                reference="ghcr.io/owner/name:" + "0" * 64,
+            )
+        )
+
+
+def test_build_builds_the_input_a_reference_names(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    project = _example_project(tmp_path, monkeypatch)
+    capsys.readouterr()
+    rosotacom.image_references_command(
+        argparse.Namespace(rosotacom_config=str(project / "rosotacom.yaml"), repository="ghcr.io/owner/name")
+    )
+    reference = capsys.readouterr().out.split()[0]
+
+    built: list[object] = []
+    monkeypatch.setattr(rosotacom, "ros2docker_build", lambda **kwargs: built.append(kwargs))
+    rosotacom.image_build_command(
+        argparse.Namespace(rosotacom_config=str(project / "rosotacom.yaml"), reference=reference)
+    )
+
+    assert len(built) == 1
+    assert built[0]["override"] == {"image_name": reference}  # type: ignore[index]
+
+
+def _example_project(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A copy of the packaged example — the project the e2e suite actually runs."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / ".config"))
+    monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path / ".run"))
+    target = tmp_path / "example"
+    rosotacom.examples_create_command(argparse.Namespace(target=str(target), force=False))
+    return target


### PR DESCRIPTION
Closes #236.

## What this does

The `image` job publishes every image the e2e suite builds to
`ghcr.io/<owner>/rosotacom-e2e`, and each of the thirteen slices pulls instead of
building. #236 measured that build at 154s per job — 57.5s pulling the multi-GB
ROS base from Docker Hub, 39.6s exporting layers, 47s of apt and pip.

**Measured on this PR's own gate run
([31678648935](https://github.com/develNor/ros_communication_devcontainer/actions/runs/31678648935)),
thirteen slices green: 154s → 70s per job.** The slowest slice's pytest run fell
from 8m19s to 6m50s, and about 18 minutes of runner time comes off each gate run.
Full numbers, both estimators and the one anomaly, are on
[#236](https://github.com/develNor/ros_communication_devcontainer/issues/236#issuecomment-5277687426).

## Why the tag is the whole design

#226 declined to cache inline because "a stale cached image is a silent
wrong-result machine". The tag is a SHA-256 of everything that decides the image,
taken from ros2docker rather than re-listed here: the rendered `docker build`
command (base image and pinned digest, `APT_PACKAGES`, `PIP_PACKAGES`, build UID)
and every file in the context it stages (Dockerfile, entrypoint, baked packages).
A change to any of them is a different name, so "stale" is not a state this can
reach rather than one it is unlikely to reach. Hashing what ros2docker *produces*
also means a ros2docker release that changes the Dockerfile moves the name
without anything here knowing it happened.

Nothing accepts a reference:

- `rosotacom image references` derives them;
- `rosotacom image build --reference` refuses anything whose inputs do not hash
  to the name it was handed;
- a consumer is told a *repository* in `ROSOTACOM_IMAGE_CACHE` and derives the
  tag itself, then fails rather than falling back to a build — a fallback would
  silently restore the cost this removes and hide the disagreement.

## Two things worth reviewing

- **Publisher and consumer read one list.** There is more than one image:
  `2_native_chatter` builds a second from a different package list, so both walk
  the project config *and* every scenario application. Publishing only the
  project image would leave that slice strict about something nobody published.
- **The availability decision lives in the workflow, not in rosotacom.** The
  `image` job reports its repository only after confirming every reference
  resolves. A read-only `GITHUB_TOKEN` (fork PR, Dependabot) can log in and pull
  but not push, and the slices then build as they always did. Probed rather than
  predicted from the event type, so it stays right when GitHub's token rules
  change.

Release and nightly still build from scratch, as does the nightly `image-scan`.
That is deliberate — they are what would notice if a published image and a fresh
build ever stopped agreeing.

## Validation

Automated: `tests/unit/test_image_cache.py` (17 tests — path independence,
sensitivity to every build input and to the staged context, the loud miss, and
that a configured repository replaces the build rather than adding to it), plus a
workflow contract that `ROSOTACOM_IMAGE_CACHE` comes from the `image` job's
output rather than a literal. `just check` is green.

Docker, locally against a checkout-local publish repository:

- both images adopted, and `docker image inspect` confirms the scoped names
  (`ros-communication-<install_id>`, `rosotacom-native-chatter-<install_id>`) are
  *tags on the published image IDs*, not fresh builds;
- `test_native_chatter_scenario_starts_apps_and_communication_together` passes
  through the adopt path;
- a reference that was never published fails with
  `Could not pull the published image ...` instead of building.

Docker, in CI: the gate run above.

## Left open on purpose

The `media` slice went the *other* way (+57s) and is now the critical path. Its
two recorded costs do not reproduce even on pre-change runs — they sum ~24s short
of what the job spends, and one of them is the last unvalidated `derived` number
from #235. That is a measurement question about `media`, not about this change,
so `E2E_SLICES` is untouched and `conftest.py` says why. The next gate run adds a
second sample.