### PR TITLE
Split E2E CI by diagnostic theme

### DIFF
--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -19,25 +19,43 @@ concurrency:
 
 jobs:
   smoke-e2e:
-    # The same six slices the merge gate and the release run, instead of one
+    # The same diagnostic slices the merge gate and the release run, instead of one
     # sequential `just test-e2e-smoke` over the whole suite (#198). Keeping the
     # monolith here was deliberate while the slices were hand-maintained `-k`
     # expressions that had silently stopped covering three files; #197's
     # test_e2e_slices_partition_the_whole_suite closed that, so the union is
     # now guaranteed to be the monolith.
     #
-    # The gain is diagnosis: a red monolith says "e2e broke", six slices say
-    # which area did. It also removes a load-induced flake. On 2026-08-11 the
+    # The gain is diagnosis: a red monolith says "e2e broke"; a named slice says
+    # which area and, where relevant, which transport or behavior failed. It
+    # also removes a load-induced flake. On 2026-08-11 the
     # nightly failed with nine "Timed out waiting for container readiness"
     # errors after 1h12m on one runner, while the same tests on the same commit
-    # passed in the merge gate — where they are spread over six.
+    # passed in the merge gate — where they were spread over six at the time.
     name: smoke-e2e-${{ matrix.slice }}
     runs-on: ubuntu-latest
     timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:
-        slice: [heartbeat, chatter, occupancy-grid, sized-payload, remote-assist, remote-assist-streams, runtime-tools, media, concurrency, benchmark-ab, benchmark-replay, benchmark-capacity, benchmark-capacity-cases]
+        slice:
+          - heartbeat
+          - chatter
+          - occupancy-grid-dds
+          - occupancy-grid-zenoh
+          - sized-payload-fastdds
+          - sized-payload-zenoh
+          - remote-assist
+          - remote-assist-costmap
+          - remote-assist-camera
+          - runtime-tools
+          - media
+          - concurrency-parallel
+          - concurrency-conflict
+          - benchmark-ab
+          - benchmark-replay
+          - benchmark-capacity
+          - benchmark-capacity-cases
 
     steps:
       - name: Check out repository

--- a/.github/workflows/pr-merge-gate.yml
+++ b/.github/workflows/pr-merge-gate.yml
@@ -159,7 +159,7 @@ jobs:
   quick-gate:
     # Everything `e2e` waits for that is not the image, and deliberately no
     # more. It exists to answer one question — is the tree obviously broken,
-    # such that thirteen slices would burn seventy runner-minutes to say so.
+    # such that seventeen slices would burn roughly 73 runner-minutes to say so.
     #
     # It replaced a `needs: preflight-success` edge that made e2e wait for the
     # whole five-version matrix. That barrier cost 2.15 min of every gate run
@@ -199,12 +199,12 @@ jobs:
 
   image:
     # Publish the images the e2e suite builds, once per set of build inputs,
-    # instead of rebuilding them in each of thirteen jobs. #236 measured that
-    # build at 154s per job: 57s pulling the multi-GB ROS base from Docker Hub,
-    # 40s exporting layers, 47s of apt and pip. A pull from GHCR — co-located
-    # with the runners, no Hub rate limit, one transfer instead of a transfer
-    # plus a build — replaces all of it, and takes twelve of the thirteen Hub
-    # pulls off the merge gate's critical path.
+    # instead of rebuilding them in every job. #236 measured that build at
+    # 154s per job when the matrix had thirteen jobs: 57s pulling the multi-GB
+    # ROS base from Docker Hub, 40s exporting layers, 47s of apt and pip. A pull
+    # from GHCR — co-located with the runners, no Hub rate limit, one transfer
+    # instead of a transfer plus a build — replaces all of it. The benefit
+    # grows with the diagnostic matrix; seventeen jobs still build only once.
     #
     # The tag is a hash of everything that decides the image (base digest,
     # package lists, Dockerfile, entrypoint, ros2docker version, build UID):
