### PR TITLE
Validate scenario host paths where the application starts, not at parse

### DIFF
--- a/src/rosotacom/cli.py
+++ b/src/rosotacom/cli.py
@@ -4350,7 +4350,13 @@ def _load_scenario_definition(resolved: ResolvedScenario) -> ScenarioDefinition:
             assert config_path is not None
             if not config_path.is_file():
                 raise RuntimeError(f"{context}.ros2docker_config must resolve to a file: {config_path}")
-            load_config(config_path)
+            # Structural validation only. A definition names applications for
+            # every peer, and a `-v` host path (a staged replay bag, a local
+            # workspace) is only required to exist on the machine that starts
+            # that application — which validates it in `_run-application`.
+            # Resolving run args here would make every peer demand every other
+            # peer's machine-local artifacts (#249).
+            load_config(config_path, resolve_run_args=False)
             seen_names.add(name)
             parsed_entries.append(ScenarioApplication(name=name, ros2docker_config=config_path))
         applications[identity] = tuple(parsed_entries)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -411,6 +411,40 @@ def test_scenario_definition_resolves_and_validates_strictly(tmp_path: Path) -> 
         rosotacom._load_scenario_definition(resolved)
 
 
+def test_scenario_definition_ignores_foreign_peers_host_paths(tmp_path: Path) -> None:
+    """Loading a definition must not require other peers' machine-local mounts.
+
+    Application b mounts a host path that exists only on b's machine (a staged
+    replay bag). Peer a still has to be able to parse the definition and start
+    its own applications; the mount is validated where b actually starts
+    (#249).
+    """
+    runtime, resolved = _write_test_scenario_project(tmp_path)
+    foreign_config = tmp_path / "apps" / "b.json"
+    foreign_config.write_text(
+        "\n".join(
+            [
+                "{",
+                '  "container_name": "b_app",',
+                '  "run_type": "command",',
+                '  "command": ["true"],',
+                '  "run_args": ["-v", "./only-on-machine-b:/bag:ro"]',
+                "}",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    definition = rosotacom._load_scenario_definition(resolved)
+    assert definition.applications["b"][0].name == "local_app"
+
+    # The start path still refuses the missing mount on the machine that runs
+    # the application: full resolution stays where it is meaningful.
+    with pytest.raises(FileNotFoundError, match="Host path does not exist"):
+        rosotacom.load_config(foreign_config)
+
+
 def test_scenario_name_completion_uses_active_project(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
Closes #249.

`_parse_scenario_definition` loaded every application's ros2docker config with run-arg resolution on, so every peer demanded that every other peer's `-v` host paths exist locally. On a two-host scenario that is wrong by construction: the staged replay bag exists only on the vehicle machine, and the center peer refused to start its own `center_logic` over the vehicle's mount (first hit live today, majestic vehicle + seat center, ccng_e2e). Git-tracked metadata stubs masked this for months by making the paths exist everywhere — the same stubs that let a replay silently play nothing.

- Definition load now parses foreign configs structurally (`resolve_run_args=False`).
- The start path (`_run-application` → build/run) still resolves and validates mounts on the machine that actually runs the application; the new unit test pins both halves.

Unit suite: 155 passed.