### PR TITLE
Declare compressed_image_transport, which desktop-full had been providing

### DIFF
--- a/src/rosotacom/resources/examples/ros2docker.json
+++ b/src/rosotacom/resources/examples/ros2docker.json
@@ -27,15 +27,23 @@
   // The base is ros-base, not desktop-full: 299 MB compressed against 1422 MB,
   // and nothing here runs a GUI (enable_gui_forwarding is false above). The
   // e2e suite was run against both to find out what desktop-full had been
-  // providing without anyone declaring it — one package, ros-kilted-gps-msgs,
-  // which the anonymized remote-assist session needs for gps_msgs/msg/GPSFix.
-  // It is declared below. Add rviz2 or a simulator here if you want them; that
-  // is a project's decision, not a default.
+  // providing without anyone declaring it. It named ros-kilted-gps-msgs, for
+  // the gps_msgs/msg/GPSFix the anonymized remote-assist session publishes.
+  //
+  // It could not name ros-kilted-compressed-image-transport, and that one is
+  // why this list is not just an inventory: no e2e session has a /compressed
+  // input topic, so the suite never loaded compressed_sub. A vehicle camera
+  // does, on both ends of the link — the sender republishes compressed to
+  // ffmpeg, the receiver decodes back to the CompressedImage twin. Declaring
+  // ros-kilted-image-transport alone gets you raw and nothing else.
+  //
+  // Add rviz2 or a simulator here if you want them; that is a project's
+  // decision, not a default.
   "build_args": {
     "BASE_IMAGE": "ros:kilted-ros-base-noble",
     "DIGEST": "@sha256:4ca53d5b084bdbe92a7a7d7186f56db6a716a6c7c33ad401ddb0ec82d6e9e479",
     "INSTALL_ZENOH":                 "1",
-    "APT_PACKAGES":                  "iputils-ping psmisc net-tools snmp iw nload iftop iproute2 tshark ros-kilted-domain-bridge ros-kilted-rmw-cyclonedds-cpp ros-kilted-rmw-zenoh-cpp ros-kilted-topic-tools ros-kilted-image-transport ros-kilted-ffmpeg-image-transport ros-kilted-ffmpeg-image-transport-msgs ros-kilted-gps-msgs",
+    "APT_PACKAGES":                  "iputils-ping psmisc net-tools snmp iw nload iftop iproute2 tshark ros-kilted-domain-bridge ros-kilted-rmw-cyclonedds-cpp ros-kilted-rmw-zenoh-cpp ros-kilted-topic-tools ros-kilted-image-transport ros-kilted-compressed-image-transport ros-kilted-ffmpeg-image-transport ros-kilted-ffmpeg-image-transport-msgs ros-kilted-gps-msgs",
     "PIP_PACKAGES":                  "numpy>=1.26,<2 lz4 pysnmp speedtest-cli psutil zstandard opencv-python"
   }
 }

--- a/src/rosotacom/resources/ros2docker.json.example
+++ b/src/rosotacom/resources/ros2docker.json.example
@@ -27,15 +27,23 @@
   // The base is ros-base, not desktop-full: 299 MB compressed against 1422 MB,
   // and nothing here runs a GUI (enable_gui_forwarding is false above). The
   // e2e suite was run against both to find out what desktop-full had been
-  // providing without anyone declaring it — one package, ros-kilted-gps-msgs,
-  // which the anonymized remote-assist session needs for gps_msgs/msg/GPSFix.
-  // It is declared below. Add rviz2 or a simulator here if you want them; that
-  // is a project's decision, not a default.
+  // providing without anyone declaring it. It named ros-kilted-gps-msgs, for
+  // the gps_msgs/msg/GPSFix the anonymized remote-assist session publishes.
+  //
+  // It could not name ros-kilted-compressed-image-transport, and that one is
+  // why this list is not just an inventory: no e2e session has a /compressed
+  // input topic, so the suite never loaded compressed_sub. A vehicle camera
+  // does, on both ends of the link — the sender republishes compressed to
+  // ffmpeg, the receiver decodes back to the CompressedImage twin. Declaring
+  // ros-kilted-image-transport alone gets you raw and nothing else.
+  //
+  // Add rviz2 or a simulator here if you want them; that is a project's
+  // decision, not a default.
   "build_args": {
     "BASE_IMAGE":                    "ros:kilted-ros-base-noble",
     "DIGEST":                        "@sha256:4ca53d5b084bdbe92a7a7d7186f56db6a716a6c7c33ad401ddb0ec82d6e9e479",
     "INSTALL_ZENOH":                 "1",
-    "APT_PACKAGES":                  "iputils-ping psmisc net-tools snmp iw nload iftop iproute2 tshark ros-kilted-domain-bridge ros-kilted-rmw-cyclonedds-cpp ros-kilted-rmw-zenoh-cpp ros-kilted-topic-tools ros-kilted-image-transport ros-kilted-ffmpeg-image-transport ros-kilted-ffmpeg-image-transport-msgs ros-kilted-gps-msgs",
+    "APT_PACKAGES":                  "iputils-ping psmisc net-tools snmp iw nload iftop iproute2 tshark ros-kilted-domain-bridge ros-kilted-rmw-cyclonedds-cpp ros-kilted-rmw-zenoh-cpp ros-kilted-topic-tools ros-kilted-image-transport ros-kilted-compressed-image-transport ros-kilted-ffmpeg-image-transport ros-kilted-ffmpeg-image-transport-msgs ros-kilted-gps-msgs",
     "PIP_PACKAGES":                  "numpy>=1.26,<2 lz4 pysnmp speedtest-cli psutil zstandard opencv-python"
   }
 }

