### PR TITLE
Stop making the e2e slices wait for a barrier that fired once in sixty runs (#248)

### DIFF
--- a/.github/actions/setup-just/action.yml
+++ b/.github/actions/setup-just/action.yml
@@ -1,0 +1,34 @@
+name: Set up just
+description: >
+  Install a pinned just release, verified by checksum.
+
+  Nineteen jobs used to reach it with `apt-get update && apt-get install -y
+  just`, and almost all of that step's 9-15s was the index refresh — in every
+  job, including all thirteen e2e slices, where it sat on the merge gate's
+  critical path. A release tarball is ~2s.
+
+  It also stops the CI toolchain drifting: apt gave whatever noble currently
+  ships (1.21.0 at the time of writing), which changes without anything here
+  saying so.
+
+runs:
+  using: composite
+  steps:
+    - name: Install just
+      shell: bash
+      run: |
+        set -euo pipefail
+        JUST_VERSION="1.58.0"
+        CHECKSUM="4a5cc2f53e6f0f8c59092a6cc38291eb729d46a7dd95d3ae582008881b84931d"
+        URL="https://github.com/casey/just/releases/download/${JUST_VERSION}/just-${JUST_VERSION}-x86_64-unknown-linux-musl.tar.gz"
+        # Unpacked outside the checkout: a stray tarball in the working tree is
+        # a thing every later step has to not trip over.
+        workdir="$(mktemp -d)"
+        # --fail, or a transient HTTP error body is saved as the tarball and
+        # reported as a checksum mismatch, which reads like a tampered release.
+        curl -sSLf --retry 3 --retry-all-errors -o "$workdir/just.tar.gz" "$URL"
+        echo "${CHECKSUM}  $workdir/just.tar.gz" | sha256sum --check
+        tar -xzf "$workdir/just.tar.gz" -C "$workdir" just
+        sudo mv "$workdir/just" /usr/local/bin/just
+        rm -rf "$workdir"
+        just --version

--- a/.github/workflows/benchmark-calibrate.yml
+++ b/.github/workflows/benchmark-calibrate.yml
@@ -44,9 +44,7 @@ jobs:
           cache: pip
 
       - name: Install just
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y just
+        uses: ./.github/actions/setup-just
 
       - name: Set up local environment
         run: just setup
@@ -87,10 +85,15 @@ jobs:
           python-version: "3.12"
           cache: pip
 
-      - name: Install just and tmux
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y just tmux
+      - name: Install just
+        uses: ./.github/actions/setup-just
+
+      - name: Ensure tmux
+        # Preinstalled on the GitHub-hosted image, so this is a probe
+        # rather than an install — but the dependency is named, so a
+        # runner image that drops it fails here instead of inside a
+        # session.
+        run: command -v tmux >/dev/null || { sudo apt-get update && sudo apt-get install -y tmux; }
 
       - name: Set up local environment
         run: just setup
@@ -132,9 +135,7 @@ jobs:
           cache: pip
 
       - name: Install just
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y just
+        uses: ./.github/actions/setup-just
 
       - name: Set up local environment
         run: just setup

--- a/.github/workflows/benchmark-gate.yml
+++ b/.github/workflows/benchmark-gate.yml
@@ -50,9 +50,7 @@ jobs:
           cache: pip
 
       - name: Install just
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y just
+        uses: ./.github/actions/setup-just
 
       - name: Set up local environment
         run: just setup
@@ -87,10 +85,15 @@ jobs:
           python-version: "3.12"
           cache: pip
 
-      - name: Install just and tmux
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y just tmux
+      - name: Install just
+        uses: ./.github/actions/setup-just
+
+      - name: Ensure tmux
+        # Preinstalled on the GitHub-hosted image, so this is a probe
+        # rather than an install — but the dependency is named, so a
+        # runner image that drops it fails here instead of inside a
+        # session.
+        run: command -v tmux >/dev/null || { sudo apt-get update && sudo apt-get install -y tmux; }
 
       - name: Set up local environment
         run: just setup
@@ -142,9 +145,7 @@ jobs:
           cache: pip
 
       - name: Install just
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y just
+        uses: ./.github/actions/setup-just
 
       - name: Set up local environment
         run: just setup

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -71,9 +71,7 @@ jobs:
           cache: pip
 
       - name: Install just
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y just
+        uses: ./.github/actions/setup-just
 
       - name: Set up local environment
         run: just setup

--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -33,9 +33,7 @@ jobs:
           cache: pip
 
       - name: Install just
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y just
+        uses: ./.github/actions/setup-just
 
       - name: Set up local environment
         run: just setup

--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -51,10 +51,15 @@ jobs:
           python-version: "3.12"
           cache: pip
 
-      - name: Install just and tmux
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y just tmux
+      - name: Install just
+        uses: ./.github/actions/setup-just
+
+      - name: Ensure tmux
+        # Preinstalled on the GitHub-hosted image, so this is a probe
+        # rather than an install — but the dependency is named, so a
+        # runner image that drops it fails here instead of inside a
+        # session.
+        run: command -v tmux >/dev/null || { sudo apt-get update && sudo apt-get install -y tmux; }
 
       - name: Set up local environment
         run: just setup
@@ -98,10 +103,15 @@ jobs:
           python-version: "3.12"
           cache: pip
 
-      - name: Install just and tmux
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y just tmux
+      - name: Install just
+        uses: ./.github/actions/setup-just
+
+      - name: Ensure tmux
+        # Preinstalled on the GitHub-hosted image, so this is a probe
+        # rather than an install — but the dependency is named, so a
+        # runner image that drops it fails here instead of inside a
+        # session.
+        run: command -v tmux >/dev/null || { sudo apt-get update && sudo apt-get install -y tmux; }
 
       - name: Set up local environment
         run: just setup

--- a/.github/workflows/pr-lightweight.yml
+++ b/.github/workflows/pr-lightweight.yml
@@ -29,9 +29,7 @@ jobs:
           cache: pip
 
       - name: Install just
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y just
+        uses: ./.github/actions/setup-just
 
       - name: Set up local environment
         run: just setup

--- a/.github/workflows/pr-merge-gate.yml
+++ b/.github/workflows/pr-merge-gate.yml
@@ -71,9 +71,7 @@ jobs:
           cache: pip
 
       - name: Install just
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y just
+        uses: ./.github/actions/setup-just
 
       - name: Set up local environment
         run: just setup
@@ -102,9 +100,7 @@ jobs:
           cache: pip
 
       - name: Install just
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y just
+        uses: ./.github/actions/setup-just
 
       - name: Set up local environment
         run: just setup
@@ -152,9 +148,7 @@ jobs:
           cache: pip
 
       - name: Install just
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y just
+        uses: ./.github/actions/setup-just
 
       - name: Set up local environment
         run: just setup
@@ -162,35 +156,46 @@ jobs:
       - name: Validate package
         run: just package
 
-  preflight-success:
-    name: preflight-success
+  quick-gate:
+    # Everything `e2e` waits for that is not the image, and deliberately no
+    # more. It exists to answer one question — is the tree obviously broken,
+    # such that thirteen slices would burn seventy runner-minutes to say so.
+    #
+    # It replaced a `needs: preflight-success` edge that made e2e wait for the
+    # whole five-version matrix. That barrier cost 2.15 min of every gate run
+    # and had fired once in sixty runs, on `workflow-lint`, which takes 0.12
+    # min; the 2.0 min of `merge-lightweight` that set its height has never
+    # stopped an e2e round, and its expensive part is `test-nondocker-cov`
+    # (38s of 45s), which is a test suite rather than a tripwire.
+    #
+    # `lint` and `typecheck` are 4s together. The rest of this job is the fixed
+    # cost every job pays, which is also what `image` pays — so sizing the
+    # tripwire this way makes it free: e2e could not start before `image`
+    # finished anyway. Nothing merges on a weaker check than before, because
+    # `ci-success` still requires every preflight job.
+    name: quick-gate
     runs-on: ubuntu-latest
-    needs: [workflow-lint, dependency-review, build-lint, merge-lightweight, package]
-    if: always() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     steps:
-      - name: Check preflight jobs
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install just
+        uses: ./.github/actions/setup-just
+
+      - name: Set up local environment
+        run: just setup
+
+      - name: Is the tree obviously broken
         run: |
-          if [[ "${{ needs.workflow-lint.result }}" != "success" ]]; then
-            echo "workflow-lint failed: ${{ needs.workflow-lint.result }}"
-            exit 1
-          fi
-          if [[ "${{ github.event_name }}" == "pull_request" && "${{ needs.dependency-review.result }}" != "success" ]]; then
-            echo "dependency-review failed: ${{ needs.dependency-review.result }}"
-            exit 1
-          fi
-          if [[ "${{ needs.build-lint.result }}" != "success" ]]; then
-            echo "build-lint failed: ${{ needs.build-lint.result }}"
-            exit 1
-          fi
-          if [[ "${{ needs.merge-lightweight.result }}" != "success" ]]; then
-            echo "merge-lightweight failed: ${{ needs.merge-lightweight.result }}"
-            exit 1
-          fi
-          if [[ "${{ needs.package.result }}" != "success" ]]; then
-            echo "package failed: ${{ needs.package.result }}"
-            exit 1
-          fi
-          echo "All preflight checks passed"
+          just lint
+          just typecheck
 
   image:
     # Publish the images the e2e suite builds, once per set of build inputs,
@@ -208,8 +213,9 @@ jobs:
     # is stale" is not a state this can reach — which is the objection #226
     # raised against caching the image inline.
     #
-    # Runs beside preflight rather than after it: on a hit it inspects two
-    # manifests and stops, so it is never on the critical path.
+    # Runs beside the preflight jobs rather than after them: on a hit it
+    # inspects two manifests and stops. It is what sets when `e2e` can
+    # start, which is why `quick-gate` is sized to finish inside it.
     name: image
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -231,9 +237,7 @@ jobs:
           cache: pip
 
       - name: Install just
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y just
+        uses: ./.github/actions/setup-just
 
       - name: Set up local environment
         run: just setup
@@ -300,8 +304,8 @@ jobs:
     name: e2e-${{ matrix.slice }}
     runs-on: ubuntu-latest
     timeout-minutes: 90
-    needs: [preflight-success, image]
-    if: always() && !cancelled() && needs.preflight-success.result == 'success' && needs.image.result == 'success'
+    needs: [quick-gate, image]
+    if: always() && !cancelled() && needs.quick-gate.result == 'success' && needs.image.result == 'success'
     permissions:
       contents: read
       packages: read
@@ -322,10 +326,15 @@ jobs:
           python-version: "3.12"
           cache: pip
 
-      - name: Install just and tmux
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y just tmux
+      - name: Install just
+        uses: ./.github/actions/setup-just
+
+      - name: Ensure tmux
+        # Preinstalled on the GitHub-hosted image, so this is a probe
+        # rather than an install — but the dependency is named, so a
+        # runner image that drops it fails here instead of inside a
+        # session.
+        run: command -v tmux >/dev/null || { sudo apt-get update && sudo apt-get install -y tmux; }
 
       - name: Set up local environment
         run: just setup
@@ -364,7 +373,7 @@ jobs:
       - build-lint
       - merge-lightweight
       - package
-      - preflight-success
+      - quick-gate
       - image
       - e2e
     if: always() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
@@ -392,8 +401,8 @@ jobs:
             echo "package failed or was skipped: ${{ needs.package.result }}"
             exit 1
           fi
-          if [[ "${{ needs.preflight-success.result }}" != "success" ]]; then
-            echo "preflight-success failed or was skipped: ${{ needs.preflight-success.result }}"
+          if [[ "${{ needs.quick-gate.result }}" != "success" ]]; then
+            echo "quick-gate failed or was skipped: ${{ needs.quick-gate.result }}"
             exit 1
           fi
           if [[ "${{ needs.image.result }}" != "success" ]]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,9 +35,7 @@ jobs:
           cache: pip
 
       - name: Install just
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y just
+        uses: ./.github/actions/setup-just
 
       - name: Set up local environment
         run: just setup
@@ -67,9 +65,7 @@ jobs:
           cache: pip
 
       - name: Install just
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y just
+        uses: ./.github/actions/setup-just
 
       - name: Set up local environment
         run: just setup
@@ -139,10 +135,15 @@ jobs:
           python-version: "3.12"
           cache: pip
 
-      - name: Install just and tmux
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y just tmux
+      - name: Install just
+        uses: ./.github/actions/setup-just
+
+      - name: Ensure tmux
+        # Preinstalled on the GitHub-hosted image, so this is a probe
+        # rather than an install — but the dependency is named, so a
+        # runner image that drops it fails here instead of inside a
+        # session.
+        run: command -v tmux >/dev/null || { sudo apt-get update && sudo apt-get install -y tmux; }
 
       - name: Set up local environment
         run: just setup

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -48,6 +48,31 @@ The merge gate runs workflow lint, dependency/security review, runtime/build ass
 Python 3.10–3.14 are supported for the host CLI; Python 3.12 is the reference
 interpreter for packaging and Docker E2E jobs.
 
+### What the e2e slices wait for
+
+Every job in the gate starts at once — there is no runner contention — so the
+only thing that decides when the thirteen slices start is their `needs`. They
+wait for exactly two jobs:
+
+- **`image`**, because a slice adopts the published image rather than building
+  it, so it cannot start before that image is known to exist. On a hit this is
+  two manifest inspections, and it is what sets the floor.
+- **`quick-gate`**, `just lint && just typecheck` on one interpreter: the
+  cheapest signal that the tree is not obviously broken, so thirteen runners do
+  not spend seventy minutes discovering a syntax error. Four seconds of work,
+  sized to finish inside `image` and therefore free.
+
+They used to wait for `preflight-success`, which meant the whole five-version
+`merge-lightweight` matrix, and that cost **2.15 min of every gate run**.
+Measured against the sixty runs before #248, it had stopped an e2e round once,
+on `workflow-lint` — 0.12 min of the 2.15. Nothing about what may merge
+changed: `ci-success` still requires `workflow-lint`, `build-lint`,
+`merge-lightweight`, `package`, `quick-gate`, `image`, and `e2e`, and it is the
+only required check in branch protection.
+
+`tests/contract/test_workflow_contracts.py::test_e2e_waits_only_for_the_cheap_gate_and_the_image`
+keeps the barrier from growing back.
+
 ```bash
 just lint-workflows
 just lint-build
@@ -159,26 +184,35 @@ with a usage error, and a test owned twice fails
 
 The costs are warm pytest `call` durations — medians over seven merge-gate runs
 of 2026-08-11/12. On top of them each job pays a fixed
-`RUNNER_SETUP_SECONDS + IMAGE_BUILD_SECONDS` (2m05s: 55s of runner setup, then
+`RUNNER_SETUP_SECONDS + IMAGE_BUILD_SECONDS` (1m19s: 46s outside the tests, then
 the project image obtained inside whichever test runs first). Because that
 constant is per job and not per test, balancing warm costs balances wall clock.
 
 `IMAGE_BUILD_SECONDS` models the merge gate, where that image is pulled rather
 than built (see above); the release and nightly lanes still build and pay the
-older 154s. One slice does not currently reproduce its recorded split: `media`
-spends about 24s more than its two costs predict, and it is the critical path,
-so it is the first thing to remeasure.
+older 154s. It has now been re-measured twice, because both changes that made
+it smaller were changes to what a job moves rather than to what it runs: 154 →
+70 when #236 replaced the build with a pull, and 70 → 33 when #245 rebased the
+image on `ros-base` and the published project image went 1640 MB → 957 MB.
+Runs 31681061779 and 31687149587 ran the same partition either side of that, so
+the paired per-slice difference measures it directly: median −37.4s over all
+thirteen.
 
 ### How many slices
 
 `floor_seconds()` is `fixed + slowest single test` — the fastest any partition
 of this suite could be, because one job has to run that test and pays the fixed
-cost like every other. It is currently **6m32s**, of which 1m10s is the image
-(7m56s before #236 published it instead of rebuilding it per job).
+cost like every other. It is currently **5m47s**, of which 33s is the image
+(7m56s before #236 published it instead of rebuilding it per job, 6m32s before
+#245 shrank it).
 
-Thirteen slices sit at 7m14s, 1.11x the floor. That is the point of choosing N
-from the numbers rather than from taste: six balanced slices were 13m37s,
-twelve reach the floor, and past twelve every extra job is pure cost. The
+Thirteen slices sit at 6m26s, **1.12x** the floor. That is the point of choosing
+N from the numbers rather than from taste: six balanced slices were 13m37s,
+twelve reach the floor, and past twelve every extra job is pure cost. Note that
+1.12x is now a partition problem rather than a count problem — thirteen slices
+*can* reach 1.00x, and the current assignment does not, because `occupancy-grid`
+holds two 150s tests. The fixed cost falling twice is what exposed it: the same
+partition was 1.11x of a floor that was a minute and a half higher. The
 contract test asserts distance to the floor rather than the spread between
 slices — spread is compressed toward 1.0 by the fixed cost as N grows, so it
 keeps reading fine while the gate stops improving.

--- a/tests/contract/test_security_maintenance_config.py
+++ b/tests/contract/test_security_maintenance_config.py
@@ -92,7 +92,7 @@ def test_merge_gate_requires_new_ci_jobs_and_no_masking() -> None:
         "build-lint",
         "merge-lightweight",
         "package",
-        "preflight-success",
+        "quick-gate",
         "image",
         "e2e",
     }
@@ -101,9 +101,9 @@ def test_merge_gate_requires_new_ci_jobs_and_no_masking() -> None:
     # Both gates the e2e slices wait on have to be green before any slice runs,
     # and the `if` has to say so job by job: `needs` alone does not stop a
     # dependency's failure from reaching a job that runs with `always()`.
-    assert set(jobs["e2e"]["needs"]) == {"preflight-success", "image"}
+    assert set(jobs["e2e"]["needs"]) == {"quick-gate", "image"}
     assert jobs["e2e"]["if"] == (
-        "always() && !cancelled() && needs.preflight-success.result == 'success' && needs.image.result == 'success'"
+        "always() && !cancelled() && needs.quick-gate.result == 'success' && needs.image.result == 'success'"
     )
 
     # Every needed job's result must be turned into an exit code by hand,

--- a/tests/contract/test_workflow_contracts.py
+++ b/tests/contract/test_workflow_contracts.py
@@ -414,3 +414,57 @@ def test_an_unowned_e2e_test_fails_every_slice_job() -> None:
 
     assert "test_a_test_nobody_assigned" in str(excinfo.value)
     assert "E2E_SLICES" in str(excinfo.value)
+
+
+def test_every_workflow_installs_just_the_same_pinned_way() -> None:
+    """`apt-get update` cost 9-15s in nineteen jobs to install one binary.
+
+    It was also the only unpinned tool in CI: apt gave whatever noble shipped
+    that week, so the `just` the gate ran changed without any commit saying so.
+    Both are fixed by the shared action, and both come back the moment one
+    workflow reintroduces the apt line — which is what this asserts.
+    """
+    offenders = [
+        path.name
+        for path in sorted(WORKFLOWS_DIR.glob("*.yml"))
+        if "install -y just" in path.read_text(encoding="utf-8")
+    ]
+    assert not offenders, "these workflows install just from apt instead of ./.github/actions/setup-just: " + ", ".join(
+        offenders
+    )
+
+    action = PACKAGE_ROOT / ".github" / "actions" / "setup-just" / "action.yml"
+    assert action.is_file(), "the shared setup-just action every workflow refers to does not exist"
+    body = action.read_text(encoding="utf-8")
+    assert "sha256sum --check" in body, "setup-just must verify the release it downloads"
+
+
+def test_e2e_waits_only_for_the_cheap_gate_and_the_image() -> None:
+    """The barrier `e2e` waits on has to stay cheaper than the image it also
+    waits on, or it starts costing wall clock again.
+
+    `needs: preflight-success` made every gate run wait 2.15 min for the
+    five-version `merge-lightweight` matrix. It had stopped an e2e round once
+    in sixty runs — on `workflow-lint`, which takes 0.12 min. `ci-success`
+    still requires every preflight job, so this is a change to when thirteen
+    runners start, not to what may merge.
+    """
+    workflow = yaml.safe_load((WORKFLOWS_DIR / "pr-merge-gate.yml").read_text(encoding="utf-8"))
+    jobs = workflow["jobs"]
+
+    assert set(jobs["e2e"]["needs"]) == {"quick-gate", "image"}, (
+        f"e2e must wait for the cheap tripwire and the image, and nothing else: {jobs['e2e']['needs']}"
+    )
+
+    quick_gate_work = "\n".join(_workflow_run_blocks(jobs["quick-gate"]))
+    expensive = [
+        recipe for recipe in ("test-nondocker-cov", "test", "docs", "package") if f"just {recipe}" in quick_gate_work
+    ]
+    assert not expensive, "quick-gate exists to be cheaper than the image job, so it must not run: " + ", ".join(
+        expensive
+    )
+
+    # And the jobs it stopped gating are still required to merge.
+    ci_success = jobs["ci-success"]
+    for name in ("workflow-lint", "build-lint", "merge-lightweight", "package"):
+        assert name in ci_success["needs"], f"{name} no longer gates the merge at all"

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -26,10 +26,15 @@ import os
 
 import pytest
 
-#: Seconds a job spends before pytest starts: checkout, Python, `just setup`,
-#: `docker info`. Measured across the e2e jobs of merge-gate runs 31597657446
-#: and 31634604888 (43-60s).
-RUNNER_SETUP_SECONDS = 55.0
+#: Seconds a job spends outside the tests: checkout, Python, `just setup`,
+#: `docker info`, plus pytest's own setup and teardown phases.
+#:
+#: 46.0 as `job wall − Σ call` over the thirteen e2e jobs of run 31687149587,
+#: median 45.3s, mean 49.3s. It was 55.0, measured the same way on runs
+#: 31597657446 and 31634604888; #248 then replaced `apt-get update &&
+#: apt-get install -y just` with a pinned release binary, which is most of the
+#: difference.
+RUNNER_SETUP_SECONDS = 46.0
 
 #: Seconds the first test in a job pays to get the rosotacom project image.
 #: Every job pays it exactly once, whichever test runs first, so it is a
@@ -43,19 +48,19 @@ RUNNER_SETUP_SECONDS = 55.0
 #: release and nightly lanes still build from scratch, deliberately, as the
 #: check that a published image and a fresh build still agree.
 #:
-#: 70.0 from run 31678648935, two estimators agreeing. Per slice, (sum of
-#: measured `call` durations − sum of the warm costs below) has a median of
-#: 67.2s over the twelve slices that behaved (43.8–77.8s). Per test, the twelve
-#: tests that run first in their job each dropped 74–119s against their median
-#: over three earlier runs, median −84s, i.e. 154 − 84 = 70.
+#: 70.0 was that pull with a `desktop-full` base. #245 rebased the image on
+#: `ros-base`, taking the published project image from 1640 MB to 957 MB, and a
+#: pull costs what it moves.
 #:
-#: `media` is the thirteenth and did not behave: it got 57s *slower*, all of it
-#: in `test_synthetic_camera_pipeline_records_quality_metrics` (+72s) while its
-#: sibling moved +2s. Its two recorded costs below do not reproduce either —
-#: they sum ~24s short of what the job actually spends — so that slice needs a
-#: measurement of its own rather than a number derived from one anomalous run.
-#: It is currently the critical path.
-IMAGE_BUILD_SECONDS = 70.0
+#: 33.0 from three estimators on runs 31681061779 (before) and 31687149587
+#: (after), which ran the same partition on either side of #245. The paired
+#: difference is the cleanest of them, because the tests are unchanged and only
+#: one test per job pays this: per-slice Σ `call` fell by a median of 37.4s
+#: (mean 37.6s) across all thirteen, i.e. 70 − 37 = 33. The three single-test
+#: slices give it directly as `call − recorded cost`: 34.0s (`benchmark-ab`),
+#: 40.4s (`benchmark-replay`), 22.5s (`remote-assist`). And the resulting model
+#: predicts the measured critical path to within 0.14 min.
+IMAGE_BUILD_SECONDS = 33.0
 
 #: Every e2e test, the slice that owns it, and its *warm* pytest `call` duration
 #: in seconds — the median over seven runs of the invocations where the project


### PR DESCRIPTION
Closes #248.

## The measurement this starts from

Post-#245 develop run ([31687149587](https://github.com/develNor/ros_communication_devcontainer/actions/runs/31687149587), 8.97 min). Queue times are 0.03-0.17 min throughout, so nothing here is runner contention — the ordering is entirely `needs`:

```
t=0.00  every preflight job and `image` start
t=0.85  image done
t=2.02  preflight-success done  (bound by merge-lightweight (3.10) at 2.00)
t=2.15  all 13 e2e slices start
t=8.85  e2e-occupancy-grid done (6.60 min)
t=8.97  ci-success
```

## What the barrier was worth

Not correctness — `ci-success` requires every preflight job either way, and it is the only check in the branch ruleset. It was a cost gate. Over the last sixty CI runs (4 failures):

| run | failed in |
|---|---|
| 31674583168 | `e2e-concurrency` |
| 31640114259 | `e2e-occupancy-grid`, `e2e-remote-assist` |
| 31634275150 | **`workflow-lint`** (0.12 min) |
| 31481339452 | `e2e-runtime-tools` |

Once in sixty, on the cheapest check in the set. The 2.0 min of `merge-lightweight` that set the barrier's height has never stopped an e2e round, and 38 of its 45s are `test-nondocker-cov` — a test suite, not a tripwire.

## What replaces it

`e2e` needs `[quick-gate, image]`. A slice cannot start before `image` regardless, because it adopts a published image rather than building one, and `image` is 0.85 min warm. So a job running `just lint && just typecheck` (4s of work on top of the fixed per-job cost) finishes inside a wait that already existed, and is free.

`preflight-success` had no other consumer and is deleted rather than kept as a job that re-checks what `ci-success` checks.

## Two smaller things, measured on the way

**`apt-get update` in nineteen jobs.** `Install just` was 9-15s in every job, nearly all of it the index refresh, including all thirteen e2e slices. The logs show tmux was never actually installed — `tmux is already the newest version (3.4-1ubuntu0.1)`, `0 upgraded, 1 newly installed` — so the whole step existed to fetch one binary. `./.github/actions/setup-just` downloads a pinned release with a checksum (~2s), the pattern this workflow already uses for actionlint, and tmux becomes an explicit probe so a runner image that drops it fails there rather than inside a session. It also stops the toolchain drifting: apt gave 1.21.0 against upstream 1.58.0, changing whenever noble does.

**The e2e cost model, which #245 invalidated.** `IMAGE_BUILD_SECONDS` was corrected 154 → 70 by #236; #245 then took the published project image 1640 MB → 957 MB. Runs [31681061779](https://github.com/develNor/ros_communication_devcontainer/actions/runs/31681061779) and [31687149587](https://github.com/develNor/ros_communication_devcontainer/actions/runs/31687149587) ran the same partition either side of it, so the paired per-slice difference measures the pull directly rather than modelling it: **median −37.4s** (mean −37.6s) over all thirteen slices, so 33. The three single-test slices agree independently (34.0 / 40.4 / 22.5s). `RUNNER_SETUP_SECONDS` is 46, not 55, as `job wall − Σ call` (median 45.3s, n=13).

## Expected, and what to read off this PR's runs

| | before | expected |
|---|---|---|
| e2e starts at | 2.15 min | ~0.75 min |
| slowest slice | 6.60 min | ~6.43 min |
| gate | 8.97 min | ~7.3 min |

## What this deliberately does not do

Corrected constants put the floor at 5m47s and the current thirteen-slice partition at 6m26s — **1.12x**, where the same thirteen slices reach 1.00x under LPT. The blocker is `occupancy-grid`: it owns two ~150s tests and no other slice has room for either. That is another 0.69 min and it is a repartition with its own trade (a cost-optimal assignment scrambles which tests sit behind which slice name), so it gets its own issue rather than riding along here.

## Validation

- `just setup && just check` green locally, 685 unit + contract tests, `lint-workflows` included — so actionlint accepts the composite action.
- The pinned tarball was verified end to end before pushing: checksum OK, `just 1.58.0`, and `just --list` against this repository's justfile.
- Two new contract tests: `test_every_workflow_installs_just_the_same_pinned_way` (the apt line cannot come back, and the action must verify what it downloads) and `test_e2e_waits_only_for_the_cheap_gate_and_the_image` (the barrier cannot grow back, and the jobs it stopped gating are still required to merge). `test_merge_gate_requires_new_ci_jobs_and_no_masking` follows the rename.

## Owner smoke

```bash
gh run list --workflow CI --branch develop --limit 3 --json databaseId --jq '.[].databaseId' | while read -r id; do
  gh api "repos/develNor/ros_communication_devcontainer/actions/runs/$id/jobs?per_page=100" \
    --jq '[.jobs[] | select(.name|startswith("e2e-")) | .started_at] | min'
done
```

Expected: on runs after this lands, the first e2e job starts under a minute after the run does, against 2.15 min before.
