### PR TITLE
Build on ros-base, now that the image is pulled rather than built thirteen times (#240)

### DIFF
--- a/src/rosotacom/resources/examples/ros2docker.json
+++ b/src/rosotacom/resources/examples/ros2docker.json
@@ -23,11 +23,19 @@
   // using ros2docker profiles (like 'zenoh' or 'project-develnor') because upstream profiles
   // are currently ROS Lyrical-oriented. Adoption of profiles will be evaluated when
   // Kilted-compatible profiles are available upstream.
+  //
+  // The base is ros-base, not desktop-full: 299 MB compressed against 1422 MB,
+  // and nothing here runs a GUI (enable_gui_forwarding is false above). The
+  // e2e suite was run against both to find out what desktop-full had been
+  // providing without anyone declaring it — one package, ros-kilted-gps-msgs,
+  // which the anonymized remote-assist session needs for gps_msgs/msg/GPSFix.
+  // It is declared below. Add rviz2 or a simulator here if you want them; that
+  // is a project's decision, not a default.
   "build_args": {
-    "BASE_IMAGE": "osrf/ros:kilted-desktop-full-noble",
-    "DIGEST": "@sha256:29eb6f48bb06549aba004a7a4b12c00ece23b156731df12cf1f3c1ae1b0fd178",
+    "BASE_IMAGE": "ros:kilted-ros-base-noble",
+    "DIGEST": "@sha256:4ca53d5b084bdbe92a7a7d7186f56db6a716a6c7c33ad401ddb0ec82d6e9e479",
     "INSTALL_ZENOH":                 "1",
-    "APT_PACKAGES":                  "iputils-ping psmisc net-tools snmp iw nload iftop iproute2 tshark ros-kilted-domain-bridge ros-kilted-rmw-cyclonedds-cpp ros-kilted-rmw-zenoh-cpp ros-kilted-topic-tools ros-kilted-image-transport ros-kilted-ffmpeg-image-transport ros-kilted-ffmpeg-image-transport-msgs",
+    "APT_PACKAGES":                  "iputils-ping psmisc net-tools snmp iw nload iftop iproute2 tshark ros-kilted-domain-bridge ros-kilted-rmw-cyclonedds-cpp ros-kilted-rmw-zenoh-cpp ros-kilted-topic-tools ros-kilted-image-transport ros-kilted-ffmpeg-image-transport ros-kilted-ffmpeg-image-transport-msgs ros-kilted-gps-msgs",
     "PIP_PACKAGES":                  "numpy>=1.26,<2 lz4 pysnmp speedtest-cli psutil zstandard opencv-python"
   }
 }

--- a/src/rosotacom/resources/examples/scripts/2_native_chatter/machine_a/external.ros2docker.json
+++ b/src/rosotacom/resources/examples/scripts/2_native_chatter/machine_a/external.ros2docker.json
@@ -14,8 +14,8 @@
   ],
 
   "build_args": {
-    "BASE_IMAGE": "osrf/ros:kilted-desktop-full-noble",
-    "DIGEST": "@sha256:29eb6f48bb06549aba004a7a4b12c00ece23b156731df12cf1f3c1ae1b0fd178",
+    "BASE_IMAGE": "ros:kilted-ros-base-noble",
+    "DIGEST": "@sha256:4ca53d5b084bdbe92a7a7d7186f56db6a716a6c7c33ad401ddb0ec82d6e9e479",
     "APT_PACKAGES": "ros-kilted-rmw-cyclonedds-cpp"
   }
 }

--- a/src/rosotacom/resources/examples/scripts/2_native_chatter/machine_b/external.ros2docker.json
+++ b/src/rosotacom/resources/examples/scripts/2_native_chatter/machine_b/external.ros2docker.json
@@ -12,8 +12,8 @@
   ],
 
   "build_args": {
-    "BASE_IMAGE": "osrf/ros:kilted-desktop-full-noble",
-    "DIGEST": "@sha256:29eb6f48bb06549aba004a7a4b12c00ece23b156731df12cf1f3c1ae1b0fd178",
+    "BASE_IMAGE": "ros:kilted-ros-base-noble",
+    "DIGEST": "@sha256:4ca53d5b084bdbe92a7a7d7186f56db6a716a6c7c33ad401ddb0ec82d6e9e479",
     "APT_PACKAGES": "ros-kilted-rmw-cyclonedds-cpp"
   }
 }

--- a/src/rosotacom/resources/examples/scripts/5_sized_payload/machine_a/external.ros2docker.json
+++ b/src/rosotacom/resources/examples/scripts/5_sized_payload/machine_a/external.ros2docker.json
@@ -15,6 +15,6 @@
   ],
 
   "build_args": {
-    "BASE_IMAGE":                    "osrf/ros:kilted-desktop-full-noble"
+    "BASE_IMAGE":                    "ros:kilted-ros-base-noble"
   }
 }

