### PR TITLE
Two-side measurement: surface a dead peer, measure the link, survive a restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -532,9 +532,15 @@ The running session writes, under
 - `status.json` — machine-readable snapshot (source of truth) for tools/agents,
   refreshed on a short interval and on every state transition,
 - `status.txt` — a human-rendered table, and
-- `events.jsonl` — state transitions plus per-`(topic, seq)` transit records for
-  wrapped topics (delivered/lost/reordered, section latency, size, inter-arrival,
-  and jitter).
+- `events.jsonl` — state transitions plus per-`(topic, epoch, seq)` transit
+  records for wrapped topics (delivered/lost/reordered, section latency, size,
+  inter-arrival, and jitter). `epoch` counts the restarts of the sending peer's
+  wrapper: sequence numbers start at zero again after one, so it is what keeps
+  the numbering unique over an instance that outlived a restart.
+
+Which of the bandwidth numbers a session publishes answers which question —
+per-stream payload, whole-interface wire traffic, and the overhead ratio
+between them — is in [link bandwidth](docs/link-bandwidth.md).
 
 For fixed-interval network-condition samples alongside the same session, enable
 the [link trace recorder](docs/link-trace.md). It writes

--- a/README.md
+++ b/README.md
@@ -266,6 +266,25 @@ rosotacom start 1_heartbeat --identity b \
 
 `rosotacom` reads the static session input and creates generated files under `session-instances/<date>/<session>_<timestamp>_<id>/config/`, including per-peer plugin/session specs, topic lists, optional QoS, and optional `domain_bridge.yaml`. Catmux pane output is logged under the same instance in `logs/<peer>/catmux/`.
 
+What else a run leaves under `logs/<peer>/`, and which file to open first when a
+peer looked healthy but did nothing:
+
+| File | Written by | Read it for |
+|---|---|---|
+| `catmux/<NN>-<WINDOW>/<pane>.log` | `catmux_log_setup.sh` (`tmux pipe-pane`) | everything a node printed, including the traceback it died with |
+| `pane_failures.log` | the same script's prompt hook | one line per non-zero pane exit — **the file that answers "is any pane dead?"** |
+| `status/startup_check.json` | `status_overview`, once, `status_startup_grace_s` after start | the verdict: which outbound stages this peer promised and never published, plus the pane failures above |
+| `status/status.{json,txt}` and `status/events.jsonl` | `status_overview`, continuously | live per-stage state and the transit records |
+| `scenario/<component>.log` | `rosotacom start <scenario>` | each scenario application's own output |
+| `launcher.log`, `docker.log` | `rosotacom start` | the exact command, and the container's own stdout where it has one |
+
+A pane whose command exits drops back to a shell prompt and keeps looking alive
+— `docker ps` shows a healthy container and the other panes keep working. That
+is how a control centre ran for two hours on 2026-08-13 with no heartbeat
+publisher, because Cyclone had no free participant index left on the local
+domain and `heartbeat_echo` died two seconds after start. The last two rows of
+that table exist so the next one announces itself.
+
 ### Complete use cases with scenarios
 
 A session intentionally describes only the communication contract. When a use

--- a/docs/link-bandwidth.md
+++ b/docs/link-bandwidth.md
@@ -1,0 +1,73 @@
+# Link bandwidth: what each number means
+
+Three bandwidth numbers exist in a running session, and they answer three
+different questions. Mixing them up is how a link that delivered ~6 Mbit/s was
+reported at ~28 Gbit/s for a whole field run.
+
+| Topic / field | Measured where | Counts | Scope |
+|---|---|---|---|
+| `/topic_monitor/<dir>/<name>[/to_<peer>]/ros_topic_bandwidth_kbps` | subscriber on the local domain | serialized ROS payload of every `/com/<dir>/<name>/…` stage topic | one peer, one direction, application payload only |
+| `/topic_monitor/<dir>/<name>[/to_<peer>]/link_bandwidth_kbps` | `/proc/net/dev` counters of the OTA interface | every byte the kernel moved over that interface | the whole interface, all peers and all protocols on it |
+| `status.json` → `link` | the same counters, plus the overview's own per-stage sizes and rates | both of the above, and their ratio | one peer, both directions |
+
+`kbps` here is **Kibit/s** — bytes × 8 / 1024 / seconds. It has meant that
+since the topic existed; the name is kept so old recordings keep their meaning.
+The factor to Mbit/s is 1.024/1000, i.e. 6000 `kbps` ≈ 6.1 Mbit/s.
+
+## Which one answers "what does the camera cost the link"
+
+Neither `link_bandwidth_kbps` alone. It is an *interface* number: it includes
+DDS discovery, RTPS retransmits, ACKs, IP/UDP headers, and anything else
+sharing the interface. That is what makes it useful — the overhead is exactly
+what a payload sum cannot see — but it is not attributable to one stream.
+
+The attributable number is the per-topic row in `topic_monitor`'s table (or the
+per-stage `mean_size_bytes` × `hz` in `status.json`), and the honest way to
+report the cost of a stream on the link is the pair: payload for the stream,
+plus the session-level `overhead_ratio_out` / `overhead_ratio_in` from
+`status.json`, which is `link / payload` at the OTA boundary. A ratio near 1
+means the wire carries little beyond the payload; well above 1 means
+retransmits, shadow connections, discovery chatter, or QoS that does not fit
+the link. Small messages have a naturally higher ratio, because per-packet
+headers are a larger share of them.
+
+Per-remote-peer wire attribution is **not** available from these counters. On
+the deployments this stack runs on, the OTA interface is a dedicated tunnel
+carrying exactly one peer, so the interface number *is* the peer number. A
+setup that multiplexes peers on one interface needs a per-peer filter (`iftop`
+in the `NET` window, or packet accounting), and the `link` numbers should then
+be read as an upper bound.
+
+## How the interface is found
+
+From `ip_local` — the peer's own OTA address — by `find_interface_for_ip`,
+inside the node. `topic_monitor` and `status_overview` share
+`resolve_link_interface`, so they cannot disagree. An explicit `interface`
+parameter overrides it for a setup an address cannot describe.
+
+**A loopback interface is refused** when `ip_local` is not itself a loopback
+address, because loopback carries this host's own intra-process ROS traffic.
+`topic_monitor` fails to start; `status_overview` disables the `link` block and
+warns. Both are better than the number that made this rule necessary.
+
+### What went wrong before (issue #267)
+
+The interface used to be resolved in the session template:
+
+```yaml
+- interface=$(ip -o addr | awk '/'${ip_local//./\\.}'\/[0-9]+/ {print $2; exit}')
+```
+
+catmux substitutes `${name}` and nothing else — see
+`tests/contract/test_session_template_substitution.py`. `${ip_local//./\\.}` is
+not that form, so it reached the pane literally, bash expanded an unset shell
+variable to the empty string, and the awk program became `/\/[0-9]+/` — "the
+first address line with a prefix length", which is `lo` on every Linux host.
+
+Both peers therefore reported loopback traffic as link bandwidth for the whole
+2026-08-13 field session. On the centre it read ~5–7 Mbit/s and looked
+plausible. On the vehicle, which was also writing a 36 GB `-a` recording over
+the same loopback, it read ~28 Gbit/s — near-constant, and identical in both
+directions, which is the loopback signature (`rx_bytes` and `tx_bytes` are the
+same bytes). `status_overview`, which already resolved the interface in the
+node, reported `tun1` correctly in the same run.

