### PR TITLE
Finding: best-effort reordering becomes reader-side loss, depth-independent

### DIFF
--- a/docs/findings/README.md
+++ b/docs/findings/README.md
@@ -28,6 +28,7 @@ living verification hook.
 
 ## Findings
 
+- [Best-effort reordering becomes reader-side loss, independent of history depth](reorder-becomes-reader-loss.md) - under pure delay jitter a Cyclone best-effort reader discards every overtaken sample (57% at 100 Hz under 50+-45 ms), delivery stays strictly monotonic, and depth 50 loses the same as depth 1.
 - [Jitter causes loss while bandwidth shortage builds latency](jitter-loss-bandwidth-latency.md) - 18 KB at 20 Hz separates jitter-induced loss from bandwidth-induced queueing.
 - [Lighter alternating messages can lose more than steady messages](lighter-message-loss.md) - a 1x18KB+1x0KB pattern lost under a tight emulated profile while the steady 18 KB comparison did not.
 - [Delay alone was not the loss boundary for the 18 KB at 20 Hz probe](delay-alone-no-loss.md) - pure delay profiles showed no material loss, and the 300 ms delay-only probe delivered all messages.

--- a/docs/findings/reorder-becomes-reader-loss.md
+++ b/docs/findings/reorder-becomes-reader-loss.md
@@ -1,0 +1,69 @@
+# Best-Effort Reordering Becomes Reader-Side Loss, Independent Of History Depth
+
+## Claim
+
+Under delay jitter large enough to reorder packets — with ZERO configured
+loss — a CycloneDDS best-effort reader discards every overtaken sample to
+preserve per-writer order: delivery is strictly monotonic, the discarded
+samples count as loss, and subscription history depth does not recover any of
+it (the drop happens in the reader proxy, before history). Variance is
+therefore a loss mechanism of its own, and it is the one QoS depth cannot
+help against — unlike bundled-publication overwrite, where depth does help.
+
+## Setup
+
+- Host pair / topology: two Docker containers on one machine (the repository's
+  communication image; any image with `rclpy`, `rmw_cyclonedds_cpp` and `tc`
+  works), unicast Cyclone peers (`AllowMulticast=false`, static IPs), one
+  `std_msgs/Int64` stream at 100 Hz, publisher history depth 10, best-effort;
+  the receiver subscribes the SAME topic twice: depth 1 and depth 50. netem on
+  the publisher's egress only, delay+jitter, no loss, no rate limit.
+- rosotacom SHA: measured at `3227daf`; re-runs record theirs.
+- Profile: inline netem args (`delay 50ms 45ms` and `delay 50ms 20ms`), not a
+  packaged profile — the experiment is below rosotacom, at the RMW layer.
+- Seed policy: seedless single runs (`n=1` per jitter level); the effect size
+  (tens of percent) dwarfs run-to-run noise.
+
+## Evidence
+
+Evidence grade: scripted container reproduction, committed next to this file.
+
+```bash
+python3 docs/findings/repro/reorder_drop_repro.py orchestrate --rate 100 --duration 40
+```
+
+2026-08-18 run (4000 messages sent per scenario, zero configured loss):
+
+| netem | depth 1 delivered | depth 50 delivered | inversions | loss of span |
+|---|---|---|---|---|
+| `delay 50ms 45ms` | 1709 | 1727 | 0 | **57%** |
+| `delay 50ms 20ms` | 2626 | 2659 | 0 | **34%** |
+
+Three readings, one per column group: delivery is strictly monotonic (zero
+inversions in every subscription), depth 50 loses the same as depth 1 (the
+0.5–1 pp difference is executor noise, not recovery), and the loss tracks the
+overtake probability — at 100 Hz the inter-message gap is 10 ms, so jitter
+±45 ms makes "the next message arrives first" the common case.
+
+Field context (2026-08-17 CCNG drive): the operational 10 Hz streams have a
+100 ms gap against ~18 ms steady jitter, so this channel is minor there
+(neighbour-delay overtake proxy: 9.6% around steady losses vs 6.0% baseline).
+It grows quadratically relevant as rates rise or jitter grows — any stream
+whose inter-message gap approaches the link's jitter pays it.
+
+Verification: manual: run the command above from a source checkout with
+Docker (build the image via the packaged `ros2docker.json.example` or pass
+`--image`); the script prints and writes `out/reorder_results.json`.
+
+## Status
+
+confirmed, 2026-08-18.
+
+## Publication notes
+
+This is the mechanism behind the jitter side of
+[jitter-loss-bandwidth-latency.md](jitter-loss-bandwidth-latency.md): the
+jitter boundary is not radio noise but the reader's monotonicity rule. For
+papers: plot delivered share vs jitter/gap ratio, and state explicitly that
+history depth is not a mitigation here — pacing (larger gaps), FEC, or
+reliable QoS are.

