### PR TITLE
Stop reporting a healthy peer as broken

### DIFF
--- a/src/rosotacom/resources/ws/ros2src/com_py/com_py/base_bridge_relay.py
+++ b/src/rosotacom/resources/ws/ros2src/com_py/com_py/base_bridge_relay.py
@@ -61,8 +61,8 @@ class BaseBridgeRelay(Node, PairRefreshMixin):
         self.qos_config_file = self.declare_parameter('qos_config_file', '').value
 
         # Optional parameters with defaults
-        self.source_names = self.declare_parameter('source_names', rclpy.Parameter.Type.STRING_ARRAY).value or []
-        self.target_names = self.declare_parameter('target_names', rclpy.Parameter.Type.STRING_ARRAY).value or []
+        self.source_names = self.declare_optional_string_array('source_names')
+        self.target_names = self.declare_optional_string_array('target_names')
 
         # Derived classes can declare additional parameters here (must happen before initialize_node()).
         self.declare_additional_parameters()
@@ -72,6 +72,36 @@ class BaseBridgeRelay(Node, PairRefreshMixin):
 
         # Create timer for periodic refresh of invalid pairs
         self.init_pair_refresh(period_s=5.0, log_prefix=self.node_role)
+
+    def declare_optional_string_array(self, name: str) -> list:
+        """Declare an optional STRING_ARRAY that reads as [] rather than as unset.
+
+        Declaring a type without a value leaves the parameter
+        PARAMETER_NOT_SET. This node never notices — it reads the value once,
+        here, and an unset parameter simply yields None. Everything *else*
+        notices: reading a not-set parameter raises, and rclpy's parameter
+        service logs one warning per read against this node,
+
+            [WARN] [ota_relay_out]: Failed to get parameters: The parameter
+            'source_names' is not initialized: source_names
+
+        which anything that enumerates parameters then produces on a timer. A
+        Foxglove bridge with a parameter panel open put 107 of those lines into
+        a single pane in one session — the kind of noise that hides the message
+        somebody actually needs to see.
+
+        A plain default cannot express this: `declare_parameter(name, [])`
+        infers the type from the value, and an empty list satisfies the
+        BYTE_ARRAY test first (`all(...)` is true for an empty sequence). The
+        parameter would be typed BYTE_ARRAY and the real string array refused
+        later with "Wrong parameter type, expected '5' got '9'". Declaring the
+        type and then setting the empty value keeps it STRING_ARRAY, so a wrong
+        type is still rejected and an override still wins.
+        """
+        self.declare_parameter(name, rclpy.Parameter.Type.STRING_ARRAY)
+        if self.get_parameter_or(name).type_ == rclpy.Parameter.Type.NOT_SET:
+            self.set_parameters([rclpy.Parameter(name, rclpy.Parameter.Type.STRING_ARRAY, [])])
+        return self.get_parameter(name).value
 
     def initialize_node(self):
         """Initialize node with resolved topics and QoS configuration."""

