### PR TITLE
Receiver-side playout pacer for packet streams

### DIFF
--- a/session-configuration.md
+++ b/session-configuration.md
@@ -518,6 +518,27 @@ the delivered topic rather than from the OTA topic:
 - `bit_rate` (int)
 - `encoder_av_options` (string)
 
+#### Receiver-side playout pacing (manual node)
+
+A receiver that hands every packet to the decoder the moment it arrives turns
+network delay jitter into display stutter. `com_py playout_pacer` re-times a
+received packet stream to `stamp + budget` (budget adaptive above the fastest
+observed path, clock-offset-proof; late packets pass through immediately, order
+always preserved — the decoder chain sees every packet):
+
+```bash
+ros2 run com_py playout_pacer --ros-args \
+  -p topic:=/cam/image/compressed/drop1of2/ffmpeg \
+  -p target_ms:=350.0 -p adaptive:=true
+```
+
+It republishes on `<topic>/paced` plus `.../paced/budget_ms` and
+`.../paced/queue_depth` debug topics; point the reverse republish (or any
+decoder) at the paced name. On the 2026-08-17 CCNG field trace this removes
+~95 % of delay-caused >200 ms display gaps at ~100 ms median added age
+(adaptive mode). Declarative wiring as a `transport.playout` block is tracked
+in issue #284.
+
 `type: foxglove` supports (CompressedVideo):
 - `gop_size` (int)
 - `bit_rate` (int)

