### PR TITLE
Transit records carry the real FFMPEG keyframe flag

### DIFF
--- a/docs/ffmpeg-keyframes.md
+++ b/docs/ffmpeg-keyframes.md
@@ -45,6 +45,18 @@ Grouping a stream into GOPs is then just splitting at keyframes. Note the
 encoder may emit keyframes *early* (scene cuts), so GOPs can be shorter than
 `gop_size` — assert spacing `<= gop_size`, not `== gop_size`.
 
+## Transit records carry the flag
+
+The receiving status overview applies the same parse live: when an inbound
+`OtaStamped` envelope's `msg_type` names an FFMPEGPacket, it walks the wrapped
+CDR bytes to `flags` (`com_py/ffmpeg_flags.py`, a dependency-free mirror of the
+host parser) and writes `keyframe: true/false` on every delivered RFC 0003
+transit row in `events.jsonl`. Synthesized lost rows have no payload and carry
+no such field; a payload the walk cannot parse simply omits it. Downstream,
+`rosotacom report` annotates a stream from these real flags whenever they cover
+more than 90% of its delivered rows (provenance `ffmpeg_flags (transit
+records)`), and only recordings without the field fall back to size bimodality.
+
 ## Automated stream-stage stats
 
 `rosotacom stream-stats` applies the same packet parser and GOP grouping to
@@ -69,8 +81,9 @@ Inputs are explicit and repeatable:
   rosbag2 storage backends fall back to `rosbag2_py` in a ROS environment.
 - `--events LABEL=PATH:/topic` reads delivered RFC 0003 transit rows from
   `events.jsonl`, using receiver-side `t_com_in` timestamps and `size_bytes`.
-  Transit rows do not carry raw CDR flags, so GOP annotation uses the documented
-  size-bimodality fallback when the keyframe share looks like a real GOP.
+  Rows carrying the per-message `keyframe` field annotate GOPs from the real
+  flags; older recordings without it use the documented size-bimodality
+  fallback when the keyframe share looks like a real GOP.
 
 The Markdown output starts with the comparison table:
 
@@ -105,9 +118,9 @@ averages 43,723 B, while positions 1-4 average 3,738 B, 4,512 B, 4,834 B, and
 
 ## Fallback: size bimodality
 
-If `flags` is unavailable (foreign recordings, or bags anonymized before
-flag preservation existed), the size distribution still separates the two
-classes: delta frames dominate the stream (a GOP of N contributes N−1), so
+If `flags` is unavailable (foreign recordings, bags anonymized before flag
+preservation existed, or `events.jsonl` written before transit rows carried
+`keyframe`), the size distribution still separates the two classes: delta frames dominate the stream (a GOP of N contributes N−1), so
 the median frame size sits on the delta mode, while keyframes are typically
 5–100× larger. `rosotacom.ffmpeg_packet.keyframes_by_size` marks frames
 above `3 × median` as keyframes. This misclassifies only when delta frames
@@ -119,6 +132,12 @@ scene at a very low bitrate) — prefer `flags` whenever present.
 - `tests/unit/test_ffmpeg_packet.py` — CDR parsing (alignment across
   odd-length strings), flag semantics, and the size fallback on a synthetic
   GOP pattern.
+- `tests/unit/test_ffmpeg_flags.py` — the receiver-side keyframe-bit walk in
+  `com_py/ffmpeg_flags.py`: agreement with the host parser on hand-built
+  packets, and `None` (never an exception) on truncated or foreign bytes.
+- `tests/unit/test_forensics.py` — `rosotacom report` prefers transit-row
+  `keyframe` flags over size bimodality, and falls back below the coverage
+  gate.
 - `tests/unit/test_stream_stats.py` — exact stream statistics, per-GOP-position
   tables from hand-built CDR packets, events-row source loading, comparison
   table shape, and CLI output writing.

--- a/src/rosotacom/forensics.py
+++ b/src/rosotacom/forensics.py
@@ -42,6 +42,11 @@ RATE_COLLAPSE = "rate_collapse"
 KEYFRAME_SHARE_MIN = 0.02
 KEYFRAME_SHARE_MAX = 0.4
 