@@ -295,12 +295,12 @@ jobs:
     # tests/contract/test_workflow_contracts.py keeps the three workflows and
     # the justfile agreeing.
     #
-    # The slices are chosen by measured cost, not grouped by theme (#226):
-    # themed slices spanned 7m39s to 18m31s, and one test ran in two of them.
-    # Thirteen rather than six because the model that predicted the balanced
-    # six within 25s also says twelve reaches the floor and more buys nothing
-    # (#235). Which tests a slice owns and what each costs is E2E_SLICES in
-    # tests/e2e/conftest.py — change that, not this line, to move a test.
+    # Slice names are diagnostic boundaries, not cost buckets. Costs tell us
+    # when a theme needs another runner; they never justify packing unrelated
+    # tests together. Seventeen is the smallest theme-preserving partition that
+    # reaches the measured floor: #253 split the four overloaded themes along
+    # transport, stream, or concurrency semantics. Which tests a slice owns and
+    # what each costs is E2E_SLICES in tests/e2e/conftest.py.
     name: e2e-${{ matrix.slice }}
     runs-on: ubuntu-latest
     timeout-minutes: 90
@@ -312,7 +312,24 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        slice: [heartbeat, chatter, occupancy-grid, sized-payload, remote-assist, remote-assist-streams, runtime-tools, media, concurrency, benchmark-ab, benchmark-replay, benchmark-capacity, benchmark-capacity-cases]
+        slice:
+          - heartbeat
+          - chatter
+          - occupancy-grid-dds
+          - occupancy-grid-zenoh
+          - sized-payload-fastdds
+          - sized-payload-zenoh
+          - remote-assist
+          - remote-assist-costmap
+          - remote-assist-camera
+          - runtime-tools
+          - media
+          - concurrency-parallel
+          - concurrency-conflict
+          - benchmark-ab
+          - benchmark-replay
+          - benchmark-capacity
+          - benchmark-capacity-cases
 
     steps:
       - name: Check out repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,7 +110,7 @@ jobs:
           retention-days: 30
 
   e2e:
-    # The same five slices the merge gate runs, in parallel, instead of one
+    # The same diagnostic slices the merge gate runs, in parallel, instead of one
     # sequential `just test-e2e-smoke` over the whole suite. That target is
     # identical to nightly-e2e.yml's smoke-e2e job, so the release used to be
     # the third sequential run of the same tests against the same tree; it