--- a/src/rosotacom/resources/ws/ros2src/com_py/com_py/qos.py
+++ b/src/rosotacom/resources/ws/ros2src/com_py/com_py/qos.py
@@ -139,7 +139,13 @@ def get_topic_qos(logger, qos_config: dict, topic_name: str, role_name: str):
     Additionally supports a fallback lookup: if no exact match for topic_name exists
     in qos_config['topics'], we look for the most specific configured base topic key
     that matches as a path segment within topic_name (e.g. '/tf' for
-    '/shuttle_ella/tf/restamped'). If such a fallback is used, it is always logged.
+    '/shuttle_ella/tf/restamped'). Such a fallback is logged at debug level: it is
+    the designed path, not a degradation. Every processing stage appends a suffix,
+    so a session that uses framebridge, latching or a transport reaches it for most
+    of its topics, and a definition that declares QoS on the base topic and lets the
+    processed names inherit it is doing exactly what the schema intends. Logged as a
+    warning it was two lines per topic per peer at every start — enough noise around
+    a bring-up to bury an actual fault.
     """
     default = qos_config.get('default', {})
 
@@ -151,7 +157,7 @@ def get_topic_qos(logger, qos_config: dict, topic_name: str, role_name: str):
     if topic_name not in topics_cfg:
         base_match = _find_best_base_topic_match(topics_cfg, topic_name)
         if base_match is not None:
-            logger.warning(
+            logger.debug(
                 f"[dds_qos] No exact QoS match for topic='{topic_name}'. "
                 f"Falling back to base topic='{base_match}'."
             )

--- a/src/rosotacom/resources/ws/session/content/base/session_plugin_base.yaml
+++ b/src/rosotacom/resources/ws/session/content/base/session_plugin_base.yaml
@@ -534,6 +534,19 @@ windows:
       - commands:
         - if [ '${ipx_4_topics}' = "None" ]; then exit; fi
         - ros2 run com_py image_pixel_capper --ros-args -p topics:=[${ipx_4_topics}] -p max_pixels_preset:=${ipx_4_preset} -p qos_config_file:='${qos_config_file}'
+  # `if ...; then ...; fi`, never `[[ ... ]] && ...`, for the optional argument
+  # lines below. catmux sends every one of these to an interactive shell, and
+  # `catmux_log_setup.sh` hooks the pane-exit recorder into PROMPT_COMMAND — so
+  # it sees the status of each line, not just of the node the pane finally runs.
+  # `&&` short-circuits to status 1 whenever the option is unset, which is the
+  # normal case for every option a session does not override, so each of these
+  # lines wrote itself into `pane_failures.log` as a dead pane:
+  #
+  #   pane=13-IT/0	exit=1	command=[[ "None" != "None" ]] && args+=(-p "ut.foxglove.bit_rate:=None")
+  #
+  # A peer then reported `STARTUP CHECK FAILED ... 4 pane(s) exited` on every
+  # start while nothing was wrong, which is the one thing that check must not
+  # do: it exists to make a genuinely dead pane visible in seconds.
   - name: IT
     if: it
     layout: even-vertical
@@ -542,15 +555,15 @@ windows:
         - if [ '${it_1_topic}' = "None" ]; then exit; fi
         - if [[ "${it_1_topic}" == *"/compressed"* ]]; then it_in_transport="compressed"; else it_in_transport="raw"; fi
         - args=(ros2 run image_transport republish --ros-args -r __node:=republish1 -p in_transport:=${it_in_transport})
-        - '[[ "${it_1_transport}" != "None" ]] && args+=(-p "out_transport:=${it_1_transport}")'
-        - '[[ "${it_1_compressed_jpeg_quality}" != "None" ]] && args+=(-p "ut.compressed.jpeg_quality:=${it_1_compressed_jpeg_quality}")'
-        - '[[ "${it_1_ffmpeg_gop_size}" != "None" ]] && args+=(-p "ut.ffmpeg.gop_size:=${it_1_ffmpeg_gop_size}")'
-        - '[[ "${it_1_ffmpeg_encoder_av_options}" != "None" ]] && args+=(-p "ut.ffmpeg.encoder_av_options:=${it_1_ffmpeg_encoder_av_options}")'
-        - '[[ "${it_1_ffmpeg_bit_rate}" != "None" ]] && args+=(-p "ut.ffmpeg.bit_rate:=${it_1_ffmpeg_bit_rate}")'
-        - '[[ "${it_1_foxglove_gop_size}" != "None" ]] && args+=(-p "ut.foxglove.gop_size:=${it_1_foxglove_gop_size}")'
-        - '[[ "${it_1_foxglove_encoder_av_options}" != "None" ]] && args+=(-p "ut.foxglove.encoder_av_options:=${it_1_foxglove_encoder_av_options}")'
-        - '[[ "${it_1_foxglove_bit_rate}" != "None" ]] && args+=(-p "ut.foxglove.bit_rate:=${it_1_foxglove_bit_rate}")'
-        - '[[ "${it_1_foxglove_qmax}" != "None" ]] && args+=(-p "ut.foxglove.qmax:=${it_1_foxglove_qmax}")'
+        - 'if [[ "${it_1_transport}" != "None" ]]; then args+=(-p "out_transport:=${it_1_transport}"); fi'
+        - 'if [[ "${it_1_compressed_jpeg_quality}" != "None" ]]; then args+=(-p "ut.compressed.jpeg_quality:=${it_1_compressed_jpeg_quality}"); fi'
+        - 'if [[ "${it_1_ffmpeg_gop_size}" != "None" ]]; then args+=(-p "ut.ffmpeg.gop_size:=${it_1_ffmpeg_gop_size}"); fi'
+        - 'if [[ "${it_1_ffmpeg_encoder_av_options}" != "None" ]]; then args+=(-p "ut.ffmpeg.encoder_av_options:=${it_1_ffmpeg_encoder_av_options}"); fi'
+        - 'if [[ "${it_1_ffmpeg_bit_rate}" != "None" ]]; then args+=(-p "ut.ffmpeg.bit_rate:=${it_1_ffmpeg_bit_rate}"); fi'
+        - 'if [[ "${it_1_foxglove_gop_size}" != "None" ]]; then args+=(-p "ut.foxglove.gop_size:=${it_1_foxglove_gop_size}"); fi'
+        - 'if [[ "${it_1_foxglove_encoder_av_options}" != "None" ]]; then args+=(-p "ut.foxglove.encoder_av_options:=${it_1_foxglove_encoder_av_options}"); fi'
+        - 'if [[ "${it_1_foxglove_bit_rate}" != "None" ]]; then args+=(-p "ut.foxglove.bit_rate:=${it_1_foxglove_bit_rate}"); fi'
+        - 'if [[ "${it_1_foxglove_qmax}" != "None" ]]; then args+=(-p "ut.foxglove.qmax:=${it_1_foxglove_qmax}"); fi'
         - if [[ "${it_1_outgoing_suffix}" != "None" ]]; then outgoing_suffix="${it_1_outgoing_suffix}"; else outgoing_suffix="${it_1_transport}"; fi
         - if [[ "${it_in_transport}" == "raw" ]]; then in_remap="in"; else in_remap="in/${it_in_transport}"; fi
         - args+=(--remap "${in_remap}:=${it_1_topic}" --remap "out/${it_1_transport}:=${it_1_topic}/${outgoing_suffix}")
@@ -560,15 +573,15 @@ windows:
         - if [ '${it_2_topic}' = "None" ]; then exit; fi
         - if [[ "${it_2_topic}" == *"/compressed"* ]]; then it_in_transport="compressed"; else it_in_transport="raw"; fi
         - args=(ros2 run image_transport republish --ros-args -r __node:=republish2 -p in_transport:=${it_in_transport})
-        - '[[ "${it_2_transport}" != "None" ]] && args+=(-p "out_transport:=${it_2_transport}")'
-        - '[[ "${it_2_compressed_jpeg_quality}" != "None" ]] && args+=(-p "ut.compressed.jpeg_quality:=${it_2_compressed_jpeg_quality}")'
-        - '[[ "${it_2_ffmpeg_gop_size}" != "None" ]] && args+=(-p "ut.ffmpeg.gop_size:=${it_2_ffmpeg_gop_size}")'
-        - '[[ "${it_2_ffmpeg_encoder_av_options}" != "None" ]] && args+=(-p "ut.ffmpeg.encoder_av_options:=${it_2_ffmpeg_encoder_av_options}")'
-        - '[[ "${it_2_ffmpeg_bit_rate}" != "None" ]] && args+=(-p "ut.ffmpeg.bit_rate:=${it_2_ffmpeg_bit_rate}")'
-        - '[[ "${it_2_foxglove_gop_size}" != "None" ]] && args+=(-p "ut.foxglove.gop_size:=${it_2_foxglove_gop_size}")'
-        - '[[ "${it_2_foxglove_encoder_av_options}" != "None" ]] && args+=(-p "ut.foxglove.encoder_av_options:=${it_2_foxglove_encoder_av_options}")'
-        - '[[ "${it_2_foxglove_bit_rate}" != "None" ]] && args+=(-p "ut.foxglove.bit_rate:=${it_2_foxglove_bit_rate}")'
-        - '[[ "${it_2_foxglove_qmax}" != "None" ]] && args+=(-p "ut.foxglove.qmax:=${it_2_foxglove_qmax}")'
+        - 'if [[ "${it_2_transport}" != "None" ]]; then args+=(-p "out_transport:=${it_2_transport}"); fi'
+        - 'if [[ "${it_2_compressed_jpeg_quality}" != "None" ]]; then args+=(-p "ut.compressed.jpeg_quality:=${it_2_compressed_jpeg_quality}"); fi'
+        - 'if [[ "${it_2_ffmpeg_gop_size}" != "None" ]]; then args+=(-p "ut.ffmpeg.gop_size:=${it_2_ffmpeg_gop_size}"); fi'
+        - 'if [[ "${it_2_ffmpeg_encoder_av_options}" != "None" ]]; then args+=(-p "ut.ffmpeg.encoder_av_options:=${it_2_ffmpeg_encoder_av_options}"); fi'
+        - 'if [[ "${it_2_ffmpeg_bit_rate}" != "None" ]]; then args+=(-p "ut.ffmpeg.bit_rate:=${it_2_ffmpeg_bit_rate}"); fi'
+        - 'if [[ "${it_2_foxglove_gop_size}" != "None" ]]; then args+=(-p "ut.foxglove.gop_size:=${it_2_foxglove_gop_size}"); fi'
+        - 'if [[ "${it_2_foxglove_encoder_av_options}" != "None" ]]; then args+=(-p "ut.foxglove.encoder_av_options:=${it_2_foxglove_encoder_av_options}"); fi'
+        - 'if [[ "${it_2_foxglove_bit_rate}" != "None" ]]; then args+=(-p "ut.foxglove.bit_rate:=${it_2_foxglove_bit_rate}"); fi'
+        - 'if [[ "${it_2_foxglove_qmax}" != "None" ]]; then args+=(-p "ut.foxglove.qmax:=${it_2_foxglove_qmax}"); fi'
         - if [[ "${it_2_outgoing_suffix}" != "None" ]]; then outgoing_suffix="${it_2_outgoing_suffix}"; else outgoing_suffix="${it_2_transport}"; fi
         - if [[ "${it_in_transport}" == "raw" ]]; then in_remap="in"; else in_remap="in/${it_in_transport}"; fi
         - args+=(--remap "${in_remap}:=${it_2_topic}" --remap "out/${it_2_transport}:=${it_2_topic}/${outgoing_suffix}")
@@ -578,15 +591,15 @@ windows:
         - if [ '${it_3_topic}' = "None" ]; then exit; fi
         - if [[ "${it_3_topic}" == *"/compressed"* ]]; then it_in_transport="compressed"; else it_in_transport="raw"; fi
         - args=(ros2 run image_transport republish --ros-args -r __node:=republish3 -p in_transport:=${it_in_transport})
-        - '[[ "${it_3_transport}" != "None" ]] && args+=(-p "out_transport:=${it_3_transport}")'
-        - '[[ "${it_3_compressed_jpeg_quality}" != "None" ]] && args+=(-p "ut.compressed.jpeg_quality:=${it_3_compressed_jpeg_quality}")'
-        - '[[ "${it_3_ffmpeg_gop_size}" != "None" ]] && args+=(-p "ut.ffmpeg.gop_size:=${it_3_ffmpeg_gop_size}")'
-        - '[[ "${it_3_ffmpeg_encoder_av_options}" != "None" ]] && args+=(-p "ut.ffmpeg.encoder_av_options:=${it_3_ffmpeg_encoder_av_options}")'
-        - '[[ "${it_3_ffmpeg_bit_rate}" != "None" ]] && args+=(-p "ut.ffmpeg.bit_rate:=${it_3_ffmpeg_bit_rate}")'
-        - '[[ "${it_3_foxglove_gop_size}" != "None" ]] && args+=(-p "ut.foxglove.gop_size:=${it_3_foxglove_gop_size}")'
-        - '[[ "${it_3_foxglove_encoder_av_options}" != "None" ]] && args+=(-p "ut.foxglove.encoder_av_options:=${it_3_foxglove_encoder_av_options}")'
-        - '[[ "${it_3_foxglove_bit_rate}" != "None" ]] && args+=(-p "ut.foxglove.bit_rate:=${it_3_foxglove_bit_rate}")'
-        - '[[ "${it_3_foxglove_qmax}" != "None" ]] && args+=(-p "ut.foxglove.qmax:=${it_3_foxglove_qmax}")'
+        - 'if [[ "${it_3_transport}" != "None" ]]; then args+=(-p "out_transport:=${it_3_transport}"); fi'
+        - 'if [[ "${it_3_compressed_jpeg_quality}" != "None" ]]; then args+=(-p "ut.compressed.jpeg_quality:=${it_3_compressed_jpeg_quality}"); fi'
+        - 'if [[ "${it_3_ffmpeg_gop_size}" != "None" ]]; then args+=(-p "ut.ffmpeg.gop_size:=${it_3_ffmpeg_gop_size}"); fi'
+        - 'if [[ "${it_3_ffmpeg_encoder_av_options}" != "None" ]]; then args+=(-p "ut.ffmpeg.encoder_av_options:=${it_3_ffmpeg_encoder_av_options}"); fi'
+        - 'if [[ "${it_3_ffmpeg_bit_rate}" != "None" ]]; then args+=(-p "ut.ffmpeg.bit_rate:=${it_3_ffmpeg_bit_rate}"); fi'
+        - 'if [[ "${it_3_foxglove_gop_size}" != "None" ]]; then args+=(-p "ut.foxglove.gop_size:=${it_3_foxglove_gop_size}"); fi'
+        - 'if [[ "${it_3_foxglove_encoder_av_options}" != "None" ]]; then args+=(-p "ut.foxglove.encoder_av_options:=${it_3_foxglove_encoder_av_options}"); fi'
+        - 'if [[ "${it_3_foxglove_bit_rate}" != "None" ]]; then args+=(-p "ut.foxglove.bit_rate:=${it_3_foxglove_bit_rate}"); fi'
+        - 'if [[ "${it_3_foxglove_qmax}" != "None" ]]; then args+=(-p "ut.foxglove.qmax:=${it_3_foxglove_qmax}"); fi'
         - if [[ "${it_3_outgoing_suffix}" != "None" ]]; then outgoing_suffix="${it_3_outgoing_suffix}"; else outgoing_suffix="${it_3_transport}"; fi
         - if [[ "${it_in_transport}" == "raw" ]]; then in_remap="in"; else in_remap="in/${it_in_transport}"; fi
         - args+=(--remap "${in_remap}:=${it_3_topic}" --remap "out/${it_3_transport}:=${it_3_topic}/${outgoing_suffix}")
@@ -596,15 +609,15 @@ windows:
         - if [ '${it_4_topic}' = "None" ]; then exit; fi
         - if [[ "${it_4_topic}" == *"/compressed"* ]]; then it_in_transport="compressed"; else it_in_transport="raw"; fi
         - args=(ros2 run image_transport republish --ros-args -r __node:=republish4 -p in_transport:=${it_in_transport})
-        - '[[ "${it_4_transport}" != "None" ]] && args+=(-p "out_transport:=${it_4_transport}")'
-        - '[[ "${it_4_compressed_jpeg_quality}" != "None" ]] && args+=(-p "ut.compressed.jpeg_quality:=${it_4_compressed_jpeg_quality}")'
-        - '[[ "${it_4_ffmpeg_gop_size}" != "None" ]] && args+=(-p "ut.ffmpeg.gop_size:=${it_4_ffmpeg_gop_size}")'
-        - '[[ "${it_4_ffmpeg_encoder_av_options}" != "None" ]] && args+=(-p "ut.ffmpeg.encoder_av_options:=${it_4_ffmpeg_encoder_av_options}")'
-        - '[[ "${it_4_ffmpeg_bit_rate}" != "None" ]] && args+=(-p "ut.ffmpeg.bit_rate:=${it_4_ffmpeg_bit_rate}")'
-        - '[[ "${it_4_foxglove_gop_size}" != "None" ]] && args+=(-p "ut.foxglove.gop_size:=${it_4_foxglove_gop_size}")'
-        - '[[ "${it_4_foxglove_encoder_av_options}" != "None" ]] && args+=(-p "ut.foxglove.encoder_av_options:=${it_4_foxglove_encoder_av_options}")'
-        - '[[ "${it_4_foxglove_bit_rate}" != "None" ]] && args+=(-p "ut.foxglove.bit_rate:=${it_4_foxglove_bit_rate}")'
-        - '[[ "${it_4_foxglove_qmax}" != "None" ]] && args+=(-p "ut.foxglove.qmax:=${it_4_foxglove_qmax}")'
+        - 'if [[ "${it_4_transport}" != "None" ]]; then args+=(-p "out_transport:=${it_4_transport}"); fi'
+        - 'if [[ "${it_4_compressed_jpeg_quality}" != "None" ]]; then args+=(-p "ut.compressed.jpeg_quality:=${it_4_compressed_jpeg_quality}"); fi'
+        - 'if [[ "${it_4_ffmpeg_gop_size}" != "None" ]]; then args+=(-p "ut.ffmpeg.gop_size:=${it_4_ffmpeg_gop_size}"); fi'
+        - 'if [[ "${it_4_ffmpeg_encoder_av_options}" != "None" ]]; then args+=(-p "ut.ffmpeg.encoder_av_options:=${it_4_ffmpeg_encoder_av_options}"); fi'
+        - 'if [[ "${it_4_ffmpeg_bit_rate}" != "None" ]]; then args+=(-p "ut.ffmpeg.bit_rate:=${it_4_ffmpeg_bit_rate}"); fi'
+        - 'if [[ "${it_4_foxglove_gop_size}" != "None" ]]; then args+=(-p "ut.foxglove.gop_size:=${it_4_foxglove_gop_size}"); fi'
+        - 'if [[ "${it_4_foxglove_encoder_av_options}" != "None" ]]; then args+=(-p "ut.foxglove.encoder_av_options:=${it_4_foxglove_encoder_av_options}"); fi'
+        - 'if [[ "${it_4_foxglove_bit_rate}" != "None" ]]; then args+=(-p "ut.foxglove.bit_rate:=${it_4_foxglove_bit_rate}"); fi'
+        - 'if [[ "${it_4_foxglove_qmax}" != "None" ]]; then args+=(-p "ut.foxglove.qmax:=${it_4_foxglove_qmax}"); fi'
         - if [[ "${it_4_outgoing_suffix}" != "None" ]]; then outgoing_suffix="${it_4_outgoing_suffix}"; else outgoing_suffix="${it_4_transport}"; fi
         - if [[ "${it_in_transport}" == "raw" ]]; then in_remap="in"; else in_remap="in/${it_in_transport}"; fi
         - args+=(--remap "${in_remap}:=${it_4_topic}" --remap "out/${it_4_transport}:=${it_4_topic}/${outgoing_suffix}")

--- a/tests/unit/test_catmux_pane_logging.py
+++ b/tests/unit/test_catmux_pane_logging.py
@@ -111,3 +111,77 @@ def test_the_hook_is_installed_once_even_if_sourced_twice(pane_env: tuple[Path, 
 
     (line,) = [ln for ln in result.stdout.splitlines() if ln.startswith("PC=")]
     assert line.count("__rosotacom_note_exit") == 1
+
+
+# What the recorder cannot know, and why the session template has to care.
+#
+# The hook runs from PROMPT_COMMAND, so it sees every line a pane shell runs --
+# including the lines that only assemble an argument list before the node
+# starts. A line of the form `[[ cond ]] && args+=(...)` exits 1 whenever the
+# condition is false, which is the normal case for every option a session leaves
+# unset, so each one recorded itself as a dead pane. A peer then reported four
+# exited panes at every start while nothing was wrong.
+
+_UNSET_OPTION = '[[ "None" != "None" ]]'
+_SET_OPTION = '[[ "22" != "None" ]]'
+
+
+def _failure_log(catmux_dir: Path) -> Path:
+    return catmux_dir.parent / "pane_failures.log"
+
+
+def test_the_short_circuit_form_records_a_false_failure(pane_env: tuple[Path, dict[str, str]]) -> None:
+    """The shape that was in the template: correct behaviour, status 1."""
+    catmux_dir, env = pane_env
+
+    _run(f'args=(); {_UNSET_OPTION} && args+=(-p "bit_rate:=None")', env)
+
+    assert _failure_log(catmux_dir).is_file()
+    assert "exit=1" in _failure_log(catmux_dir).read_text(encoding="utf-8")
+
+
+def test_the_if_form_leaves_an_unset_option_silent(pane_env: tuple[Path, dict[str, str]]) -> None:
+    """The shape it was replaced with: same behaviour, status 0."""
+    catmux_dir, env = pane_env
+
+    _run(f'args=(); if {_UNSET_OPTION}; then args+=(-p "bit_rate:=None"); fi', env)
+
+    assert not _failure_log(catmux_dir).exists()
+
+
+def test_the_if_form_still_appends_a_set_option(pane_env: tuple[Path, dict[str, str]]) -> None:
+    """Silencing the status must not silence the argument."""
+    catmux_dir, env = pane_env
+
+    result = _run(
+        f'args=(); if {_SET_OPTION}; then args+=(-p "bit_rate:=22"); fi\necho "ARGS=${{args[*]}}"',
+        env,
+    )
+
+    assert "ARGS=-p bit_rate:=22" in result.stdout
+    assert not _failure_log(catmux_dir).exists()
+
+
+def test_no_session_template_line_uses_the_short_circuit_form() -> None:
+    """The template is where this reaches a running session, so it is checked there."""
+    template = (
+        REPO_ROOT
+        / "src"
+        / "rosotacom"
+        / "resources"
+        / "ws"
+        / "session"
+        / "content"
+        / "base"
+        / "session_plugin_base.yaml"
+    )
+    offenders = [
+        line.strip()
+        for line in template.read_text(encoding="utf-8").splitlines()
+        if line.lstrip().startswith("- '[[") and "&&" in line
+    ]
+
+    assert offenders == [], (
+        "these lines exit non-zero when their option is unset and land in "
+        f"pane_failures.log; use `if ...; then ...; fi`: {offenders}"
+    )

--- a/tests/unit/test_qos_fallback_logging.py
+++ b/tests/unit/test_qos_fallback_logging.py
@@ -1,0 +1,139 @@
+"""At which level `get_topic_qos` reports a base-topic fallback.
+
+A session declares QoS on the base topic (`/tf_static`), and every processing
+stage appends a suffix to the name that is actually published
+(`/tf_static/globalframe`). Resolving the suffixed name through its base is
+therefore the designed path, not a degradation — and it was logged as a warning,
+twice per topic per peer, at every bring-up. That is the noise a real message has
+to compete with while a peer is starting, which is exactly when somebody is
+reading the pane.
+
+The module imports rclpy, which the host suite does not have, so its ROS surface
+is stubbed before the module is loaded by file path (same approach as
+`tests/unit/test_ota_unwrapper.py`).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from collections.abc import Iterator
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+QOS_PY = REPO_ROOT / "src" / "rosotacom" / "resources" / "ws" / "ros2src" / "com_py" / "com_py" / "qos.py"
+
+_STUBBED = ("rclpy", "rclpy.node", "rclpy.qos", "rclpy.duration", "rosidl_runtime_py", "rosidl_runtime_py.utilities")
+
+
+class _QoSProfile:
+    def __init__(self, depth: int = 10) -> None:
+        self.depth = depth
+
+
+class _Policy:
+    BEST_EFFORT = "best_effort"
+    RELIABLE = "reliable"
+    KEEP_ALL = "keep_all"
+    KEEP_LAST = "keep_last"
+    TRANSIENT_LOCAL = "transient_local"
+    VOLATILE = "volatile"
+    AUTOMATIC = "automatic"
+    MANUAL_BY_TOPIC = "manual_by_topic"
+
+
+def _stub_module(name: str, **attrs: object) -> ModuleType:
+    module = ModuleType(name)
+    for key, value in attrs.items():
+        setattr(module, key, value)
+    sys.modules[name] = module
+    return module
+
+
+class _RecordingLogger:
+    """Counts what was said and at which level."""
+
+    def __init__(self) -> None:
+        self.warnings: list[str] = []
+        self.debugs: list[str] = []
+
+    def warning(self, message: str) -> None:
+        self.warnings.append(message)
+
+    def debug(self, message: str) -> None:
+        self.debugs.append(message)
+
+    def info(self, message: str) -> None:
+        pass
+
+    def error(self, message: str) -> None:
+        pass
+
+
+@pytest.fixture(scope="module")
+def qos_module() -> Iterator[ModuleType]:
+    saved = {name: sys.modules.get(name) for name in _STUBBED}
+    _stub_module("rclpy")
+    _stub_module("rclpy.node", Node=object)
+    _stub_module(
+        "rclpy.qos",
+        QoSProfile=_QoSProfile,
+        ReliabilityPolicy=_Policy,
+        HistoryPolicy=_Policy,
+        DurabilityPolicy=_Policy,
+        LivelinessPolicy=_Policy,
+    )
+    _stub_module("rclpy.duration", Duration=lambda **kwargs: kwargs)
+    _stub_module("rosidl_runtime_py", utilities=None)
+    _stub_module("rosidl_runtime_py.utilities", get_message=lambda type_str: None)
+
+    spec = importlib.util.spec_from_file_location("rosotacom_qos_fallback", QOS_PY)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["rosotacom_qos_fallback"] = module
+    spec.loader.exec_module(module)
+    yield module
+
+    sys.modules.pop("rosotacom_qos_fallback", None)
+    for name, previous in saved.items():
+        if previous is None:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = previous
+
+
+CONFIG = {
+    "default": {"depth": 10},
+    "topics": {"/tf_static": {"reliability": "reliable", "durability": "transient_local"}},
+}
+
+
+def test_a_processed_name_resolves_through_its_base_without_warning(qos_module: ModuleType) -> None:
+    logger = _RecordingLogger()
+
+    qos_module.get_topic_qos(logger, CONFIG, "/tf_static/globalframe", "ota_pub")
+
+    assert logger.warnings == []
+    assert any("Falling back to base topic='/tf_static'" in line for line in logger.debugs)
+
+
+def test_the_fallback_still_delivers_the_base_topic_settings(qos_module: ModuleType) -> None:
+    """Quiet must not mean ignored: the resolved profile is the base topic's."""
+    logger = _RecordingLogger()
+
+    profile = qos_module.get_topic_qos(logger, CONFIG, "/tf_static/globalframe", "ota_pub")
+
+    assert profile.reliability == _Policy.RELIABLE
+    assert profile.durability == _Policy.TRANSIENT_LOCAL
+
+
+def test_an_exact_match_says_nothing_at_all(qos_module: ModuleType) -> None:
+    logger = _RecordingLogger()
+
+    qos_module.get_topic_qos(logger, CONFIG, "/tf_static", "ota_pub")
+
+    assert logger.warnings == []
+    assert not any("Falling back" in line for line in logger.debugs)

