### PR TITLE
Drop the start_rosotacom and stop_rosotacom entry points

### DIFF
--- a/DEVELOPMENT_PRINCIPLES.md
+++ b/DEVELOPMENT_PRINCIPLES.md
@@ -13,9 +13,15 @@ A change is complete only if:
 
 ## Compatibility Policy
 
-Preserve documented CLI behavior and the legacy `start_rosotacom` and
-`stop_rosotacom` entry points. Do not add silent aliases for removed behavior
+Preserve documented CLI behavior. Do not add silent aliases for removed behavior
 unless a migration explicitly requires them.
+
+`rosotacom` is the only console script this package installs. The
+`start_rosotacom` / `stop_rosotacom` entry points were the one standing
+exception to rule 6 above; they were removed on 2026-08-14 because they were
+nothing but `rosotacom start` and `rosotacom stop` under a second name, and a
+second name is what makes a stale shim on a machine indistinguishable from a
+live command. `rosotacom doctor` reports one that is still lying around.
 
 ## Testing Policy
 

--- a/install.sh
+++ b/install.sh
@@ -85,8 +85,18 @@ echo "  just setup"
 if [[ "$INSTALL_GLOBAL_SYMLINKS" == true ]]; then
   mkdir -p "$BIN_DIR"
   ln -sf "$VENV_DIR/bin/rosotacom" "$BIN_DIR/rosotacom"
-  ln -sf "$VENV_DIR/bin/start_rosotacom" "$BIN_DIR/start_rosotacom"
-  ln -sf "$VENV_DIR/bin/stop_rosotacom" "$BIN_DIR/stop_rosotacom"
   echo
-  echo "Installed legacy global symlinks into: $BIN_DIR"
+  echo "Installed global symlink into: $BIN_DIR"
+  # `start_rosotacom` / `stop_rosotacom` were entry points until 2026-08-14. A
+  # machine that ran an older install.sh still has their symlinks, and they now
+  # point into a venv whose package no longer provides them. Only links this
+  # script could have written are touched — into THIS checkout's venv, never a
+  # file or a link belonging to something else.
+  for retired in start_rosotacom stop_rosotacom; do
+    link="$BIN_DIR/$retired"
+    if [[ -L "$link" && "$(readlink -- "$link")" == "$VENV_DIR/bin/$retired" ]]; then
+      rm -- "$link"
+      echo "Removed retired symlink: $link  (use 'rosotacom start' / 'rosotacom stop')"
+    fi
+  done
 fi

--- a/justfile
+++ b/justfile
@@ -19,7 +19,7 @@ format:
 lint:
 	{{python}} -m ruff check .
 	{{python}} -m ruff format --check .
