### PR TITLE
Forensics: rate-collapse events name their culprit (source vs link)

### DIFF
--- a/docs/forensics-report.md
+++ b/docs/forensics-report.md
@@ -77,6 +77,22 @@ missing tail after the last record is not judged either — without a sender-sid
 end marker it is indistinguishable from a normal shutdown (RFC 0003, honest
 limits).
 
+A receiver-only view also cannot tell a broken link from a source that simply
+stopped publishing — on the 2026-08-17 CCNG drive, "0 Hz collapses" on the
+planner visualization were the source pausing during manual interventions while
+the link delivered everything offered. When the instance also contains the
+sending peer's own transit records for a stream (`direction: outbound`, stage
+`com_out`), the report bins their `t_wrap` stamps into a per-bin **offered**
+rate on the same publish timeline and each collapse event names its culprit in
+`details.cause`: `source` when every collapsed bin was offered below the same
+threshold — the collapse is fully explained by the source, and the markdown
+line reads "source paused" (0 Hz offered) or "source slowed"; `link` when at
+least one collapsed bin was offered at/above threshold and the link still
+delivered below it; `unknown` without sender-side records. `min_offered_hz` /
+`max_offered_hz` accompany the verdict. Sender-side rows feed only the offered
+rate — they never enter the delivered view, where the cross-peer join would
+upgrade receiver-inferred lost rows to delivered.
+
 Events across streams and kinds are grouped into **incidents** when their
 windows touch (merge gap defaults to one bin): one degradation moment, several
 lenses on it.

--- a/src/rosotacom/forensics.py
+++ b/src/rosotacom/forensics.py
@@ -342,6 +342,52 @@ def build_stream_bins(stream: Stream, *, run_start: float, bin_s: float) -> list
     return bins
 
 
+def build_offered_timelines(
+    offered_records: list[dict[str, Any]],
+    streams: list[Stream],
+    timelines: dict[str, list[dict[str, Any]]],
+    *,
+    run_start: float,
+    bin_s: float,
+) -> dict[str, list[float]]:
+    """Per-bin offered rate per stream, from the sending peer's own transit records.
+
+    ``offered_records`` are ``direction: outbound`` rows (stage ``com_out``):
+    what the source handed to the link. Their ``t_wrap`` is the same header
+    stamp the receiving side records, so offered and delivered bins share one
+    publish timeline with no clock join. Streams without a single stamped
+    sender-side row are absent from the result — their collapse cause stays
+    unknowable.
+    """
+    grouped: dict[tuple[str, str, str], list[float]] = {}
+    for record in join_transit_records(offered_records):
+        if record.get("t_wrap") is None:
+            continue
+        key = (
+            str(record.get("source") or ""),
+            str(record.get("target") or ""),
+            str(record.get("topic") or ""),
+        )
+        grouped.setdefault(key, []).append(float(record["t_wrap"]))
+
+    offered: dict[str, list[float]] = {}
+    for stream in streams:
+        stamps = grouped.get((stream.source, stream.target, stream.topic))
+        bins = timelines[stream.label]
+        if not stamps or not bins:
+            continue
+        # bin_start_epoch is run_start + index * bin_s by construction; round
+        # instead of floor so float error cannot shift the alignment by one.
+        first_index = round((float(bins[0]["bin_start_epoch"]) - run_start) / bin_s)
+        counts = [0] * len(bins)
+        for stamp in stamps:
+            index = math.floor((stamp - run_start) / bin_s) - first_index
+            if 0 <= index < len(counts):
+                counts[index] += 1
+        offered[stream.label] = [round(count / bin_s, 3) for count in counts]
+    return offered
+
+
 # --------------------------------------------------------------------------- #
 # Event detection
 # --------------------------------------------------------------------------- #