@@ -121,7 +121,24 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        slice: [heartbeat, chatter, occupancy-grid, sized-payload, remote-assist, remote-assist-streams, runtime-tools, media, concurrency, benchmark-ab, benchmark-replay, benchmark-capacity, benchmark-capacity-cases]
+        slice:
+          - heartbeat
+          - chatter
+          - occupancy-grid-dds
+          - occupancy-grid-zenoh
+          - sized-payload-fastdds
+          - sized-payload-zenoh
+          - remote-assist
+          - remote-assist-costmap
+          - remote-assist-camera
+          - runtime-tools
+          - media
+          - concurrency-parallel
+          - concurrency-conflict
+          - benchmark-ab
+          - benchmark-replay
+          - benchmark-capacity
+          - benchmark-capacity-cases
 
     steps:
       - name: Check out repository

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -43,23 +43,22 @@ check is:
 ci-success
 ```
 
-The merge gate runs workflow lint, dependency/security review, runtime/build asset lint, Python 3.10 through 3.14 non-Docker checks, package validation, and the Docker single-machine smoke matrix (one matrix job per slice, thirteen in parallel):
+The merge gate runs workflow lint, dependency/security review, runtime/build asset lint, Python 3.10 through 3.14 non-Docker checks, package validation, and the Docker single-machine smoke matrix (one matrix job per slice, seventeen in parallel):
 
 Python 3.10–3.14 are supported for the host CLI; Python 3.12 is the reference
 interpreter for packaging and Docker E2E jobs.
 
 ### What the e2e slices wait for
 
-Every job in the gate starts at once — there is no runner contention — so the
-only thing that decides when the thirteen slices start is their `needs`. They
+The only explicit barriers before the seventeen slices are their `needs`. They
 wait for exactly two jobs:
 
 - **`image`**, because a slice adopts the published image rather than building
   it, so it cannot start before that image is known to exist. On a hit this is
   two manifest inspections, and it is what sets the floor.
 - **`quick-gate`**, `just lint && just typecheck` on one interpreter: the
-  cheapest signal that the tree is not obviously broken, so thirteen runners do
-  not spend seventy minutes discovering a syntax error. Four seconds of work,
+  cheapest signal that the tree is not obviously broken, so seventeen runners
+  do not spend roughly 73 minutes discovering a syntax error. Four seconds of work,
   sized to finish inside `image` and therefore free.
 
 They used to wait for `preflight-success`, which meant the whole five-version
@@ -84,13 +83,17 @@ just package
 # Parallel E2E lanes, one per slice:
 just test-e2e-slice heartbeat
 just test-e2e-slice chatter
-just test-e2e-slice occupancy-grid
-just test-e2e-slice sized-payload
+just test-e2e-slice occupancy-grid-dds
+just test-e2e-slice occupancy-grid-zenoh
+just test-e2e-slice sized-payload-fastdds
+just test-e2e-slice sized-payload-zenoh
 just test-e2e-slice remote-assist
-just test-e2e-slice remote-assist-streams
+just test-e2e-slice remote-assist-costmap
+just test-e2e-slice remote-assist-camera
 just test-e2e-slice runtime-tools
 just test-e2e-slice media
-just test-e2e-slice concurrency
+just test-e2e-slice concurrency-parallel
+just test-e2e-slice concurrency-conflict
 just test-e2e-slice benchmark-ab
 just test-e2e-slice benchmark-replay
 just test-e2e-slice benchmark-capacity
@@ -102,7 +105,7 @@ Docker E2E is not collected for coverage.
 
 ## Docker E2E
 
-`just test-e2e-smoke` runs the entire local single-machine smoke matrix through Docker. In the CI merge gate, the same collection runs as thirteen parallel
+`just test-e2e-smoke` runs the entire local single-machine smoke matrix through Docker. In the CI merge gate, the same collection runs as seventeen parallel
 jobs, one per slice, named `e2e-<slice>`. Each smoke run writes generated
 config, catmux pane logs, Docker logs when available, and the smoke verification
 log under `session-instances/`; collect that directory as the first debugging
@@ -112,8 +115,9 @@ artifact when an E2E job fails.
 
 Every e2e job used to build the project image from scratch. #236 measured that
 at 154s per job — 57s pulling the multi-GB ROS base from Docker Hub, 40s
-exporting layers, 47s of apt and pip — which at thirteen slices is 33 minutes of
-runner time and thirteen Hub pulls on the critical path of every merge gate.
+exporting layers, 47s of apt and pip — which was 33 minutes of runner time and
+thirteen Hub pulls with the matrix at that time. The image is still published
+only once now that the diagnostic matrix has seventeen jobs.
 
 The `image` job now publishes those images to
 `ghcr.io/<owner>/rosotacom-e2e` and each slice pulls instead of building. GHCR
@@ -165,14 +169,13 @@ Content-addressed tags accumulate in the GHCR package — one per distinct set o
 build inputs, so roughly one per change to the base digest or package lists.
 Nothing prunes them yet.
 
-### Balancing the e2e slices
+### Diagnostic e2e slices
 
 A slice is not its own pytest invocation. `just test-e2e-slice <name>` runs the
 monolith's collection with `--e2e-slice=<name>`, and everything the named slice
 does not own is deselected. Which tests a slice owns, and what each one costs,
 is `E2E_SLICES` in `tests/e2e/conftest.py`; `just e2e-slice-costs` prints the
-resulting balance. Moving a test between slices is one line there — the
-workflow matrices only name slices.
+resulting costs. The workflow matrices only name slices.
 
 That shape exists because the previous one, per-slice file lists and `-k`
 filters, could not say what it ran. `-k "remote_assist"` silently missed the
@@ -182,11 +185,17 @@ twice a run. A partition can do neither: an unowned test fails every slice job
 with a usage error, and a test owned twice fails
 `test_e2e_slices_partition_the_whole_suite`.
 
+The slice name is an advisor: it states the subsystem and, where that is the
+useful first distinction, the transport, stream, or behavior that failed.
+Costs decide when one such theme needs another runner. They do not justify
+moving a test behind an unrelated name just because its duration fits there.
+
 The costs are warm pytest `call` durations — medians over seven merge-gate runs
 of 2026-08-11/12. On top of them each job pays a fixed
 `RUNNER_SETUP_SECONDS + IMAGE_BUILD_SECONDS` (1m19s: 46s outside the tests, then
 the project image obtained inside whichever test runs first). Because that
-constant is per job and not per test, balancing warm costs balances wall clock.
+constant is per job and not per test, the cost model predicts wall clock and
+shows when a diagnostic group has become too large.
 
 `IMAGE_BUILD_SECONDS` models the merge gate, where that image is pulled rather
 than built (see above); the release and nightly lanes still build and pay the
@@ -206,26 +215,25 @@ cost like every other. It is currently **5m47s**, of which 33s is the image
 (7m56s before #236 published it instead of rebuilding it per job, 6m32s before
 #245 shrank it).
 
-Thirteen slices sit at 6m26s, **1.12x** the floor. That is the point of choosing
-N from the numbers rather than from taste: six balanced slices were 13m37s,
-twelve reach the floor, and past twelve every extra job is pure cost. Note that
-1.12x is now a partition problem rather than a count problem — thirteen slices
-*can* reach 1.00x, and the current assignment does not, because `occupancy-grid`
-holds two 150s tests. The fixed cost falling twice is what exposed it: the same
-partition was 1.11x of a floor that was a minute and a half higher. The
-contract test asserts distance to the floor rather than the spread between
-slices — spread is compressed toward 1.0 by the fixed cost as N grows, so it
-keeps reading fine while the gate stops improving.
+Thirteen diagnostic slices sat at 6m26s, **1.12x** the floor. Four groups were
+over the 267s warm target: occupancy grid, sized payload, the two remote-assist
+single-stream cuts, and the two concurrency guarantees. Each has a real seam —
+transport, stream, or behavior — so each became two explicitly named jobs.
 
-Runner minutes are not the constraint here (this repository is public, so
-standard GitHub-hosted runners are free); the concurrent-job cap is, and
-thirteen stays under it.
+The resulting seventeen slices reach **1.00x**, without cross-theme packing.
+Seventeen is also the smallest theme-preserving count that can do so: each of
+the four overloaded groups needs at least one additional runner. Splitting
+every test into its own job would add runner cost without improving the critical
+path; keeping thirteen would save runner setup but leave 42s on every gate run.
+This is the balance: use the fewest runners that preserve diagnostic ownership
+and reach the floor, rather than optimizing either runner count or time alone.
 
 To refresh the numbers, read a merge-gate run: every e2e invocation runs
 `--durations=0`, so each job prints the cost of every test it ran. A test that
 ran first in its job carries the image build and needs `IMAGE_BUILD_SECONDS`
 subtracted. `tests/contract/test_workflow_contracts.py::test_e2e_slices_stay_close_to_the_floor`
-fails when the slowest slice passes 1.25x the floor.
+fails as soon as a grouped slice becomes slower than the floor. Split that
+slice on a diagnostic boundary; do not fill spare time with unrelated tests.
 
 ## Performance Regression Gate
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -127,24 +127,29 @@ from one-host smoke.
 
 - `just test-e2e-slice heartbeat`: the heartbeat matrix (and the opt-in RMW matrix).
 - `just test-e2e-slice chatter`: the native chatter scenario, smoke, and debug rig.
-- `just test-e2e-slice occupancy-grid`: compressed occupancy grid over both transports.
-- `just test-e2e-slice sized-payload`: sized payload over both transports.
+- `just test-e2e-slice occupancy-grid-dds`: compressed occupancy grid over direct DDS.
+- `just test-e2e-slice occupancy-grid-zenoh`: compressed occupancy grid over Zenoh.
+- `just test-e2e-slice sized-payload-fastdds`: sized payload over Fast DDS.
+- `just test-e2e-slice sized-payload-zenoh`: sized payload over Zenoh.
 - `just test-e2e-slice remote-assist`: the full anonymized remote-assist rig.
-- `just test-e2e-slice remote-assist-streams`: its costmap and camera single-stream cuts.
+- `just test-e2e-slice remote-assist-costmap`: its costmap single-stream cut.
+- `just test-e2e-slice remote-assist-camera`: its camera single-stream cut.
 - `just test-e2e-slice runtime-tools`: link latency and live timeline stepping.
 - `just test-e2e-slice media`: anonymization and video quality.
-- `just test-e2e-slice concurrency`: the concurrency/isolation gate.
+- `just test-e2e-slice concurrency-parallel`: independent smoke runs coexist.
+- `just test-e2e-slice concurrency-conflict`: a conflicting smoke run is rejected safely.
 - `just test-e2e-slice benchmark-ab`: the A/B reliability verdict.
 - `just test-e2e-slice benchmark-replay`: loss boundaries against costmap replay.
 - `just test-e2e-slice benchmark-capacity`: the band-asserted capacity rows.
 - `just test-e2e-slice benchmark-capacity-cases`: the capacity good/bad-case verdicts.
 - `just test-e2e-node <nodeid>`: Reruns a specific pytest node ID directly.
-- `just e2e-slice-costs`: prints what each slice costs and how balanced the six are.
+- `just e2e-slice-costs`: prints what each slice costs and its distance to the floor.
 
-The slices are chosen by measured cost, and split where the tests already
-differ so a red job names an area. `E2E_SLICES` in `tests/e2e/conftest.py`
-decides which slice owns which test; see
-[ci.md](ci.md#balancing-the-e2e-slices) before moving one.
+The slices are grouped by diagnostic theme and split where transport, stream,
+or behavior gives a useful first failure distinction. Measured cost decides
+when a theme needs another runner, not which unrelated tests should share one.
+`E2E_SLICES` in `tests/e2e/conftest.py` decides which slice owns which test;
+see [ci.md](ci.md#diagnostic-e2e-slices) before changing one.
 
 The generated RMW matrix is available as an opt-in full local slice:
 

--- a/justfile
+++ b/justfile
@@ -46,7 +46,7 @@ test-e2e-fast: test-e2e-smoke
 # with everything the slice does not own deselected — so a slice cannot miss a
 # test or run one twice, which per-slice file lists and `-k` filters both did.
 # Which tests a slice owns, and what each costs, is E2E_SLICES in
-# tests/e2e/conftest.py; `just e2e-slice-costs` prints the balance.
+# tests/e2e/conftest.py; `just e2e-slice-costs` prints the cost model.
 test-e2e-slice slice:
 	ROSOTACOM_RUN_E2E=1 {{python}} -m pytest -q --durations=0 tests/e2e/ -m e2e --e2e-slice={{slice}}
 

--- a/src/rosotacom/image_cache.py
+++ b/src/rosotacom/image_cache.py
@@ -1,10 +1,10 @@
 """Content-addressed names for the images this project builds.
 
-Every e2e job rebuilds the same project image from scratch, and #236 measured
-what that costs: 154s per job, thirteen jobs per merge-gate run. Publishing the
-built image once and adopting it in each job removes the build — but only if
-"adopt" can never mean "adopt something else". A cached image that no longer
-matches its build inputs is a silent wrong-result machine, which is why #226
+Every e2e job used to rebuild the same project image from scratch, and #236
+measured what that cost: 154s per job across the thirteen jobs in that run.
+Publishing the built image once and adopting it in each job removes the build —
+but only if "adopt" can never mean "adopt something else". A cached image that
+no longer matches its build inputs is a silent wrong-result machine, which is why #226
 declined to do this inline.
 
 So the name of a published image is a hash of everything that determines it:

--- a/tests/contract/test_benched_set_registry.py
+++ b/tests/contract/test_benched_set_registry.py
@@ -211,8 +211,9 @@ def test_merge_gate_lane_actually_selects_the_benchmark_e2e() -> None:
 
     The slice runner carries no `-k` at all now — it deselects by node id
     against E2E_SLICES — so the contract is that both benchmark E2E files are
-    owned by a slice. Which slice is a balance decision (#226 split the
-    capacity probes out of `runtime-tools`); that they run at all is not.
+    owned by a slice. Which diagnostic slice owns them is a partition decision
+    (#226 split the capacity probes out of `runtime-tools`, #253 rejects
+    cross-theme cost packing); that they run at all is not.
     """
     slice_recipe = re.search(
         r"^test-e2e-slice[^\n:]*:\n((?:\t.*\n?)+)",

--- a/tests/contract/test_security_maintenance_config.py
+++ b/tests/contract/test_security_maintenance_config.py
@@ -60,18 +60,22 @@ def test_merge_gate_requires_non_docker_package_and_docker_smoke() -> None:
     assert "just test-e2e-slice" in merge_gate
     # Named individually rather than compared to E2E_SLICES, so that dropping a
     # slice from the manifest and the matrix together still fails here. Which
-    # slices exist is a balance decision (#226, #235); that the gate runs the
-    # Docker smoke suite at all is what this file is about.
+    # slices exist is a diagnostic/cost decision (#226, #235, #253); that the
+    # gate runs the Docker smoke suite at all is what this file is about.
     assert set(jobs["e2e"]["strategy"]["matrix"]["slice"]) >= {
         "heartbeat",
         "chatter",
-        "occupancy-grid",
-        "sized-payload",
+        "occupancy-grid-dds",
+        "occupancy-grid-zenoh",
+        "sized-payload-fastdds",
+        "sized-payload-zenoh",
         "remote-assist",
-        "remote-assist-streams",
+        "remote-assist-costmap",
+        "remote-assist-camera",
         "runtime-tools",
         "media",
-        "concurrency",
+        "concurrency-parallel",
+        "concurrency-conflict",
         "benchmark-ab",
         "benchmark-replay",
         "benchmark-capacity",

--- a/tests/contract/test_workflow_contracts.py
+++ b/tests/contract/test_workflow_contracts.py
@@ -302,33 +302,32 @@ def test_workflow_matrices_expand_the_slices_that_exist() -> None:
 
 
 def test_e2e_slices_stay_close_to_the_floor() -> None:
-    """Balance is a number now, so it can be kept rather than rediscovered.
+    """Diagnostic slices reach the floor without cross-theme packing.
 
     Themed slices drifted to a 2.4x spread (7m39s against 18m31s) with nobody
     noticing, because the only place a per-test cost existed was a `pytest -q`
     total that nothing compared.
 
-    Measured against the floor rather than the spread, which is what this test
-    asserted at six slices and what stopped meaning anything at thirteen. The
-    fixed cost per job compresses spread toward 1.0 as N grows, so a suite could
-    go badly wrong while spread still read 1.1; and past N=12 the spread is set
-    by tests too small to split rather than by imbalance. Distance to
-    `floor_seconds()` says the one thing worth asserting at any N — the gate is
-    near the fastest it could possibly be — and needs no retuning when a test is
-    added.
+    The cost model remains useful, but #253 makes the slice name the stronger
+    constraint: costs can require another runner inside a theme, never move a
+    test behind an unrelated name. The four groups above the floor all had a
+    diagnostic seam (transport, stream, or concurrency behavior), so seventeen
+    named slices reach 1.00x without arbitrary packing.
 
-    1.25x, not 1.0x, because the floor assumes tests can be divided arbitrarily
-    and they cannot. At thirteen slices the partition sits at 1.09x.
+    Exact distance to the floor keeps that choice durable. A new grouped slice
+    above it must be split on a useful diagnostic boundary; spare seconds in an
+    unrelated slice are not capacity to fill.
     """
     module = _e2e_conftest()
     predicted = {name: module.predicted_slice_seconds(name) for name in module.E2E_SLICES}
     slowest = max(predicted.values())
     floor = module.floor_seconds()
 
-    assert slowest <= 1.25 * floor, (
+    assert slowest <= floor, (
         f"the slowest e2e slice is predicted at {slowest / 60:.2f}m against a "
-        f"{floor / 60:.2f}m floor ({slowest / floor:.2f}x). Move tests between slices, "
-        f"or split the slowest one, in tests/e2e/conftest.py:\n{module.slice_cost_report()}"
+        f"{floor / 60:.2f}m floor ({slowest / floor:.2f}x). Split the slowest "
+        "slice on a diagnostic boundary; do not move tests into an unrelated "
+        f"slice:\n{module.slice_cost_report()}"
     )
 
 
@@ -446,7 +445,7 @@ def test_e2e_waits_only_for_the_cheap_gate_and_the_image() -> None:
     `needs: preflight-success` made every gate run wait 2.15 min for the
     five-version `merge-lightweight` matrix. It had stopped an e2e round once
     in sixty runs — on `workflow-lint`, which takes 0.12 min. `ci-success`
-    still requires every preflight job, so this is a change to when thirteen
+    still requires every preflight job, so this is a change to when seventeen
     runners start, not to what may merge.
     """
     workflow = yaml.safe_load((WORKFLOWS_DIR / "pr-merge-gate.yml").read_text(encoding="utf-8"))

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,7 +1,7 @@
 """Collection rules for the Docker-backed e2e suite, and the CI slice partition.
 
 `just test-e2e-smoke` runs the whole suite in one process; CI runs the same
-collection as thirteen parallel slices, selected with `--e2e-slice=<name>`. A
+collection as seventeen parallel slices, selected with `--e2e-slice=<name>`. A
 slice is a deselection of one shared collection, not a separate pytest
 invocation with its own file list — which is what it used to be, and that shape
 got two things wrong that a partition cannot get wrong:
@@ -16,8 +16,10 @@ got two things wrong that a partition cannot get wrong:
 
 The number next to each test is what it costs. #226 balanced six themed slices
 on those numbers and the run came back within 25s of every prediction, so #235
-used the same model to choose N instead of guessing it: thirteen slices, split
-where the tests already differ, is 1.09x the fastest any partition could be.
+used the same model to choose N instead of guessing it. #253 makes diagnosis
+the stronger constraint: costs decide when a theme needs another runner, but
+unrelated tests are never packed together merely because their durations fit.
+Seventeen is the smallest theme-preserving partition that reaches the floor.
 """
 
 from __future__ import annotations
@@ -97,16 +99,20 @@ E2E_SLICES: dict[str, dict[str, float]] = {
         "tests/e2e/test_smoke.py::test_interactive_native_chatter_smoke_starts_full_local_debug_rig": 74.4,
     },
     # `transforms` was one slice over two unrelated questions. Compression and
-    # payload size each keep their RMW pair together, because the pair is the
-    # comparison: a red job here means "this transform, both transports" or
-    # "this transform, one transport", which is the first thing you ask.
-    "occupancy-grid": {
+    # payload size were then kept as transport pairs, but both pairs grew past
+    # the floor. A job per transport now names both the transform and the
+    # transport that failed instead of hiding that distinction in pytest output.
+    "occupancy-grid-dds": {
         "tests/e2e/test_smoke.py::test_local_compressed_occupancy_grid_smoke_from_copied_example_project[compressed-occupancy-grid]": 158.3,  # derived
+    },
+    "occupancy-grid-zenoh": {
         "tests/e2e/test_smoke.py::test_local_zenoh_compressed_occupancy_grid_smoke_from_copied_example_project[compressed-occupancy-grid-zenoh]": 150.4,
     },
-    "sized-payload": {
-        "tests/e2e/test_smoke.py::test_local_zenoh_sized_payload_smoke_from_copied_example_project[sized-payload-zenoh]": 172.5,
+    "sized-payload-fastdds": {
         "tests/e2e/test_smoke.py::test_local_wrapped_sized_payload_smoke_from_copied_example_project[sized-payload-fastdds]": 117.4,
+    },
+    "sized-payload-zenoh": {
+        "tests/e2e/test_smoke.py::test_local_zenoh_sized_payload_smoke_from_copied_example_project[sized-payload-zenoh]": 172.5,
     },
     # The full anonymized rig, alone: at 267s warm it is the slowest single test
     # in the suite and therefore sets the floor every other slice is measured
@@ -114,9 +120,12 @@ E2E_SLICES: dict[str, dict[str, float]] = {
     "remote-assist": {
         "tests/e2e/test_smoke.py::test_local_remote_assist_anonymized_smoke_from_copied_example_project[remote-assist-anonymized]": 267.0,
     },
-    # Its two single-stream cuts, which share a trace with the rig above.
-    "remote-assist-streams": {
+    # Its two single-stream cuts share a trace with the rig above, but exercise
+    # different processing paths and should name which stream failed.
+    "remote-assist-costmap": {
         "tests/e2e/test_smoke.py::test_local_single_stream_anonymized_smoke_from_copied_example_project[remote-assist-anonymized-costmap]": 145.2,
+    },
+    "remote-assist-camera": {
         "tests/e2e/test_smoke.py::test_local_single_stream_anonymized_smoke_from_copied_example_project[remote-assist-anonymized-camera]": 145.1,
     },
     # What a live session exposes and what can be changed under it.
@@ -128,8 +137,12 @@ E2E_SLICES: dict[str, dict[str, float]] = {
         "tests/e2e/test_video_quality_e2e.py::test_synthetic_camera_pipeline_records_quality_metrics": 161.8,
         "tests/e2e/test_anonymize_e2e.py::test_anonymize_headless_end_to_end_preserves_keyframe_structure": 10.4,  # derived
     },
-    "concurrency": {
+    # These are complementary concurrency guarantees, but a failure in safe
+    # parallel execution says something different from a rejected conflict.
+    "concurrency-parallel": {
         "tests/e2e/test_parallel_smoke.py::test_independent_local_smoke_tests_run_in_parallel": 146.6,
+    },
+    "concurrency-conflict": {
         "tests/e2e/test_parallel_smoke.py::test_second_same_target_smoke_aborts_and_leaves_first_intact": 125.0,
     },
     # The two benchmark verdicts, one job each: at 202s and 174s neither fits


### PR DESCRIPTION
Fixes #253

## Summary

- Split only the four overloaded E2E themes, at transport, stream, or behavior boundaries.
- Expand merge-gate, nightly, and release matrices to 17 precise job names.
- Tighten the cost contract to the exact measured floor without cross-theme packing.
- Document diagnosis as the primary partition rule and runner count as the tradeoff.

## Design

Seventeen is the smallest theme-preserving partition that reaches the floor: each of the four groups above 267 seconds needs one additional runner. Predicted critical path changes from 6m28s to 5m47s (1.00x floor). No test is assigned to an unrelated slice to fill spare capacity.

## Validation

- just e2e-slice-costs — 17 jobs, 5.77m critical path, 1.00x floor
- focused workflow/security/benchmark contracts — 35 passed
- just check — 693 tests passed, 74.29% coverage, lint, typing, docs, and package validation green
- just lint-workflows — green
- Docker E2E — pending in this PR merge gate; the local monolith was not started while an unrelated local benchmark owned active rosotacom containers

Commit: 64fda7f0cc2f3b0e57bc2a99ed2e97dc50dafda7

Dependencies: none.