-	{{python}} -m py_compile src/rosotacom/*.py run_session_in_container.py stop_session_in_container.py
+	{{python}} -m py_compile src/rosotacom/*.py
 
 typecheck:
 	{{python}} -m mypy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,8 +61,6 @@ plots = [
 
 [project.scripts]
 rosotacom = "rosotacom.cli:main"
-start_rosotacom = "rosotacom.cli:start_compat_main"
-stop_rosotacom = "rosotacom.cli:stop_compat_main"
 
 [tool.setuptools]
 include-package-data = true

--- a/run_session_in_container.py
+++ b/run_session_in_container.py
@@ -1,9 +1,0 @@
-#!/usr/bin/env python3
-"""Compatibility entrypoint for the legacy `start_rosotacom` command."""
-
-from __future__ import annotations
-
-from rosotacom.cli import start_compat_main
-
-if __name__ == "__main__":
-    raise SystemExit(start_compat_main())

--- a/src/rosotacom/cli.py
+++ b/src/rosotacom/cli.py
@@ -5676,18 +5676,21 @@ def doctor(args: argparse.Namespace) -> int:
     except Exception as exc:  # noqa: BLE001 - doctor reports all setup failures.
         line("ERROR", "config", str(exc))
 
-    stale = Path.home() / ".local" / "bin" / "start_rosotacom"
-    if stale.exists() or stale.is_symlink():
-        try:
-            target = stale.resolve(strict=False)
-        except OSError:
-            target = Path(os.readlink(stale))
-        if PROJECT_DIR not in [target, *target.parents]:
-            line("WARN", "legacy start_rosotacom", f"{stale} points to {target}, outside this checkout")
-        else:
-            line("OK", "legacy start_rosotacom", f"{stale} points to this checkout")
+    # `start_rosotacom` / `stop_rosotacom` were entry points of this package until
+    # 2026-08-14; `rosotacom start` and `rosotacom stop` are the command. A shim
+    # left behind keeps dispatching through whichever venv it points at, which is
+    # exactly the stale-install confusion this check used to report — so it is a
+    # leftover to delete now, not a second way to run this.
+    retired = [Path.home() / ".local" / "bin" / name for name in ("start_rosotacom", "stop_rosotacom")]
+    leftovers = [p for p in retired if p.exists() or p.is_symlink()]
+    if leftovers:
+        line(
+            "WARN",
+            "retired entry points",
+            f"{', '.join(str(p) for p in leftovers)} — remove; `rosotacom start` / `rosotacom stop` replaced them",
+        )
     else:
-        line("INFO", "legacy start_rosotacom", "no global legacy symlink found")
+        line("OK", "retired entry points", "no start_rosotacom/stop_rosotacom shim left")
 
     tmux = shutil.which("tmux")
     if tmux:
@@ -9755,14 +9758,6 @@ def main(argv: list[str] | None = None) -> int:
     except Exception as exc:  # noqa: BLE001 - CLI should be concise.
         print(f"rosotacom: error: {exc}", file=sys.stderr)
         return 1
-
-
-def start_compat_main() -> int:
-    return main(["start", *sys.argv[1:]])
-
-
-def stop_compat_main() -> int:
-    return main(["stop", *sys.argv[1:]])
 
 
 if __name__ == "__main__":

--- a/stop_session_in_container.py
+++ b/stop_session_in_container.py
@@ -1,9 +1,0 @@
-#!/usr/bin/env python3
-"""Compatibility entrypoint for the legacy `stop_rosotacom` command."""
-
-from __future__ import annotations
-
-from rosotacom.cli import stop_compat_main
-
-if __name__ == "__main__":
-    raise SystemExit(stop_compat_main())

--- a/tests/contract/test_package_metadata.py
+++ b/tests/contract/test_package_metadata.py
@@ -15,12 +15,20 @@ def test_package_version_is_derived_from_scm_metadata() -> None:
     assert '__version__ = "0.1.0"' not in package_init
 
 
-def test_console_scripts_target_package_cli() -> None:
+def test_rosotacom_is_the_only_console_script() -> None:
+    """One installed command, so a shim in ~/.local/bin cannot be mistaken for it.
+
+    `start_rosotacom` / `stop_rosotacom` were removed on 2026-08-14: they were
+    `rosotacom start` / `rosotacom stop` under a second name (see
+    DEVELOPMENT_PRINCIPLES.md, Compatibility Policy). This pins that no second
+    name comes back.
+    """
     pyproject = (PACKAGE_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    scripts = pyproject.split("[project.scripts]", 1)[1].split("\n[", 1)[0]
+    entries = [line.split("=", 1)[0].strip() for line in scripts.splitlines() if "=" in line]
 
     assert 'rosotacom = "rosotacom.cli:main"' in pyproject
-    assert 'start_rosotacom = "rosotacom.cli:start_compat_main"' in pyproject
-    assert 'stop_rosotacom = "rosotacom.cli:stop_compat_main"' in pyproject
+    assert entries == ["rosotacom"], entries
 
 
 def test_videoquality_reader_dependencies_are_packaged() -> None:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1990,20 +1990,14 @@ rosbag2_bagfile_information:
     assert "TEST OK" in capsys.readouterr().out
 
 
-def test_start_and_stop_compat_entrypoints_prefix_commands(monkeypatch: pytest.MonkeyPatch) -> None:
-    calls: list[list[str]] = []
+def test_the_retired_compat_entrypoints_are_gone() -> None:
+    """Removed on 2026-08-14 — they were `start`/`stop` under a second name.
 
-    def fake_main(argv: list[str] | None = None) -> int:
-        calls.append(list(argv or []))
-        return 0
-
-    monkeypatch.setattr(rosotacom, "main", fake_main)
-    monkeypatch.setattr(sys, "argv", ["start_rosotacom", "1_heartbeat"])
-    assert rosotacom.start_compat_main() == 0
-    monkeypatch.setattr(sys, "argv", ["stop_rosotacom", "1_heartbeat"])
-    assert rosotacom.stop_compat_main() == 0
-
-    assert calls == [["start", "1_heartbeat"], ["stop", "1_heartbeat"]]
+    Asserting their absence is the point: a re-added alias would otherwise pass
+    every other test in this file silently.
+    """
+    assert not hasattr(rosotacom, "start_compat_main")
+    assert not hasattr(rosotacom, "stop_compat_main")
 
 
 def test_path_yaml_and_network_helpers(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Closes #272.

`start_rosotacom` / `stop_rosotacom` were `rosotacom start` / `rosotacom stop` under a second name (one line each). A second installed name is what makes a stale shim on a machine indistinguishable from a live command — it keeps dispatching through whichever venv it points at, which is exactly what `rosotacom doctor`'s `legacy start_rosotacom` check existed to report. This removes the failure mode instead of reporting it.

## What changed

- `pyproject.toml`: `rosotacom` is the only console script.
- `src/rosotacom/cli.py`: both compat functions gone; the doctor check now says *a shim is left over, delete it* rather than grading where it points.
- `run_session_in_container.py` / `stop_session_in_container.py`: deleted — each was only `raise SystemExit(<compat>_main())`. `justfile`'s `py_compile` line follows.
- `install.sh`: no longer writes the two symlinks, and removes the ones an older run of *itself* wrote — matched against this checkout's venv path, so nothing else in `~/.local/bin` is touched.
- `DEVELOPMENT_PRINCIPLES.md`: the Compatibility Policy named these two as the standing exception to rule 6 ("obsolete behavior is removed"). Lifted, with the reason recorded.

## Validation

Both suites now assert the **absence**, so a re-added alias fails instead of passing silently: `test_the_retired_compat_entrypoints_are_gone` (unit) and `test_rosotacom_is_the_only_console_script` (contract, parses the `[project.scripts]` table rather than grepping single lines). `test_bundle_console_scripts_match_the_project` already compared installed metadata against the project and covers this for free.

Run in a fresh worktree venv:

```
.venv/bin/python -m pytest -q tests/unit tests/contract   # 761 passed
.venv/bin/python -m ruff check . && .venv/bin/python -m ruff format --check .
.venv/bin/python -m mypy                                   # 23 source files, clean
```

## Downstream

The consumer is `remote-assist`, which has always called `rosotacom start`/`stop` through the CLI and never the aliases. Machines pick the removal up on the next `pipx install --force`; until then their `~/.local/bin` shims keep working against the old install, and `rosotacom doctor` names them.