--- a/src/rosotacom/resources/ws/ros2src/com_py/com_py/playout_pacer.py
+++ b/src/rosotacom/resources/ws/ros2src/com_py/com_py/playout_pacer.py
@@ -1,0 +1,100 @@
+"""Receiver-side playout pacer node: re-time a topic to `stamp + budget`.
+
+Subscribes ``topic`` (any type with a ``header.stamp``, resolved dynamically),
+holds each message until its release time from
+:class:`com_py.playout_pacer_core.PlayoutSchedule`, and republishes on
+``<topic><topic_suffix>`` (default ``/paced``) — in order, never dropping.
+Inserted between the OTA unwrapper and a decoder chain it turns network jitter
+into a constant, bounded age instead of visible stutter.
+
+Debug topics next to the output: ``.../paced/budget_ms`` (current delay
+budget) and ``.../paced/queue_depth``.
+"""
+
+from __future__ import annotations
+
+import collections
+import time
+
+import rclpy
+from rclpy.node import Node
+from rosidl_runtime_py.utilities import get_message
+from std_msgs.msg import Float64, Int32
+
+from com_py.playout_pacer_core import PacerConfig, PlayoutSchedule
+from com_py.qos import get_topic_qos, load_qos_config
+
+
+class PlayoutPacerNode(Node):
+    def __init__(self) -> None:
+        super().__init__("playout_pacer")
+        self.declare_parameter("topic", "")
+        self.declare_parameter("msg_type", "ffmpeg_image_transport_msgs/msg/FFMPEGPacket")
+        self.declare_parameter("topic_suffix", "/paced")
+        self.declare_parameter("target_ms", 350.0)
+        self.declare_parameter("min_ms", 100.0)
+        self.declare_parameter("max_ms", 800.0)
+        self.declare_parameter("adaptive", True)
+        self.declare_parameter("qos_config_file", "")
+
+        topic = self.get_parameter("topic").value
+        if not topic:
+            raise ValueError("playout_pacer requires a 'topic' parameter")
+        msg_cls = get_message(self.get_parameter("msg_type").value)
+        out_topic = topic + self.get_parameter("topic_suffix").value
+
+        self.schedule = PlayoutSchedule(
+            PacerConfig(
+                target_ms=float(self.get_parameter("target_ms").value),
+                min_ms=float(self.get_parameter("min_ms").value),
+                max_ms=float(self.get_parameter("max_ms").value),
+                adaptive=bool(self.get_parameter("adaptive").value),
+            )
+        )
+        self._queue: collections.deque = collections.deque()
+
+        qos_file = self.get_parameter("qos_config_file").value
+        if qos_file:
+            qos_config = load_qos_config(self.get_logger(), qos_file)
+            qos = get_topic_qos(self.get_logger(), qos_config, topic, "playout_pacer")
+        else:
+            qos = 10
+        self._pub = self.create_publisher(msg_cls, out_topic, qos)
+        self._budget_pub = self.create_publisher(Float64, out_topic + "/budget_ms", 10)
+        self._depth_pub = self.create_publisher(Int32, out_topic + "/queue_depth", 10)
+        self.create_subscription(msg_cls, topic, self._on_message, qos)
+        # 2 ms release tick: bounds added jitter to well below frame cadence.
+        self.create_timer(0.002, self._release_due)
+        self.create_timer(1.0, self._publish_debug)
+        self.get_logger().info(f"pacing {topic} -> {out_topic}")
+
+    def _on_message(self, msg) -> None:
+        now = time.time()
+        stamp = msg.header.stamp.sec + msg.header.stamp.nanosec * 1e-9
+        release = self.schedule.on_message(stamp, now)
+        self._queue.append((release, msg))
+
+    def _release_due(self) -> None:
+        now = time.time()
+        while self._queue and self._queue[0][0] <= now:
+            self._pub.publish(self._queue.popleft()[1])
+
+    def _publish_debug(self) -> None:
+        self._budget_pub.publish(Float64(data=float(self.schedule.budget_ms)))
+        self._depth_pub.publish(Int32(data=len(self._queue)))
+
+
+def main(args=None) -> None:
+    rclpy.init(args=args)
+    node = PlayoutPacerNode()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/rosotacom/resources/ws/ros2src/com_py/com_py/playout_pacer_core.py
+++ b/src/rosotacom/resources/ws/ros2src/com_py/com_py/playout_pacer_core.py
@@ -1,0 +1,83 @@
+"""Playout scheduling for a received message stream (pure logic, no rclpy).
+
+A receiver that displays every message the moment it arrives converts network
+delay *jitter* directly into display stutter. A playout pacer re-times the
+stream: release each message at ``stamp + L``, where ``L`` is a delay budget
+above the fastest observed path. Messages later than their deadline pass
+through immediately and in order — pacing must never reorder or drop, because
+downstream consumers (an H.264 decoder chain) need every message, in order.
+
+Clock offset between sender and receiver is unknown here, so ``L`` is never
+anchored to the raw ``arrival - stamp`` value (which contains the offset) but
+to its rolling *minimum* ``d_floor``: the fastest path observed carries
+network base delay + clock offset, and every budget is expressed relative to
+it. That makes the schedule clock-offset-proof without any synchronization.
+
+Adaptive mode tracks a high percentile of ``arrival - stamp`` with a bounded
+window and adds a margin, clamped to ``[d_floor + min_ms, d_floor + max_ms]``;
+fixed mode uses ``d_floor + target_ms``.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class PacerConfig:
+    target_ms: float = 350.0  # fixed mode: budget above the observed floor
+    min_ms: float = 100.0  # adaptive clamp, relative to the floor
+    max_ms: float = 800.0
+    adaptive: bool = True
+    percentile: float = 0.95  # of (arrival - stamp), window-local
+    margin_ms: float = 40.0  # headroom above the tracked percentile
+    window: int = 400  # samples (~40 s at 10 Hz)
+
+    def __post_init__(self) -> None:
+        if not 0.0 < self.percentile < 1.0:
+            raise ValueError(f"percentile must be in (0, 1), got {self.percentile}")
+        if self.min_ms > self.max_ms:
+            raise ValueError(f"min_ms {self.min_ms} > max_ms {self.max_ms}")
+        if self.window < 10:
+            raise ValueError("window must hold at least 10 samples")
+
+
+class PlayoutSchedule:
+    """Assigns a release time to each (stamp, arrival) pair, in arrival order."""
+
+    def __init__(self, config: PacerConfig | None = None) -> None:
+        self.config = config or PacerConfig()
+        self._d: deque[float] = deque(maxlen=self.config.window)
+        self._d_floor: float | None = None
+        self._last_release: float | None = None
+
+    @property
+    def budget_ms(self) -> float:
+        """The current delay budget above the observed floor (for observability)."""
+        cfg = self.config
+        if not cfg.adaptive or not self._d:
+            return cfg.target_ms
+        ordered = sorted(self._d)
+        idx = min(len(ordered) - 1, int(cfg.percentile * len(ordered)))
+        floor = self._d_floor if self._d_floor is not None else ordered[0]
+        budget = (ordered[idx] - floor) * 1000.0 + cfg.margin_ms
+        return min(max(budget, cfg.min_ms), cfg.max_ms)
+
+    def on_message(self, stamp_s: float, arrival_s: float) -> float:
+        """Release time (same clock as ``arrival_s``) for the message.
+
+        Monotonic per stream: a release never precedes the previous one, so
+        arrival order is preserved even when a late message resets the pace.
+        """
+        d = arrival_s - stamp_s
+        self._d.append(d)
+        if self._d_floor is None or d < self._d_floor:
+            self._d_floor = d
+        release = stamp_s + self._d_floor + self.budget_ms / 1000.0
+        if release < arrival_s:  # already late: pass through immediately
+            release = arrival_s
+        if self._last_release is not None and release < self._last_release:
+            release = self._last_release
+        self._last_release = release
+        return release

--- a/src/rosotacom/resources/ws/ros2src/com_py/setup.py
+++ b/src/rosotacom/resources/ws/ros2src/com_py/setup.py
@@ -48,6 +48,7 @@ setup(
             'restamp = com_py.restamp:main',
             'latch_relay = com_py.latch_relay:main',
             'trickle = com_py.trickle:main',
+            'playout_pacer = com_py.playout_pacer:main',
             'sized_publisher = com_py.sized_publisher:main',
             'stage_latency = com_py.stage_latency:main',
         ],

--- a/tests/unit/test_playout_pacer.py
+++ b/tests/unit/test_playout_pacer.py
@@ -1,0 +1,81 @@
+"""Playout pacer core — schedule properties on synthetic arrival traces."""
+
+from __future__ import annotations
+
+import random
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WS_PY = REPO_ROOT / "src" / "rosotacom" / "resources" / "ws" / "ros2src" / "com_py"
+sys.path.insert(0, str(WS_PY))
+
+from com_py.playout_pacer_core import PacerConfig, PlayoutSchedule  # noqa: E402
+
+
+def _run(schedule: PlayoutSchedule, stamps, delays):
+    releases = []
+    for stamp, d in zip(stamps, delays, strict=True):
+        releases.append(schedule.on_message(stamp, stamp + d))
+    return releases
+
+
+def test_jittered_arrivals_release_on_a_regular_grid() -> None:
+    # 10 Hz stream, delay jitter far above the frame period: released cadence
+    # must be the sender cadence, not the arrival cadence.
+    rng = random.Random(1)
+    stamps = [i / 10 for i in range(300)]
+    delays = [0.030 + rng.random() * 0.120 for _ in stamps]  # 30-150 ms
+    schedule = PlayoutSchedule(PacerConfig(adaptive=True, min_ms=100.0, max_ms=800.0))
+    releases = _run(schedule, stamps, delays)
+    gaps = [b - a for a, b in zip(releases[50:], releases[51:], strict=False)]
+    assert max(gaps) < 0.150  # no visible stutter (>150 ms) left
+    assert sum(1 for g in gaps if abs(g - 0.1) < 0.01) / len(gaps) > 0.95
+
+
+def test_late_message_passes_through_immediately_and_order_is_kept() -> None:
+    schedule = PlayoutSchedule(PacerConfig(adaptive=False, target_ms=200.0))
+    stamps = [i / 10 for i in range(50)]
+    delays = [0.030] * 50
+    delays[25] = 0.700  # one message far beyond any budget
+    releases = _run(schedule, stamps, delays)
+    # Late message is released at its arrival, not held further...
+    assert releases[25] == pytest.approx(stamps[25] + 0.700)
+    # ...and ordering is never violated.
+    assert all(b >= a for a, b in zip(releases, releases[1:], strict=False))
+
+
+def test_budget_is_clock_offset_proof() -> None:
+    # Same jitter, sender clock shifted by -3 s: the budget must not explode.
+    rng = random.Random(2)
+    delays = [0.030 + rng.random() * 0.060 for _ in range(200)]
+    plain = PlayoutSchedule()
+    shifted = PlayoutSchedule()
+    for i, d in enumerate(delays):
+        plain.on_message(i / 10, i / 10 + d)
+        shifted.on_message(i / 10 - 3.0, i / 10 + d)  # stamp 3 s in the "past"
+    assert shifted.budget_ms == pytest.approx(plain.budget_ms, rel=0.05)
+    assert shifted.budget_ms < 800.0
+
+
+def test_adaptive_budget_tracks_jitter_and_respects_clamps() -> None:
+    calm = PlayoutSchedule(PacerConfig(min_ms=100.0, max_ms=800.0, margin_ms=40.0))
+    rough = PlayoutSchedule(PacerConfig(min_ms=100.0, max_ms=800.0, margin_ms=40.0))
+    rng = random.Random(3)
+    for i in range(300):
+        calm.on_message(i / 10, i / 10 + 0.030 + rng.random() * 0.010)
+        rough.on_message(i / 10, i / 10 + 0.030 + rng.random() * 0.400)
+    assert calm.budget_ms == pytest.approx(100.0)  # clamped at min
+    assert rough.budget_ms > 300.0
+    assert rough.budget_ms <= 800.0
+
+
+def test_config_validation() -> None:
+    with pytest.raises(ValueError):
+        PacerConfig(percentile=1.5)
+    with pytest.raises(ValueError):
+        PacerConfig(min_ms=500.0, max_ms=100.0)
+    with pytest.raises(ValueError):
+        PacerConfig(window=3)


### PR DESCRIPTION
Closes-part-of #284 (node + core + evaluation; the declarative `transport.playout` session block stays open in the issue with the in-suffix wiring design).

Displaying every frame on arrival converts network delay jitter into visible stutter. The pacer re-times a received stream to `stamp + budget`:
- budget adaptive above the fastest observed path — a rolling minimum of `arrival − stamp` absorbs the unknown sender/receiver clock offset, so no synchronization is needed (`test_budget_is_clock_offset_proof`);
- late packets pass through immediately, order always preserved, nothing dropped — a decoder chain still sees every packet;
- `com_py/playout_pacer_core.py` is pure logic (host-tested), `com_py/playout_pacer.py` the thin node (dynamic type resolution, `<topic>/paced` output, `budget_ms`/`queue_depth` debug topics, `ros2 run com_py playout_pacer`).

**Evaluation on the 2026-08-17 CCNG field trace** (11 443 decoded camera frames, remote-assist `transmission_analysis/reports/2026-08-17_ccng_ministerdemo-rehearsal3/`):

| policy | >300 ms gaps | >200 ms gaps | added age p50 |
|---|---|---|---|
| today (display on arrival) | 134 | 428 | — |
| fixed 350 ms | 106 | 179 | 301 ms |
| adaptive (p95+40, clamp 100–800) | 109 | 186 | **104 ms** |

The residual ~105 >300 ms gaps are loss holes (missing frames — no buffer can fix them; that is the encoder-side cascade addressed separately). Delay-caused stutter is removed at ~100 ms median added age, well inside the costmap age budget (397 ms).

**Validation**: `pytest tests/unit/test_playout_pacer.py` (5 tests: regular release grid under heavy jitter, late passthrough + ordering, clock-offset proofness, adaptive clamps, config validation); full unit+contract suite 771 pass; ruff + mypy clean. Docs: session-configuration.md "Receiver-side playout pacing".