--- a/src/rosotacom/resources/examples/scripts/5_sized_payload/machine_b/external.ros2docker.json
+++ b/src/rosotacom/resources/examples/scripts/5_sized_payload/machine_b/external.ros2docker.json
@@ -15,6 +15,6 @@
   ],
 
   "build_args": {
-    "BASE_IMAGE":                    "osrf/ros:kilted-desktop-full-noble"
+    "BASE_IMAGE":                    "ros:kilted-ros-base-noble"
   }
 }

--- a/src/rosotacom/resources/examples/scripts/6_sized_payload_zen/machine_a/external.ros2docker.json
+++ b/src/rosotacom/resources/examples/scripts/6_sized_payload_zen/machine_a/external.ros2docker.json
@@ -13,6 +13,6 @@
   ],
 
   "build_args": {
-    "BASE_IMAGE":                    "osrf/ros:kilted-desktop-full-noble"
+    "BASE_IMAGE":                    "ros:kilted-ros-base-noble"
   }
 }

--- a/src/rosotacom/resources/examples/scripts/6_sized_payload_zen/machine_b/external.ros2docker.json
+++ b/src/rosotacom/resources/examples/scripts/6_sized_payload_zen/machine_b/external.ros2docker.json
@@ -13,6 +13,6 @@
   ],
 
   "build_args": {
-    "BASE_IMAGE":                    "osrf/ros:kilted-desktop-full-noble"
+    "BASE_IMAGE":                    "ros:kilted-ros-base-noble"
   }
 }

--- a/src/rosotacom/resources/ros2docker.json.example
+++ b/src/rosotacom/resources/ros2docker.json.example
@@ -23,11 +23,19 @@
   // using ros2docker profiles (like 'zenoh' or 'project-develnor') because upstream profiles
   // are currently ROS Lyrical-oriented. Adoption of profiles will be evaluated when
   // Kilted-compatible profiles are available upstream.
+  //
+  // The base is ros-base, not desktop-full: 299 MB compressed against 1422 MB,
+  // and nothing here runs a GUI (enable_gui_forwarding is false above). The
+  // e2e suite was run against both to find out what desktop-full had been
+  // providing without anyone declaring it — one package, ros-kilted-gps-msgs,
+  // which the anonymized remote-assist session needs for gps_msgs/msg/GPSFix.
+  // It is declared below. Add rviz2 or a simulator here if you want them; that
+  // is a project's decision, not a default.
   "build_args": {
-    "BASE_IMAGE":                    "osrf/ros:kilted-desktop-full-noble",
-    "DIGEST":                        "@sha256:29eb6f48bb06549aba004a7a4b12c00ece23b156731df12cf1f3c1ae1b0fd178",
+    "BASE_IMAGE":                    "ros:kilted-ros-base-noble",
+    "DIGEST":                        "@sha256:4ca53d5b084bdbe92a7a7d7186f56db6a716a6c7c33ad401ddb0ec82d6e9e479",
     "INSTALL_ZENOH":                 "1",
-    "APT_PACKAGES":                  "iputils-ping psmisc net-tools snmp iw nload iftop iproute2 tshark ros-kilted-domain-bridge ros-kilted-rmw-cyclonedds-cpp ros-kilted-rmw-zenoh-cpp ros-kilted-topic-tools ros-kilted-image-transport ros-kilted-ffmpeg-image-transport ros-kilted-ffmpeg-image-transport-msgs",
+    "APT_PACKAGES":                  "iputils-ping psmisc net-tools snmp iw nload iftop iproute2 tshark ros-kilted-domain-bridge ros-kilted-rmw-cyclonedds-cpp ros-kilted-rmw-zenoh-cpp ros-kilted-topic-tools ros-kilted-image-transport ros-kilted-ffmpeg-image-transport ros-kilted-ffmpeg-image-transport-msgs ros-kilted-gps-msgs",
     "PIP_PACKAGES":                  "numpy>=1.26,<2 lz4 pysnmp speedtest-cli psutil zstandard opencv-python"
   }
 }

--- a/tests/contract/test_packaged_resources.py
+++ b/tests/contract/test_packaged_resources.py
@@ -83,7 +83,11 @@ def test_default_ros2docker_config_pins_supported_kilted_noble_image() -> None:
     default_build_args = default_config["build_args"]
     example_build_args = example_config["build_args"]
 