--- a/tests/unit/test_relay_optional_parameters.py
+++ b/tests/unit/test_relay_optional_parameters.py
@@ -1,0 +1,176 @@
+"""Optional relay parameters must read as empty, not as unset.
+
+`source_names` and `target_names` are optional: a peer that names no sources
+simply has none. They were declared with a type and no value, which leaves them
+PARAMETER_NOT_SET. The node itself never noticed, because it reads them once
+through `.value or []`. Every *other* reader did: reading a not-set parameter
+raises, and rclpy's parameter service logs one warning per read against the
+node, so anything that enumerates parameters on a timer — a Foxglove bridge with
+a parameter panel open is the usual one — filled the pane with
+
+    [WARN] [ota_relay_out]: Failed to get parameters: The parameter
+    'source_names' is not initialized: source_names
+
+An empty list cannot be a plain default: `declare_parameter(name, [])` infers
+the type from the value and an empty sequence satisfies the BYTE_ARRAY test
+first, so the parameter ends up typed BYTE_ARRAY and a real string array is
+refused later. The fakes below reproduce that rclpy behaviour, which was
+confirmed against a live rclpy node before this was written.
+
+rclpy is not available to the host suite, so the ROS surface is stubbed and the
+module is loaded by file path (same approach as `tests/unit/test_ota_unwrapper.py`).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from collections.abc import Iterator
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+COM_PY = REPO_ROOT / "src" / "rosotacom" / "resources" / "ws" / "ros2src" / "com_py" / "com_py"
+RELAY_PY = COM_PY / "base_bridge_relay.py"
+
+_STUBBED = (
+    "rclpy",
+    "rclpy.node",
+    "com_py",
+    "com_py.topic_resolution",
+    "com_py.qos",
+    "com_py.pub_sub_pair",
+    "com_py.pair_management",
+)
+
+
+class _Type:
+    NOT_SET = "not_set"
+    STRING_ARRAY = "string_array"
+    STRING = "string"
+
+
+class _Parameter:
+    Type = _Type
+
+    def __init__(self, name: str, type_: str = _Type.NOT_SET, value: object = None) -> None:
+        self.name = name
+        self.type_ = type_
+        self.value = value
+
+
+class _FakeNode:
+    """rclpy's declare/get/set semantics, only as far as this method uses them."""
+
+    def __init__(self, overrides: dict[str, list[str]] | None = None) -> None:
+        self._overrides = overrides or {}
+        self._parameters: dict[str, _Parameter] = {}
+        self.set_calls: list[tuple[str, str, object]] = []
+
+    def declare_parameter(self, name: str, type_: str) -> _Parameter:
+        if name in self._overrides:
+            parameter = _Parameter(name, type_, self._overrides[name])
+        else:
+            parameter = _Parameter(name, _Type.NOT_SET, None)
+        self._parameters[name] = parameter
+        return parameter
+
+    def get_parameter_or(self, name: str) -> _Parameter:
+        return self._parameters.get(name, _Parameter(name))
+
+    def get_parameter(self, name: str) -> _Parameter:
+        parameter = self._parameters[name]
+        if parameter.type_ == _Type.NOT_SET:
+            raise RuntimeError(f"The parameter '{name}' is not initialized: {name}")
+        return parameter
+
+    def set_parameters(self, parameters: list[_Parameter]) -> None:
+        for parameter in parameters:
+            self.set_calls.append((parameter.name, parameter.type_, parameter.value))
+            self._parameters[parameter.name] = parameter
+
+
+def _stub_module(name: str, **attrs: object) -> ModuleType:
+    module = ModuleType(name)
+    for key, value in attrs.items():
+        setattr(module, key, value)
+    sys.modules[name] = module
+    return module
+
+
+@pytest.fixture(scope="module")
+def relay_module() -> Iterator[ModuleType]:
+    saved = {name: sys.modules.get(name) for name in _STUBBED}
+    _stub_module("rclpy", Parameter=_Parameter)
+    # Distinct classes: `BaseBridgeRelay(Node, PairRefreshMixin)` cannot be built
+    # from one base twice.
+    _stub_module("rclpy.node", Node=type("Node", (), {}))
+    _stub_module("com_py")
+    _stub_module("com_py.topic_resolution", resolve_topics=lambda *a, **k: [])
+    _stub_module("com_py.qos", load_qos_config=lambda *a, **k: {})
+    _stub_module("com_py.pub_sub_pair", PubSubPair=type("PubSubPair", (), {}))
+    _stub_module("com_py.pair_management", PairRefreshMixin=type("PairRefreshMixin", (), {}))
+
+    spec = importlib.util.spec_from_file_location("rosotacom_base_bridge_relay", RELAY_PY)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["rosotacom_base_bridge_relay"] = module
+    spec.loader.exec_module(module)
+    yield module
+
+    sys.modules.pop("rosotacom_base_bridge_relay", None)
+    for name, previous in saved.items():
+        if previous is None:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = previous
+
+
+def _declare(module: ModuleType, node: _FakeNode, name: str = "source_names") -> object:
+    """The method under test, unbound — the surrounding __init__ needs a live ROS graph."""
+    return module.BaseBridgeRelay.declare_optional_string_array(node, name)
+
+
+def test_an_unsupplied_parameter_becomes_an_empty_string_array(relay_module: ModuleType) -> None:
+    node = _FakeNode()
+
+    value = _declare(relay_module, node)
+
+    assert value == []
+    assert node.set_calls == [("source_names", _Type.STRING_ARRAY, [])]
+
+
+def test_the_parameter_is_readable_afterwards(relay_module: ModuleType) -> None:
+    """The whole point: a read no longer raises, so nothing logs a warning."""
+    node = _FakeNode()
+
+    _declare(relay_module, node)
+
+    assert node.get_parameter("source_names").value == []
+
+
+def test_supplied_names_are_left_alone(relay_module: ModuleType) -> None:
+    node = _FakeNode(overrides={"source_names": ["center", "vehicle"]})
+
+    value = _declare(relay_module, node)
+
+    assert value == ["center", "vehicle"]
+    assert node.set_calls == [], "an override must not be overwritten by the default"
+
+
+def test_it_stays_a_string_array(relay_module: ModuleType) -> None:
+    """Not BYTE_ARRAY, which is what a plain `[]` default would have inferred."""
+    node = _FakeNode()
+
+    _declare(relay_module, node)
+
+    assert node.get_parameter("source_names").type_ == _Type.STRING_ARRAY
+
+
+def test_both_optional_parameters_use_it(relay_module: ModuleType) -> None:
+    source = RELAY_PY.read_text(encoding="utf-8")
+
+    for name in ("source_names", "target_names"):
+        assert f"self.declare_optional_string_array('{name}')" in source


