### PR TITLE
Wrap what actually crosses the link, always last

### DIFF
--- a/session-configuration.md
+++ b/session-configuration.md
@@ -477,15 +477,31 @@ Given a base topic like `/tf`, stages are applied in this order:
 
 1) base topic (e.g. `/tf`)
 2) restamp → `+ shared.processing_suffixes.restamped` (default `/restamped`)
-3) drop → `+ /drop{drop_count}of{window_size}` (e.g. `/drop2of3`)
-4) throttle → `+ /max{hz}hz`
-5) pixel cap → `+ /{preset}`
-6) framebridge:
+3) latch → `+ shared.processing_suffixes.latched` (default `/latched`)
+4) drop → `+ /drop{drop_count}of{window_size}` (e.g. `/drop2of3`)
+5) throttle → `+ /max{hz}hz`
+6) pixel cap → `+ /{preset}`
+7) framebridge:
    - `local_to_global`: appended to the current topic state via `+ /globalframe`
    - `global_to_local`: appended to the base topic via `+ /globalframe` (configured inbound-side)
-7) compress → `+ /<algorithm>` (default `/bz2`)
-8) transport → `+ /<type>` (e.g. `/ffmpeg`, `/foxglove`, `/compressed`)
-9) optional `local_republish: true` triggers reverse-transport configuration.
+8) compress → `+ /<algorithm>` (default `/bz2`)
+9) transport → `+ /<type>` (e.g. `/ffmpeg`, `/foxglove`, `/compressed`)
+10) OTA wrapper → `+ /ota_stamped`
+
+The wrapper is **always last**. Its `seq` and send stamp are read as a statement
+about the traffic on the link, so it has to wrap exactly what crosses it — an
+encoded stream is wrapped as `<base>/<type>/ota_stamped`, not the other way
+round. Nothing may append a suffix after it, or the delivered topic would be
+renamed under a receiver that subscribes by a fixed name.
+
+The receiver undoes the chain in reverse, and every stage there is computed from
+the delivered topic rather than from the OTA topic:
+
+1) unwrap → republishes on the pre-wrap name (so wrapping renames nothing)
+2) `local_republish: true` → reverse transport decodes into `+ /raw`
+3) decompress → republishes on the pre-compress name
+4) framebridge `global_to_local` → the local base topic
+5) trickle → `+ /trickle`, the only receiver-side stage that adds a suffix
 
 #### Transport parameters
 `type: ffmpeg` supports:

--- a/src/rosotacom/resources/examples/sessions/17_synthetic_camera_quality/session-definition.yaml
+++ b/src/rosotacom/resources/examples/sessions/17_synthetic_camera_quality/session-definition.yaml
@@ -52,6 +52,17 @@ topics:
           local_republish: true
           gop_size: 4
           bit_rate: 2000000
+        # Wrapping an encoded stream: the wrapper runs after the encoder, so the
+        # envelope carries the FFMPEGPacket that actually crosses the link, and
+        # the unwrapper republishes onto `/camera/image/ffmpeg` -- the name the
+        # reverse republish already decodes from. Nothing downstream is renamed,
+        # which is what this example proves end to end.
+        use_ota_wrapper: true
       expect:
         hz: { min: 3, max: 8 }
         latency_ms: { max: 1000 }
+        # The bound is the same 30% the video-quality check tolerates on this
+        # synthetic link; the assertion's purpose is that the number exists at
+        # all. Without the wrapper an encoded stream has no per-message
+        # accounting, and `loss_pct` on a topic that cannot report it fails.
+        loss_pct: { max: 30 }

--- a/src/rosotacom/resources/ws/session/creation/generate_session_files.py
+++ b/src/rosotacom/resources/ws/session/creation/generate_session_files.py
@@ -1255,10 +1255,14 @@ def _final_topic_type(entry: TopicEntry, pipe: Dict[str, Any]) -> str:
                 f"Unsupported transport type '{transport.type}' for topic '{entry.base}'. "
                 f"Known output type mappings: {sorted(TRANSPORT_OUTPUT_TYPES)}"
             )
