### PR TITLE
Confirm a startup gap before calling it one

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ peer looked healthy but did nothing:
 |---|---|---|
 | `catmux/<NN>-<WINDOW>/<pane>.log` | `catmux_log_setup.sh` (`tmux pipe-pane`) | everything a node printed, including the traceback it died with |
 | `pane_failures.log` | the same script's prompt hook | one line per non-zero pane exit — **the file that answers "is any pane dead?"** |
-| `status/startup_check.json` | `status_overview`, once, `status_startup_grace_s` after start | the verdict: which outbound stages this peer promised and never published, plus the pane failures above |
+| `status/startup_check.json` | `status_overview`, once, after `status_startup_grace_s` and one confirming look a grace later | the verdict: which outbound stages this peer produces and never published, plus the pane failures above |
 | `status/status.{json,txt}` and `status/events.jsonl` | `status_overview`, continuously | live per-stage state and the transit records |
 | `scenario/<component>.log` | `rosotacom start <scenario>` | each scenario application's own output |
 | `launcher.log`, `docker.log` | `rosotacom start` | the exact command, and the container's own stdout where it has one |

--- a/src/rosotacom/resources/ws/ros2src/com_py/com_py/status_overview_core.py
+++ b/src/rosotacom/resources/ws/ros2src/com_py/com_py/status_overview_core.py
@@ -633,6 +633,10 @@ class StatusAggregator:
         self._startup_grace_s = startup_grace_s
         self._started_mono = time.monotonic() if started_mono is None else started_mono
         self._startup_check: Optional[Dict[str, Any]] = None
+        #: (when, topics) of the first evaluation that found a defect. A verdict
+        #: is only committed once the same defect survives a second look; see
+        #: `_maybe_run_startup_check`.
+        self._startup_pending: Optional[Tuple[float, set]] = None
 
     # -- observation lookup --
     def _obs_for(self, stage: Dict[str, Any]) -> Optional[StageObservation]:
@@ -1159,6 +1163,24 @@ class StatusAggregator:
         mine = [gap for gap in gaps if gap["owner"] == "rosotacom"]
         theirs = [gap for gap in gaps if gap["owner"] != "rosotacom"]
         pane_failures = self._read_pane_failures()
+
+        # A stage can be late rather than dead. `relay_out` and the wrapper
+        # create their publisher on *discovering* their input, on a refresh
+        # interval, so an input that started publishing shortly before this
+        # moment leaves a gap that is about to close on its own. Waiting a
+        # second grace period and reporting only what is still missing
+        # separates the two without weakening either: a node that exited never
+        # recovers. CI found this the way it should be found -- the smoke that
+        # starts its payload publisher last failed on a topic whose relay was
+        # working seconds later.
+        if mine and self._startup_pending is None:
+            self._startup_pending = (now, {gap["topic"] for gap in mine})
+            return
+        if mine and self._startup_pending is not None:
+            first_seen_at, first_seen = self._startup_pending
+            if now - first_seen_at < self._startup_grace_s:
+                return
+            mine = [gap for gap in mine if gap["topic"] in first_seen]
         verdict = "ok" if not mine and not pane_failures else "incomplete"
         self._startup_check = {
             "verdict": verdict,

--- a/tests/unit/test_status_overview.py
+++ b/tests/unit/test_status_overview.py
@@ -1028,14 +1028,21 @@ def test_no_startup_verdict_before_the_grace_period(tmp_path: Path) -> None:
 
 
 def test_a_peer_that_publishes_nothing_fails_its_startup_check(tmp_path: Path) -> None:
-    """The 2026-08-13 centre: heartbeat_echo died, so /heartbeat_a never existed."""
+    """The 2026-08-13 centre: heartbeat_echo died, so /heartbeat_a never existed.
+
+    Two writes: the verdict is only committed once the same defect has survived
+    a second look one grace period later. A node that exited never recovers, so
+    this costs the report 20 s and nothing else.
+    """
     agg = _startup_aggregator({"local": _FakeObserver(), "ota": _FakeObserver()}, tmp_path, started_mono=0.0)
 
     agg.write(now_mono=25.0)
+    assert not (tmp_path / "status" / "startup_check.json").exists()
+    agg.write(now_mono=46.0)
 
     verdict = json.loads((tmp_path / "status" / "startup_check.json").read_text())
     assert verdict["verdict"] == "incomplete"
-    assert verdict["checked_after_s"] == 25.0
+    assert verdict["checked_after_s"] == 46.0
     # Only the first break, not the cascade behind it.
     assert [gap["topic"] for gap in verdict["missing_outbound_stages"]] == ["/heartbeat_a"]
     assert verdict["missing_outbound_stages"][0]["produced_by"] == "heartbeat_echo"
@@ -1089,9 +1096,36 @@ def test_the_verdict_is_computed_once(tmp_path: Path) -> None:
 
     agg.write(now_mono=25.0)
     agg.write(now_mono=99.0)
+    agg.write(now_mono=140.0)
 
     verdict = json.loads((tmp_path / "status" / "startup_check.json").read_text())
-    assert verdict["checked_after_s"] == 25.0
+    assert verdict["checked_after_s"] == 99.0
+
+
+def test_a_stage_that_was_only_late_does_not_fail_the_check(tmp_path: Path) -> None:
+    """CI, 2026-08-14: `relay_out` had no publisher for /topic13 at t+20 s.
+
+    It creates one on discovering its input, and the input had just started.
+    Seconds later the relay was working. The first version of this check called
+    that a peer failure and turned the smoke red -- a check that fires on the
+    order of events is a check that gets ignored.
+    """
+    observers = {"local": _FakeObserver(), "ota": _FakeObserver()}
+    agg = _startup_aggregator(observers, tmp_path, started_mono=0.0)
+
+    agg.write(now_mono=25.0)
+    assert not (tmp_path / "status" / "startup_check.json").exists()
+
+    observers["local"].observations = {
+        "/heartbeat_a": _obs(pub=1, last_msg_at=45.9),
+        "/com/out/a/heartbeat_a": _obs(pub=1, last_msg_at=45.9),
+    }
+    observers["ota"].observations = {"/ota/a/heartbeat_a": _obs(pub=1, last_msg_at=45.9, graph_only=True)}
+    agg.write(now_mono=46.0)
+
+    verdict = json.loads((tmp_path / "status" / "startup_check.json").read_text())
+    assert verdict["verdict"] == "ok"
+    assert verdict["missing_outbound_stages"] == []
 
 
 def test_inbound_gaps_are_not_this_peers_startup_problem() -> None:


### PR DESCRIPTION
Follow-up to #269, which turned CI red on develop.

`14_remote_assist_anonymized`: `relay_out` had no publisher for `/com/out/b/topic13` at t+20 s. It creates one on *discovering* its input, on a refresh interval, and the input had just started publishing — seconds later the relay was working. Ownership alone cannot separate that from a node that died, because both read as "this peer produces it and there is no publisher".

Time can: a node that exited never recovers. The verdict is now committed only once the same gap survives a second look one grace period later, and only the stages still missing are reported. A healthy peer commits `ok` immediately; a pane failure — a latched fact in a file — commits immediately too. A real failure is reported at 2×grace (40 s), against the two hours it went unnoticed on 2026-08-13.

Tests: `test_a_stage_that_was_only_late_does_not_fail_the_check` is the CI case, and `test_a_peer_that_publishes_nothing_fails_its_startup_check` now asserts nothing is written after the first evaluation. 756 host tests pass.