### PR TITLE
Stop fetching rosdep during container readiness

### DIFF
--- a/src/rosotacom/resources/examples/ros2docker.json
+++ b/src/rosotacom/resources/examples/ros2docker.json
@@ -11,7 +11,6 @@
   "run_args": [
     "-e", "ROS_DOMAIN_ID=48",
     "-e", "BUILD_ROS2WS=1",
-    "-e", "CHECK_ROS2WS_DEPENDENCIES=1",
     "--network", "host"
   ],
 

--- a/src/rosotacom/resources/ros2docker.json.example
+++ b/src/rosotacom/resources/ros2docker.json.example
@@ -11,7 +11,6 @@
   "run_args": [
     "-e", "ROS_DOMAIN_ID=47",
     "-e", "BUILD_ROS2WS=1",
-    "-e", "CHECK_ROS2WS_DEPENDENCIES=1",
     "--network", "host"
   ],
 

--- a/tests/contract/test_packaged_resources.py
+++ b/tests/contract/test_packaged_resources.py
@@ -164,6 +164,28 @@ def test_every_image_transport_the_session_plugin_can_select_is_installed() -> N
         assert not missing, f"{config_path.name} does not install {sorted(missing)}"
 
 
+def test_packaged_configs_do_not_fetch_rosdep_on_container_start() -> None:
+    """Readiness must cover the workspace build, not a third-party index fetch.
+
+    The packaged workspace dependencies come from the pinned base image and
+    explicit image package lists, then Docker smoke exercises the real build.
+    Enabling ros2docker's runtime check would run ``rosdep update`` for every
+    communication container before that small build and make readiness depend
+    on raw.githubusercontent.com.
+    """
+    configs = (
+        cli.DEFAULT_ROS2DOCKER_CONFIG,
+        cli.EXAMPLE_PROJECT_DIR / "ros2docker.json",
+    )
+
+    for config_path in configs:
+        config = cli.load_config(config_path)
+        run_args = [str(value) for value in config["run_args"]]
+
+        assert "BUILD_ROS2WS=1" in run_args
+        assert not any(arg.startswith("CHECK_ROS2WS_DEPENDENCIES=") for arg in run_args)
+
+
 def test_external_ros2docker_configs_install_selected_rmw_implementations() -> None:
     configs = sorted(cli.EXAMPLE_PROJECT_DIR.glob("scripts/**/external.ros2docker.json"))
     assert configs


### PR DESCRIPTION
Fixes #252

## Summary

- remove the runtime rosdep dependency check from both packaged ros2docker configs
- keep BUILD_ROS2WS enabled so readiness still gates on the actual workspace build
- add a contract test that prevents any CHECK_ROS2WS_DEPENDENCIES setting from returning to the packaged configs

The packaged workspace dependencies come from the pinned base image and explicit image package lists. Docker E2E exercises the real workspace build without making every container start fetch the rosdistro index from raw.githubusercontent.com.

## Validation

- `just check` — passed: lint, type checking, 725 unit/contract tests, docs/policy checks, and package validation
- full Docker E2E collection exercised: all 23 active cases passed across the monolithic run and isolated completion reruns; 5 opt-in Full-RMW cases skipped as designed
- `ROSOTACOM_RUN_E2E=1 .venv/bin/python -m pytest -q tests/e2e/test_benchmark_replay.py::test_loss_boundaries_against_costmap_replay` — 1 passed in 137.61s
- final sized-payload/timeline/video completion rerun — 3 passed in 286.52s

Commit: `c2d1c73`  
CI: pending