### PR TITLE
ota-smoke: wait for the com container name the start actually gives

### DIFF
--- a/src/rosotacom/cli.py
+++ b/src/rosotacom/cli.py
@@ -3661,14 +3661,29 @@ def _ota_wait_for_running_container_suffix_script(suffix: str, label: str, timeo
     )
 
 
+def _ota_communication_wait_suffix(runtime: RuntimeConfig, remote_peer_name: str) -> str:
+    """What the application windows wait for, following `_container_name`.
+
+    The wait must make the same naming decision the start makes, or it waits
+    forever for a name that will never exist: a project with
+    `com_container_prefix` names its com container `<prefix>_com-to-<peer>`,
+    and the instance-scoped `_com_to_<peer>` suffix matches nothing (#254).
+    """
+    fixed = _fixed_com_container_name(runtime, remote_peer_name)
+    if fixed is not None:
+        return fixed
+    return _sanitize_docker_name(f"_com_to_{remote_peer_name}")
+
+
 def _ota_application_run_script(
     plan: OtaSmokePlan,
     target: InteractiveSmokeTarget,
     peer_name: str,
     application: ScenarioApplication,
     instance_id: str,
+    runtime: RuntimeConfig,
 ) -> str:
-    communication_suffix = _sanitize_docker_name(f"_com_to_{_remote_peer_name(target.cfg, peer_name)}")
+    communication_suffix = _ota_communication_wait_suffix(runtime, _remote_peer_name(target.cfg, peer_name))
     label = f"{peer_name}:{application.name}"
     command = _ota_rosotacom_command(
         plan, _ota_application_parts(target, peer_name, application, instance_id), plan.peers[peer_name]
@@ -3825,7 +3840,7 @@ def _ota_create_tmux(
         for peer in peers:
             for application in target.scenario_definition.applications.get(peer.name, ()):
                 application_script = _ota_application_run_script(
-                    plan, target, peer.name, application, instance.instance_id
+                    plan, target, peer.name, application, instance.instance_id, runtime
                 )
                 created_application = subprocess.run(
                     _tmux_command(

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1085,6 +1085,48 @@ def test_ota_bounded_wait_script_succeeds_once_the_container_runs(tmp_path: Path
     assert f"[INFO] found running container: {container}" in result.stdout
 
 
+def _runtime_with_prefix(tmp_path: Path, prefix_line: str = "") -> rosotacom.RuntimeConfig:
+    (tmp_path / "ros2docker.json").write_text('{"image_name": "test"}\n', encoding="utf-8")
+    config = tmp_path / "rosotacom.yaml"
+    config.write_text(f"ros2docker_config: ros2docker.json\n{prefix_line}", encoding="utf-8")
+    return rosotacom._load_runtime_config(argparse.Namespace(rosotacom_config=str(config)))
+
+
+def test_ota_application_wait_matches_the_name_the_start_gives(tmp_path: Path) -> None:
+    """The wait and the start must make the same naming decision, in both modes.
+
+    When `com_container_prefix` was introduced (#247), the start named the com
+    container `<prefix>_com-to-<peer>` while the application windows kept
+    waiting for the instance-scoped `_com_to_<peer>` suffix — so every scenario
+    application waited forever on a healthy machine (#254).
+    """
+    for prefix_line in ("", "com_container_prefix: remote-assist\n"):
+        runtime = _runtime_with_prefix(tmp_path, prefix_line)
+        actual_name = rosotacom._container_name("center", runtime, "run1")
+        suffix = rosotacom._ota_communication_wait_suffix(runtime, "center")
+        assert actual_name.endswith(suffix), (
+            f"wait suffix {suffix!r} does not match the started container {actual_name!r}"
+        )
+
+
+def test_ota_application_wait_script_finds_the_prefixed_container(tmp_path: Path) -> None:
+    runtime = _runtime_with_prefix(tmp_path, "com_container_prefix: remote-assist\n")
+    container = rosotacom._container_name("center", runtime, "run1")
+    assert container == "remote-assist_com-to-center"
+
+    script = rosotacom._ota_wait_for_running_container_suffix_script(
+        rosotacom._ota_communication_wait_suffix(runtime, "center"),
+        "vehicle:communication",
+        timeout_s=2,
+    )
+    result = subprocess.run(
+        ["bash", "-c", script], env=_wait_script_env(tmp_path, container), text=True, capture_output=True
+    )
+
+    assert result.returncode == 0
+    assert f"[INFO] found running container: {container}" in result.stdout
+
+
 def test_ota_wait_for_scenario_applications_waits_per_declared_application(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
Closes #254.

With `com_container_prefix` set (#247), `_container_name` gives the com container its fixed name `<prefix>_com-to-<peer>`, but `_ota_application_run_script` kept waiting for the instance-scoped `_com_to_<peer>` suffix — so on a healthy two-host run every scenario application looped on `waiting for running container: <peer>:communication` forever and the verification died after its 600 s bound. Found live by the fleet_mgmt 4-container test (seat centre / majestic vehicle, 2026-08-13, instance `1b69e2bb`) on 2.5.dev26, the first pinned version to carry the key.

The wait now goes through `_ota_communication_wait_suffix`, which follows `_fixed_com_container_name` first and falls back to the instance-scoped suffix — the same decision the start makes.

Validation: `tests/unit/test_cli.py` pins the invariant that the wait suffix matches whatever `_container_name` produces, in both naming modes, plus an executable wait-script check against a docker stub returning `remote-assist_com-to-center`. Full unit suite: 159 passed.