--- a/docs/rfcs/0003-metric-backbone.md
+++ b/docs/rfcs/0003-metric-backbone.md
@@ -46,7 +46,8 @@ It **feeds** the existing verdict layer (unlocks `expect.loss_pct`; sharpens
 Every metric on the wishlist is a projection of one recorded object per message:
 
 ```
-(topic, seq):
+(topic, epoch, seq):
+  epoch       (receiver-derived)  — which run of the sender's wrapper this seq belongs to
   t_wrap      (sender clock)     — OtaStamped.header.stamp
   t_com_in    (receiver clock)   — arrival immediately after bridge_in
   status      — delivered | lost | reordered                        [from seq gap]
@@ -54,6 +55,21 @@ Every metric on the wishlist is a projection of one recorded object per message:
     ota_hop   = (t_com_in + θ) − t_wrap          (θ = sender/peer − receiver/local)
   inter_arrival / jitter         — receiver-local regularity
 ```
+
+**Why `epoch` is part of the key.** `universal_ota_wrapper` counts per topic
+from zero, so a peer that restarts inside an instance replays sequence numbers
+the receiver has already seen. The receiver detects the restart from the
+sequence stream itself (a backward jump larger than any reordering the
+transport can produce — `is_sequence_epoch_reset`) and counts epochs from 0.
+Without it, two things break at once and neither announces itself: live
+accounting calls every arrival after the restart `reordered`, and the offline
+join collapses the second run onto the first. On the 2026-08-13 field instance
+that was 124,572 of 304,876 records misclassified and 123,253 dropped from the
+joined output — 40% of the run, concentrated in the mission window.
+
+Epochs are receiver-local numbering, not an identifier the peers agree on:
+each side counts the restarts it observes on its own inbound stream. That is
+enough for both consumers, because both key within one receiver's records.
 
 The envelope carries only what the cross-host **OTA hop** needs (`t_wrap` +
 `seq`). Local / per-stage latency — including the message's pre-OTA pipeline cost —
@@ -210,6 +226,11 @@ in-order.
   restamp/latch/drop/throttle/pixel/frame transforms before compression and
   wrapping. Therefore `com_in` sequence gaps exclude intended pre-wrap shaping
   and measure failure after the wrap point.
+- **A restart costs the epoch's head, not the run.** The receiver cannot know
+  how many messages the peer published before DDS discovery matched the reader,
+  so the messages before the first arrival of a new epoch are not counted as
+  lost. In the 2026-08-13 instance that head was 37 to 41 messages per restart.
+  Counting them would report a loss the link never caused.
 - **`θ` drifts.** Re-estimate continuously; fine for short runs, relevant for
   hour-long sessions.
 - **Head-of-line blocking is the real failure mode.** Field data: a heavy message
@@ -275,9 +296,18 @@ PR; the e2e row runs in the single-machine smoke matrix (`just test-e2e-smoke`);
 the cross-host rows are the operator OTA gate.
 
 - [x] **Sequence loss / reorder / burst / epoch reset** — host:
-  `test_status_overview.py::test_sequence_loss_reorder_and_transit_records` and
-  `::test_sequence_zero_starts_new_epoch_after_publisher_restart`. Live: the e2e
+  `test_status_overview.py::test_sequence_loss_reorder_and_transit_records`,
+  `::test_sequence_zero_starts_new_epoch_after_publisher_restart`,
+  `::test_restart_is_recognised_when_seq_zero_never_arrives` (the field shape:
+  the first arrival of a new epoch is seq 37, not 0),
+  `::test_a_small_backward_jump_is_still_reordering` and
+  `::test_transit_records_carry_the_epoch_they_were_counted_in`. Live: the e2e
   row asserts delivered transit records on a running pipeline.
+- [x] **Epoch-keyed offline join** — host:
+  `test_transit.py::test_join_keeps_sequence_numbers_from_different_epochs_apart`,
+  `::test_records_without_an_epoch_are_one_epoch`,
+  `::test_lost_records_are_bounded_within_their_own_epoch` and
+  `::test_nominal_send_period_ignores_the_step_across_a_restart`.
 - [x] **`expect.loss_pct { max, stage? }` evaluation** — host:
   `test_status_eval.py::test_loss_pct_uses_first_sequence_aware_stage`,
   `::test_loss_pct_exceeded_fails`,

--- a/session-configuration.md
+++ b/session-configuration.md
@@ -169,6 +169,15 @@ Per-side config blocks:
 - DDS implementations (`cyclone`, `fastdds`) accept:
   - `config: <template>` — template file under `ws/ota_configs/` (e.g. `fastdds_v1.xml`, `cyclonedds.xml`, `fastdds_easy_mode.xml`). Omit to use the RMW's built-in defaults.
   - `easy_mode_ip: <string>` — only honored by `fastdds_easy_mode.xml`; defaults to the first resolved peer address.
+
+  On the **local** side of a busy machine, set
+  `config: cyclonedds_local_participants.xml`. Cyclone allows 33 participants
+  per domain per host by default, and a control centre running its own
+  application next to the communication peer exceeds that: the processes that
+  start last fail with `Failed to find a free participant index for domain N`
+  and exit. That template raises the limit and changes nothing else — it pins no
+  interface and sets no peer list, because local discovery must keep working.
+  The OTA templates are not usable on the local side for exactly that reason.
 - `zenoh_connect_endpoints` (native, OTA side only; `zenoh` is still accepted as a legacy OTA alias) accepts:
   - `main_peer: <peer_key>` — the peer whose zenoh router listens. Defaults to the first peer declared under `peers:`.
   - `main_port: 7447` — listening port. Default `7447`.

--- a/src/rosotacom/cli.py
+++ b/src/rosotacom/cli.py
@@ -1083,9 +1083,29 @@ def _mark_interactive_smoke_stopped(instance_dir: Path, target_type: str, target
 
 
 def _write_docker_log(container_name: str, instance: SessionInstance, identity: str) -> None:
+    """Snapshot the peer container's own stdout into ``logs/<peer>/docker.log``.
+
+    In `attach` mode the container is `--rm` and already gone by the time this
+    runs, so `docker logs` answers "No such container". That answer used to be
+    written verbatim, which produced a 75-byte file that reads like the record
+    of the run and says nothing -- it was the whole of `logs/<peer>/` besides
+    `launcher.log` when a field session had to be diagnosed after the fact
+    (#266). The catmux per-pane logs under `catmux/` are the actual record, so
+    say that instead of pretending this file is one.
+    """
     try:
         result = subprocess.run(["docker", "logs", container_name], text=True, capture_output=True, check=False)
     except Exception:
+        return
+    if result.returncode != 0:
+        stderr = (result.stderr or "").strip()
+        _append_log(
+            _peer_docker_log(instance, identity),
+            f"[rosotacom] docker logs {container_name}: {stderr or 'unavailable'}\n"
+            "[rosotacom] The container is not (or no longer) present -- in attach mode it is\n"
+            "[rosotacom] `--rm` and exits with the foreground command. What each pane inside\n"
+            f"[rosotacom] it printed is under {_peer_docker_log(instance, identity).parent / 'catmux'}.",
+        )
         return
     logs = (result.stdout or "") + (result.stderr or "")
     if logs:

--- a/src/rosotacom/resources/ws/ota_configs/cyclonedds_local_participants.xml.template
+++ b/src/rosotacom/resources/ws/ota_configs/cyclonedds_local_participants.xml.template
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Local-domain CycloneDDS configuration: default discovery, more participants.
+
+Set it as `shared.rmw.local.cyclone.config` (or a peer's `local_config_template`)
+on a machine where many processes share the communication peer's local domain.
+
+Why: Cyclone gives each process one participant index per domain, and its default
+MaxAutoParticipantIndex is 32 - 33 slots per domain per host. A control centre
+spends them faster than that sounds. The processes that start last then lose the
+race, and the error names the domain rather than the cause:
+
+  [46] heartbeat_: Failed to find a free participant index for domain 46
+  [ERROR] [rmw_cyclonedds_cpp]: rmw_create_node: failed to create domain, error Error
+
+On 2026-08-13 that killed the centre's `heartbeat_echo` and one `topic_monitor`
+two seconds after start. catmux left both panes at a shell prompt, so the session
+ran for two hours with no heartbeat publisher: no RTT, no clock-offset estimate,
+and every EchoHeartbeat the far side received carried `echo_valid=false`.
+
+119, not higher: Cyclone's unicast discovery ports are
+7400 + 250*domain + 10 + 2*index, so 119 is the last index whose ports stay
+inside this domain's 250-port block. Index 120 would answer on the next
+domain's ports.
+
+Nothing else is set. This is the *local* domain -- intra-host discovery must keep
+working, so unlike the OTA templates it pins no interface, disables no multicast,
+and sets no peer list.
+-->
+<CycloneDDS xmlns="https://cdds.io/config">
+  <Domain Id="any">
+    <Discovery>
+      <ParticipantIndex>auto</ParticipantIndex>
+      <MaxAutoParticipantIndex>119</MaxAutoParticipantIndex>
+    </Discovery>
+  </Domain>
+</CycloneDDS>

--- a/src/rosotacom/resources/ws/ros2src/com_py/com_py/link_bytes.py
+++ b/src/rosotacom/resources/ws/ros2src/com_py/com_py/link_bytes.py
@@ -78,6 +78,19 @@ def parse_ip_addr_for_ip(text: str, ip: str) -> Optional[str]:
     return None
 
 
+#: Interface names that carry intra-host traffic only. Sampling one of these and
+#: calling the result "link bandwidth" is the failure of issue #267: the number
+#: is real, it is just not the link. On a machine that also runs a `-a` recorder
+#: it reads ~28 Gbit/s next to a 6 Mbit/s OTA link.
+LOOPBACK_INTERFACES = frozenset({"lo", "lo0"})
+
+
+def is_loopback_address(ip: str) -> bool:
+    """Is ``ip`` a loopback address (so a loopback interface would be correct)?"""
+    ip = (ip or "").strip()
+    return ip.startswith("127.") or ip in {"::1", "0:0:0:0:0:0:0:1"}
+
+
 def find_interface_for_ip(ip: str) -> Optional[str]:
     """The interface owning ``ip``, via `ip -o addr show` (None if not found)."""
     if not ip:
@@ -89,6 +102,40 @@ def find_interface_for_ip(ip: str) -> Optional[str]:
     except (OSError, subprocess.SubprocessError):
         return None
     return parse_ip_addr_for_ip(out, ip)
+
+
+def resolve_link_interface(
+    explicit: str,
+    host_ip: str,
+    finder=find_interface_for_ip,
+) -> Tuple[str, str]:
+    """The OTA link interface and where it came from, or raise.
+
+    ``explicit`` wins when given; otherwise the interface is the one owning
+    ``host_ip`` (the peer's own OTA address). A loopback interface for a
+    non-loopback address is refused rather than reported: loopback carries this
+    host's own ROS traffic, which on a machine running an ``-a`` recorder is
+    three orders of magnitude above the link and looks like a working
+    measurement. That mistake is issue #267; it survived a field session and an
+    offline analysis before anyone doubted the number.
+    """
+    interface = (explicit or "").strip()
+    provenance = "given explicitly"
+    if not interface:
+        interface = (finder(host_ip) or "").strip()
+        provenance = f"resolved from {host_ip}"
+    if not interface:
+        raise ValueError(
+            f"no interface owns the OTA address '{host_ip}'; "
+            "pass ip_local (preferred) or interface"
+        )
+    if interface in LOOPBACK_INTERFACES and not is_loopback_address(host_ip):
+        raise ValueError(
+            f"refusing to report loopback interface '{interface}' as the link for OTA "
+            f"address '{host_ip}' ({provenance}). Loopback carries this host's own ROS "
+            "traffic, not the link."
+        )
+    return interface, provenance
 
 
 def read_iface_counters(iface: str, proc_path: str = PROC_NET_DEV) -> Optional[Tuple[int, int]]:

--- a/src/rosotacom/resources/ws/ros2src/com_py/com_py/status_overview.py
+++ b/src/rosotacom/resources/ws/ros2src/com_py/com_py/status_overview.py
@@ -70,6 +70,7 @@ from rosidl_runtime_py.utilities import get_message
 from com_py.link_bytes import LinkByteSampler, resolve_link_interface
 from com_py.link_trace import LinkTraceRecorder
 from com_py.status_overview_core import (
+    STARTUP_GRACE_S,
     ClockOffsetEstimator,
     StageObservation,
     StatusAggregator,
@@ -334,6 +335,8 @@ class StatusOverview(Node):
         self.declare_parameter("link_trace_interval_s", 1.0)
         self.declare_parameter("link_trace_modem_command", "")
         self.declare_parameter("link_trace_modem_timeout_s", 2.0)
+        # Grace before the one-shot startup verdict (#266). 0 disables it.
+        self.declare_parameter("startup_grace_s", STARTUP_GRACE_S)
 
         spec_file = str(self.get_parameter("status_spec_file").value or "").strip()
         output_dir = str(self.get_parameter("output_dir").value or "").strip()
@@ -453,6 +456,7 @@ class StatusOverview(Node):
             link_sampler=link_sampler,
             clock_estimator=clock_estimator,
             link_trace_recorder=link_trace_recorder,
+            startup_grace_s=float(self.get_parameter("startup_grace_s").value),
         )
 
         self.create_timer(self.write_interval_s, self._on_write)

--- a/src/rosotacom/resources/ws/ros2src/com_py/com_py/status_overview.py
+++ b/src/rosotacom/resources/ws/ros2src/com_py/com_py/status_overview.py
@@ -67,7 +67,7 @@ from rclpy.qos import DurabilityPolicy, HistoryPolicy, QoSProfile, ReliabilityPo
 from rclpy.serialization import serialize_message
 from rosidl_runtime_py.utilities import get_message
 
-from com_py.link_bytes import LinkByteSampler, find_interface_for_ip
+from com_py.link_bytes import LinkByteSampler, resolve_link_interface
 from com_py.link_trace import LinkTraceRecorder
 from com_py.status_overview_core import (
     ClockOffsetEstimator,
@@ -410,20 +410,23 @@ class StatusOverview(Node):
 
         ota_interface = str(self.get_parameter("ota_interface").value or "").strip()
         ota_local_ip = str(self.get_parameter("ota_local_ip").value or "").strip()
-        if not ota_interface and ota_local_ip:
-            ota_interface = find_interface_for_ip(ota_local_ip) or ""
-            if not ota_interface:
-                self.get_logger().info(
-                    f"status_overview: no interface found for OTA address '{ota_local_ip}'; "
-                    "link-overhead measurement disabled"
-                )
         link_sampler = None
-        if ota_interface:
-            link_sampler = LinkByteSampler(ota_interface)
-            self.get_logger().info(
-                f"status_overview: link-overhead sampling on interface '{ota_interface}'"
-                + (f" (resolved from {ota_local_ip})" if ota_local_ip else "")
-            )
+        if ota_interface or ota_local_ip:
+            # Same resolution and the same loopback refusal as topic_monitor: a
+            # link number nobody can tell apart from loopback traffic is worse
+            # than no link number, so this reports nothing rather than that.
+            try:
+                ota_interface, provenance = resolve_link_interface(ota_interface, ota_local_ip)
+            except ValueError as exc:
+                self.get_logger().warning(
+                    f"status_overview: {exc}; link-overhead measurement disabled"
+                )
+            else:
+                link_sampler = LinkByteSampler(ota_interface)
+                self.get_logger().info(
+                    f"status_overview: link-overhead sampling on interface "
+                    f"'{ota_interface}' ({provenance})"
+                )
 
         link_trace_recorder = None
         if bool(self.get_parameter("link_trace").value):

--- a/src/rosotacom/resources/ws/ros2src/com_py/com_py/status_overview_core.py
+++ b/src/rosotacom/resources/ws/ros2src/com_py/com_py/status_overview_core.py
@@ -175,6 +175,44 @@ def stamp_delay(raw_delay_s: float, clock_offset_s: Optional[float] = None) -> O
     return None
 
 
+#: How far back a sequence number may jump and still be called reordering.
+#: `universal_ota_wrapper` counts per topic from zero and increments by one, so
+#: a receiver sees a backward jump only when the wire reordered a message or
+#: when the publishing peer restarted. Reordering is bounded by the transport's
+#: history depth (single digits for the QoS this stack uses); a restart lands
+#: thousands of sequence numbers back. 64 sits between the two by two orders of
+#: magnitude on both sides.
+SEQUENCE_REORDER_TOLERANCE = 64
+
+
+def is_sequence_epoch_reset(
+    seq: int,
+    expected_next_seq: Optional[int],
+    tolerance: int = SEQUENCE_REORDER_TOLERANCE,
+) -> bool:
+    """Does ``seq`` begin a new sequence epoch (the peer's wrapper restarted)?
+
+    Zero is unambiguous and was the only case handled before. It is also the
+    case that almost never arrives: DDS discovery takes long enough that the
+    first tens of messages of a fresh publisher are written before the reader
+    has matched. In the 2026-08-13 field instance the peer restarted four times
+    and the first arrival after each restart carried seq 37, 39, 39 and 41 --
+    never 0. Every one of them was therefore counted as `reordered`, and
+    because the baseline was never reset, so was every message after it: 26,453
+    of 55,437 transits on one 10 Hz topic, for the rest of the instance.
+
+    So a large backward jump counts as a restart too. It is corroborated by an
+    arrival gap (105 s, 32 s, 44 s and 195 s in that instance), but the gap is
+    not required: a fast restart is still a restart, and the jump alone already
+    separates the two causes by orders of magnitude.
+    """
+    if expected_next_seq is None or seq >= expected_next_seq:
+        return False
+    if seq == 0:
+        return True
+    return (expected_next_seq - seq) > tolerance
+
+
 # --- Link overhead (session-level) -----------------------------------------
 
 def _payload_kbps(stage: Optional[Dict[str, Any]]) -> float:
@@ -258,6 +296,8 @@ class StageObservation:
     expected_next_seq: Optional[int] = None
     last_seq: Optional[int] = None
     tracks_sequence: bool = False
+    epoch: int = 0
+    epoch_resets: int = 0
     total_expected: int = 0
     total_missing: int = 0
     total_reordered: int = 0
@@ -302,11 +342,15 @@ class StageObservation:
                 if self.expected_next_seq is None:
                     expected_delta = 1
                     self.expected_next_seq = seq + 1
-                elif seq == 0 and self.expected_next_seq > 1:
-                    # A publisher restart begins a new sequence epoch. Without
-                    # an explicit boot id, zero is the only unambiguous reset.
+                elif is_sequence_epoch_reset(seq, self.expected_next_seq):
+                    # A publisher restart begins a new sequence epoch: the
+                    # wrapper counts from zero again. See
+                    # `is_sequence_epoch_reset` for why the first arrival after
+                    # a restart is almost never seq 0, and what that cost.
+                    self.epoch += 1
+                    self.epoch_resets += 1
                     expected_delta = 1
-                    self.expected_next_seq = 1
+                    self.expected_next_seq = seq + 1
                 elif seq >= self.expected_next_seq:
                     missing = seq - self.expected_next_seq
                     missing_start = self.expected_next_seq if missing else None
@@ -331,6 +375,10 @@ class StageObservation:
                     "topic": transit.get("topic"),
                     "direction": transit.get("direction"),
                     "stage": transit.get("stage"),
+                    # Which run of the peer's wrapper produced this sequence
+                    # number. Without it the offline join collapses seq 0..N of
+                    # every epoch after the first onto the first epoch's rows.
+                    "epoch": self.epoch,
                 }
                 if missing_start is not None:
                     for missing_seq in range(missing_start, int(seq)):
@@ -421,6 +469,8 @@ class StageObservation:
             total_missing = self.total_missing
             total_reordered = self.total_reordered
             total_max_burst = self.max_burst_missing
+            epoch = self.epoch
+            epoch_resets = self.epoch_resets
         hz = count / window_s if window_s > 0 else 0.0
         mean_size = (total_bytes / count) if count > 0 else 0.0
         age = (now_mono - last_recv_mono) if last_recv_mono is not None else None
@@ -441,6 +491,8 @@ class StageObservation:
             "loss_total_pct": _pct(total_missing, total_expected) if tracks_sequence else None,
             "reordered_total": total_reordered if tracks_sequence else None,
             "max_burst_missing_total": total_max_burst if tracks_sequence else None,
+            "epoch": epoch if tracks_sequence else None,
+            "epoch_resets": epoch_resets if tracks_sequence else None,
         }
 
     def drain_transit_records(self) -> List[Dict[str, Any]]:
@@ -516,6 +568,8 @@ class StatusAggregator:
             "reordered_total": None,
             "max_burst_missing": None,
             "max_burst_missing_total": None,
+            "epoch": None,
+            "epoch_resets": None,
             "age_s": None,
             "last_message_wall": None,
             "messages_total": 0,
@@ -551,6 +605,8 @@ class StatusAggregator:
             "reordered_total",
             "max_burst_missing",
             "max_burst_missing_total",
+            "epoch",
+            "epoch_resets",
         ):
             result[key] = m[key]
         if m["last_recv_wall"] is not None:
@@ -589,6 +645,8 @@ class StatusAggregator:
             "reordered_total",
             "max_burst_missing",
             "max_burst_missing_total",
+            "epoch",
+            "epoch_resets",
             "age_s",
             "last_message_wall",
             "messages_total",

--- a/src/rosotacom/resources/ws/ros2src/com_py/com_py/status_overview_core.py
+++ b/src/rosotacom/resources/ws/ros2src/com_py/com_py/status_overview_core.py
@@ -175,6 +175,47 @@ def stamp_delay(raw_delay_s: float, clock_offset_s: Optional[float] = None) -> O
     return None
 
 
+#: How long a peer is given to bring its own publishers up before their absence
+#: is called a defect. Node start, DDS discovery and the first `refresh_interval`
+#: of the observers all happen inside it; 20 s is roughly four times what a
+#: healthy bring-up needs.
+STARTUP_GRACE_S = 20.0
+
+
+def outbound_startup_gaps(snapshot: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Stages this peer promised to publish and did not, once past the grace.
+
+    Only outbound topics: every stage of one is produced on this machine, so its
+    absence is this peer's problem. Inbound stages depend on the peer and the
+    link, which the per-topic rollup already diagnoses.
+
+    This exists because of a failure that produced no error anywhere. On
+    2026-08-13 the centre's `heartbeat_echo` and one `topic_monitor` died two
+    seconds after start -- Cyclone had no free participant index left on the
+    local domain -- and catmux left both panes sitting at a shell prompt. The
+    session ran for two hours with no heartbeat publisher, so the run has no RTT
+    and no clock-offset measurement, and the far side reported `status=LOST
+    reason=age hz=0.00` about a peer that was otherwise healthy.
+    """
+    gaps: List[Dict[str, Any]] = []
+    for topic in snapshot.get("topics", []):
+        if topic.get("direction") != "outbound":
+            continue
+        for stage in topic.get("stages", []):
+            if stage.get("state") != ABSENT:
+                continue
+            gaps.append(
+                {
+                    "base": topic.get("base"),
+                    "stage": stage.get("stage"),
+                    "topic": stage.get("topic"),
+                    "domain": stage.get("domain"),
+                    "produced_by": stage.get("produced_by"),
+                }
+            )
+    return gaps
+
+
 #: How far back a sequence number may jump and still be called reordering.
 #: `universal_ota_wrapper` counts per topic from zero and increments by one, so
 #: a receiver sees a backward jump only when the wire reordered a message or
@@ -516,7 +557,9 @@ class StatusAggregator:
                  *, liveness_window_s: float = 3.0, stale_after_s: float = 3.0,
                  delay_good_ms: float = 100.0, delay_bad_ms: float = 200.0,
                  link_sampler: Any = None, clock_estimator: Any = None,
-                 link_trace_recorder: Any = None):
+                 link_trace_recorder: Any = None,
+                 startup_grace_s: float = STARTUP_GRACE_S,
+                 started_mono: Optional[float] = None):
         self._log = logger
         self._spec = spec
         self._output_dir = output_dir
@@ -536,6 +579,17 @@ class StatusAggregator:
         self._json_path = os.path.join(self._output_dir, "status.json")
         self._txt_path = os.path.join(self._output_dir, "status.txt")
         self._events_path = os.path.join(self._output_dir, "events.jsonl")
+        self._startup_path = os.path.join(self._output_dir, "startup_check.json")
+        # `pane_failures.log` is written by catmux_log_setup.sh one level up, in
+        # logs/<peer>/. The verdict quotes it because a pane that exited is the
+        # most common reason a promised publisher never appears, and the two
+        # facts are useless apart.
+        self._pane_failure_path = os.path.join(
+            os.path.dirname(os.path.abspath(self._output_dir)), "pane_failures.log"
+        )
+        self._startup_grace_s = startup_grace_s
+        self._started_mono = time.monotonic() if started_mono is None else started_mono
+        self._startup_check: Optional[Dict[str, Any]] = None
 
     # -- observation lookup --
     def _obs_for(self, stage: Dict[str, Any]) -> Optional[StageObservation]:
@@ -896,6 +950,7 @@ class StatusAggregator:
             "summary": counts,
             "link": compute_link_overview(topics_out, link_sample),
             "clock_sync": self._clock_snapshot(now_mono),
+            "startup_check": self._startup_check,
             "topics": topics_out,
         }
 
@@ -973,6 +1028,20 @@ class StatusAggregator:
             f"summary: OK={s.get('OK', 0)} PARTIAL={s.get('PARTIAL', 0)} "
             f"STALLED={s.get('STALLED', 0)} ABSENT={s.get('ABSENT', 0)}   (Phase 1: local observation)"
         )
+        # The STAT watcher pane shows this file, so a failed startup check has to
+        # be readable here or it is not surfaced where anybody looks.
+        check = snapshot.get("startup_check")
+        if check and check.get("verdict") != "ok":
+            gaps = check.get("missing_outbound_stages") or []
+            panes = check.get("pane_failures") or []
+            lines.append(
+                f"STARTUP CHECK FAILED after {check.get('checked_after_s')}s: "
+                f"{len(gaps)} outbound stage(s) without a publisher, {len(panes)} pane(s) exited"
+            )
+            for gap in gaps:
+                lines.append(f"    no publisher: {gap.get('topic')} ({gap.get('produced_by')})")
+            for line in panes:
+                lines.append(f"    pane exited: {line}")
         lines.append("")
         for t in snapshot["topics"]:
             arrow = "->" if t["direction"] == "outbound" else "<-"
@@ -1020,6 +1089,70 @@ class StatusAggregator:
             fp.write(text)
         os.replace(tmp, path)
 
+    def _read_pane_failures(self) -> List[str]:
+        try:
+            with open(self._pane_failure_path, "r", encoding="utf-8", errors="replace") as fp:
+                return [line.rstrip("\n") for line in fp if line.strip()]
+        except OSError:
+            return []
+
+    def _maybe_run_startup_check(
+        self, snapshot: Dict[str, Any], now_mono: Optional[float]
+    ) -> None:
+        """Once, after the grace period: did this peer bring up what it promised?
+
+        Written as a verdict at a defined moment rather than left implicit in a
+        table that is refreshed every two seconds. `status.json` already carried
+        the evidence on 2026-08-13 -- 13 stages STALLED, `clock_sync: null` --
+        and nobody read it, because nothing said "this is wrong now".
+        """
+        if self._startup_check is not None or self._startup_grace_s <= 0.0:
+            return
+        now = time.monotonic() if now_mono is None else now_mono
+        if now - self._started_mono < self._startup_grace_s:
+            return
+
+        gaps = outbound_startup_gaps(snapshot)
+        pane_failures = self._read_pane_failures()
+        verdict = "ok" if not gaps and not pane_failures else "incomplete"
+        self._startup_check = {
+            "verdict": verdict,
+            "checked_after_s": round(now - self._started_mono, 1),
+            "generated_at": snapshot.get("generated_at"),
+            "peer": snapshot.get("peer"),
+            "missing_outbound_stages": gaps,
+            "pane_failures": pane_failures,
+        }
+        snapshot["startup_check"] = self._startup_check
+        try:
+            self._atomic_write(
+                self._startup_path, json.dumps(self._startup_check, indent=2) + "\n"
+            )
+        except Exception as exc:  # pragma: no cover - defensive
+            if self._log is not None:
+                self._log.warning(f"status_overview: failed to write startup check: {exc}")
+        if self._log is None:
+            return
+        if verdict == "ok":
+            self._log.info(
+                "status_overview: startup check OK -- every outbound stage of "
+                f"{snapshot.get('peer')} has a publisher"
+            )
+            return
+        self._log.error(
+            f"status_overview: STARTUP CHECK FAILED for peer {snapshot.get('peer')} "
+            f"after {self._startup_check['checked_after_s']}s -- "
+            f"{len(gaps)} outbound stage(s) have no publisher, "
+            f"{len(pane_failures)} pane(s) exited. See {self._startup_path}"
+        )
+        for gap in gaps:
+            self._log.error(
+                f"status_overview:   no publisher on {gap['topic']} "
+                f"(stage {gap['stage']}, produced_by {gap['produced_by']})"
+            )
+        for line in pane_failures:
+            self._log.error(f"status_overview:   pane exited: {line}")
+
     def write(self, now_mono: Optional[float] = None) -> int:
         """Build a snapshot, write artifacts, and return number of transition events."""
         link_sample = None
@@ -1030,6 +1163,7 @@ class StatusAggregator:
                 if self._log is not None:
                     self._log.warning(f"status_overview: link sampling failed: {exc}")
         snapshot = self.build_snapshot(now_mono, link_sample=link_sample)
+        self._maybe_run_startup_check(snapshot, now_mono)
         if self._link_trace_recorder is not None:
             try:
                 self._link_trace_recorder.maybe_write(snapshot, link_sample)

--- a/src/rosotacom/resources/ws/ros2src/com_py/com_py/status_overview_core.py
+++ b/src/rosotacom/resources/ws/ros2src/com_py/com_py/status_overview_core.py
@@ -182,12 +182,35 @@ def stamp_delay(raw_delay_s: float, clock_offset_s: Optional[float] = None) -> O
 STARTUP_GRACE_S = 20.0
 
 
-def outbound_startup_gaps(snapshot: Dict[str, Any]) -> List[Dict[str, Any]]:
-    """Stages this peer promised to publish and did not, once past the grace.
+#: Stage producers rosotacom starts itself, and can therefore promise. The
+#: application that feeds a link is the user's, and a session that declares a
+#: topic says nothing about whether its publisher is running right now -- a
+#: smoke run legitimately exercises the peers without the data source.
+ROSOTACOM_STAGE_PRODUCERS = frozenset({"heartbeat_echo", "preprocessing", "relay_out", "bridge_out"})
 
-    Only outbound topics: every stage of one is produced on this machine, so its
-    absence is this peer's problem. Inbound stages depend on the peer and the
-    link, which the per-topic rollup already diagnoses.
+
+def outbound_startup_gaps(snapshot: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Where each outbound topic first has no publisher at all, and whose fault it is.
+
+    Only outbound topics: their stages are produced on this machine. Inbound
+    stages depend on the peer and the link, which the per-topic rollup already
+    diagnoses.
+
+    Only the *first* absent stage per topic, because the ones behind it are
+    absent for the trivial reason that nothing reached them, and reporting a
+    cascade as four findings buries the one that matters.
+
+    `owner` is what makes the finding actionable, and it takes three values that
+    look identical in the graph:
+
+    * ``rosotacom`` -- a stage this peer starts itself, whose input is arriving.
+      It had something to forward and forwarded nothing. This is the defect.
+    * ``application`` -- the native stage of a topic the user's application (or a
+      replay) publishes. Not this peer's promise.
+    * ``upstream`` -- a stage this peer starts whose input has not delivered a
+      message yet. Its publisher appears on discovery of the input, so there is
+      nothing wrong: `universal_ota_wrapper` has no `…/ota_stamped` publisher
+      until something publishes the topic it wraps.
 
     This exists because of a failure that produced no error anywhere. On
     2026-08-13 the centre's `heartbeat_echo` and one `topic_monitor` died two
@@ -195,24 +218,44 @@ def outbound_startup_gaps(snapshot: Dict[str, Any]) -> List[Dict[str, Any]]:
     local domain -- and catmux left both panes sitting at a shell prompt. The
     session ran for two hours with no heartbeat publisher, so the run has no RTT
     and no clock-offset measurement, and the far side reported `status=LOST
-    reason=age hz=0.00` about a peer that was otherwise healthy.
+    reason=age hz=0.00` about a peer that was otherwise healthy. The heartbeat is
+    the one outbound topic rosotacom publishes itself, which is why the
+    generator marks its native stage `heartbeat_echo` rather than `application`.
     """
     gaps: List[Dict[str, Any]] = []
     for topic in snapshot.get("topics", []):
         if topic.get("direction") != "outbound":
             continue
+        upstream: Optional[Dict[str, Any]] = None
         for stage in topic.get("stages", []):
             if stage.get("state") != ABSENT:
+                upstream = stage
                 continue
+            producer = stage.get("produced_by")
+            if producer not in ROSOTACOM_STAGE_PRODUCERS:
+                owner = "application"
+                reason = "the application that publishes this topic is not running"
+            elif upstream is not None and upstream.get("state") not in (FLOWING, STALE):
+                owner = "upstream"
+                reason = (
+                    f"nothing has arrived on {upstream.get('topic')} "
+                    f"(stage {upstream.get('stage')}), so there is nothing to publish yet"
+                )
+            else:
+                owner = "rosotacom"
+                reason = f"{producer} did not come up"
             gaps.append(
                 {
                     "base": topic.get("base"),
                     "stage": stage.get("stage"),
                     "topic": stage.get("topic"),
                     "domain": stage.get("domain"),
-                    "produced_by": stage.get("produced_by"),
+                    "produced_by": producer,
+                    "owner": owner,
+                    "reason": reason,
                 }
             )
+            break
     return gaps
 
 
@@ -1113,14 +1156,17 @@ class StatusAggregator:
             return
 
         gaps = outbound_startup_gaps(snapshot)
+        mine = [gap for gap in gaps if gap["owner"] == "rosotacom"]
+        theirs = [gap for gap in gaps if gap["owner"] != "rosotacom"]
         pane_failures = self._read_pane_failures()
-        verdict = "ok" if not gaps and not pane_failures else "incomplete"
+        verdict = "ok" if not mine and not pane_failures else "incomplete"
         self._startup_check = {
             "verdict": verdict,
             "checked_after_s": round(now - self._started_mono, 1),
             "generated_at": snapshot.get("generated_at"),
             "peer": snapshot.get("peer"),
-            "missing_outbound_stages": gaps,
+            "missing_outbound_stages": mine,
+            "waiting_for_input": theirs,
             "pane_failures": pane_failures,
         }
         snapshot["startup_check"] = self._startup_check
@@ -1133,19 +1179,29 @@ class StatusAggregator:
                 self._log.warning(f"status_overview: failed to write startup check: {exc}")
         if self._log is None:
             return
+        if theirs:
+            # Not a defect and deliberately not an error: whether the data source
+            # is publishing is the application's business, not this peer's, and a
+            # stage with no input has nothing to publish.
+            self._log.info(
+                f"status_overview: startup check -- {len(theirs)} outbound topic(s) are "
+                "waiting for input: "
+                + ", ".join(gap["topic"] for gap in theirs[:8])
+                + (" ..." if len(theirs) > 8 else "")
+            )
         if verdict == "ok":
             self._log.info(
-                "status_overview: startup check OK -- every outbound stage of "
-                f"{snapshot.get('peer')} has a publisher"
+                "status_overview: startup check OK -- every stage this peer produces "
+                f"for {snapshot.get('peer')} has a publisher"
             )
             return
         self._log.error(
             f"status_overview: STARTUP CHECK FAILED for peer {snapshot.get('peer')} "
             f"after {self._startup_check['checked_after_s']}s -- "
-            f"{len(gaps)} outbound stage(s) have no publisher, "
+            f"{len(mine)} stage(s) this peer produces have no publisher, "
             f"{len(pane_failures)} pane(s) exited. See {self._startup_path}"
         )
-        for gap in gaps:
+        for gap in mine:
             self._log.error(
                 f"status_overview:   no publisher on {gap['topic']} "
                 f"(stage {gap['stage']}, produced_by {gap['produced_by']})"

--- a/src/rosotacom/resources/ws/ros2src/com_py/com_py/topic_monitor.py
+++ b/src/rosotacom/resources/ws/ros2src/com_py/com_py/topic_monitor.py
@@ -47,7 +47,7 @@ from rosidl_runtime_py.utilities import get_message
 from rclpy.serialization import serialize_message
 from std_msgs.msg import Float64
 
-from com_py.link_bytes import LinkByteSampler
+from com_py.link_bytes import LinkByteSampler, resolve_link_interface
 
 
 def is_internal_transport_topic(topic_name: str) -> bool:
@@ -99,7 +99,9 @@ class TopicMonitor(Node):
         self.declare_parameter('to_adressant', '')  # optional, e.g., 'shuttle_ella' for /to_shuttle_ella
         self.declare_parameter("ip_local", "")
         self.declare_parameter("ip_remote", "")
-        self.declare_parameter("interface", "")      # OTA link interface (e.g. the VPN tunnel)
+        # Explicit override for the OTA link interface. Normally left empty:
+        # it is resolved from ip_local below.
+        self.declare_parameter("interface", "")
         # Accepted for launch compatibility; the /proc/net/dev sampler needs no
         # capture window, so this tshark-era buffer is no longer used.
         self.declare_parameter("link_duration_buffer_s", 1.0)
@@ -109,9 +111,9 @@ class TopicMonitor(Node):
         self.sourcename = self.get_parameter('sourcename').value
         self.direction = self.get_parameter('direction').value
         self.to_adressant = self.get_parameter('to_adressant').value
-        self.host_ip = self.get_parameter("ip_local").value
-        self.peer_ip = self.get_parameter("ip_remote").value
-        self.interface = self.get_parameter("interface").value
+        self.host_ip = str(self.get_parameter("ip_local").value or "").strip()
+        self.peer_ip = str(self.get_parameter("ip_remote").value or "").strip()
+        self.interface = str(self.get_parameter("interface").value or "")
 
         # Track actual elapsed time between prints (avoid timer drift issues)
         self._last_print_t = time.monotonic()
@@ -131,8 +133,22 @@ class TopicMonitor(Node):
         else:
             self.topic_prefix = f"/com/{self.direction}/{self.sourcename}/"
 
-        if not self.interface:
-            raise ValueError("Parameter 'interface' is required for link bandwidth measurement")
+        # The OTA link interface. `ip_local` is the peer's own OTA address, so
+        # the interface follows from it -- the same resolution status_overview
+        # does, in the same place, from the same helper. `interface` stays an
+        # explicit override for a setup the address cannot describe.
+        #
+        # It used to be resolved in the session template instead, by a shell
+        # line that expanded a catmux parameter with bash's substring-replace
+        # syntax. catmux substitutes `${name}` and nothing else, so the pattern
+        # stayed literal, bash expanded an unset variable to nothing, and the
+        # awk program collapsed to "first address line with a prefix length" --
+        # `lo`, on every machine. See docs/link-bandwidth.md.
+        try:
+            self.interface, provenance = resolve_link_interface(self.interface, self.host_ip)
+        except ValueError as exc:
+            raise ValueError(f"topic_monitor: {exc}") from exc
+        self.get_logger().info(f"OTA link interface '{self.interface}' ({provenance})")
 
         # Link bandwidth is measured from the kernel's own interface byte counters
         # (/proc/net/dev) via the shared link_bytes sampler -- no tshark, no sudo,
@@ -163,8 +179,14 @@ class TopicMonitor(Node):
         )
 
         self.get_logger().info(f"topic_monitor node started. Searching for topics with prefix: {self.topic_prefix}")
-        self.get_logger().info(f"Publishing ROS topic bandwidth to: {self.ros_topic_bandwidth_topic}")
-        self.get_logger().info(f"Publishing link bandwidth to: {self.link_bandwidth_topic}")
+        self.get_logger().info(
+            f"Publishing ROS topic bandwidth to: {self.ros_topic_bandwidth_topic} "
+            f"(serialized payload of {self.topic_prefix}*, Kibit/s)"
+        )
+        self.get_logger().info(
+            f"Publishing link bandwidth to: {self.link_bandwidth_topic} "
+            f"(wire bytes on '{self.interface}', {'tx' if self.direction == 'out' else 'rx'}, Kibit/s)"
+        )
 
         # Prime the link sampler so the first print reports a real delta.
         self._link_sampler.sample()

--- a/src/rosotacom/resources/ws/session/content/base/session_plugin_base.yaml
+++ b/src/rosotacom/resources/ws/session/content/base/session_plugin_base.yaml
@@ -62,6 +62,9 @@ parameters:
   status_write_interval_s: 2.0
   status_liveness_window_s: 3.0
   status_stale_after_s: 3.0
+  # One-shot verdict N seconds after start: does every outbound stage this peer
+  # promises actually have a publisher, and did any pane exit? 0 disables it.
+  status_startup_grace_s: 20.0
   link_trace: false
   link_trace_interval_s: 1.0
   link_trace_modem_command: ""
@@ -356,6 +359,7 @@ windows:
             -p write_interval_s:=${status_write_interval_s}
             -p liveness_window_s:=${status_liveness_window_s}
             -p stale_after_s:=${status_stale_after_s}
+            -p startup_grace_s:=${status_startup_grace_s}
             -p ota_local_ip:=${ip_local}
             -p link_trace:=${link_trace}
             -p link_trace_interval_s:=${link_trace_interval_s}

--- a/src/rosotacom/resources/ws/session/content/base/session_plugin_base.yaml
+++ b/src/rosotacom/resources/ws/session/content/base/session_plugin_base.yaml
@@ -330,12 +330,16 @@ windows:
   - name: TM
     if: topic_monitor
     splits:
+      # No `interface=` line: the node resolves the OTA interface from ip_local
+      # itself (com_py.link_bytes.find_interface_for_ip), exactly as the STAT
+      # window's status_overview does. The line that used to stand here expanded
+      # a catmux parameter with bash substring-replace syntax, which catmux does
+      # not substitute -- so it resolved `lo` on every machine and reported this
+      # host's own ROS traffic as link bandwidth (#267).
       - commands:
-        - interface=$(ip -o addr | awk '/'${ip_local//./\\.}'\/[0-9]+/ {print $2; exit}')
-        - ros2 run com_py topic_monitor --ros-args -p sourcename:=${remote_name} -p direction:=in -p to_adressant:='${tm_in_to_adressant}' -p ip_local:=${ip_local} -p ip_remote:=${ip_remote} -p interface:=${interface} -p link_duration_buffer_s:=${tm_link_duration_buffer_s}
+        - ros2 run com_py topic_monitor --ros-args -p sourcename:=${remote_name} -p direction:=in -p to_adressant:='${tm_in_to_adressant}' -p ip_local:=${ip_local} -p ip_remote:=${ip_remote} -p link_duration_buffer_s:=${tm_link_duration_buffer_s}
       - commands:
-        - interface=$(ip -o addr | awk '/'${ip_local//./\\.}'\/[0-9]+/ {print $2; exit}')
-        - ros2 run com_py topic_monitor --ros-args -p sourcename:=${local_name} -p direction:=out -p to_adressant:='${tm_out_to_adressant}' -p ip_local:=${ip_local} -p ip_remote:=${ip_remote} -p interface:=${interface} -p link_duration_buffer_s:=${tm_link_duration_buffer_s}
+        - ros2 run com_py topic_monitor --ros-args -p sourcename:=${local_name} -p direction:=out -p to_adressant:='${tm_out_to_adressant}' -p ip_local:=${ip_local} -p ip_remote:=${ip_remote} -p link_duration_buffer_s:=${tm_link_duration_buffer_s}
   - name: STAT
     if: status_overview
     layout: even-vertical
@@ -360,12 +364,15 @@ windows:
       - commands:
         - status_out_dir="$(dirname "${ROSOTACOM_CATMUX_LOG_DIR:-/tmp/rosotacom_logs/catmux}")/status"
         - status_txt="$status_out_dir/status.txt"
-        - 'while true; do clear; echo "[INFO] watching status overview file: $status_txt"; if [ -f "$status_txt" ]; then cat "$status_txt"; else echo "[INFO] waiting for status_overview to write status.txt"; fi; sleep "${status_write_interval_s:-2.0}"; done'
+        - 'while true; do clear; echo "[INFO] watching status overview file: $status_txt"; if [ -f "$status_txt" ]; then cat "$status_txt"; else echo "[INFO] waiting for status_overview to write status.txt"; fi; sleep "${status_write_interval_s}"; done'
   - name: NET
     if: network_monitor
     splits:
       - commands:
-        - interface=$(ip -o addr | awk '/'${ip_local//./\\.}'\/[0-9]+/ {print $2; exit}')
+        # Exact match on the address column, with the address passed in through
+        # awk -v: no shell pattern expansion, so nothing here depends on catmux
+        # substituting a form it does not know (#267).
+        - interface=$(ip -o -4 addr show | awk -v ip='${ip_local}' '{split($4, a, "/"); if (a[1] == ip) {print $2; exit}}')
         - sudo iftop -i "$interface" -f "host ${ip_local} and host ${ip_remote}"
   - name: METRIC_BAG
     if: metric_stage_bag

--- a/src/rosotacom/resources/ws/session/creation/catmux_log_setup.sh
+++ b/src/rosotacom/resources/ws/session/creation/catmux_log_setup.sh
@@ -52,6 +52,50 @@ fi
 tmux pipe-pane -o -t "${TMUX_PANE}" \
   "${__rosotacom_pipe_filter} >> '${__rosotacom_pane_log_file//\'/\'\\\'\'}'"
 
+# --- a pane whose command dies must say so -----------------------------------
+#
+# A pane log is only read by somebody who already suspects the pane. On
+# 2026-08-13 the centre's `heartbeat_echo` and one `topic_monitor` exited two
+# seconds after start (Cyclone had no free participant index left on domain 46),
+# catmux left both panes at a shell prompt, and the session ran for two hours
+# with no heartbeat publisher. Nothing anywhere said so: `docker ps` showed a
+# healthy container, the other panes worked, and the far side blamed the link.
+#
+# So every non-zero exit of a pane command is appended to one file per peer,
+# which the status overview's startup check reads and quotes. 130 (Ctrl-C) is
+# excluded: that is an operator stopping a pane on purpose.
+ROSOTACOM_PANE_FAILURE_LOG="$(dirname "${ROSOTACOM_CATMUX_LOG_DIR}")/pane_failures.log"
+ROSOTACOM_PANE_LABEL="${__rosotacom_window_prefix}-${__rosotacom_window_safe}/${__rosotacom_pane}"
+export ROSOTACOM_PANE_FAILURE_LOG ROSOTACOM_PANE_LABEL
+
+__rosotacom_note_exit() {
+  local __status=$?
+  if [ "${__status}" -ne 0 ] && [ "${__status}" -ne 130 ]; then
+    local __cmd
+    __cmd="$(HISTTIMEFORMAT='' builtin history 1 2>/dev/null | sed 's/^[[:space:]]*[0-9]*[[:space:]]*//')"
+    printf '%s\tpane=%s\texit=%s\tcommand=%s\n' \
+      "$(date -Iseconds)" "${ROSOTACOM_PANE_LABEL}" "${__status}" "${__cmd}" \
+      >> "${ROSOTACOM_PANE_FAILURE_LOG}" 2>/dev/null
+    printf '\n[rosotacom] pane %s: command exited %s -- this pane is no longer doing its job.\n' \
+      "${ROSOTACOM_PANE_LABEL}" "${__status}" >&2
+    printf '[rosotacom] recorded in %s\n\n' "${ROSOTACOM_PANE_FAILURE_LOG}" >&2
+  fi
+  return "${__status}"
+}
+
+case "$-" in
+  *i*)
+    # Deliberately not exported: a child shell would inherit the hook without
+    # the function and complain at every prompt.
+    if [[ ";${PROMPT_COMMAND:-};" != *";__rosotacom_note_exit;"* ]]; then
+      PROMPT_COMMAND="__rosotacom_note_exit;${PROMPT_COMMAND:+${PROMPT_COMMAND}}"
+    fi
+    ;;
+  *)
+    echo "[rosotacom_catmux_log] non-interactive shell; pane-exit reporting disabled" >&2
+    ;;
+esac
+
 {
   printf '\n--- rosotacom catmux pipe-pane started %s ---\n' "$(date -Iseconds)"
   printf '    window=%s (#%s) pane=%s\n' \

--- a/src/rosotacom/resources/ws/session/creation/generate_session_files.py
+++ b/src/rosotacom/resources/ws/session/creation/generate_session_files.py
@@ -1413,6 +1413,12 @@ def _build_status_pipeline_spec(
             outbound_items.insert(0, (hb_entry, hb_pipe))
 
         for e, p in outbound_items:
+            # Who publishes the native stage decides who is answerable when it is
+            # missing. The heartbeat is the one outbound topic rosotacom publishes
+            # itself (`heartbeat_echo`), so its absence is a defect here rather
+            # than an application that has not started -- which is exactly the
+            # 2026-08-13 failure the startup check exists for.
+            native_produced_by = "heartbeat_echo" if e.index == -1 else "application"
             base = e.base
             final = p.get("final", base)
             forward_final = f"/to_{remote_name}{final}" if use_target_prefix else final
@@ -1441,7 +1447,7 @@ def _build_status_pipeline_spec(
                     "topic": native_topic,
                     "type": native_type,
                     "domain": "local",
-                    "produced_by": "application",
+                    "produced_by": native_produced_by,
                 },
             ]
             if final != base and not is_g2l:

--- a/src/rosotacom/transit.py
+++ b/src/rosotacom/transit.py
@@ -32,15 +32,34 @@ def load_transit_records(paths: Iterable[Path]) -> list[dict[str, Any]]:
     return records
 
 
+def record_epoch(record: dict[str, Any]) -> int:
+    """Which run of the publishing peer's wrapper produced this record.
+
+    A peer restart resets ``seq`` to zero mid-instance, so ``(source, topic,
+    seq)`` is not unique over an instance that outlived one. Records written
+    before the field learned this carry no ``epoch``; they are all epoch 0,
+    which is what a single-epoch instance produces anyway.
+    """
+    value = record.get("epoch")
+    return 0 if value is None else int(value)
+
+
 def join_transit_records(records: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
-    """Join duplicate observations by ``(topic, seq)`` and keep the richest row."""
-    joined: dict[tuple[str, str, int], dict[str, Any]] = {}
+    """Join duplicate observations by ``(source, topic, epoch, seq)``.
+
+    Keeps the richest row per key. ``epoch`` is part of the key because it is
+    what makes the key unique: on 2026-08-13 the vehicle restarted four times
+    inside one centre instance, and joining on ``(source, topic, seq)`` alone
+    silently dropped 123,253 of 304,876 raw transit lines -- 40% of the run,
+    concentrated in exactly the mission window the analysis was about.
+    """
+    joined: dict[tuple[str, str, int, int], dict[str, Any]] = {}
     status_rank = {"lost": 0, "reordered": 1, "delivered": 2}
     for record in records:
         topic = str(record.get("topic") or "")
         source = str(record.get("source") or "")
         seq = int(record["seq"])
-        key = (source, topic, seq)
+        key = (source, topic, record_epoch(record), seq)
         current = joined.get(key)
         if current is None:
             joined[key] = dict(record)
@@ -67,19 +86,26 @@ def filter_transit_records_by_publish_window(
 ) -> list[dict[str, Any]]:
     """Keep records whose publish time falls inside a measurement window.
 
-    Lost records do not carry timestamps. For each source/topic/target stream,
-    keep lost sequence records only when they are bounded by delivered/reordered
-    records inside the window. This excludes startup and teardown sequence gaps
-    without hiding losses that happened during the measured interval.
+    Lost records do not carry timestamps. For each source/target/topic/epoch
+    stream, keep lost sequence records only when they are bounded by
+    delivered/reordered records inside the window. This excludes startup and
+    teardown sequence gaps without hiding losses that happened during the
+    measured interval.
+
+    The epoch belongs in the grouping key for the same reason it belongs in the
+    join key: sequence numbers only order messages within one run of the
+    publishing wrapper, so a post-restart seq 40 must not bound a pre-restart
+    seq 40's loss.
     """
     if end_s < start_s:
         raise ValueError("end_s must be >= start_s")
-    grouped: dict[tuple[str, str, str], list[dict[str, Any]]] = {}
+    grouped: dict[tuple[str, str, str, int], list[dict[str, Any]]] = {}
     for record in join_transit_records(records):
         key = (
             str(record.get("source") or ""),
             str(record.get("target") or ""),
             str(record.get("topic") or ""),
+            record_epoch(record),
         )
         grouped.setdefault(key, []).append(record)
 
@@ -111,6 +137,7 @@ def filter_transit_records_by_publish_window(
             str(record.get("source") or ""),
             str(record.get("target") or ""),
             str(record.get("topic") or ""),
+            record_epoch(record),
             int(record["seq"]),
         ),
     )
@@ -173,15 +200,24 @@ def _latency_trend_ms(
 
 
 def _nominal_send_period_ms(topic_records: list[dict[str, Any]], *, time_field: str = "t_wrap") -> float | None:
-    """Median publish spacing per sequence step — the send cadence of the stream."""
-    stamped = sorted(
-        (int(record["seq"]), float(record[time_field]))
-        for record in topic_records
-        if record.get(time_field) is not None
-    )
-    periods = [
-        (t1 - t0) / (s1 - s0) for (s0, t0), (s1, t1) in zip(stamped, stamped[1:], strict=False) if s1 > s0 and t1 >= t0
-    ]
+    """Median publish spacing per sequence step — the send cadence of the stream.
+
+    Per epoch: a sequence step only means "one message" inside one run of the
+    publishing wrapper. Across a restart the step is a reset, and dividing the
+    wall-clock gap by it produces a period that describes nothing.
+    """
+    periods: list[float] = []
+    for epoch in {record_epoch(record) for record in topic_records}:
+        stamped = sorted(
+            (int(record["seq"]), float(record[time_field]))
+            for record in topic_records
+            if record.get(time_field) is not None and record_epoch(record) == epoch
+        )
+        periods.extend(
+            (t1 - t0) / (s1 - s0)
+            for (s0, t0), (s1, t1) in zip(stamped, stamped[1:], strict=False)
+            if s1 > s0 and t1 >= t0
+        )
     if not periods:
         return None
     ordered = sorted(periods)
@@ -239,6 +275,10 @@ def summarize_transit_records(records: Iterable[dict[str, Any]]) -> dict[str, An
             "expected": len(topic_records),
             "delivered": delivered,
             "lost": lost,
+            # >1 means the publishing peer restarted inside this instance. Kept
+            # in the summary because it changes how every rate-like number
+            # below should be read, and because it is otherwise invisible.
+            "epochs": len({record_epoch(record) for record in topic_records}),
             "loss_pct": round(100.0 * lost / len(topic_records), 3) if topic_records else 0.0,
             "reordered": reordered,
             "ota_hop_ms": _distribution_ms(ota),

--- a/tests/contract/test_packaged_resources.py
+++ b/tests/contract/test_packaged_resources.py
@@ -38,6 +38,7 @@ def test_packaged_resources_include_curated_examples_and_runtime_workspace() -> 
         "resources/ws/session/creation/catmux_log_setup.sh",
         "resources/ws/session/creation/strip_ansi.py",
         "resources/ws/ota_configs/cyclonedds_tuned.xml.template",
+        "resources/ws/ota_configs/cyclonedds_local_participants.xml.template",
         "resources/ws/ota_configs/fastdds_unicast.xml.template",
         "resources/ws/ros2src/com_msgs/msg/EchoHeartbeat.msg",
     )

--- a/tests/contract/test_session_template_substitution.py
+++ b/tests/contract/test_session_template_substitution.py
@@ -1,0 +1,75 @@
+"""catmux substitutes ``${name}`` and nothing else.
+
+`catmux.session.Session._replace_parameters` walks the loaded YAML and, for
+every declared parameter, does ``re.sub(r"\\${%s}" % key, value, text)``. The
+pattern requires the closing brace immediately after the name, so any bash
+parameter-expansion form written around a *catmux parameter* survives into the
+pane verbatim, where bash expands an unset shell variable to the empty string.
+
+That is not hypothetical. Two of them shipped:
+
+* ``${ip_local//./\\.}`` inside topic_monitor's interface lookup. The awk
+  program collapsed to "first address line with a prefix length", i.e. ``lo``,
+  and `/topic_monitor/*/link_bandwidth_kbps` reported this host's own ROS
+  traffic as link bandwidth -- 28 Gbit/s next to a 6 Mbit/s link (#267).
+* ``${status_write_interval_s:-2.0}`` in the status watcher, which quietly
+  ignored a configured interval and always slept the literal default.
+
+Neither failed; both reported. So the rule is checked rather than remembered.
+
+Bash forms around variables the pane itself sets (``${topics//,/ }`` after
+``topics=...``) or around environment variables (``${ROSOTACOM_CATMUX_LOG_DIR:-...}``)
+are fine and stay allowed -- catmux never touches those names.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SESSION_CONTENT = REPO_ROOT / "src" / "rosotacom" / "resources" / "ws" / "session" / "content"
+PLUGIN_BASE = SESSION_CONTENT / "base" / "session_plugin_base.yaml"
+
+#: Any ``${...}`` group, including the ones catmux will not substitute.
+_BRACED = re.compile(r"\$\{([^}]*)\}")
+#: What catmux does substitute: the bare name, closing brace right after it.
+_PLAIN_NAME = re.compile(r"^[A-Za-z_][A-Za-z_0-9]*$")
+
+
+def _declared_parameters() -> set[str]:
+    parameters = yaml.safe_load(PLUGIN_BASE.read_text(encoding="utf-8"))["parameters"]
+    return set(parameters)
+
+
+def _template_files() -> list[Path]:
+    return sorted(path for path in SESSION_CONTENT.rglob("*.yaml") if "__pycache__" not in path.parts)
+
+
+def test_the_plugin_base_is_where_parameters_are_declared() -> None:
+    assert PLUGIN_BASE.is_file()
+    assert "ip_local" in _declared_parameters()
+
+
+@pytest.mark.parametrize("path", _template_files(), ids=lambda path: path.name)
+def test_catmux_parameters_are_used_in_the_only_form_catmux_substitutes(path: Path) -> None:
+    declared = _declared_parameters()
+    offenders: list[str] = []
+    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        for match in _BRACED.finditer(line):
+            inner = match.group(1)
+            if _PLAIN_NAME.match(inner):
+                continue
+            # A non-plain form is only a defect when it wraps a catmux
+            # parameter; around a shell or environment variable it is correct.
+            name = re.match(r"[A-Za-z_][A-Za-z_0-9]*", inner)
+            if name and name.group(0) in declared:
+                offenders.append(f"{path.name}:{line_number}: ${{{inner}}}")
+
+    assert not offenders, (
+        "catmux only substitutes ${name}; these wrap a declared parameter in a form it "
+        "leaves literal, so bash expands an unset variable instead:\n  " + "\n  ".join(offenders)
+    )

--- a/tests/unit/test_catmux_pane_logging.py
+++ b/tests/unit/test_catmux_pane_logging.py
@@ -1,0 +1,113 @@
+"""The pane-exit reporter in `catmux_log_setup.sh`.
+
+A catmux pane whose command dies drops back to a shell prompt and keeps looking
+alive. On 2026-08-13 that hid two dead nodes on the centre for two hours, so the
+script now records every non-zero exit into one file per peer, which the status
+overview's startup check reads.
+
+The script needs `tmux` and `TMUX_PANE`, so the test provides a fake `tmux` that
+answers the three `display-message` queries and swallows `pipe-pane`. bash runs
+`PROMPT_COMMAND` when it is interactive, which it is when reading a script from
+a pipe -- exactly how the assertions below reach the hook.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SETUP_SH = REPO_ROOT / "src" / "rosotacom" / "resources" / "ws" / "session" / "creation" / "catmux_log_setup.sh"
+
+_FAKE_TMUX = """#!/usr/bin/env bash
+# Only what catmux_log_setup.sh asks for:
+#   tmux display-message -p -t <pane> '#{window_name}'
+if [ "$1" = display-message ]; then
+    case "$5" in
+        '#{window_name}')  echo BEAT ;;
+        '#{window_index}') echo 5 ;;
+        '#{pane_index}')   echo 0 ;;
+        *) echo "fake tmux: unexpected format $5" >&2; exit 64 ;;
+    esac
+    exit 0
+fi
+exit 0
+"""
+
+
+@pytest.fixture
+def pane_env(tmp_path: Path) -> tuple[Path, dict[str, str]]:
+    """A catmux log directory plus an environment whose `tmux` is the fake one."""
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    tmux = fake_bin / "tmux"
+    tmux.write_text(_FAKE_TMUX, encoding="utf-8")
+    tmux.chmod(0o755)
+
+    catmux_dir = tmp_path / "logs" / "center" / "catmux"
+    catmux_dir.mkdir(parents=True)
+
+    env = dict(os.environ)
+    env["PATH"] = f"{fake_bin}:{env['PATH']}"
+    env["TMUX_PANE"] = "%7"
+    env["ROSOTACOM_CATMUX_LOG_DIR"] = str(catmux_dir)
+    env.pop("PROMPT_COMMAND", None)
+    return catmux_dir, env
+
+
+def _run(script: str, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    bash = shutil.which("bash")
+    assert bash, "bash is required for this test"
+    return subprocess.run(
+        [bash, "-i"],
+        input=f"source {SETUP_SH}\n{script}\nexit 0\n",
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=60,
+        check=False,
+    )
+
+
+def test_a_failing_pane_command_is_recorded_and_announced(pane_env: tuple[Path, dict[str, str]]) -> None:
+    catmux_dir, env = pane_env
+
+    result = _run("ros2-run-that-does-not-exist", env)
+
+    failure_log = catmux_dir.parent / "pane_failures.log"
+    assert failure_log.is_file(), result.stderr
+    line = failure_log.read_text(encoding="utf-8").strip()
+    assert "pane=05-BEAT/0" in line
+    assert "exit=127" in line
+    assert "ros2-run-that-does-not-exist" in line
+    assert "no longer doing its job" in result.stderr
+
+
+def test_a_pane_whose_command_succeeds_writes_nothing(pane_env: tuple[Path, dict[str, str]]) -> None:
+    catmux_dir, env = pane_env
+
+    _run("true", env)
+
+    assert not (catmux_dir.parent / "pane_failures.log").exists()
+
+
+def test_an_operator_interrupt_is_not_a_failure(pane_env: tuple[Path, dict[str, str]]) -> None:
+    """130 is Ctrl-C: somebody stopped a pane on purpose."""
+    catmux_dir, env = pane_env
+
+    _run("(exit 130)", env)
+
+    assert not (catmux_dir.parent / "pane_failures.log").exists()
+
+
+def test_the_hook_is_installed_once_even_if_sourced_twice(pane_env: tuple[Path, dict[str, str]]) -> None:
+    _catmux_dir, env = pane_env
+
+    result = _run(f'source {SETUP_SH}\necho "PC=$PROMPT_COMMAND"', env)
+
+    (line,) = [ln for ln in result.stdout.splitlines() if ln.startswith("PC=")]
+    assert line.count("__rosotacom_note_exit") == 1

--- a/tests/unit/test_link_bytes.py
+++ b/tests/unit/test_link_bytes.py
@@ -124,3 +124,58 @@ def test_parse_ip_addr_resolves_interface_by_address() -> None:
 def test_parse_ip_addr_unknown_or_empty() -> None:
     assert lb.parse_ip_addr_for_ip(IP_ADDR_OUT, "10.0.0.99") is None
     assert lb.parse_ip_addr_for_ip(IP_ADDR_OUT, "") is None
+
+
+# --- OTA link interface resolution (#267) ----------------------------------
+
+
+def test_explicit_interface_wins_and_says_so() -> None:
+    assert lb.resolve_link_interface("tun3", "10.254.0.39", finder=lambda ip: "tun1") == (
+        "tun3",
+        "given explicitly",
+    )
+
+
+def test_interface_is_resolved_from_the_ota_address() -> None:
+    interface, provenance = lb.resolve_link_interface("", "10.254.0.39", finder=lambda ip: "tun1")
+    assert interface == "tun1"
+    assert provenance == "resolved from 10.254.0.39"
+
+
+def test_an_address_no_interface_owns_is_an_error() -> None:
+    try:
+        lb.resolve_link_interface("", "10.254.0.39", finder=lambda ip: None)
+    except ValueError as exc:
+        assert "10.254.0.39" in str(exc)
+    else:  # pragma: no cover - the call must raise
+        raise AssertionError("expected a ValueError")
+
+
+def test_loopback_is_refused_for_a_real_ota_address() -> None:
+    """The #267 defect, as the number that made it visible.
+
+    The session template's interface lookup collapsed to `lo` on both peers.
+    Loopback carries this host's own ROS traffic, so on the vehicle -- which
+    also ran a 36 GB `-a` recording -- `link_bandwidth_kbps` read ~28,000,000
+    (~28 Gbit/s) for an OTA link delivering ~6 Mbit/s, near-constant, on both
+    directions at once (rx and tx are the same bytes on loopback).
+    """
+    try:
+        lb.resolve_link_interface("", "10.254.0.38", finder=lambda ip: "lo")
+    except ValueError as exc:
+        assert "loopback" in str(exc)
+    else:  # pragma: no cover - the call must raise
+        raise AssertionError("expected a ValueError")
+
+
+def test_loopback_is_fine_when_the_ota_address_is_loopback() -> None:
+    """Single-machine smoke sessions really do run both peers over loopback."""
+    assert lb.resolve_link_interface("", "127.0.0.1", finder=lambda ip: "lo")[0] == "lo"
+
+
+def test_is_loopback_address() -> None:
+    assert lb.is_loopback_address("127.0.0.1")
+    assert lb.is_loopback_address("127.0.1.1")
+    assert lb.is_loopback_address("::1")
+    assert not lb.is_loopback_address("10.254.0.39")
+    assert not lb.is_loopback_address("")

--- a/tests/unit/test_status_overview.py
+++ b/tests/unit/test_status_overview.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import argparse
 import importlib.util
+import json
 import sys
 from pathlib import Path
 from types import ModuleType
@@ -996,3 +997,113 @@ def test_metric_stage_bag_is_generated_from_local_pipeline(tmp_path: Path) -> No
     plugin = (tmp_path / "a" / "plugin.yaml").read_text(encoding="utf-8")
     assert "metric_stage_bag: true" in plugin
     assert "metric_stage_topics: /heartbeat_a,/com/out/a/heartbeat_a" in plugin
+
+
+# ---------------------------------------------------------------------------
+# Startup check (#266): a peer that did not bring up its own publishers
+# ---------------------------------------------------------------------------
+
+
+def _startup_aggregator(observers: dict, output_dir: Path, *, started_mono: float) -> core.StatusAggregator:
+    return core.StatusAggregator(
+        logger=None,
+        spec=_outbound_spec(),
+        output_dir=str(output_dir / "status"),
+        observers_by_domain=observers,
+        liveness_window_s=3.0,
+        stale_after_s=3.0,
+        startup_grace_s=20.0,
+        started_mono=started_mono,
+    )
+
+
+def test_no_startup_verdict_before_the_grace_period(tmp_path: Path) -> None:
+    """Nothing publishes yet at t+5s, and that is not news."""
+    agg = _startup_aggregator({"local": _FakeObserver(), "ota": _FakeObserver()}, tmp_path, started_mono=0.0)
+
+    agg.write(now_mono=5.0)
+
+    assert json.loads((tmp_path / "status" / "status.json").read_text())["startup_check"] is None
+    assert not (tmp_path / "status" / "startup_check.json").exists()
+
+
+def test_a_peer_that_publishes_nothing_fails_its_startup_check(tmp_path: Path) -> None:
+    """The 2026-08-13 centre: heartbeat_echo died, so /heartbeat_a never existed."""
+    agg = _startup_aggregator({"local": _FakeObserver(), "ota": _FakeObserver()}, tmp_path, started_mono=0.0)
+
+    agg.write(now_mono=25.0)
+
+    verdict = json.loads((tmp_path / "status" / "startup_check.json").read_text())
+    assert verdict["verdict"] == "incomplete"
+    assert verdict["checked_after_s"] == 25.0
+    assert [gap["topic"] for gap in verdict["missing_outbound_stages"]] == [
+        "/heartbeat_a",
+        "/com/out/a/heartbeat_a",
+        "/ota/a/heartbeat_a",
+    ]
+    assert "STARTUP CHECK FAILED" in (tmp_path / "status" / "status.txt").read_text()
+
+
+def test_a_healthy_peer_passes_its_startup_check(tmp_path: Path) -> None:
+    local = _FakeObserver()
+    local.observations = {
+        "/heartbeat_a": _obs(pub=1, last_msg_at=24.9),
+        "/com/out/a/heartbeat_a": _obs(pub=1, last_msg_at=24.9),
+    }
+    ota = _FakeObserver()
+    ota.observations = {"/ota/a/heartbeat_a": _obs(pub=1, last_msg_at=24.9, graph_only=True)}
+    agg = _startup_aggregator({"local": local, "ota": ota}, tmp_path, started_mono=0.0)
+
+    agg.write(now_mono=25.0)
+
+    verdict = json.loads((tmp_path / "status" / "startup_check.json").read_text())
+    assert verdict["verdict"] == "ok"
+    assert verdict["missing_outbound_stages"] == []
+    assert "STARTUP CHECK FAILED" not in (tmp_path / "status" / "status.txt").read_text()
+
+
+def test_the_verdict_quotes_the_panes_that_exited(tmp_path: Path) -> None:
+    """A dead pane and a missing publisher are the same fact seen twice."""
+    local = _FakeObserver()
+    local.observations = {
+        "/heartbeat_a": _obs(pub=1, last_msg_at=24.9),
+        "/com/out/a/heartbeat_a": _obs(pub=1, last_msg_at=24.9),
+    }
+    ota = _FakeObserver()
+    ota.observations = {"/ota/a/heartbeat_a": _obs(pub=1, last_msg_at=24.9, graph_only=True)}
+    (tmp_path / "pane_failures.log").write_text(
+        "2026-08-13T14:49:50+02:00\tpane=05-BEAT/0\texit=1\tcommand=ros2 run com_py heartbeat_echo\n",
+        encoding="utf-8",
+    )
+    agg = _startup_aggregator({"local": local, "ota": ota}, tmp_path, started_mono=0.0)
+
+    agg.write(now_mono=25.0)
+
+    verdict = json.loads((tmp_path / "status" / "startup_check.json").read_text())
+    assert verdict["verdict"] == "incomplete"
+    assert verdict["pane_failures"] == [
+        "2026-08-13T14:49:50+02:00\tpane=05-BEAT/0\texit=1\tcommand=ros2 run com_py heartbeat_echo"
+    ]
+
+
+def test_the_verdict_is_computed_once(tmp_path: Path) -> None:
+    agg = _startup_aggregator({"local": _FakeObserver(), "ota": _FakeObserver()}, tmp_path, started_mono=0.0)
+
+    agg.write(now_mono=25.0)
+    agg.write(now_mono=99.0)
+
+    verdict = json.loads((tmp_path / "status" / "startup_check.json").read_text())
+    assert verdict["checked_after_s"] == 25.0
+
+
+def test_inbound_gaps_are_not_this_peers_startup_problem() -> None:
+    snapshot = {
+        "topics": [
+            {
+                "base": "/camera",
+                "direction": "inbound",
+                "stages": [{"stage": "ota_recv", "topic": "/ota/b/camera", "state": core.ABSENT}],
+            }
+        ]
+    }
+    assert core.outbound_startup_gaps(snapshot) == []

--- a/tests/unit/test_status_overview.py
+++ b/tests/unit/test_status_overview.py
@@ -929,6 +929,55 @@ def test_sequence_zero_starts_new_epoch_after_publisher_restart() -> None:
     metrics = obs.metrics(4.0, 10.0)
     assert metrics["reordered"] == 0
     assert metrics["loss_pct"] == 0.0
+    assert metrics["epoch"] == 1
+    assert metrics["epoch_resets"] == 1
+
+
+def test_restart_is_recognised_when_seq_zero_never_arrives() -> None:
+    """The field case: the reader matches after the first tens of messages.
+
+    ``/can/twist`` on 2026-08-13 restarted at seq 28983 and the first arrival of
+    the new run carried seq 37. Under the seq==0 rule that was `reordered`, and
+    so was every message for the remaining 105 minutes of the instance.
+    """
+    obs = core.StageObservation()
+    obs.record(1, None, now_mono=1.0, seq=28982)
+    obs.record(1, None, now_mono=2.0, seq=28983)
+    obs.record(1, None, now_mono=110.0, seq=37)
+    obs.record(1, None, now_mono=110.1, seq=38)
+
+    metrics = obs.metrics(111.0, 200.0)
+    assert metrics["reordered"] == 0
+    assert metrics["epoch_resets"] == 1
+    assert metrics["loss_pct"] == 0.0
+
+
+def test_a_small_backward_jump_is_still_reordering() -> None:
+    """Restart detection must not swallow the reordering it exists next to."""
+    obs = core.StageObservation()
+    obs.record(1, None, now_mono=1.0, seq=1000)
+    obs.record(1, None, now_mono=2.0, seq=1002)
+    obs.record(1, None, now_mono=2.1, seq=1001)
+
+    metrics = obs.metrics(3.0, 10.0)
+    assert metrics["reordered"] == 1
+    assert metrics["epoch_resets"] == 0
+
+
+def test_transit_records_carry_the_epoch_they_were_counted_in() -> None:
+    obs = core.StageObservation(type_str="com_msgs/msg/OtaStamped")
+    transit = {
+        "topic": "/wrapped",
+        "direction": "inbound",
+        "stage": "com_in",
+        "t_wrap": 1.01,
+        "t_com_in": 1.05,
+    }
+    obs.record(100, 0.04, now_mono=10.0, now_wall=1.05, seq=5000, transit=transit)
+    obs.record(100, 0.04, now_mono=200.0, now_wall=2.05, seq=40, transit=transit)
+
+    records = obs.drain_transit_records()
+    assert [(record["seq"], record["epoch"]) for record in records] == [(5000, 0), (40, 1)]
 
 
 def test_loss_expect_classifies_wrapped_stage_bad(tmp_path: Path) -> None:

--- a/tests/unit/test_status_overview.py
+++ b/tests/unit/test_status_overview.py
@@ -220,7 +220,7 @@ def _outbound_spec() -> dict:
                 "type": "com_msgs/msg/EchoHeartbeat",
                 "expected_hz": None,
                 "stages": [
-                    {"stage": "native", "topic": "/heartbeat_a", "domain": "local", "produced_by": "application"},
+                    {"stage": "native", "topic": "/heartbeat_a", "domain": "local", "produced_by": "heartbeat_echo"},
                     {
                         "stage": "com_out",
                         "topic": "/com/out/a/heartbeat_a",
@@ -1036,11 +1036,9 @@ def test_a_peer_that_publishes_nothing_fails_its_startup_check(tmp_path: Path) -
     verdict = json.loads((tmp_path / "status" / "startup_check.json").read_text())
     assert verdict["verdict"] == "incomplete"
     assert verdict["checked_after_s"] == 25.0
-    assert [gap["topic"] for gap in verdict["missing_outbound_stages"]] == [
-        "/heartbeat_a",
-        "/com/out/a/heartbeat_a",
-        "/ota/a/heartbeat_a",
-    ]
+    # Only the first break, not the cascade behind it.
+    assert [gap["topic"] for gap in verdict["missing_outbound_stages"]] == ["/heartbeat_a"]
+    assert verdict["missing_outbound_stages"][0]["produced_by"] == "heartbeat_echo"
     assert "STARTUP CHECK FAILED" in (tmp_path / "status" / "status.txt").read_text()
 
 
@@ -1107,3 +1105,133 @@ def test_inbound_gaps_are_not_this_peers_startup_problem() -> None:
         ]
     }
     assert core.outbound_startup_gaps(snapshot) == []
+
+
+def _application_spec() -> dict:
+    """An outbound topic whose publisher is the user's application, not ours."""
+    spec = _outbound_spec()
+    topic = spec["topics"][0]
+    topic["base"] = "/costmap"
+    topic["stages"] = [
+        {"stage": "native", "topic": "/costmap", "domain": "local", "produced_by": "application"},
+        {"stage": "com_out", "topic": "/com/out/a/costmap", "domain": "local", "produced_by": "relay_out"},
+        {"stage": "ota_sent", "topic": "/ota/a/costmap", "domain": "ota", "produced_by": "bridge_out"},
+    ]
+    return spec
+
+
+def test_an_application_that_is_not_publishing_is_not_a_peer_failure(tmp_path: Path) -> None:
+    """A smoke run exercises the peers without the data source, and that is fine.
+
+    The session declares the topic; whether the AD stack (or a replay) is
+    publishing right now is not something this peer promised. Reporting it as a
+    peer defect would make the verdict fire on every partial run, which is how a
+    check stops being read.
+    """
+    agg = core.StatusAggregator(
+        logger=None,
+        spec=_application_spec(),
+        output_dir=str(tmp_path / "status"),
+        observers_by_domain={"local": _FakeObserver(), "ota": _FakeObserver()},
+        liveness_window_s=3.0,
+        stale_after_s=3.0,
+        startup_grace_s=20.0,
+        started_mono=0.0,
+    )
+
+    agg.write(now_mono=25.0)
+
+    verdict = json.loads((tmp_path / "status" / "startup_check.json").read_text())
+    assert verdict["verdict"] == "ok"
+    assert verdict["missing_outbound_stages"] == []
+    assert [gap["topic"] for gap in verdict["waiting_for_input"]] == ["/costmap"]
+    assert "STARTUP CHECK FAILED" not in (tmp_path / "status" / "status.txt").read_text()
+
+
+def test_only_the_first_break_of_a_topic_is_reported() -> None:
+    """A cascade is one finding: relay_out is running, it just has no input."""
+    snapshot = {
+        "topics": [
+            {
+                "base": "/x",
+                "direction": "outbound",
+                "stages": [
+                    {"stage": "native", "topic": "/x", "state": core.FLOWING, "produced_by": "application"},
+                    {"stage": "com_out", "topic": "/com/out/a/x", "state": core.ABSENT, "produced_by": "relay_out"},
+                    {"stage": "ota_sent", "topic": "/ota/a/x", "state": core.ABSENT, "produced_by": "bridge_out"},
+                ],
+            }
+        ]
+    }
+
+    gaps = core.outbound_startup_gaps(snapshot)
+
+    assert [(gap["stage"], gap["owner"]) for gap in gaps] == [("com_out", "rosotacom")]
+
+
+def test_the_heartbeat_native_stage_is_owned_by_rosotacom(tmp_path: Path) -> None:
+    """The generator must mark it, or the startup check blames the application."""
+    _generate(_heartbeat_cfg(), tmp_path)
+
+    spec = yaml.safe_load((tmp_path / "a" / "pipeline_spec.yaml").read_text(encoding="utf-8"))
+    outbound = next(t for t in spec["topics"] if t["direction"] == "outbound" and t["base"] == "/heartbeat_a")
+    native = next(s for s in outbound["stages"] if s["stage"] == "native")
+    assert native["produced_by"] == "heartbeat_echo"
+
+
+def test_a_stage_with_no_input_yet_is_waiting_not_broken() -> None:
+    """`5_sized_payload`: the wrapper's publisher appears when its input does.
+
+    `universal_ota_wrapper` creates `…/ota_stamped` on discovering the topic it
+    wraps, so before anything publishes `/size_test_a` the absence is the order
+    of events, not a defect. Calling it one made the check fire on a smoke that
+    starts its payload publisher after the peers — which is how a check stops
+    being read.
+    """
+    snapshot = {
+        "topics": [
+            {
+                "base": "/size_test_a",
+                "direction": "outbound",
+                "stages": [
+                    {"stage": "native", "topic": "/size_test_a", "state": core.IDLE, "produced_by": "application"},
+                    {
+                        "stage": "processed",
+                        "topic": "/size_test_a/ota_stamped",
+                        "state": core.ABSENT,
+                        "produced_by": "preprocessing",
+                    },
+                ],
+            }
+        ]
+    }
+
+    (gap,) = core.outbound_startup_gaps(snapshot)
+
+    assert gap["owner"] == "upstream"
+    assert "nothing has arrived on /size_test_a" in gap["reason"]
+
+
+def test_a_stage_whose_input_is_flowing_and_publishes_nothing_is_broken() -> None:
+    snapshot = {
+        "topics": [
+            {
+                "base": "/size_test_a",
+                "direction": "outbound",
+                "stages": [
+                    {"stage": "native", "topic": "/size_test_a", "state": core.FLOWING, "produced_by": "application"},
+                    {
+                        "stage": "processed",
+                        "topic": "/size_test_a/ota_stamped",
+                        "state": core.ABSENT,
+                        "produced_by": "preprocessing",
+                    },
+                ],
+            }
+        ]
+    }
+
+    (gap,) = core.outbound_startup_gaps(snapshot)
+
+    assert gap["owner"] == "rosotacom"
+    assert gap["reason"] == "preprocessing did not come up"

--- a/tests/unit/test_status_overview_observer.py
+++ b/tests/unit/test_status_overview_observer.py
@@ -117,7 +117,11 @@ def node_module() -> Iterator[ModuleType]:
     _stub_module("rosidl_runtime_py", utilities=None)
     _stub_module("rosidl_runtime_py.utilities", get_message=lambda type_str: None)
     _stub_module("com_py", link_bytes=None)
-    _stub_module("com_py.link_bytes", LinkByteSampler=object, find_interface_for_ip=lambda *a: None)
+    _stub_module(
+        "com_py.link_bytes",
+        LinkByteSampler=object,
+        resolve_link_interface=lambda explicit, host_ip: (explicit or "tun0", "stubbed"),
+    )
     _stub_module("com_py.link_trace", LinkTraceRecorder=object)
     sys.modules["com_py.status_overview_core"] = core
 

--- a/tests/unit/test_transit.py
+++ b/tests/unit/test_transit.py
@@ -161,3 +161,64 @@ def test_summarize_arrival_spacing_without_timestamps_has_no_bunching_verdict() 
     assert spacing["nominal_period_ms"] is None
     assert spacing["bunched_pct"] is None
     assert spacing["stall_then_bunch_pct"] is None
+
+
+def test_join_keeps_sequence_numbers_from_different_epochs_apart() -> None:
+    """A peer restart replays seq 0..N; the join must not collapse the second run.
+
+    Field shape (2026-08-13): one centre instance outlived four vehicle
+    restarts, and joining on ``(source, topic, seq)`` dropped 123,253 of
+    304,876 raw lines -- silently, and concentrated in the mission window.
+    """
+    before = [{**_record(seq, "delivered", 10.0, t_wrap=float(seq)), "epoch": 0} for seq in range(5)]
+    after = [{**_record(seq, "delivered", 12.0, t_wrap=100.0 + seq), "epoch": 1} for seq in range(5)]
+
+    joined = join_transit_records(before + after)
+
+    assert len(joined) == 10
+    assert [record["epoch"] for record in joined] == [0] * 5 + [1] * 5
+    assert summarize_transit_records(before + after)["topics"]["/x"]["epochs"] == 2
+
+
+def test_records_without_an_epoch_are_one_epoch() -> None:
+    """Instances recorded before the field learned this carry no epoch field."""
+    records = [_record(seq, "delivered", 10.0, t_wrap=float(seq)) for seq in range(3)]
+
+    assert len(join_transit_records(records)) == 3
+    assert summarize_transit_records(records)["topics"]["/x"]["epochs"] == 1
+
+
+def test_lost_records_are_bounded_within_their_own_epoch() -> None:
+    """A post-restart seq must not vouch for a pre-restart seq's loss.
+
+    Both epochs number their messages 0..3. Only epoch 1 publishes inside the
+    window, so only epoch 1's gap may be kept.
+    """
+    epoch0 = [
+        {**_record(0, "delivered", 10.0, t_wrap=1.0), "epoch": 0},
+        {**_record(1, "lost"), "epoch": 0},
+        {**_record(2, "delivered", 10.0, t_wrap=3.0), "epoch": 0},
+    ]
+    epoch1 = [
+        {**_record(0, "delivered", 10.0, t_wrap=101.0), "epoch": 1},
+        {**_record(1, "lost"), "epoch": 1},
+        {**_record(2, "delivered", 10.0, t_wrap=103.0), "epoch": 1},
+    ]
+
+    kept = filter_transit_records_by_publish_window(epoch0 + epoch1, start_s=100.0, end_s=110.0)
+
+    assert [(record["epoch"], record["seq"], record["status"]) for record in kept] == [
+        (1, 0, "delivered"),
+        (1, 1, "lost"),
+        (1, 2, "delivered"),
+    ]
+
+
+def test_nominal_send_period_ignores_the_step_across_a_restart() -> None:
+    """10 Hz before and after a 100 s outage is still a 10 Hz stream."""
+    from rosotacom.transit import _nominal_send_period_ms
+
+    records = [{**_record(seq, "delivered", 5.0, t_wrap=seq * 0.1), "epoch": 0} for seq in range(10)]
+    records += [{**_record(seq, "delivered", 5.0, t_wrap=100.0 + seq * 0.1), "epoch": 1} for seq in range(10)]
+
+    assert _nominal_send_period_ms(records) == 100.0


### PR DESCRIPTION
Closes #266, closes #267, closes #268.

All three were found in the same 2026-08-13 two-peer field session, and the
first two share a root cause, so they land together: one release, one pin bump,
one sync of both machines before the next drive.

## #266 — a peer that failed to start said nothing

The centre's `heartbeat_echo` and one `topic_monitor` exited two seconds after
start. Cyclone had no free participant index left on the local domain:

```
1786625388.607559 [46] heartbeat_: Failed to find a free participant index for domain 46
[ERROR] [rmw_cyclonedds_cpp]: rmw_create_node: failed to create domain, error Error
[ros2run]: Process exited with failure 1
```

catmux left both panes at a shell prompt, so `docker ps` showed a healthy
container and the other panes kept working. The session then ran for two hours
with no heartbeat publisher: no RTT, no clock-offset estimate, and every
`EchoHeartbeat` the far side received carried `echo_valid=false`. The evidence
was in `status.json` the whole time (13 stalled stages, `clock_sync: null`) —
nothing said it was wrong.

- `catmux_log_setup.sh` installs a prompt hook: every non-zero pane exit lands
  in `logs/<peer>/pane_failures.log` with pane, status and command, and prints a
  banner into the pane log. 130 (Ctrl-C) excluded. Covers every pane of every
  peer and every scenario application.
- `status_overview` writes a one-shot verdict `status/startup_check.json`
  `status_startup_grace_s` (20 s) after start: the outbound stages this peer
  promised and never published, plus the pane failures, plus an ERROR per
  finding. `status.txt` — what the STAT watcher pane shows — carries it at the top.
- `cyclonedds_local_participants.xml.template`: the cause as a selectable local
  config. `MaxAutoParticipantIndex` 119, nothing else touched, because local
  discovery must keep working.
- `docker.log` no longer writes "No such container" as if it were a run log; in
  attach mode the container is `--rm` and gone, so it says that and points at
  the pane logs.

On the issue's ask 1: per-pane and per-scenario-application logs are already
persisted under `logs/<peer>/` (`catmux/`, `scenario/`) and were present on both
machines from that session — that is how the traceback above was recovered. What
was missing was anything that *pointed* at them, which is what the two new files
do. README now has the table.

## #267 — link bandwidth was loopback

`/topic_monitor/*/link_bandwidth_kbps` read ~28,000,000 (~28 Gbit/s), constant,
identical in both directions, on a link delivering ~6 Mbit/s. The interface was
resolved in the session template:

```yaml
- interface=$(ip -o addr | awk '/'${ip_local//./\\.}'\/[0-9]+/ {print $2; exit}')
```

catmux substitutes `${name}` and nothing else, so the pattern reached the pane
literally, bash expanded an unset shell variable to nothing, and the awk program
became `/\/[0-9]+/` — "first address line with a prefix length", i.e. `lo`, on
every Linux host. Identical rx and tx is the loopback signature; the vehicle was
also writing a 36 GB `-a` recording over that loopback. `status_overview`, which
resolved the interface inside the node, reported `tun1` correctly in the same run.

- resolution moves into the node; `topic_monitor` and `status_overview` share
  `resolve_link_interface`;
- a loopback interface for a non-loopback OTA address is refused, not reported;
- `${status_write_interval_s:-2.0}` was the same defect in the status watcher —
  a configured interval was silently ignored;
- `tests/contract/test_session_template_substitution.py` fails on any catmux
  parameter written in a form catmux does not substitute. It fails on both
  shipped occurrences and passes on the fixes.
- `docs/link-bandwidth.md` says what each of the three bandwidth numbers means,
  that `kbps` is Kibit/s, and why per-remote-peer wire attribution is a property
  of the interface rather than of a topic.

## #268 — a restart poisoned the accounting and the join

A restart resets `OtaStamped.seq` to zero, and the receiver only recognised that
when seq 0 itself arrived — the one case that almost never happens, because DDS
discovery takes long enough that the first tens of messages of a fresh publisher
are written before the reader matched. Four restarts in that instance; the first
arrival after each carried seq 37, 39, 39, 41.

The receiver now derives an epoch from the sequence stream (a backward jump
larger than any reordering the transport can produce), carries it in the transit
record, and keys the offline join, the lost-record window grouping and the
send-cadence estimate on it.

Replaying the real instance (304,876 records) through the new rule:

| | before | after |
|---|---|---|
| classified `reordered` | 124,572 (40.9%) | 84 (0.03%) |
| rows dropped by the join | 123,253 (40.4%) | 83 |

The remainder is the genuine reordering the classification exists for.

## Validation

`just check` green (lint, workflow lint, build lint, mypy, 750 host tests with
coverage, docs, package). New tests:

- `tests/unit/test_status_overview.py::test_restart_is_recognised_when_seq_zero_never_arrives`
  (the field shape), `::test_a_small_backward_jump_is_still_reordering`,
  `::test_transit_records_carry_the_epoch_they_were_counted_in`,
  and five startup-check cases
- `tests/unit/test_transit.py` — epoch-keyed join, no-epoch records, per-epoch
  lost bounding, per-epoch send cadence
- `tests/unit/test_link_bytes.py` — interface resolution precedence, loopback
  refusal, loopback allowed for a loopback OTA address
- `tests/unit/test_catmux_pane_logging.py` — drives the real shell hook under
  bash with a fake tmux: a failing command is recorded and announced, a
  succeeding one is not, Ctrl-C is not, the hook installs once
- `tests/contract/test_session_template_substitution.py` — the substitution-form
  guard

## Owner smoke

On existing material, no drive needed:

```bash
python - <<'PY'
import json, sys
sys.path.insert(0, "src/rosotacom/resources/ws/ros2src/com_py")
from com_py.status_overview_core import is_sequence_epoch_reset
# the four real restarts of 2026-08-13, as (last seen seq, first seq after)
for last, first in ((28983, 37), (2416, 39), (143, 39), (12543, 41)):
    assert is_sequence_epoch_reset(first, last + 1), (last, first)
assert not is_sequence_epoch_reset(1001, 1003)   # genuine reordering stays
print("epoch detection: 4/4 field restarts recognised, reordering preserved")
PY
```

and

```bash
python -m pytest -q tests/unit/test_link_bytes.py tests/contract/test_session_template_substitution.py
```

Expected: `epoch detection: 4/4 …`, then `19 passed`.