@@ -470,7 +516,11 @@ def detect_latency_excursions(stream: Stream, config: DetectionConfig) -> list[D
 
 
 def detect_rate_collapses(
-    stream: Stream, bins: list[dict[str, Any]], config: DetectionConfig
+    stream: Stream,
+    bins: list[dict[str, Any]],
+    config: DetectionConfig,
+    *,
+    offered_hz: list[float] | None = None,
 ) -> list[DegradationEvent]:
     """Runs of >= ``rate_collapse_min_bins`` interior bins delivering far below nominal.
 
@@ -478,45 +528,75 @@ def detect_rate_collapses(
     becomes lost rows when a later message arrives) and throttled-but-delivering
     regimes. Needs a nominal rate; the first and last bin of a stream are never
     judged (they are partial by construction).
+
+    ``offered_hz`` — one rate per entry of ``bins``, from the sending peer's own
+    records (``build_offered_timelines``) — names each event's culprit as
+    ``cause``: ``source`` when every collapsed bin was offered below the same
+    threshold (the collapse is fully explained by the source pausing or slowing;
+    the link delivered what it was given), ``link`` when at least one collapsed
+    bin was offered at/above threshold and the link still delivered below it,
+    and ``unknown`` without sender-side records. The receiver alone cannot tell
+    these apart: on the 2026-08-17 CCNG drive, 0 Hz "collapses" on the planner
+    visualization were the source pausing during manual interventions, not the
+    link.
     """
     nominal_hz = stream.nominal_hz
     if nominal_hz is None or len(bins) < 3:
         return []
+    threshold_hz = config.rate_collapse_fraction * nominal_hz
     events: list[DegradationEvent] = []
-    run: list[dict[str, Any]] = []
+    run: list[tuple[int, dict[str, Any]]] = []
+
+    def cause_details() -> dict[str, Any]:
+        if offered_hz is None or len(offered_hz) != len(bins):
+            return {"cause": "unknown"}
+        rates = [float(offered_hz[index]) for index, _entry in run]
+        return {
+            "cause": "source" if max(rates) < threshold_hz else "link",
+            "min_offered_hz": round(min(rates), 3),
+            "max_offered_hz": round(max(rates), 3),
+        }
 
     def flush() -> None:
         if len(run) >= config.rate_collapse_min_bins:
+            entries = [entry for _index, entry in run]
             events.append(
                 DegradationEvent(
                     kind=RATE_COLLAPSE,
                     stream=stream.label,
-                    start_epoch=float(run[0]["bin_start_epoch"]),
-                    end_epoch=float(run[-1]["bin_start_epoch"]) + config.bin_s,
-                    count=len(run),
+                    start_epoch=float(entries[0]["bin_start_epoch"]),
+                    end_epoch=float(entries[-1]["bin_start_epoch"]) + config.bin_s,
+                    count=len(entries),
                     details={
                         "nominal_hz": round(nominal_hz, 3),
-                        "min_delivered_hz": min(float(entry["delivered_hz"]) for entry in run),
-                        "threshold_hz": round(config.rate_collapse_fraction * nominal_hz, 3),
+                        "min_delivered_hz": min(float(entry["delivered_hz"]) for entry in entries),
+                        "threshold_hz": round(threshold_hz, 3),
+                        **cause_details(),
                     },
                 )
             )
         run.clear()
 
-    for entry in bins[1:-1]:
-        if float(entry["delivered_hz"]) < config.rate_collapse_fraction * nominal_hz:
-            run.append(entry)
+    for index, entry in enumerate(bins[1:-1], start=1):
+        if float(entry["delivered_hz"]) < threshold_hz:
+            run.append((index, entry))
         else:
             flush()
     flush()
     return events
 
 
-def detect_events(stream: Stream, bins: list[dict[str, Any]], config: DetectionConfig) -> list[DegradationEvent]:
+def detect_events(
+    stream: Stream,
+    bins: list[dict[str, Any]],
+    config: DetectionConfig,
+    *,
+    offered_hz: list[float] | None = None,
+) -> list[DegradationEvent]:
     events = [
         *detect_loss_bursts(stream, config),
         *detect_latency_excursions(stream, config),
-        *detect_rate_collapses(stream, bins, config),
+        *detect_rate_collapses(stream, bins, config, offered_hz=offered_hz),
     ]
     events.sort(key=lambda event: (event.start_epoch, event.end_epoch, event.kind, event.stream))
     return events
@@ -843,8 +923,15 @@ def build_report(
     config = config or DetectionConfig()
     inputs = discover_inputs(instance_dir, peers=peers)
     records = load_transit_records(inputs.events_paths)
+    # The sending peer's own rows (direction=outbound, stage com_out) carry the
+    # offered rate. They must stay out of the delivered view: the cross-peer
+    # join keys on (source, topic, epoch, seq), so a sender row would upgrade
+    # the receiver's lost row to delivered and flatten delivered_hz to the
+    # offered rate.
+    offered_records = [record for record in records if record.get("direction") == "outbound"]
+    delivered_records = [record for record in records if record.get("direction") != "outbound"]
     declared = load_declared_ffmpeg_topics(inputs.status_paths)
-    streams = build_streams(records, declared_ffmpeg_topics=declared)
+    streams = build_streams(delivered_records, declared_ffmpeg_topics=declared)
 
     send_spans = [(stream.send_time(stream.records[0]), stream.send_time(stream.records[-1])) for stream in streams]
     run_start = min((span[0] for span in send_spans), default=0.0)
@@ -859,9 +946,10 @@ def build_report(
     )
 
     timelines = {stream.label: build_stream_bins(stream, run_start=run_start, bin_s=config.bin_s) for stream in streams}
+    offered = build_offered_timelines(offered_records, streams, timelines, run_start=run_start, bin_s=config.bin_s)
     events: list[DegradationEvent] = []
     for stream in streams:
-        events.extend(detect_events(stream, timelines[stream.label], config))
+        events.extend(detect_events(stream, timelines[stream.label], config, offered_hz=offered.get(stream.label)))
     events.sort(key=lambda event: (event.start_epoch, event.end_epoch, event.kind, event.stream))
 
     incidents = group_incidents(events, merge_gap_s=config.merge_gap_s)
@@ -881,7 +969,7 @@ def build_report(
 
     from .transit import summarize_transit_records
 
-    summary = summarize_transit_records(records)["topics"]
+    summary = summarize_transit_records(delivered_records)["topics"]
     stream_entries: dict[str, Any] = {}
     for stream in streams:
         entry = dict(summary.get(stream.label, {}))
@@ -984,9 +1072,21 @@ def _event_line(event: dict[str, Any]) -> str:
             f"baseline {_format_ms(details.get('baseline_ms'))} (threshold {_format_ms(details.get('threshold_ms'))}), "
             f"{window}"
         )
+    cause = details.get("cause")
+    if cause == "source":
+        name = (
+            "rate collapse (source paused)" if details.get("max_offered_hz") == 0.0 else "rate collapse (source slowed)"
+        )
+    elif cause == "link":
+        name = "rate collapse (link)"
+    else:
+        name = "rate collapse"
+    low, high = details.get("min_offered_hz"), details.get("max_offered_hz")
+    offered = "" if low is None else (f", offered {low}Hz" if low == high else f", offered {low}-{high}Hz")
+    suffix = "" if cause in ("source", "link") else "; cause unknown (no sender-side records)"
     return (
-        f"**rate collapse** on `{event['stream']}` — {event['count']} bins, delivered rate down to "
-        f"{details.get('min_delivered_hz')}Hz vs nominal {details.get('nominal_hz')}Hz, {window}"
+        f"**{name}** on `{event['stream']}` — {event['count']} bins, delivered rate down to "
+        f"{details.get('min_delivered_hz')}Hz vs nominal {details.get('nominal_hz')}Hz{offered}, {window}{suffix}"
     )
 
 

--- a/tests/unit/test_forensics.py
+++ b/tests/unit/test_forensics.py
@@ -78,6 +78,25 @@ def _steady(count: int, **kwargs: Any) -> list[dict[str, Any]]:
     return [_record(seq, **kwargs) for seq in range(count)]
 
 
+def _sender_record(seq: int, *, topic: str = "/cam", t0: float = T0, period_s: float = PERIOD_S) -> dict[str, Any]:
+    """The sending peer's own observation of the same message (stage com_out)."""
+    return {
+        "kind": "transit",
+        "peer": "a",
+        "source": "a",
+        "target": "b",
+        "topic": topic,
+        "direction": "outbound",
+        "stage": "com_out",
+        "seq": seq,
+        "status": "delivered",
+        "t_wrap": t0 + seq * period_s,
+        "t_com_in": None,
+        "sections": {"ota_hop_ms": None},
+        "size_bytes": 1000,
+    }
+
+
 def _write_instance(
     root: Path,
     rows: list[dict[str, Any]],
@@ -206,6 +225,103 @@ def test_stream_edges_are_never_rate_collapsed() -> None:
     config = DetectionConfig()
     bins = build_stream_bins(stream, run_start=T0, bin_s=config.bin_s)
     assert detect_rate_collapses(stream, bins, config) == []
+
+
+def test_rate_collapse_cause_from_offered_rate() -> None:
+    # Same delivered collapse (bins 5-7 at 5 Hz), three sender-side views:
+    # offered stayed nominal -> the link dropped it; offered collapsed with it
+    # -> the source did; no sender records -> unknowable from this instance.
+    rows = [_record(seq) for seq in range(300) if not (100 <= seq < 160) or seq % 4 == 0]
+    stream = _stream(rows)
+    config = DetectionConfig()
+    bins = build_stream_bins(stream, run_start=T0, bin_s=config.bin_s)
+
+    (event,) = detect_rate_collapses(stream, bins, config, offered_hz=[20.0] * len(bins))
+    assert event.details["cause"] == "link"
+    assert event.details["min_offered_hz"] == pytest.approx(20.0)
+
+    offered = [0.0 if 5 <= index <= 7 else 20.0 for index in range(len(bins))]
+    (event,) = detect_rate_collapses(stream, bins, config, offered_hz=offered)
+    assert event.details["cause"] == "source"
+    assert event.details["max_offered_hz"] == pytest.approx(0.0)
+
+    (event,) = detect_rate_collapses(stream, bins, config)
+    assert event.details["cause"] == "unknown"
+    assert "min_offered_hz" not in event.details
+
+
+def test_report_names_link_collapse_when_offered_stays_nominal(tmp_path: Path) -> None:
+    # Receiver sees 5 Hz in the stall window; the sender's own records show all
+    # 300 messages offered at 20 Hz. Sender rows must feed only the offered
+    # rate: merged into the delivered view they would fill the stall and hide
+    # the collapse entirely.
+    receiver = [_record(seq) for seq in range(300) if not (100 <= seq < 160) or seq % 4 == 0]
+    sender = [_sender_record(seq) for seq in range(300)]
+    instance = _write_instance(tmp_path / "inst", receiver, peer="b")
+    _write_instance(instance, sender, peer="a")
+    report = build_report(instance, argv=["test"])
+    (event,) = report["events"]
+    assert event["kind"] == RATE_COLLAPSE
+    assert event["details"]["cause"] == "link"
+    assert event["details"]["min_delivered_hz"] == pytest.approx(5.0)
+    assert event["details"]["min_offered_hz"] == pytest.approx(20.0)
+    assert "**rate collapse (link)**" in render_markdown(report)
+
+
+def test_report_names_source_pause_with_sender_side_records(tmp_path: Path) -> None:
+    # The source publishes nothing for 3 s (seq continues afterwards, so no
+    # lost rows): both sides go to 0 Hz in bins 5-7 -- the 2026-08-17 CCNG
+    # shape, where the link delivered everything offered.
+    receiver = [_record(seq, t0=T0 + 3.0 if seq >= 100 else T0) for seq in range(300)]
+    sender = [_sender_record(seq, t0=T0 + 3.0 if seq >= 100 else T0) for seq in range(300)]
+    instance = _write_instance(tmp_path / "inst", receiver, peer="b")
+    _write_instance(instance, sender, peer="a")
+    report = build_report(instance, argv=["test"])
+    (event,) = report["events"]
+    assert event["kind"] == RATE_COLLAPSE
+    assert event["count"] == 3
+    assert event["details"]["cause"] == "source"
+    assert event["details"]["max_offered_hz"] == pytest.approx(0.0)
+    assert "**rate collapse (source paused)**" in render_markdown(report)
+
+
+def test_report_names_source_slowdown_distinct_from_pause(tmp_path: Path) -> None:
+    # The source throttled to 5 Hz and the link delivered all of it: cause is
+    # still the source, but the line must not claim a pause.
+    pattern = [seq for seq in range(300) if not (100 <= seq < 160) or seq % 4 == 0]
+    receiver = [_record(seq) for seq in pattern]
+    sender = [_sender_record(seq) for seq in pattern]
+    instance = _write_instance(tmp_path / "inst", receiver, peer="b")
+    _write_instance(instance, sender, peer="a")
+    report = build_report(instance, argv=["test"])
+    (event,) = report["events"]
+    assert event["details"]["cause"] == "source"
+    assert event["details"]["min_offered_hz"] == pytest.approx(5.0)
+    assert "**rate collapse (source slowed)**" in render_markdown(report)
+
+
+def test_rate_collapse_without_sender_records_reads_cause_unknown(tmp_path: Path) -> None:
+    rows = [_record(seq) for seq in range(300) if not (100 <= seq < 160) or seq % 4 == 0]
+    report = build_report(_write_instance(tmp_path / "inst", rows), argv=["test"])
+    (event,) = report["events"]
+    assert event["details"]["cause"] == "unknown"
+    assert "cause unknown (no sender-side records)" in render_markdown(report)
+
+
+def test_offered_bins_align_when_stream_starts_mid_bin(tmp_path: Path) -> None:
+    # A second stream starting 2.5 s earlier shifts the shared run_start, so
+    # /cam's bins begin at a non-zero bin index. The offered rate must land in
+    # those same bins: misaligned by the offset, the paused source would read
+    # as offered-at-nominal and the cause would flip to "link".
+    cam_receiver = [_record(seq, t0=T0 + 3.0 if seq >= 100 else T0) for seq in range(300)]
+    tel_receiver = [_record(seq, topic="/tel", t0=T0 - 2.5) for seq in range(300)]
+    cam_sender = [_sender_record(seq, t0=T0 + 3.0 if seq >= 100 else T0) for seq in range(300)]
+    instance = _write_instance(tmp_path / "inst", [*cam_receiver, *tel_receiver], peer="b")
+    _write_instance(instance, cam_sender, peer="a")
+    report = build_report(instance, argv=["test"])
+    collapses = [event for event in report["events"] if event["kind"] == RATE_COLLAPSE]
+    assert [event["stream"] for event in collapses] == ["a->b:/cam"]
+    assert collapses[0]["details"]["cause"] == "source"
 
 
 # -- timeline bins ------------------------------------------------------------ #


### PR DESCRIPTION
Closes #283.

On the 2026-08-17 CCNG drive the report flagged 0 Hz "rate collapse" on the planner visualization during manual interventions — the SOURCE had paused; the link delivered everything offered. A receiver-only detector cannot tell these apart.

- `build_offered_timelines`: per-bin offered rate from the sending peer's own outbound (`com_out`) transit records — same `t_wrap` publish timeline as the delivered bins, so no clock join; alignment pinned against mid-bin stream starts.
- `detect_rate_collapses(..., offered_hz=...)` stays pure and classifies each event: `cause=source` (every collapsed bin offered below threshold — pause or slowdown, rendered distinctly), `cause=link` (offered nominal, arrived collapsed), `cause=unknown` (no sender records), with `min/max_offered_hz` in the details and the offered rate in the markdown event line.
- `build_report` partitions records by direction before the cross-peer join — sender rows would otherwise upgrade receiver-inferred `lost` rows to `delivered` and hide exactly the link collapse this exists to catch (pinned by test).

Honest scope note: today's recorders emit only receiver-side `com_in` records, so current instances render `cause unknown (no sender-side records)` explicitly; the classification engages as soon as the sender writes outbound records (follow-up issue filed).

**Validation**: 6 new tests (pure detector causes; e2e link/source-pause/source-slowdown/unknown renderings; mid-bin alignment). Full unit+contract 767 pass; ruff + mypy clean. docs/forensics-report.md updated.