-    assert default_build_args["BASE_IMAGE"] == "osrf/ros:kilted-desktop-full-noble"
+    # ros-base rather than desktop-full: nothing rosotacom ships runs a GUI, and
+    # the difference is 299 MB compressed against 1422 MB — bytes every peer
+    # transfers on a cold build and every e2e slice pulls from the published
+    # image.
+    assert default_build_args["BASE_IMAGE"] == "ros:kilted-ros-base-noble"
     assert default_build_args["DIGEST"].startswith("@sha256:")
     assert default_build_args["BASE_IMAGE"] == example_build_args["BASE_IMAGE"]
     assert default_build_args["DIGEST"] == example_build_args["DIGEST"]
@@ -98,6 +102,10 @@ def test_default_ros2docker_config_pins_supported_kilted_noble_image() -> None:
         # the -msgs package alone only provides FFMPEGPacket definitions.
         assert "ros-kilted-ffmpeg-image-transport" in apt_packages
         assert "ros-kilted-ffmpeg-image-transport-msgs" in apt_packages
+        # gps_msgs/msg/GPSFix, published by the anonymized remote-assist
+        # session. desktop-full carried it, so nothing declared it; on ros-base
+        # its absence is a missing type at runtime, not a build error.
+        assert "ros-kilted-gps-msgs" in apt_packages
 
 
 def test_external_ros2docker_configs_install_selected_rmw_implementations() -> None:


### PR DESCRIPTION
Closes #240.

## What #241 established, and what it got wrong

The experiment answered the question #240 asked: thirteen green slices on
`ros:kilted-ros-base`. The suite does not need `desktop-full`. Two things were
being relied on without declaration — `ros-kilted-gps-msgs`, for the
`gps_msgs/msg/GPSFix` the anonymized remote-assist session publishes, and a
working `lz4` import, which turned out to be #242 and is fixed on develop by
#243. Only the first is in this PR.

It then concluded the change was not worth it, and the reasoning was sound at
the time: median build fell 158s → 107s, but the spread went from 139-171s to
83-209s, because the bytes moved from a Docker Hub layer pull (a CDN transfer of
prebuilt layers) to `apt-get` (archive.ubuntu.com, packages.ros.org). With
thirteen independent builds, the gate is a **max over thirteen draws** from that
distribution. The two slowest ate the whole median saving; the critical path
moved by 10s.

## Why #244 inverts it

There are no longer thirteen builds. The wide distribution is now sampled once,
in the `image` job, and what each of the thirteen slices pays is a **pull**.
Pull cost tracks bytes, and bytes is exactly what this changes:

| | compressed |
|---|---|
| `osrf/ros:kilted-desktop-full-noble` | 1425 MB |
| `ros:kilted-ros-base-noble` | **299 MB** |
| published `rosotacom-e2e` image today | 1499 MB |

#241 predicted the two would compound and had the order backwards. They do, in
this order: caching makes the build a one-time cost, and shrinking the base
makes the thirteen pulls cheap.

Measurements from this PR's runs go in the comments — the first run builds and
publishes the new tag (cold), a re-run of the same commit measures the steady
state, and both are compared against the post-#244 develop baseline
([31681061779](https://github.com/develNor/ros_communication_devcontainer/actions/runs/31681061779):
9.6 min wall, 7.30 min slowest slice, 79.3 runner-minutes of e2e).

## The decision #240 asked for, and the answer

> whether the e2e image and the deployed image may differ, and who owns the risk

They may not, and this PR does not make them. Every config the suite builds from
moves together, including the packaged default that `deployment-configuration.md`
ships to peers — so CI keeps testing what ships.

What is given up is the desktop stack on a deployed peer. Nothing rosotacom ships
uses it: `enable_gui_forwarding` is `false` in the packaged config and in the FZI
project that runs on the vehicles, and a project that wants `rviz2` declares it in
`APT_PACKAGES` like everything else it needs. The base is also what a **cold peer**
builds — `_build_image` without `ROSOTACOM_IMAGE_CACHE` is still `ros2docker
build` — so this takes ~1.1 GB off a vehicle's link on first deployment, at the
cost of more `apt` over that same link.

## Validation

- `just check` green locally (683 unit + contract tests), which does not build an
  image and therefore says nothing about the question; the thirteen e2e slices do.
- `tests/contract/test_packaged_resources.py` now asserts the base and
  `ros-kilted-gps-msgs`, so the undeclared dependency cannot come back silently.

## Owner smoke

```bash
just setup && .venv/bin/rosotacom image references \
  --project "$(.venv/bin/rosotacom resources path examples)/rosotacom.yaml" \
  --repository ghcr.io/develnor/rosotacom-e2e
```

Expected: two references whose tags differ from the two published today, because
the base digest and `APT_PACKAGES` are part of the hash. Pull one and check the
size is a few hundred MB rather than 1.5 GB.