-        return TRANSPORT_OUTPUT_TYPES[transport.type]
 
+    # Same order as the pipeline stages themselves: whatever is applied last
+    # decides the type of what crosses the link, and the wrapper is always last.
     if pipe.get("ota_wrap"):
         return OTA_STAMPED_MSG_TYPE
+
+    if transport is not None:
+        return TRANSPORT_OUTPUT_TYPES[transport.type]
 
     if pipe.get("compress"):
         return COMPRESSED_MSG_TYPE
@@ -1269,6 +1273,49 @@ def _final_topic_type(entry: TopicEntry, pipe: Dict[str, Any]) -> str:
             f"Topic '{entry.base}' requires a 'type' when peer_settings.<peer>.domain_id/shared.ota_domain_id are used."
         )
     return msg_type
+
+
+def _delivered_topic(pipe: Dict[str, Any], final: str) -> str:
+    """The topic the receiver's post-processing chain ends on, before trickle.
+
+    The receiver undoes the sender's stages in reverse order, so this walks the
+    same chain backwards rather than picking one branch: unwrap, decode a
+    transport, decompress, framebridge down.
+    """
+    topic = final
+    if pipe.get("ota_wrap"):
+        # The unwrapper republishes on the pre-wrap name, which is why wrapping
+        # renames nothing downstream of it.
+        topic = str(pipe["ota_in"])
+    transport = pipe.get("transport")
+    if isinstance(transport, TransportSpec) and transport.local_republish:
+        # image_transport reverse republish decodes the encoded topic into
+        # `<encoded>/raw`; PSNR/SSIM and application-level checks need that
+        # decoded sensor_msgs/Image stage, not the encoded packet.
+        topic = str(pipe["irt_in"]) + "/raw"
+    elif pipe.get("compress"):
+        topic = str(pipe["comp_in"])
+    if pipe.get("framebridge") == "global_to_local":
+        # global_to_local runs on the receiver: the OTA `final` is the global
+        # (globalframe) topic, and the framebridge transforms it down to the
+        # local base topic -- that base is the post-framebridge native_in.
+        topic = str(pipe["fb_g2l_base"])
+    return topic
+
+
+def _postprocessed_topic(pipe: Dict[str, Any], final: str) -> str:
+    """The topic the receiving application actually reads."""
+    topic = _delivered_topic(pipe, final)
+    if pipe.get("trickle_hz") is not None:
+        # Receiver-side trickle re-publishes the delivered topic at a fixed rate
+        # to `<delivered>/trickle` (the trickle node's trickle_topic_suffix).
+        # That republished topic is the real delivered output, so it is the
+        # monitored native_in stage -- otherwise the trickle re-publish is an
+        # observability blind spot (its rate cannot be asserted). It republishes
+        # what the application would read, not the envelope: on a wrapped topic
+        # that is the unwrapped one.
+        topic = topic + "/trickle"
+    return topic
 
 
 def _heartbeat_monitor_overrides(heartbeat_expect: Optional[Dict[str, Any]]) -> List[Tuple[str, Any]]:
@@ -1341,31 +1388,6 @@ def _build_status_pipeline_spec(
         if pipe.get("trickle_hz") is not None:
             return float(pipe["trickle_hz"])
         return None
-
-    def _postprocessed_topic(pipe: Dict[str, Any], final: str) -> str:
-        if pipe.get("trickle_hz") is not None:
-            # Receiver-side trickle re-publishes the delivered OTA `final` at a fixed
-            # rate to `<final>/trickle` (the trickle node's trickle_topic_suffix). That
-            # republished topic is the real delivered output, so it is the monitored
-            # native_in stage -- otherwise the trickle re-publish is an observability
-            # blind spot (its rate cannot be asserted).
-            return final + "/trickle"
-        if pipe.get("compress"):
-            return str(pipe["comp_in"])
-        if pipe.get("ota_wrap"):
-            return str(pipe["ota_in"])
-        if pipe.get("framebridge") == "global_to_local":
-            # global_to_local runs on the receiver: the OTA `final` is the global
-            # (globalframe) topic, and the framebridge transforms it down to the
-            # local base topic -- that base is the post-framebridge native_in.
-            return str(pipe["fb_g2l_base"])
-        transport = pipe.get("transport")
-        if isinstance(transport, TransportSpec) and transport.local_republish:
-            # image_transport reverse republish decodes `<final>` into
-            # `<final>/raw`; PSNR/SSIM and application-level checks need that
-            # decoded sensor_msgs/Image stage, not the encoded packet.
-            return final + "/raw"
-        return final
 
     def _relay_in_local_topic(topic: str) -> str:
         if inbound_keep_source_prefix:
@@ -1714,11 +1736,6 @@ def _compute_pipeline(
         comp_in = topic
         topic = topic + comp_alg_suffix
 
-    ota_in = None
-    if ota_wrap:
-        ota_in = topic
-        topic = topic + ota_suffix
-
     it_in = None
     irt_in = None
     if transport:
@@ -1726,6 +1743,15 @@ def _compute_pipeline(
         topic = topic + f"/{transport.type}"
         if transport.local_republish:
             irt_in = topic
+
+    # The wrapper is last, always. Its `seq` and send stamp describe whatever it
+    # wraps, so anything applied after it would be measured by an envelope that
+    # never carried it -- and would append its own suffix to the wrapped name,
+    # renaming the delivered topic under a receiver that subscribes by name.
+    ota_in = None
+    if ota_wrap:
+        ota_in = topic
+        topic = topic + ota_suffix
 
     return {
         "final": topic,
@@ -2546,8 +2572,16 @@ def func(
         # Trickle: local-only periodic republisher (receiver side only).
         # Subscribes to inbound final topics (with source-name prefix when applicable)
         # and republishes at a fixed rate for visualization software.
+        # Trickle runs at the very end of the receiver chain, so it republishes
+        # what the local post-processing produced -- not the OTA `final`, which
+        # on a wrapped topic is still the envelope. `_delivered_topic` is the
+        # same computation the status pipeline spec uses for `native_in`, so the
+        # two cannot drift apart.
         trickle_in_items = [
-            (_prefix_with_source_name_if_needed(local, remote, p["final"]), p["trickle_hz"])
+            (
+                _prefix_with_source_name_if_needed(local, remote, _delivered_topic(p, p["final"])),
+                p["trickle_hz"],
+            )
             for p in in_pipes
             if p["trickle_hz"] is not None
         ]
@@ -2599,7 +2633,10 @@ def func(
             if not p["normalize"]:
                 continue
             base = e.base.lstrip("/")
-            suffix_source = p["comp_in"] if p["comp_in"] else p["final"]
+            # Normalization is receiver-side too, so it works on the delivered
+            # topic rather than the OTA `final` (identical unless something is
+            # wrapped, where `final` is still the envelope).
+            suffix_source = _delivered_topic(p, p["final"])
             suffix = suffix_source[len(e.base) :]
             nor_items.append((base, suffix))
 

--- a/tests/unit/test_session_pipeline.py
+++ b/tests/unit/test_session_pipeline.py
@@ -1,0 +1,196 @@
+"""Stage composition in the session generator.
+
+The pipeline is a chain of topic-name transformations, and two things have to
+stay true of it: what the wrapper wraps is what actually crosses the link, and
+every receiver-side stage is computed from the same delivered name. Otherwise a
+topic is renamed under a receiver that subscribes by a fixed name and simply
+receives nothing, with every panel still green (#259).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GENERATOR_PY = (
+    REPO_ROOT / "src" / "rosotacom" / "resources" / "ws" / "session" / "creation" / "generate_session_files.py"
+)
+
+
+def _load_module(path: Path, name: str) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+generator = _load_module(GENERATOR_PY, "rosotacom_generate_session_files_pipeline")
+
+SUFFIXES = {
+    "restamped_suffix": "/restamped",
+    "latched_suffix": "/latched",
+    "globalframe_suffix": "/globalframe",
+    "comp_alg_suffix": "/bz2",
+    "ota_suffix": "/ota_stamped",
+}
+
+
+def _pipeline(processing: dict, base: str = "/camera/image", msg_type: str = "sensor_msgs/msg/Image"):
+    entry = generator.TopicEntry(
+        base=base,
+        msg_type=msg_type,
+        processing=processing,
+        qos=None,
+        zen_qos=None,
+        index=0,
+    )
+    pipe = generator._compute_pipeline(entry, {}, **SUFFIXES)
+    return entry, pipe
+
+
+def _ffmpeg(**extra: object) -> dict:
+    spec = {"type": "ffmpeg", "local_republish": True}
+    spec.update(extra)
+    return {"transport": spec}
+
+
+# ---------------------------------------------------------------------------
+# the wrapper is the last sender-side stage
+# ---------------------------------------------------------------------------
+
+
+def test_transport_is_encoded_before_it_is_wrapped() -> None:
+    """#259: the envelope must carry what crosses the link, i.e. the packet."""
+    entry, pipe = _pipeline({**_ffmpeg(), "use_ota_wrapper": True})
+
+    assert pipe["it_in"] == "/camera/image"  # encoder input: the raw image
+    assert pipe["ota_in"] == "/camera/image/ffmpeg"  # wrapper input: the packet
+    assert pipe["final"] == "/camera/image/ffmpeg/ota_stamped"
+    assert generator._final_topic_type(entry, pipe) == generator.OTA_STAMPED_MSG_TYPE
+
+
+def test_wrapping_a_transport_does_not_rename_the_delivered_topic() -> None:
+    """The unwrapper republishes on the pre-wrap name -- where the decoder listens."""
+    _, wrapped = _pipeline({**_ffmpeg(), "use_ota_wrapper": True})
+    _, plain = _pipeline(_ffmpeg())
+
+    assert wrapped["irt_in"] == plain["irt_in"] == "/camera/image/ffmpeg"
+    delivered = generator._postprocessed_topic(wrapped, wrapped["final"])
+    assert delivered == generator._postprocessed_topic(plain, plain["final"]) == "/camera/image/ffmpeg/raw"
+
+
+def test_transport_without_republish_delivers_the_unwrapped_packet() -> None:
+    _, pipe = _pipeline({**_ffmpeg(local_republish=False), "use_ota_wrapper": True})
+
+    assert pipe["irt_in"] is None
+    assert generator._postprocessed_topic(pipe, pipe["final"]) == "/camera/image/ffmpeg"
+
+
+def test_trickle_republishes_the_unwrapped_topic() -> None:
+    """#259: `<latched>/ota_stamped/trickle` is a name no application subscribes to."""
+    _, pipe = _pipeline(
+        {"latch": True, "trickle_hz": 1, "use_ota_wrapper": True},
+        base="/can/autonomous",
+        msg_type="std_msgs/msg/Bool",
+    )
+
+    assert pipe["final"] == "/can/autonomous/latched/ota_stamped"
+    assert generator._delivered_topic(pipe, pipe["final"]) == "/can/autonomous/latched"
+    assert generator._postprocessed_topic(pipe, pipe["final"]) == "/can/autonomous/latched/trickle"
+
+
+# ---------------------------------------------------------------------------
+# every combination that existed before keeps its names
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("processing", "final", "delivered"),
+    [
+        ({}, "/t", "/t"),
+        ({"use_ota_wrapper": True}, "/t/ota_stamped", "/t"),
+        ({"compress": True}, "/t/bz2", "/t"),
+        ({"compress": True, "use_ota_wrapper": True}, "/t/bz2/ota_stamped", "/t"),
+        ({"latch": True, "trickle_hz": 1}, "/t/latched", "/t/latched/trickle"),
+        ({"framebridge": "local_to_global"}, "/t/globalframe", "/t/globalframe"),
+        ({"framebridge": "global_to_local"}, "/t/globalframe", "/t"),
+        (
+            {"framebridge": "local_to_global", "compress": True, "use_ota_wrapper": True},
+            "/t/globalframe/bz2/ota_stamped",
+            "/t/globalframe",
+        ),
+        ({"throttle_hz": 10, "use_ota_wrapper": True}, "/t/max10hz/ota_stamped", "/t/max10hz"),
+        ({"drop": {"drop_count": 1, "window_size": 2}}, "/t/drop1of2", "/t/drop1of2"),
+    ],
+)
+def test_existing_combinations_are_unchanged(processing: dict, final: str, delivered: str) -> None:
+    _, pipe = _pipeline(processing, base="/t", msg_type="std_msgs/msg/Bool")
+
+    assert pipe["final"] == final
+    assert generator._postprocessed_topic(pipe, pipe["final"]) == delivered
+
+
+# ---------------------------------------------------------------------------
+# end to end: the generated peer configuration
+# ---------------------------------------------------------------------------
+
+
+def _camera_cfg(processing: dict) -> dict:
+    return {
+        "peers": {"a": {}, "b": {}},
+        "peer_settings": {"a": {"domain_id": 46}, "b": {"domain_id": 47}},
+        "shared": {
+            "use_heartbeat": False,
+            "use_status_overview": True,
+            "rmw": {
+                "local": {"cyclone": {"config": "cyclonedds_minimal.xml"}},
+                "ota": {"cyclone": {"config": "cyclonedds_minimal.xml"}},
+            },
+            "ota_domain_id": 48,
+        },
+        "topics": {
+            "b_to_a": [
+                {
+                    "topic": "/camera/image",
+                    "type": "sensor_msgs/msg/Image",
+                    "processing": processing,
+                    "expect": {"hz": {"min": 3, "max": 8}},
+                }
+            ]
+        },
+    }
+
+
+def test_generated_peer_files_wire_the_wrapped_camera(tmp_path: Path) -> None:
+    generator.func(
+        session_config_obj=_camera_cfg({**_ffmpeg(gop_size=4), "use_ota_wrapper": True}),
+        output_dir=str(tmp_path),
+        force=True,
+        peer_addresses={"a": "127.0.0.1", "b": "127.0.0.2"},
+    )
+
+    # Sender wraps the encoded packet stream, not the image.
+    sender = yaml.safe_load((tmp_path / "b" / "ota_wrapper.yaml").read_text(encoding="utf-8"))
+    assert [item["topic_regex"] for item in sender["ota_wrapper"]] == ["^/camera/image/ffmpeg$"]
+
+    # Receiver unwraps back onto the name the decoder subscribes to.
+    receiver = yaml.safe_load((tmp_path / "a" / "ota_unwrapper.yaml").read_text(encoding="utf-8"))
+    assert [item["topic_regex"] for item in receiver["ota_unwrapper"]] == ["^/camera/image/ffmpeg/ota_stamped$"]
+
+    spec = yaml.safe_load((tmp_path / "a" / "pipeline_spec.yaml").read_text(encoding="utf-8"))
+    topic = next(t for t in spec["topics"] if t["base"] == "/camera/image")
+    stages = {stage["stage"]: stage for stage in topic["stages"]}
+    # com_in is where loss and OTA transit are read, so it has to be the envelope.
+    assert stages["com_in"]["topic"] == "/com/in/b/camera/image/ffmpeg/ota_stamped"
+    assert stages["com_in"]["type"] == generator.OTA_STAMPED_MSG_TYPE
+    # ... and what the application finally reads is the decoded image.
+    assert stages["native_in"]["topic"] == "/camera/image/ffmpeg/raw"
+    assert stages["native_in"]["type"] == "sensor_msgs/msg/Image"


### PR DESCRIPTION
Closes #259.

`use_ota_wrapper` exists so that a stream crossing OTA carries a `seq` and a
send stamp — the only per-message accounting there is. That holds only if the
envelope carries *what actually crosses the link*. The stage chain did not
guarantee it: the wrapper ran before the transport, so a topic with both would
hand the ffmpeg encoder a `com_msgs/OtaStamped` and deliver
`<base>/ota_stamped/ffmpeg`. Not rejected — silently built as nonsense, which is
why downstream projects blacklist the pair in their own definition checkers, and
why an encoded camera is the one stream on a real link with neither `loss_pct`
nor a true OTA transit time.

Nothing about the sensible composition is exotic: what crosses OTA for an ffmpeg
stream is an ordinary `FFMPEGPacket` topic, the wrapper is type-agnostic, and
the unwrapper republishes on the pre-wrap name — exactly where the reverse
republish already subscribes. Only the stage order made it inexpressible.

### What changed

- **The wrapper is the last sender-side stage**, unconditionally: `transport`
  now runs before `ota_wrap`, and `_final_topic_type` reports `OtaStamped` for a
  wrapped topic (the unsupported-transport-type check still runs first).
- **One place computes the receiver-side name.** `_delivered_topic()` walks the
  chain backwards (unwrap → decode → decompress → framebridge down) and
  `_postprocessed_topic()` appends `/trickle`. The status pipeline spec, the
  trickle node's subscription and the normalizer's suffix all use it.
- **Trickle no longer republishes the envelope.** It subscribed to the OTA
  `final`, so a wrapped topic got its `OtaStamped` republished at a fixed rate
  under `<wrapped>/trickle` while the application waited on
  `<unwrapped>/trickle` — the same defect on the receiver side.
- `session-configuration.md`'s "exact" pipeline order listed neither `latch` nor
  the wrapper; it now lists both, states that the wrapper is always last and
  why, and documents the receiver-side chain.

One behaviour change beyond the wrapper: `framebridge: global_to_local` combined
with `compress` used to report the pre-compress (globalframe) topic as delivered
instead of the local base topic. No session in this repository or downstream
combines the two, so nothing observable moves.

### Validation

New `tests/unit/test_session_pipeline.py` (15 tests):

- `transport` + `use_ota_wrapper` → OTA topic `<base>/ffmpeg/ota_stamped` typed
  `com_msgs/OtaStamped`, encoder input `<base>`, wrapper input `<base>/ffmpeg`;
- the delivered topic is `<base>/ffmpeg/raw`, **identical to the unwrapped
  pipeline** — that is the property that makes wrapping safe;
- `trickle_hz` + `use_ota_wrapper` delivers `<unwrapped>/trickle`;
- a parametrized table pins the names of every combination that existed before;
- an end-to-end generation check on the written peer files: `ota_wrapper.yaml`
  matches `^/camera/image/ffmpeg$`, `ota_unwrapper.yaml` matches
  `^/camera/image/ffmpeg/ota_stamped$`, and the status spec's `com_in` is the
  envelope (so loss/transit are readable) while `native_in` is the decoded
  image.

End to end in CI: example `17_synthetic_camera_quality` now wraps its encoded
camera and asserts `loss_pct`, so the `media` e2e slice exercises
encode → wrap → OTA → unwrap → decode and still compares PSNR/SSIM on
`/camera/image/ffmpeg/raw` — the same topic name as before. The bound is the
same 30% the video-quality check already tolerates on that synthetic link; the
assertion's purpose is that the number exists at all, since `loss_pct` on a
topic that cannot report it fails.

```bash
python -m pytest tests/unit/test_session_pipeline.py -q
just test-e2e-slice media
```

Depends on nothing, but #257 (payload as a buffer) is what makes wrapping a
~100 kB video packet reasonable in practice.