--- a/tests/contract/test_packaged_resources.py
+++ b/tests/contract/test_packaged_resources.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import re
 import subprocess
 from importlib import resources
 from pathlib import Path
@@ -106,6 +107,61 @@ def test_default_ros2docker_config_pins_supported_kilted_noble_image() -> None:
         # session. desktop-full carried it, so nothing declared it; on ros-base
         # its absence is a missing type at runtime, not a build error.
         assert "ros-kilted-gps-msgs" in apt_packages
+
+
+# `image_transport republish` resolves a transport name to a pluginlib class at
+# runtime, so a transport nobody installed is not a build failure — it is a
+# container that starts fine and aborts on the first image message. `raw` ships
+# with image_transport itself; every other transport needs its own package.
+IMAGE_TRANSPORT_APT_PACKAGES = {
+    "raw": "ros-kilted-image-transport",
+    "compressed": "ros-kilted-compressed-image-transport",
+    "ffmpeg": "ros-kilted-ffmpeg-image-transport",
+}
+
+
+def _packaged_session_plugin() -> dict:
+    return yaml.safe_load(
+        (cli.WS_DIR / "session" / "content" / "base" / "session_plugin_base.yaml").read_text(encoding="utf-8")
+    )
+
+
+def test_every_image_transport_the_session_plugin_can_select_is_installed() -> None:
+    """The packaged image must carry every transport the packaged session can ask for.
+
+    This is the guard that was missing when the base image moved from
+    desktop-full to ros-base: compressed_image_transport had arrived with
+    desktop-full's perception variant, nothing in this repository declared it,
+    and no e2e session has a /compressed input topic — so the suite stayed green
+    while a vehicle camera link could no longer start. Deriving the transport set
+    from the plugin rather than restating it means a new transport, or a thinner
+    base image, fails here instead of on a vehicle.
+    """
+    plugin = _packaged_session_plugin()
+
+    # Incoming republish: the transport the receiving peer decodes back to.
+    selected = {
+        str(value)
+        for key, value in plugin["parameters"].items()
+        if key.startswith("irt_") and key.endswith("_out_transport") and value
+    }
+    # Outgoing republish: the in-transport is chosen from the source topic name.
+    it_window = next(window for window in plugin["windows"] if window["name"] == "IT")
+    for split in it_window["splits"]:
+        for command in split["commands"]:
+            selected.update(re.findall(r'it_in_transport="([a-z]+)"', command))
+
+    # Both branches of that choice, so a rewrite that drops one is visible here.
+    assert {"raw", "compressed"} <= selected
+
+    unknown = selected - set(IMAGE_TRANSPORT_APT_PACKAGES)
+    assert not unknown, f"no apt package recorded for image transport(s): {sorted(unknown)}"
+
+    required = {IMAGE_TRANSPORT_APT_PACKAGES[transport] for transport in selected}
+    for config_path in (cli.DEFAULT_ROS2DOCKER_CONFIG, cli.EXAMPLE_PROJECT_DIR / "ros2docker.json"):
+        apt_packages = set(str(cli.load_config(config_path)["build_args"]["APT_PACKAGES"]).split())
+        missing = required - apt_packages
+        assert not missing, f"{config_path.name} does not install {sorted(missing)}"
 
 
 def test_external_ros2docker_configs_install_selected_rmw_implementations() -> None:


### PR DESCRIPTION
Closes #260. Follows #245, which is where the plugin was lost.

## The change

`ros-kilted-compressed-image-transport` in the packaged `APT_PACKAGES`
(`resources/ros2docker.json.example` — `cli.DEFAULT_ROS2DOCKER_CONFIG` — and
`resources/examples/ros2docker.json`), plus a contract test that would have
caught its absence.

## Why it was missing

#245 moved the base from `osrf/ros:kilted-desktop-full-noble` to
`ros:kilted-ros-base-noble`. `desktop-full` pulls in the `perception` variant and
with it `image_transport_plugins`, which is where `compressed_image_transport`
comes from. `ros-base` does not, and nothing in this repository declared it — the
swap removed a plugin no file mentions.

Found on the FZI vehicle, where the outgoing republish aborts on the first camera
topic:

```
Unable to load plugin for transport 'image_transport/compressed_sub'
Declared types are  image_transport/ffmpeg_sub image_transport/raw_sub
```

## Both ends need it

Declaring it for the sender alone would move the failure rather than fix it:

| Direction | What selects `compressed` | Failure without the plugin |
|---|---|---|
| Outgoing (`it_*`) | `in_transport` is taken from the source topic name, so any `/compressed` topic loads `compressed_sub` | Loud — the node aborts |
| Incoming (`irt_*`) | `irt_N_out_transport` defaults to `compressed`; the peer decodes ffmpeg back to the `CompressedImage` twin | Quiet — the twin is simply never published |

## The test, and why it is not a string assertion

#241 measured desktop-full against ros-base to find what it had been providing
undeclared, and concluded it was one package (`ros-kilted-gps-msgs`). It was two.
The method is why: no e2e session has a `/compressed` input topic, so the suite
never selected that branch.

Restating the package name in an assertion would reproduce that blind spot one
level up. `test_every_image_transport_the_session_plugin_can_select_is_installed`
instead derives the transport set from the packaged session plugin — the
`irt_*_out_transport` defaults plus the `in_transport` literals the `IT` window
can choose — and asserts a declaring apt package for each. A new transport, or a
thinner base image, fails in CI rather than on a vehicle.

## Validation

- `just check` — green (exit 0).
- Guard proven to bite: with the two config files reverted to `develop`, the new
  test fails with
  `AssertionError: ros2docker.json.example does not install ['ros-kilted-compressed-image-transport']`.

Base: `5cfc936`.