### PR TITLE
Correct an inbound header stamp by the clock offset the node measures

### DIFF
--- a/src/rosotacom/resources/ws/ros2src/com_py/com_py/status_overview.py
+++ b/src/rosotacom/resources/ws/ros2src/com_py/com_py/status_overview.py
@@ -75,6 +75,7 @@ from com_py.status_overview_core import (
     StatusAggregator,
     collect_stage_metadata,
     collect_stage_topics,
+    stamp_delay,
 )
 
 ECHO_HEARTBEAT_TYPE = "com_msgs/msg/EchoHeartbeat"
@@ -274,12 +275,26 @@ class StageObserver(Node):
                 stamp = getattr(header, "stamp", None) if header is not None else None
                 if stamp is not None:
                     try:
-                        msg_time = rclpy.time.Time.from_msg(stamp)
-                        d = (now_ros - msg_time).nanoseconds / 1e9
-                        if -1.0 < d < 1000.0:  # guard unsynced clocks / zero stamps
-                            delay_s = d
+                        stamp_s = _stamp_seconds(stamp)
                     except Exception:
-                        delay_s = None
+                        stamp_s = None
+                    if stamp_s is not None:
+                        d = now_ros_s - stamp_s
+                        # An inbound stage carries a stamp written by the peer's
+                        # clock, so it is comparable to ours only once the offset
+                        # the heartbeat measures is applied -- exactly what the
+                        # OtaStamped branch above does with `t_wrap`. A local
+                        # stage was stamped by this machine and must stay raw.
+                        contexts = self._stage_metadata.get(topic, [])
+                        peer_stamped = any(
+                            context.get("direction") == "inbound" for context in contexts
+                        )
+                        estimate = self.clock_estimator.estimate() if peer_stamped else None
+                        if estimate is not None:
+                            clock_offset_s = estimate["offset_s"]
+                            rtt_s = estimate["rtt_s"]
+                            raw_delay_s = d
+                        delay_s = stamp_delay(d, clock_offset_s)
 
             obs.record(
                 size,

--- a/src/rosotacom/resources/ws/ros2src/com_py/com_py/status_overview_core.py
+++ b/src/rosotacom/resources/ws/ros2src/com_py/com_py/status_overview_core.py
@@ -148,6 +148,33 @@ class ClockOffsetEstimator:
             }
 
 
+#: Plausibility window (seconds) for a latency derived from a message header
+#: stamp. Outside it the number is not a latency but an unset stamp (epoch 0) or
+#: a clock difference no offset estimate explains.
+STAMP_DELAY_MIN_S = -1.0
+STAMP_DELAY_MAX_S = 1000.0
+
+
+def stamp_delay(raw_delay_s: float, clock_offset_s: Optional[float] = None) -> Optional[float]:
+    """Latency from a header stamp, corrected by the estimated peer clock offset.
+
+    ``raw_delay_s`` is ``local_now - stamp``. ``clock_offset_s`` is peer clock
+    minus local clock (as ``ClockOffsetEstimator`` reports it), so the corrected
+    delay is their sum -- the same arithmetic the OtaStamped path uses on its
+    ``t_wrap``.
+
+    Returns ``None`` when the result falls outside the plausibility window. The
+    guard is applied to the corrected value on purpose: a topic whose stamp is
+    written by the peer used to be dropped for an offset this node has already
+    measured, which reads as "no latency available" instead of "latency, once
+    the clocks are reconciled".
+    """
+    corrected = raw_delay_s if clock_offset_s is None else raw_delay_s + clock_offset_s
+    if STAMP_DELAY_MIN_S < corrected < STAMP_DELAY_MAX_S:
+        return corrected
+    return None
+
+
 # --- Link overhead (session-level) -----------------------------------------
 
 def _payload_kbps(stage: Optional[Dict[str, Any]]) -> float:

--- a/tests/unit/test_status_overview_observer.py
+++ b/tests/unit/test_status_overview_observer.py
@@ -1,0 +1,225 @@
+"""Latency measurement in the status overview's stage observer.
+
+Two layers: the ROS-independent `stamp_delay` in `status_overview_core`, and the
+observer callback that decides *whether* a stamp is comparable to the local
+clock at all. The node module imports rclpy, which the host suite does not have,
+so its ROS surface is stubbed and the real core module is registered under the
+name the node imports (`tests/unit/test_ota_wrapper.py` uses the same approach).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from collections.abc import Iterator
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+COM_PY = REPO_ROOT / "src" / "rosotacom" / "resources" / "ws" / "ros2src" / "com_py" / "com_py"
+CORE_PY = COM_PY / "status_overview_core.py"
+NODE_PY = COM_PY / "status_overview.py"
+
+#: Modules the node imports at load time and the host suite does not have.
+_STUBBED = (
+    "rclpy",
+    "rclpy.context",
+    "rclpy.executors",
+    "rclpy.node",
+    "rclpy.qos",
+    "rclpy.serialization",
+    "rosidl_runtime_py",
+    "rosidl_runtime_py.utilities",
+    "com_py",
+    "com_py.link_bytes",
+    "com_py.link_trace",
+    "com_py.status_overview_core",
+)
+
+
+def _load(path: Path, name: str) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class _FakeNode:
+    pass
+
+
+def _stub_module(name: str, **attrs: object) -> ModuleType:
+    module = ModuleType(name)
+    for key, value in attrs.items():
+        setattr(module, key, value)
+    sys.modules[name] = module
+    return module
+
+
+core = _load(CORE_PY, "rosotacom_status_overview_core_observer")
+
+
+# ---------------------------------------------------------------------------
+# stamp_delay (ROS-independent)
+# ---------------------------------------------------------------------------
+
+
+def test_stamp_delay_without_an_estimate_is_the_raw_difference() -> None:
+    assert core.stamp_delay(0.25) == pytest.approx(0.25)
+
+
+def test_stamp_delay_adds_the_peer_offset() -> None:
+    """offset_s is peer minus local, so a peer running late shortens the delay."""
+    assert core.stamp_delay(0.25, 0.10) == pytest.approx(0.35)
+    assert core.stamp_delay(0.25, -0.10) == pytest.approx(0.15)
+
+
+def test_stamp_delay_guards_the_corrected_value_not_the_raw_one() -> None:
+    """#258: a stamp the raw guard rejects is reported once the offset explains it.
+
+    A peer clock 5 s ahead makes every raw delay negative; the old guard dropped
+    the sample and the topic reported no latency at all.
+    """
+    assert core.stamp_delay(-4.9) is None
+    assert core.stamp_delay(-4.9, 5.0) == pytest.approx(0.1)
+
+
+def test_stamp_delay_still_rejects_an_unset_stamp() -> None:
+    """An epoch-0 stamp is decades, not a latency -- with or without an offset."""
+    assert core.stamp_delay(1.7e9) is None
+    assert core.stamp_delay(1.7e9, 0.01) is None
+
+
+# ---------------------------------------------------------------------------
+# the observer callback
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def node_module() -> Iterator[ModuleType]:
+    saved = {name: sys.modules.get(name) for name in _STUBBED}
+    _stub_module("rclpy", init=lambda *a, **k: None, shutdown=lambda *a, **k: None)
+    _stub_module("rclpy.context", Context=object)
+    _stub_module("rclpy.executors", MultiThreadedExecutor=object)
+    _stub_module("rclpy.node", Node=_FakeNode)
+    _stub_module(
+        "rclpy.qos",
+        DurabilityPolicy=SimpleNamespace(TRANSIENT_LOCAL=1, VOLATILE=0),
+        HistoryPolicy=SimpleNamespace(KEEP_LAST=1),
+        QoSProfile=lambda **k: SimpleNamespace(**k),
+        ReliabilityPolicy=SimpleNamespace(RELIABLE=1, BEST_EFFORT=0),
+    )
+    _stub_module("rclpy.serialization", serialize_message=lambda msg: b"\x00" * 16)
+    _stub_module("rosidl_runtime_py", utilities=None)
+    _stub_module("rosidl_runtime_py.utilities", get_message=lambda type_str: None)
+    _stub_module("com_py", link_bytes=None)
+    _stub_module("com_py.link_bytes", LinkByteSampler=object, find_interface_for_ip=lambda *a: None)
+    _stub_module("com_py.link_trace", LinkTraceRecorder=object)
+    sys.modules["com_py.status_overview_core"] = core
+
+    module = _load(NODE_PY, "rosotacom_status_overview_node")
+
+    yield module
+
+    sys.modules.pop("rosotacom_status_overview_node", None)
+    for name, previous in saved.items():
+        if previous is None:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = previous
+
+
+_NOW_S = 1_000.0
+
+
+class _Estimator:
+    def __init__(self, offset_s: float | None, rtt_s: float = 0.04) -> None:
+        self._offset_s = offset_s
+        self._rtt_s = rtt_s
+
+    def estimate(self, now_mono: float | None = None) -> dict | None:
+        if self._offset_s is None:
+            return None
+        return {"offset_s": self._offset_s, "rtt_s": self._rtt_s, "age_s": 0.1, "samples": 12.0}
+
+
+def _observer(node_module: ModuleType, topic: str, *, direction: str, offset_s: float | None):
+    node = object.__new__(node_module.StageObserver)
+    node.observations = {topic: core.StageObservation(type_str="sensor_msgs/msg/CompressedImage")}
+    node._stage_metadata = {topic: [{"direction": direction, "stage": "com_in"}]}
+    node.clock_estimator = _Estimator(offset_s)
+    node.get_clock = lambda: SimpleNamespace(now=lambda: SimpleNamespace(nanoseconds=int(_NOW_S * 1e9)))
+    node.get_logger = lambda: SimpleNamespace(error=lambda *a, **k: None, warning=lambda *a, **k: None)
+    return node
+
+
+def _stamped(delay_s: float):
+    stamp_s = _NOW_S - delay_s
+    sec = int(stamp_s)
+    return SimpleNamespace(header=SimpleNamespace(stamp=SimpleNamespace(sec=sec, nanosec=int((stamp_s - sec) * 1e9))))
+
+
+def test_inbound_stamp_is_corrected_by_the_peer_offset(node_module: ModuleType) -> None:
+    topic = "/ccng/camera/compressed"
+    node = _observer(node_module, topic, direction="inbound", offset_s=0.12)
+
+    node._make_cb(topic)(_stamped(0.03))
+
+    obs = node.observations[topic]
+    assert obs.last_delay_s == pytest.approx(0.15, abs=1e-3)
+    assert obs.last_raw_delay_s == pytest.approx(0.03, abs=1e-3)
+    assert obs.last_clock_offset_s == pytest.approx(0.12)
+    assert obs.last_rtt_s == pytest.approx(0.04)
+
+
+def test_local_stage_stamp_is_left_alone(node_module: ModuleType) -> None:
+    """A stage this machine published was stamped by this machine's clock.
+
+    Correcting it would inject the peer offset into a purely local measurement.
+    """
+    topic = "/camera/compressed"
+    node = _observer(node_module, topic, direction="outbound", offset_s=0.12)
+
+    node._make_cb(topic)(_stamped(0.03))
+
+    obs = node.observations[topic]
+    assert obs.last_delay_s == pytest.approx(0.03, abs=1e-3)
+    assert obs.last_clock_offset_s is None
+    assert obs.last_raw_delay_s is None
+
+
+def test_inbound_without_an_estimate_falls_back_to_the_raw_delay(node_module: ModuleType) -> None:
+    topic = "/ccng/camera/compressed"
+    node = _observer(node_module, topic, direction="inbound", offset_s=None)
+
+    node._make_cb(topic)(_stamped(0.03))
+
+    obs = node.observations[topic]
+    assert obs.last_delay_s == pytest.approx(0.03, abs=1e-3)
+    assert obs.last_clock_offset_s is None
+
+
+def test_offset_rescues_a_sample_the_raw_guard_would_drop(node_module: ModuleType) -> None:
+    """#258 regression: the whole point -- a peer 5 s ahead used to report nothing."""
+    topic = "/ccng/camera/compressed"
+    node = _observer(node_module, topic, direction="inbound", offset_s=5.0)
+
+    node._make_cb(topic)(_stamped(-4.9))
+
+    obs = node.observations[topic]
+    assert obs.last_delay_s == pytest.approx(0.1, abs=1e-3)
+
+
+def test_a_message_without_a_header_reports_no_latency(node_module: ModuleType) -> None:
+    topic = "/ccng/tf"
+    node = _observer(node_module, topic, direction="inbound", offset_s=0.12)
+
+    node._make_cb(topic)(SimpleNamespace())
+
+    obs = node.observations[topic]
+    assert obs.last_delay_s is None
+    assert obs.msg_total == 1