### PR DESCRIPTION
Closes #274.

Three defects with one consequence: a peer that started correctly reports itself
as broken, so the signals built to surface a real fault arrive already
discredited. They were found together in a two-host session that *did* have a
real fault — and finding it took longer because of them.

## 1. `pane_failures.log` recorded setup lines as dead panes

`catmux_log_setup.sh` hooks the exit recorder into `PROMPT_COMMAND`, so it sees
the status of every line a pane shell runs, not just of the node the pane exists
for. The 36 optional-argument lines in `session_plugin_base.yaml` were written as

```bash
[[ "${it_1_foxglove_bit_rate}" != "None" ]] && args+=(-p "ut.foxglove.bit_rate:=...")
```

`&&` short-circuits to status 1 whenever the option is unset — the normal case
for every option a session does not override — so each line wrote itself into
`pane_failures.log`, and the peer reported `STARTUP CHECK FAILED ... 4 pane(s)
exited` at every start with nothing wrong. Rewritten as `if ...; then ...; fi`,
which is the same behaviour at status 0.

## 2. Optional relay parameters read as unset, so every external read warned

`source_names` and `target_names` were declared with a type and no value, which
leaves them `PARAMETER_NOT_SET`. The node never noticed — it reads them once
through `.value or []` — but reading a not-set parameter raises, and rclpy's
parameter service logs one warning per read against the node:

```
[WARN] [ota_relay_out]: Failed to get parameters: The parameter 'source_names' is not initialized: source_names
```

Anything that enumerates parameters produces this on a timer; a Foxglove bridge
with a parameter panel open put 107 of those lines into a single pane.

They cannot take `[]` as a plain default. The type is inferred from the value,
and an empty sequence satisfies the `BYTE_ARRAY` test first (`all(...)` is true
for an empty list), after which a real string array is refused with `Wrong
parameter type, expected '5' got '9'`. Confirmed against a live rclpy node
before writing the fix. Declaring the type and then setting the empty value
keeps the parameter `STRING_ARRAY`, still rejects a wrong type, and still lets
an override win.

## 3. The QoS base-topic fallback is the designed path, logged as a warning

Every processing stage appends a suffix, so a definition that declares QoS on
the base topic and lets `/tf_static/globalframe` inherit it is doing exactly what
the schema intends. As a warning that was two lines per topic per peer at every
bring-up. Moved to debug; the resolved profile is unchanged.

## Validation

```
just lint        # ruff check + ruff format --check + py_compile
just lint-build  # shellcheck + packaged-resource contract tests
just typecheck   # mypy, 23 source files
just test-unit   # 691 passed
```

New tests:

- `tests/unit/test_catmux_pane_logging.py` — four cases driving the *real*
  recorder through `bash -i`: the short-circuit form records a failure, the `if`
  form does not, the `if` form still appends a set option, and a guard that no
  template line carries the short-circuit shape again.
- `tests/unit/test_relay_optional_parameters.py` — unsupplied becomes `[]` and
  is readable, supplied names survive untouched, the type stays `STRING_ARRAY`.
- `tests/unit/test_qos_fallback_logging.py` — the fallback is debug-level, still
  delivers the base topic's settings, and an exact match says nothing.

No behaviour outside the logging and the argument-list construction changes.