+# Real per-message FFMPEG flags win over the size heuristic once they cover
+# most delivered rows; the slack tolerates isolated parse failures in a
+# recording that otherwise carries the field.
+KEYFRAME_FLAG_COVERAGE_MIN = 0.9
+
 CAVEAT = (
     "Context is correlation, not causation: a link-trace sample or profile step that overlaps an event "
     "does not prove it caused the event. The causal test is reproduction under an emulated profile."
@@ -228,13 +233,27 @@ class Stream:
 
 
 def _annotate_keyframes(stream: Stream, *, declared: bool) -> None:
-    """Mark keyframes by size bimodality (transit records carry sizes, not FFMPEG flags).
+    """Mark keyframes, preferring the real FFMPEG flags in the transit records.
 
-    ``rosotacom.ffmpeg_packet.keyframes_by_size`` is the documented fallback for
-    exactly this case. Declared FFMPEGPacket streams (type from status.json) are
-    always annotated; other streams only when the flagged share looks like a real
-    GOP structure, so uniform or spiky non-video streams are not mislabeled.
+    The receiver parses ``AV_PKT_FLAG_KEY`` out of the wrapped FFMPEGPacket CDR
+    at com_in and writes it as ``keyframe`` on delivered rows, so when the field
+    covers (nearly) all delivered rows the real flags are authoritative — the
+    field only exists where the wrapper's ``msg_type`` named an FFMPEGPacket,
+    which is a stronger declaration than status.json, so no share gate applies.
+
+    Recordings from before the field existed fall back to
+    ``rosotacom.ffmpeg_packet.keyframes_by_size``: declared FFMPEGPacket streams
+    (type from status.json) are always annotated; other streams only when the
+    flagged share looks like a real GOP structure, so uniform or spiky
+    non-video streams are not mislabeled.
     """
+    delivered = [record for record in stream.records if record.get("status") != "lost"]
+    flagged = [record for record in delivered if isinstance(record.get("keyframe"), bool)]
+    if delivered and len(flagged) / len(delivered) > KEYFRAME_FLAG_COVERAGE_MIN:
+        stream.keyframe_seqs = frozenset(int(record["seq"]) for record in flagged if record["keyframe"])
+        stream.keyframe_provenance = "ffmpeg_flags (transit records)"
+        return
+
     sized = [record for record in stream.records if record.get("size_bytes") is not None]
     if not sized:
         return
@@ -246,7 +265,7 @@ def _annotate_keyframes(stream: Stream, *, declared: bool) -> None:
         return
     stream.keyframe_seqs = frozenset(int(record["seq"]) for record, flag in zip(sized, flags, strict=True) if flag)
     origin = "declared FFMPEGPacket stream" if declared else f"size share {share * 100.0:.1f}%"
-    stream.keyframe_provenance = f"size_bimodality ({origin}); transit records carry no FFMPEG flags"
+    stream.keyframe_provenance = f"size_bimodality ({origin}); these transit records carry no FFMPEG flags"
 
 
 def build_streams(records: list[dict[str, Any]], *, declared_ffmpeg_topics: Collection[str] = ()) -> list[Stream]:

--- a/src/rosotacom/resources/ws/ros2src/com_py/com_py/ffmpeg_flags.py
+++ b/src/rosotacom/resources/ws/ros2src/com_py/com_py/ffmpeg_flags.py
@@ -1,0 +1,58 @@
+"""Keyframe bit of a serialized FFMPEGPacket, straight from its CDR bytes.
+
+An ``OtaStamped`` envelope carries the wrapped message as serialized CDR
+(``serialized_msg``), so the receiving status overview can read the packet's
+``flags`` field -- bit 0 is libav's ``AV_PKT_FLAG_KEY``, set exactly on
+keyframes -- without deserializing through rclpy. That matters twice: the inner
+message package need not be installed on the receiving peer, and the OTA
+observer must never grow a dependency on it just for one bit.
+
+This mirrors the field walk of ``rosotacom.ffmpeg_packet.parse_ffmpeg_packet``
+(the host-side analysis parser) but lives in com_py because the ROS container
+does not ship the host analysis package. Only little-endian CDR (the ROS 2
+default on all supported platforms) is handled; anything else -- including a
+truncated or foreign buffer -- yields ``None``, never an exception.
+"""
+
+from __future__ import annotations
+
+import struct
+from typing import Optional
+
+AV_PKT_FLAG_KEY = 0x1
+
+FFMPEG_PACKET_TYPE = "ffmpeg_image_transport_msgs/msg/FFMPEGPacket"
+
+
+def _align(offset: int, alignment: int) -> int:
+    return (offset + alignment - 1) // alignment * alignment
+
+
+def parse_keyframe_flag(cdr: bytes) -> Optional[bool]:
+    """``flags & AV_PKT_FLAG_KEY`` of a serialized FFMPEGPacket, or ``None``.
+
+    Field order per the message definition: ``std_msgs/Header header``,
+    ``int32 width``, ``int32 height``, ``string encoding``, ``uint64 pts``,
+    ``uint8 flags``, ... CDR alignment is relative to the payload start,
+    after the 4-byte encapsulation header.
+    """
+    try:
+        if len(cdr) < 4 or cdr[1] != 0x01:
+            return None
+        body = cdr[4:]
+        offset = 8  # header.stamp: int32 sec + uint32 nanosec
+
+        offset = _align(offset, 4)
+        (str_len,) = struct.unpack_from("<I", body, offset)
+        offset += 4 + str_len  # frame_id, NUL included in str_len
+
+        offset = _align(offset, 4) + 8  # int32 width + int32 height
+
+        offset = _align(offset, 4)
+        (str_len,) = struct.unpack_from("<I", body, offset)
+        offset += 4 + str_len  # encoding
+
+        offset = _align(offset, 8) + 8  # uint64 pts
+        return bool(body[offset] & AV_PKT_FLAG_KEY)
+    except (struct.error, IndexError):
+        return None

--- a/src/rosotacom/resources/ws/ros2src/com_py/com_py/status_overview.py
+++ b/src/rosotacom/resources/ws/ros2src/com_py/com_py/status_overview.py
@@ -67,6 +67,7 @@ from rclpy.qos import DurabilityPolicy, HistoryPolicy, QoSProfile, ReliabilityPo
 from rclpy.serialization import serialize_message
 from rosidl_runtime_py.utilities import get_message
 
+from com_py.ffmpeg_flags import FFMPEG_PACKET_TYPE, parse_keyframe_flag
 from com_py.link_bytes import LinkByteSampler, resolve_link_interface
 from com_py.link_trace import LinkTraceRecorder
 from com_py.status_overview_core import (
@@ -261,6 +262,12 @@ class StageObserver(Node):
                         clock_offset_s = estimate["offset_s"]
                         rtt_s = estimate["rtt_s"]
                         delay_s = now_ros_s + clock_offset_s - t_wrap_s
+                    keyframe: Optional[bool] = None
+                    try:
+                        if msg.msg_type == FFMPEG_PACKET_TYPE:
+                            keyframe = parse_keyframe_flag(bytes(msg.serialized_msg))
+                    except Exception:
+                        keyframe = None
                     transit = {
                         "peer": com_in.get("peer"),
                         "source": com_in.get("source"),
@@ -270,6 +277,7 @@ class StageObserver(Node):
                         "stage": com_in.get("stage"),
                         "t_wrap": t_wrap_s,
                         "t_com_in": now_ros_s,
+                        "keyframe": keyframe,
                     }
             else:
                 header = getattr(msg, "header", None)

--- a/src/rosotacom/resources/ws/ros2src/com_py/com_py/status_overview_core.py
+++ b/src/rosotacom/resources/ws/ros2src/com_py/com_py/status_overview_core.py
@@ -493,39 +493,44 @@ class StageObservation:
                 if inter_arrival_s is not None:
                     self.last_inter_arrival_s = inter_arrival_s
                 self.last_transit_recv_wall = wall
-                self.transit_records.append(
-                    {
-                        **common,
-                        "seq": int(seq),
-                        "status": sequence_status,
-                        "t_wrap": transit.get("t_wrap"),
-                        "t_com_in": transit.get("t_com_in"),
-                        "clock_offset_ms": (
-                            round(clock_offset_s * 1000.0, 3)
-                            if clock_offset_s is not None
+                row = {
+                    **common,
+                    "seq": int(seq),
+                    "status": sequence_status,
+                    "t_wrap": transit.get("t_wrap"),
+                    "t_com_in": transit.get("t_com_in"),
+                    "clock_offset_ms": (
+                        round(clock_offset_s * 1000.0, 3)
+                        if clock_offset_s is not None
+                        else None
+                    ),
+                    "sections": {
+                        "ota_hop_ms": (
+                            round(delay_s * 1000.0, 3) if delay_s is not None else None
+                        ),
+                        "ota_hop_uncorrected_ms": (
+                            round(raw_delay_s * 1000.0, 3)
+                            if raw_delay_s is not None
                             else None
                         ),
-                        "sections": {
-                            "ota_hop_ms": (
-                                round(delay_s * 1000.0, 3) if delay_s is not None else None
-                            ),
-                            "ota_hop_uncorrected_ms": (
-                                round(raw_delay_s * 1000.0, 3)
-                                if raw_delay_s is not None
-                                else None
-                            ),
-                        },
-                        "size_bytes": size,
-                        "inter_arrival_ms": (
-                            round(inter_arrival_s * 1000.0, 3)
-                            if inter_arrival_s is not None
-                            else None
-                        ),
-                        "jitter_ms": (
-                            round(jitter_s * 1000.0, 3) if jitter_s is not None else None
-                        ),
-                    }
-                )
+                    },
+                    "size_bytes": size,
+                    "inter_arrival_ms": (
+                        round(inter_arrival_s * 1000.0, 3)
+                        if inter_arrival_s is not None
+                        else None
+                    ),
+                    "jitter_ms": (
+                        round(jitter_s * 1000.0, 3) if jitter_s is not None else None
+                    ),
+                }
+                # The FFMPEG keyframe bit (AV_PKT_FLAG_KEY) exists only for
+                # recognized FFMPEGPacket payloads; other streams' rows omit
+                # the field rather than carrying a null on every message.
+                keyframe = transit.get("keyframe")
+                if keyframe is not None:
+                    row["keyframe"] = bool(keyframe)
+                self.transit_records.append(row)
 
     def metrics(self, now_mono: float, window_s: float) -> Dict[str, Any]:
         with self.lock:

--- a/src/rosotacom/stream_stats.py
+++ b/src/rosotacom/stream_stats.py
@@ -360,7 +360,14 @@ def load_events_source(spec: SourceSpec) -> StreamSource:
             stamp = record.get("t_wrap")
         if stamp is None:
             continue
-        samples.append(StreamSample(timestamp_ns=int(float(stamp) * 1_000_000_000), size_bytes=int(size)))
+        keyframe = record.get("keyframe")
+        samples.append(
+            StreamSample(
+                timestamp_ns=int(float(stamp) * 1_000_000_000),
+                size_bytes=int(size),
+                keyframe=keyframe if isinstance(keyframe, bool) else None,
+            )
+        )
     return StreamSource(
         label=spec.label,
         kind="events",

--- a/tests/unit/test_ffmpeg_flags.py
+++ b/tests/unit/test_ffmpeg_flags.py
@@ -1,0 +1,130 @@
+"""Unit tests for com_py/ffmpeg_flags.py — the receiver-side keyframe-bit walk.
+
+The module mirrors ``rosotacom.ffmpeg_packet.parse_ffmpeg_packet`` but runs in
+the ROS container without the host analysis package, so it is loaded by file
+path and cross-checked against the host parser on the same hand-built CDR
+bytes. Unlike the host parser it must never raise into a subscription
+callback: every unparseable input yields ``None``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import struct
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+from rosotacom.ffmpeg_packet import AV_PKT_FLAG_KEY, parse_ffmpeg_packet
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+FFMPEG_FLAGS_PY = (
+    REPO_ROOT / "src" / "rosotacom" / "resources" / "ws" / "ros2src" / "com_py" / "com_py" / "ffmpeg_flags.py"
+)
+
+
+def _load(path: Path, name: str) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+ffmpeg_flags = _load(FFMPEG_FLAGS_PY, "rosotacom_com_py_ffmpeg_flags")
+
+
+def _cdr_string(offset: int, value: str) -> tuple[bytes, int]:
+    pad = (-offset) % 4
+    raw = value.encode() + b"\x00"
+    chunk = b"\x00" * pad + struct.pack("<I", len(raw)) + raw
+    return chunk, offset + len(chunk)
+
+
+def make_packet(
+    *,
+    frame_id: str = "camera",
+    encoding: str = "h264",
+    pts: int = 42,
+    flags: int = AV_PKT_FLAG_KEY,
+    payload: bytes = b"\x01\x02\x03",
+) -> bytes:
+    """Serialize an FFMPEGPacket by hand, following XCDR1 little-endian rules."""
+    body = b""
+    offset = 0
+    body += struct.pack("<iI", 7, 9)  # header.stamp
+    offset += 8
+    chunk, offset = _cdr_string(offset, frame_id)
+    body += chunk
+    pad = (-offset) % 4
+    body += b"\x00" * pad + struct.pack("<ii", 640, 480)
+    offset += pad + 8
+    chunk, offset = _cdr_string(offset, encoding)
+    body += chunk
+    pad = (-offset) % 8
+    body += b"\x00" * pad + struct.pack("<Q", pts)
+    offset += pad + 8
+    body += struct.pack("<BB", flags, 0)  # flags + is_bigendian
+    offset += 2
+    pad = (-offset) % 4
+    body += b"\x00" * pad + struct.pack("<I", len(payload)) + payload
+    return b"\x00\x01\x00\x00" + body
+
+
+def _flags_offset() -> int:
+    """Index of the flags byte, located by diffing a flags=0 against a flags=1 build."""
+    diffs = [
+        index for index, (a, b) in enumerate(zip(make_packet(flags=0), make_packet(flags=1), strict=True)) if a != b
+    ]
+    assert len(diffs) == 1
+    return diffs[0]
+
+
+def test_keyframe_bit_set_and_unset() -> None:
+    assert ffmpeg_flags.parse_keyframe_flag(make_packet(flags=AV_PKT_FLAG_KEY)) is True
+    assert ffmpeg_flags.parse_keyframe_flag(make_packet(flags=0)) is False
+
+
+def test_non_key_flag_bits_do_not_mark_keyframes() -> None:
+    # e.g. AV_PKT_FLAG_CORRUPT (0x2) alone is not a keyframe marker.
+    assert ffmpeg_flags.parse_keyframe_flag(make_packet(flags=0x2)) is False
+    assert ffmpeg_flags.parse_keyframe_flag(make_packet(flags=0x3)) is True
+
+
+# Odd-length strings shift subsequent fields across alignment boundaries; a
+# walk with a wrong alignment origin reads the wrong byte exactly there.
+@pytest.mark.parametrize("frame_id", ["camera", "c", "front_medium_x", ""])
+@pytest.mark.parametrize("encoding", ["h264", "hevc_nvenc", "x"])
+@pytest.mark.parametrize("flags", [0, 1])
+def test_agrees_with_the_host_parser_on_hand_built_packets(frame_id: str, encoding: str, flags: int) -> None:
+    cdr = make_packet(frame_id=frame_id, encoding=encoding, flags=flags)
+
+    assert ffmpeg_flags.parse_keyframe_flag(cdr) is parse_ffmpeg_packet(cdr).is_keyframe
+
+
+def test_every_truncation_before_the_flags_byte_yields_none() -> None:
+    cdr = make_packet(flags=AV_PKT_FLAG_KEY)
+    offset = _flags_offset()
+
+    for length in range(offset + 1):
+        assert ffmpeg_flags.parse_keyframe_flag(cdr[:length]) is None
+    # The flags byte itself is the last one the walk needs.
+    assert ffmpeg_flags.parse_keyframe_flag(cdr[: offset + 1]) is True
+
+
+def test_big_endian_encapsulation_yields_none() -> None:
+    cdr = bytearray(make_packet())
+    cdr[1] = 0x00
+
+    assert ffmpeg_flags.parse_keyframe_flag(bytes(cdr)) is None
+
+
+def test_garbage_string_length_yields_none_not_an_exception() -> None:
+    # A frame_id length pointing far past the buffer must not escape as an error.
+    cdr = bytearray(make_packet())
+    struct.pack_into("<I", cdr, 12, 2**31)  # frame_id length field
+
+    assert ffmpeg_flags.parse_keyframe_flag(bytes(cdr)) is None

--- a/tests/unit/test_forensics.py
+++ b/tests/unit/test_forensics.py
@@ -365,6 +365,43 @@ def test_keyframes_annotated_by_size_bimodality_without_declaration(tmp_path: Pa
     assert "size_bimodality" in keyframes["provenance"]
 
 
+def test_keyframes_prefer_transit_flags_over_size_bimodality(tmp_path: Path) -> None:
+    # Uniform sizes carry no GOP signal and there is no declaration: only the
+    # real per-row flags can be the source of this annotation.
+    rows = [{**_record(seq), "keyframe": seq % 5 == 0} for seq in range(200)]
+    instance = _write_instance(tmp_path / "inst", rows)
+    report = build_report(instance, argv=["test"])
+    keyframes = report["streams"]["a->b:/cam"]["keyframes"]
+    assert keyframes["count"] == 40
+    assert keyframes["provenance"] == "ffmpeg_flags (transit records)"
+
+
+def test_keyframe_flag_coverage_counts_delivered_rows_only(tmp_path: Path) -> None:
+    rows = [
+        _record(seq, status="lost") if 50 <= seq < 80 else {**_record(seq), "keyframe": seq % 5 == 0}
+        for seq in range(200)
+    ]
+    report = build_report(_write_instance(tmp_path / "inst", rows), argv=["test"])
+    keyframes = report["streams"]["a->b:/cam"]["keyframes"]
+    assert keyframes["provenance"] == "ffmpeg_flags (transit records)"
+    assert keyframes["count"] == 34  # 40 flagged positions minus the 6 lost ones
+
+
+def test_sparse_keyframe_flags_fall_back_to_size_bimodality(tmp_path: Path) -> None:
+    # Half the rows predate the field (receiver upgraded mid-instance): coverage
+    # 50% is below the gate, so the documented size fallback decides.
+    rows = [
+        {**_record(seq, size_bytes=40000 if seq % 5 == 0 else 3000), "keyframe": seq % 5 == 0}
+        if seq < 100
+        else _record(seq, size_bytes=40000 if seq % 5 == 0 else 3000)
+        for seq in range(200)
+    ]
+    report = build_report(_write_instance(tmp_path / "inst", rows), argv=["test"])
+    keyframes = report["streams"]["a->b:/cam"]["keyframes"]
+    assert keyframes["count"] == 40
+    assert keyframes["provenance"].startswith("size_bimodality")
+
+
 def test_uniform_and_rare_spike_streams_are_not_keyframe_annotated(tmp_path: Path) -> None:
     uniform = _steady(200)
     # One 100x outlier in 200 messages: share 0.5 % — below the GOP gate.

--- a/tests/unit/test_status_overview.py
+++ b/tests/unit/test_status_overview.py
@@ -981,6 +981,33 @@ def test_transit_records_carry_the_epoch_they_were_counted_in() -> None:
     assert [(record["seq"], record["epoch"]) for record in records] == [(5000, 0), (40, 1)]
 
 
+def test_transit_records_carry_the_ffmpeg_keyframe_flag() -> None:
+    obs = core.StageObservation(type_str="com_msgs/msg/OtaStamped")
+    transit = {
+        "topic": "/cam",
+        "direction": "inbound",
+        "stage": "com_in",
+        "t_wrap": 1.01,
+        "t_com_in": 1.05,
+        "keyframe": True,
+    }
+    obs.record(40000, 0.04, now_mono=10.0, now_wall=1.05, seq=0, transit=transit)
+    obs.record(3000, 0.04, now_mono=10.1, now_wall=1.15, seq=1, transit={**transit, "keyframe": False})
+    # seq 2 never arrives: the synthesized lost row has no payload to parse.
+    obs.record(3000, 0.04, now_mono=10.3, now_wall=1.35, seq=3, transit={**transit, "keyframe": False})
+    # A non-FFMPEG stream's transit dict carries keyframe=None -> field absent.
+    obs.record(3000, 0.04, now_mono=10.4, now_wall=1.45, seq=4, transit={**transit, "keyframe": None})
+
+    records = obs.drain_transit_records()
+    assert [(record["seq"], record.get("keyframe", "absent")) for record in records] == [
+        (0, True),
+        (1, False),
+        (2, "absent"),
+        (3, False),
+        (4, "absent"),
+    ]
+
+
 def test_loss_expect_classifies_wrapped_stage_bad(tmp_path: Path) -> None:
     agg = _build({"local": _FakeObserver(), "ota": _FakeObserver()}, tmp_path)
     metrics = {"hz": 10.0, "last_delay_s": 0.01, "loss_pct": 4.0}

--- a/tests/unit/test_status_overview_observer.py
+++ b/tests/unit/test_status_overview_observer.py
@@ -1,16 +1,20 @@
-"""Latency measurement in the status overview's stage observer.
+"""Latency and keyframe measurement in the status overview's stage observer.
 
-Two layers: the ROS-independent `stamp_delay` in `status_overview_core`, and the
+Three layers: the ROS-independent `stamp_delay` in `status_overview_core`, the
 observer callback that decides *whether* a stamp is comparable to the local
-clock at all. The node module imports rclpy, which the host suite does not have,
-so its ROS surface is stubbed and the real core module is registered under the
-name the node imports (`tests/unit/test_ota_wrapper.py` uses the same approach).
+clock at all, and the OtaStamped branch that reads the FFMPEG keyframe bit out
+of the wrapped payload. The node module imports rclpy, which the host suite
+does not have, so its ROS surface is stubbed and the real core and
+ffmpeg_flags modules are registered under the names the node imports
+(`tests/unit/test_ota_wrapper.py` uses the same approach).
 """
 
 from __future__ import annotations
 
 import importlib.util
+import struct
 import sys
+from array import array
 from collections.abc import Iterator
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
@@ -33,6 +37,7 @@ _STUBBED = (
     "rosidl_runtime_py",
     "rosidl_runtime_py.utilities",
     "com_py",
+    "com_py.ffmpeg_flags",
     "com_py.link_bytes",
     "com_py.link_trace",
     "com_py.status_overview_core",
@@ -61,6 +66,7 @@ def _stub_module(name: str, **attrs: object) -> ModuleType:
 
 
 core = _load(CORE_PY, "rosotacom_status_overview_core_observer")
+ffmpeg_flags = _load(COM_PY / "ffmpeg_flags.py", "rosotacom_status_overview_ffmpeg_flags")
 
 
 # ---------------------------------------------------------------------------
@@ -124,6 +130,7 @@ def node_module() -> Iterator[ModuleType]:
     )
     _stub_module("com_py.link_trace", LinkTraceRecorder=object)
     sys.modules["com_py.status_overview_core"] = core
+    sys.modules["com_py.ffmpeg_flags"] = ffmpeg_flags
 
     module = _load(NODE_PY, "rosotacom_status_overview_node")
 
@@ -227,3 +234,97 @@ def test_a_message_without_a_header_reports_no_latency(node_module: ModuleType) 
     obs = node.observations[topic]
     assert obs.last_delay_s is None
     assert obs.msg_total == 1
+
+
+# ---------------------------------------------------------------------------
+# the OtaStamped branch: FFMPEG keyframe flag into the transit record
+# ---------------------------------------------------------------------------
+
+
+def _cdr_string(offset: int, value: str) -> tuple[bytes, int]:
+    pad = (-offset) % 4
+    raw = value.encode() + b"\x00"
+    chunk = b"\x00" * pad + struct.pack("<I", len(raw)) + raw
+    return chunk, offset + len(chunk)
+
+
+def _ffmpeg_packet(flags: int) -> bytes:
+    """A minimal serialized FFMPEGPacket (XCDR1 little-endian)."""
+    body = struct.pack("<iI", 7, 9)  # header.stamp
+    chunk, offset = _cdr_string(8, "camera")
+    body += chunk
+    body += b"\x00" * ((-offset) % 4) + struct.pack("<ii", 640, 480)
+    offset += (-offset) % 4 + 8
+    chunk, offset = _cdr_string(offset, "h264")
+    body += chunk
+    body += b"\x00" * ((-offset) % 8) + struct.pack("<QBB", 42, flags, 0)
+    return b"\x00\x01\x00\x00" + body
+
+
+def _ota_observer(node_module: ModuleType, topic: str):
+    node = object.__new__(node_module.StageObserver)
+    node.observations = {topic: core.StageObservation(type_str="com_msgs/msg/OtaStamped")}
+    node._stage_metadata = {
+        topic: [
+            {
+                "peer": "b",
+                "source": "a",
+                "target": "b",
+                "base": "/cam",
+                "direction": "inbound",
+                "stage": "com_in",
+            }
+        ]
+    }
+    node.clock_estimator = _Estimator(0.0)
+    node.get_clock = lambda: SimpleNamespace(now=lambda: SimpleNamespace(nanoseconds=int(_NOW_S * 1e9)))
+    node.get_logger = lambda: SimpleNamespace(error=lambda *a, **k: None, warning=lambda *a, **k: None)
+    return node
+
+
+def _ota_stamped(seq: int, *, msg_type: str, serialized_msg) -> SimpleNamespace:
+    stamp_s = _NOW_S - 0.03
+    sec = int(stamp_s)
+    return SimpleNamespace(
+        header=SimpleNamespace(stamp=SimpleNamespace(sec=sec, nanosec=int((stamp_s - sec) * 1e9))),
+        seq=seq,
+        msg_type=msg_type,
+        serialized_msg=serialized_msg,
+    )
+
+
+def test_ota_ffmpeg_payload_marks_the_transit_record_keyframe(node_module: ModuleType) -> None:
+    topic = "/cam/ffmpeg/ota"
+    node = _ota_observer(node_module, topic)
+    cb = node._make_cb(topic)
+
+    # rclpy delivers uint8[] as array('B'); the branch must take it as-is.
+    cb(_ota_stamped(0, msg_type=ffmpeg_flags.FFMPEG_PACKET_TYPE, serialized_msg=array("B", _ffmpeg_packet(1))))
+    cb(_ota_stamped(1, msg_type=ffmpeg_flags.FFMPEG_PACKET_TYPE, serialized_msg=_ffmpeg_packet(0)))
+
+    records = node.observations[topic].drain_transit_records()
+    assert [(record["seq"], record["keyframe"]) for record in records] == [(0, True), (1, False)]
+
+
+def test_ota_non_ffmpeg_payload_gets_no_keyframe_field(node_module: ModuleType) -> None:
+    topic = "/twist/ota"
+    node = _ota_observer(node_module, topic)
+
+    node._make_cb(topic)(_ota_stamped(0, msg_type="geometry_msgs/msg/Twist", serialized_msg=_ffmpeg_packet(1)))
+
+    (record,) = node.observations[topic].drain_transit_records()
+    assert record["topic"] == "/cam"
+    assert "keyframe" not in record
+
+
+def test_ota_unparseable_ffmpeg_payload_omits_the_flag(node_module: ModuleType) -> None:
+    topic = "/cam/ffmpeg/ota"
+    node = _ota_observer(node_module, topic)
+    cb = node._make_cb(topic)
+
+    cb(_ota_stamped(0, msg_type=ffmpeg_flags.FFMPEG_PACKET_TYPE, serialized_msg=b"\x00\x01\x00\x00\x07"))
+    cb(_ota_stamped(1, msg_type=ffmpeg_flags.FFMPEG_PACKET_TYPE, serialized_msg=None))
+
+    records = node.observations[topic].drain_transit_records()
+    assert [record["seq"] for record in records] == [0, 1]
+    assert all("keyframe" not in record for record in records)

--- a/tests/unit/test_stream_stats.py
+++ b/tests/unit/test_stream_stats.py
@@ -154,6 +154,18 @@ def test_events_source_filters_topic_and_detects_gop_by_size(tmp_path: Path) -> 
     assert stats["gop"]["keyframes"] == 2
 
 
+def test_events_source_prefers_recorded_keyframe_flags(tmp_path: Path) -> None:
+    # Uniform sizes: only the transit rows' keyframe field can mark the GOP.
+    rows = [{**_event(seq, size=3000), "keyframe": seq % 5 == 0} for seq in range(10)]
+    events = tmp_path / "events.jsonl"
+    events.write_text("\n".join(json.dumps(row) for row in rows) + "\n", encoding="utf-8")
+
+    stats = summarize_source(load_events_source(parse_source_spec("events", f"post={events}:/cam")))
+
+    assert stats["gop"]["method"] == "ffmpeg_packet.flags"
+    assert stats["gop"]["keyframes"] == 2
+
+
 def test_mcap_bag_source_reads_metadata_without_rosbag2(tmp_path: Path, monkeypatch) -> None:
     bag = tmp_path / "bag"
     bag.mkdir()


### PR DESCRIPTION
Closes #282.

The forensics report counted keyframes by size bimodality (3× median), which on the 2026-08-17 CCNG drive reported ~35% keyframes where the real share (FFMPEGPacket `flags & 1`) is 21% at GOP 5 — every keyframe-conditioned statistic inherited the error (remote-assist `transmission_analysis/reports/2026-08-17_ccng_ministerdemo-rehearsal3/`).

- `com_py/ffmpeg_flags.py` (new): dependency-free CDR walk to the FFMPEGPacket flags byte (alignment-correct, truncation/garbage → `None`, never raises); cross-checked against the host parser on hand-built packets in tests.
- `status_overview.py`: when the wrapper's `msg_type` names an FFMPEGPacket, the com_in observer parses the keyframe bit from the wrapped payload; `status_overview_core.py` writes `keyframe: true/false` on delivered rows (lost rows and non-FFMPEG streams omit the field).
- `forensics.py`: real flags win once they cover >90% of delivered rows (provenance `ffmpeg_flags (transit records)`); size bimodality stays the explicit fallback for pre-field recordings, with its gate and provenance intact.
- `stream_stats.py`: recorded flag feeds the existing explicit-flags preference.
- docs/ffmpeg-keyframes.md updated.

**Validation**: 29 new/extended tests across `test_ffmpeg_flags.py` (incl. every-prefix truncation sweep and host-parser agreement), `test_status_overview_observer.py`, `test_status_overview.py`, `test_forensics.py` (preference, coverage counting, sparse fallback), `test_stream_stats.py`. Full unit+contract: 798 pass; ruff + mypy clean.