--- a/docs/findings/repro/reorder_drop_repro.py
+++ b/docs/findings/repro/reorder_drop_repro.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Does jitter-induced reordering become LOSS at a CycloneDDS best-effort
+reader, and does history depth help?
+
+Two containers (rcd image, cyclone RMW). Publisher shapes its egress with
+pure delay+jitter (NO configured loss, no rate limit). Receiver subscribes
+the same topic twice: depth 1 and depth 50.
+
+Discriminates two mechanisms:
+  - loss seen by depth-50 sub  = reader-proxy drop of overtaken samples
+    (depth cannot help)        (or nothing, if cyclone delivers OOO)
+  - extra loss of depth-1 sub  = history overwrite from arrival bunching
+    (depth DOES help)
+  - delivered inversions       = out-of-order delivery (would mean no drop)
+
+Modes: orchestrate (host) | pub | sub (in container).
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+IMG = "ros-communication:latest"  # any image with rclpy + rmw_cyclonedds + tc (--image overrides)
+NET = "claude_reorder_net"
+TOPIC = "/reorder_probe"
+
+
+def mode_pub(args):
+    import rclpy
+    from rclpy.node import Node
+    from rclpy.qos import HistoryPolicy, QoSProfile, ReliabilityPolicy
+    from std_msgs.msg import Int64
+
+    rclpy.init()
+    node = Node("reorder_pub")
+    qos = QoSProfile(reliability=ReliabilityPolicy.BEST_EFFORT, history=HistoryPolicy.KEEP_LAST, depth=10)
+    pub = node.create_publisher(Int64, TOPIC, qos)
+    time.sleep(5.0)  # discovery
+    n = int(args.rate * args.duration)
+    period = 1.0 / args.rate
+    t0 = time.monotonic()
+    for i in range(n):
+        while time.monotonic() < t0 + i * period:
+            time.sleep(0.0005)
+        m = Int64()
+        m.data = i
+        pub.publish(m)
+    time.sleep(3.0)
+    print(f"published {n}")
+    node.destroy_node()
+    rclpy.shutdown()
+
+
+def mode_sub(args):
+    import rclpy
+    from rclpy.node import Node
+    from rclpy.qos import HistoryPolicy, QoSProfile, ReliabilityPolicy
+    from std_msgs.msg import Int64
+
+    rclpy.init()
+    node = Node("reorder_sub")
+    got = {1: [], 50: []}
+
+    def make_cb(depth):
+        def cb(msg):
+            got[depth].append(msg.data)
+
+        return cb
+
+    subs = []
+    for depth in (1, 50):
+        qos = QoSProfile(reliability=ReliabilityPolicy.BEST_EFFORT, history=HistoryPolicy.KEEP_LAST, depth=depth)
+        subs.append(node.create_subscription(Int64, TOPIC, make_cb(depth), qos))
+    t_end = time.monotonic() + args.duration + 20
+    while time.monotonic() < t_end:
+        rclpy.spin_once(node, timeout_sec=0.05)
+    out = {}
+    for depth, seqs in got.items():
+        inv = sum(1 for a, b in zip(seqs, seqs[1:], strict=False) if b < a)
+        out[f"depth{depth}"] = {
+            "received": len(seqs),
+            "unique": len(set(seqs)),
+            "inversions": inv,
+            "first": seqs[0] if seqs else None,
+            "last": max(seqs) if seqs else None,
+        }
+    Path(args.out).write_text(json.dumps(out, indent=2))
+    print(json.dumps(out))
+    node.destroy_node()
+    rclpy.shutdown()
+
+
+def run(cmd):
+    r = subprocess.run(cmd, shell=True, capture_output=True, text=True)
+    if r.returncode != 0:
+        raise RuntimeError(f"{cmd}\n{r.stderr or r.stdout}")
+    return r.stdout
+
+
+def mode_orchestrate(args):
+    global IMG
+    IMG = args.image
+    me = Path(__file__).resolve()
+    outdir = me.parent / "out"
+    scenarios = [
+        ("jitter45", "tc qdisc replace dev eth0 root netem delay 50ms 45ms"),
+        ("jitter20", "tc qdisc replace dev eth0 root netem delay 50ms 20ms"),
+    ]
+    ip_sub, ip_pub = "10.97.0.2", "10.97.0.3"
+    ddsuri = (
+        "<CycloneDDS><Domain><General><AllowMulticast>false</AllowMulticast>"
+        '</General><Discovery><Peers><Peer address=\\"' + ip_sub + '\\"/>'
+        '<Peer address=\\"' + ip_pub + '\\"/></Peers>'
+        "<ParticipantIndex>auto</ParticipantIndex></Discovery></Domain></CycloneDDS>"
+    )
+    subprocess.run(f"docker network rm {NET}", shell=True, capture_output=True)
+    run(f"docker network create --subnet 10.97.0.0/24 {NET}")
+    results = {}
+    try:
+        for name, netem in scenarios:
+            subprocess.run("docker rm -f claude_reorder_pub claude_reorder_sub", shell=True, capture_output=True)
+            env = f'-e RMW_IMPLEMENTATION=rmw_cyclonedds_cpp -e ROS_DOMAIN_ID=77 -e CYCLONEDDS_URI="{ddsuri}"'
+            run(
+                f"docker run -d --name claude_reorder_sub --network {NET} --ip {ip_sub} {env} "
+                f"-v {me.parent}:/w -v {outdir}:/out {IMG} bash -lc "
+                f"'python3 /w/{me.name} sub --duration {args.duration} "
+                f"--out /out/reorder_{name}.json'"
+            )
+            time.sleep(2)
+            run(
+                f"docker run -d --name claude_reorder_pub --network {NET} --ip {ip_pub} "
+                f"--cap-add NET_ADMIN {env} -v {me.parent}:/w {IMG} bash -lc "
+                f"'{netem} && python3 /w/{me.name} pub --rate {args.rate} "
+                f"--duration {args.duration}'"
+            )
+            run("docker wait claude_reorder_pub")
+            run("docker wait claude_reorder_sub")
+            data = json.loads((outdir / f"reorder_{name}.json").read_text())
+            sent = int(args.rate * args.duration)
+            for d in ("depth1", "depth50"):
+                span = (data[d]["last"] or 0) - (data[d]["first"] or 0) + 1
+                data[d]["loss_pct_of_span"] = round(100 * (1 - data[d]["unique"] / max(span, 1)), 2)
+            data["sent"] = sent
+            results[name] = data
+            print(f"== {name}: {json.dumps(data)}")
+    finally:
+        subprocess.run("docker rm -f claude_reorder_pub claude_reorder_sub", shell=True, capture_output=True)
+        subprocess.run(f"docker network rm {NET}", shell=True, capture_output=True)
+    (outdir / "reorder_results.json").write_text(json.dumps(results, indent=2))
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    sub = ap.add_subparsers(dest="mode", required=True)
+    for m in ("orchestrate", "pub", "sub"):
+        p = sub.add_parser(m)
+        p.add_argument("--rate", type=float, default=100.0)
+        p.add_argument("--duration", type=float, default=40.0)
+        p.add_argument("--image", default=IMG)
+        if m == "sub":
+            p.add_argument("--out", required=True)
+    args = ap.parse_args()
+    {"pub": mode_pub, "sub": mode_sub, "orchestrate": mode_orchestrate}[args.mode](args)
+
+
+if __name__ == "__main__":
+    sys.exit(main() or 0)


### PR DESCRIPTION
Closes #290.

Ledger entry + committed portable repro (`docs/findings/repro/reorder_drop_repro.py`, two containers, netem delay+jitter only, zero configured loss):

| netem | depth 1 | depth 50 | inversions | loss |
|---|---|---|---|---|
| `delay 50ms 45ms` @100 Hz | 1709/4000 | 1727/4000 | 0 | **57%** |
| `delay 50ms 20ms` @100 Hz | 2626/4000 | 2659/4000 | 0 | **34%** |

CycloneDDS best-effort readers discard overtaken samples to preserve per-writer order — variance becomes loss, history depth does not recover it (proxy-level, not history). This is the mechanism behind the jitter side of `jitter-loss-bandwidth-latency.md`; field context from the 2026-08-17 CCNG drive included (minor channel at 10 Hz/100 ms gaps vs 18 ms jitter; grows as gap approaches jitter).

Validation: `tests/contract/test_findings.py` (ledger contract incl. index linkage) passes; full unit+contract 787 pass; ruff+mypy clean.