### PR DESCRIPTION
Closes #258.

The observer already estimates the peer clock offset from the heartbeat echo
(`ClockOffsetEstimator`, minimum-RTT over 60 s) and applied it in exactly two
branches: the heartbeat itself and `com_msgs/OtaStamped`. Everything else was
measured as `now - header.stamp` against a clock that was never reconciled, so
the reported latency of an unwrapped topic was `true latency + clock offset` —
and when the offset pushed the value below the `-1 s` plausibility guard, the
sample was dropped and the topic reported *no* latency, which reads as
"unmeasurable" rather than "measured against the wrong clock".

This matters beyond tidiness: it is the only path that can measure latency
*through* a codec. A stream carried by `transport: ffmpeg` is decoded on the
receiver and still carries the sensor's `header.stamp`, so the corrected value
is sensor-to-delivery including encode and decode. Wrapping (#259) only ever
sees the link hop.

### What changed

- `status_overview_core.stamp_delay(raw_delay_s, clock_offset_s)` — ROS-independent:
  applies the offset and the plausibility window, with the window now applied to
  the *corrected* value.
- The observer's generic branch uses it, and reports `raw_delay_s` / `rtt_s` /
  `clock_offset_s` the way the wrapped branch does, so `latency_uncorrected_ms`,
  `rtt_ms` and `clock_offset_ms` appear for these topics too.
- **Only for inbound stages.** A local stage was stamped by this machine; adding
  a peer offset there would corrupt a measurement that was already correct. The
  direction comes from the stage metadata the heartbeat branch already uses.

### Validation

New `tests/unit/test_status_overview_observer.py` — nine tests over both layers:
`stamp_delay` arithmetic and guard behaviour, and the callback driven directly
with a stub estimator (ROS surface stubbed, real core module registered under
the name the node imports):

- inbound stamp is corrected, and reports raw/offset/rtt alongside;
- a local (outbound) stage is left raw and reports no offset;
- inbound without an estimate falls back to the raw value;
- a peer 5 s ahead — the sample the old guard silently dropped — now reports
  0.1 s;
- a headerless message still counts as received and reports no latency.

```bash
python -m pytest tests/unit/test_status_overview_observer.py -q
```
