### PR TITLE
Fail starts on unusable network bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,24 @@ rosotacom start 1_heartbeat --identity b \
   --peer-address a=10.0.0.10 --peer-address b=10.0.0.11
 ```
 
+Before `start` stops a conflicting container, writes an instance, or builds an
+image, it verifies that the selected identity's address belongs to this host and
+that the route to the other peer selects that address as its source. A missing
+VPN/data-plane interface or a route through the wrong network therefore fails
+without disturbing a working session. Run the same check on its own with
+`preflight`; deployments that require the other host to be online already can
+also make three bounded ICMP probes mandatory:
+
+```bash
+rosotacom preflight 1_heartbeat --identity a \
+  --peer-address a=10.0.0.10 --peer-address b=10.0.0.11 \
+  --require-peer-reachable
+```
+
+Peer reachability is opt-in because some valid networks block ICMP and peers may
+be started in either order. `rosotacom start` accepts the same
+`--require-peer-reachable` policy when a deployment does require it.
+
 `rosotacom` reads the static session input and creates generated files under `session-instances/<date>/<session>_<timestamp>_<id>/config/`, including per-peer plugin/session specs, topic lists, optional QoS, and optional `domain_bridge.yaml`. Catmux pane output is logged under the same instance in `logs/<peer>/catmux/`.
 
 What else a run leaves under `logs/<peer>/`, and which file to open first when a

--- a/deployment-configuration.md
+++ b/deployment-configuration.md
@@ -85,6 +85,29 @@ Precedence is explicit:
 All logical peers must resolve to addresses before a session starts. Session
 definitions do not accept physical addresses or SSH targets.
 
+## Data-plane preflight
+
+`rosotacom start` checks the resolved bindings against the host before it stops
+or creates containers:
+
+1. The selected identity's IPv4 address must be assigned locally.
+2. `ip route get` for the other peer must select that same address as its
+   source.
+
+This makes an absent VPN/interface, a wrong identity, and a route escaping over
+another network startup errors instead of silent communication failures. Inspect
+the result without starting anything:
+
+```bash
+rosotacom preflight SESSION --identity PEER
+```
+
+Add `--require-peer-reachable` to `preflight` or `start` when this deployment
+also requires three bounded ICMP probes to succeed. Reachability is not the
+global default: ICMP can be intentionally filtered, and valid peers can be
+started in either order. Docker-isolated local smoke networks use their own
+network lifecycle and bypass this host data-plane check.
+
 ## Project selection and completion
 
 The nearest `rosotacom.yaml` is discovered upward from the current directory.

--- a/src/rosotacom/cli.py
+++ b/src/rosotacom/cli.py
@@ -64,6 +64,7 @@ from .image_cache import (
     image_fingerprint,
     reference_tag,
 )
+from .network_preflight import NetworkPreflightResult, run_network_preflight
 
 anonymize_lib = importlib.import_module("rosotacom.anonymize")
 
@@ -1125,7 +1126,7 @@ def _get_local_ipv4s() -> list[str]:
         out = subprocess.check_output(["ip", "-o", "-4", "addr", "show"], text=True)
     except Exception:
         return []
-    return _IPV4_RE.findall(out)
+    return re.findall(r"\binet\s+(\d+\.\d+\.\d+\.\d+)/", out)
 
 
 def _default_local_ip() -> str:
@@ -1232,6 +1233,29 @@ def _auto_identity(bindings: dict[str, PeerBinding]) -> str:
             f"Auto identity failed: no peer address matched local IPv4s={sorted(local_ips)}. Use --identity."
         )
     raise RuntimeError(f"Auto identity ambiguous: matched peers={matches} for local IPv4s={sorted(local_ips)}.")
+
+
+def _network_preflight(
+    bindings: dict[str, PeerBinding],
+    identity: str,
+    *,
+    require_peer_reachable: bool = False,
+) -> NetworkPreflightResult:
+    return run_network_preflight(
+        bindings,
+        identity,
+        local_addresses=_get_local_ipv4s(),
+        require_peer_reachable=require_peer_reachable,
+    )
+
+
+def _print_network_preflight(result: NetworkPreflightResult) -> None:
+    reachability = "peer reachable" if result.peer_reachable else "route verified"
+    print(
+        f"Network preflight OK: {result.identity} ({result.local_address}) -> "
+        f"{result.remote_identity} ({result.remote_address}) via {result.interface} "
+        f"src {result.source_address}; {reachability}."
+    )
 
 
 def _peer_com_name(peers: dict[str, Any], peer_key: str) -> str:
@@ -5123,10 +5147,18 @@ def start_session(args: argparse.Namespace) -> str:
     identity = args.identity or _auto_identity(bindings)
     if not args.identity:
         print(f"Auto-selected identity: {identity}")
+    network_isolated = bool(getattr(args, "network_name", None))
+    if not network_isolated:
+        _print_network_preflight(
+            _network_preflight(
+                bindings,
+                identity,
+                require_peer_reachable=getattr(args, "require_peer_reachable", False),
+            )
+        )
     remote_name = _remote_peer_name(cfg, identity)
     instance = _resolve_session_instance(runtime, session, getattr(args, "instance_id", None))
     container_name = _container_name(remote_name, runtime, instance.instance_id)
-    network_isolated = bool(getattr(args, "network_name", None))
     if not network_isolated and not getattr(args, "skip_conflict_check", False):
         matching = _matching_com_containers(runtime, remote_name)
         if _fixed_com_container_name(runtime, remote_name) is not None:
@@ -5233,6 +5265,30 @@ def start_session(args: argparse.Namespace) -> str:
 
     print(f"rosotacom session started in container: {container_name}")
     return container_name
+
+
+def preflight_session(args: argparse.Namespace) -> NetworkPreflightResult:
+    runtime = _load_runtime_config(args)
+    session = _resolve_session(args.session_dir, runtime)
+    cfg = _effective_session_config(session.host_dir, runtime)
+    bindings = _resolve_bindings(
+        cfg,
+        runtime,
+        peer=getattr(args, "peer", None),
+        peer_address=getattr(args, "peer_address", None),
+    )
+    if not args.identity and not getattr(args, "auto_identity", True):
+        raise RuntimeError("Missing --identity. Provide --identity <peer> or allow auto identity.")
+    identity = args.identity or _auto_identity(bindings)
+    if not args.identity:
+        print(f"Auto-selected identity: {identity}")
+    result = _network_preflight(
+        bindings,
+        identity,
+        require_peer_reachable=getattr(args, "require_peer_reachable", False),
+    )
+    _print_network_preflight(result)
+    return result
 
 
 def stop_session(args: argparse.Namespace) -> None:
@@ -8668,6 +8724,11 @@ def _add_start_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--rewrite-formatting", action="store_true")
     _add_peer_arg(parser)
     _add_peer_address_arg(parser)
+    parser.add_argument(
+        "--require-peer-reachable",
+        action="store_true",
+        help="Require three bounded ICMP probes to the peer to succeed before starting.",
+    )
     parser.add_argument("--instance-id", help="Join or create a named runtime session instance.")
     parser.add_argument(
         "--skip-conflict-check",
@@ -8679,6 +8740,22 @@ def _add_start_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--network-name", help=argparse.SUPPRESS)
     parser.add_argument("--network-ip", help=argparse.SUPPRESS)
     parser.set_defaults(force=True, auto_identity=True)
+
+
+def _add_preflight_args(parser: argparse.ArgumentParser) -> None:
+    _add_common_config_args(parser)
+    _add_session_arg(parser, "session_dir_positional", nargs="?")
+    _add_session_arg(parser, "-s", "--session-dir", dest="session_dir")
+    _add_identity_arg(parser)
+    parser.add_argument("--no-auto-identity", dest="auto_identity", action="store_false")
+    _add_peer_arg(parser)
+    _add_peer_address_arg(parser)
+    parser.add_argument(
+        "--require-peer-reachable",
+        action="store_true",
+        help="Require three bounded ICMP probes to the peer to succeed.",
+    )
+    parser.set_defaults(auto_identity=True)
 
 
 def _normalize_session_arg(args: argparse.Namespace) -> None:
@@ -8694,6 +8771,12 @@ def _normalize_session_arg(args: argparse.Namespace) -> None:
 def start_command(args: argparse.Namespace) -> int:
     _normalize_session_arg(args)
     start_session(args)
+    return 0
+
+
+def preflight_command(args: argparse.Namespace) -> int:
+    _normalize_session_arg(args)
+    preflight_session(args)
     return 0
 
 
@@ -9052,6 +9135,7 @@ def videoquality_command(args: argparse.Namespace) -> int:
 # turn into `rosotacom start foo` — so a contract test keeps the two in sync.
 TOP_LEVEL_COMMANDS = {
     "start",
+    "preflight",
     "stop",
     "doctor",
     "ps",
@@ -9126,6 +9210,13 @@ def main(argv: list[str] | None = None) -> int:
     start_parser = subparsers.add_parser("start", help="Start a rosotacom session.")
     _add_start_args(start_parser)
     start_parser.set_defaults(func=start_command)
+
+    preflight_parser = subparsers.add_parser(
+        "preflight",
+        help="Validate the resolved local address, peer route, and optional peer reachability.",
+    )
+    _add_preflight_args(preflight_parser)
+    preflight_parser.set_defaults(func=preflight_command)
 
     stop_parser = subparsers.add_parser("stop", help="Stop rosotacom containers for a session.")
     _add_common_config_args(stop_parser)

--- a/src/rosotacom/network_preflight.py
+++ b/src/rosotacom/network_preflight.py
@@ -1,0 +1,134 @@
+"""Host data-plane validation for resolved communication peers."""
+
+from __future__ import annotations
+
+import ipaddress
+import re
+import subprocess
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+from .deployment import PeerBinding
+
+
+@dataclass(frozen=True)
+class NetworkPreflightResult:
+    identity: str
+    local_address: str
+    remote_identity: str
+    remote_address: str
+    interface: str
+    source_address: str
+    peer_reachable: bool | None
+
+
+def _binding_ipv4(binding: PeerBinding, *, role: str) -> str:
+    try:
+        return str(ipaddress.IPv4Address(binding.address))
+    except ipaddress.AddressValueError as exc:
+        raise RuntimeError(
+            f"Network preflight failed: {role} peer {binding.peer!r} has non-IPv4 address "
+            f"{binding.address!r}. Communication peer addresses must be concrete IPv4 addresses."
+        ) from exc
+
+
+def run_network_preflight(
+    bindings: dict[str, PeerBinding],
+    identity: str,
+    *,
+    local_addresses: Iterable[str],
+    require_peer_reachable: bool = False,
+) -> NetworkPreflightResult:
+    """Validate the selected local binding and kernel path to its peer."""
+    if identity not in bindings:
+        raise RuntimeError(f"Network preflight failed: identity {identity!r} is not one of peers={sorted(bindings)}.")
+    if len(bindings) != 2:
+        raise RuntimeError(f"Network preflight failed: expected exactly 2 peers, got peers={sorted(bindings)}.")
+
+    local = bindings[identity]
+    remote_identity = next(peer for peer in bindings if peer != identity)
+    remote = bindings[remote_identity]
+    local_address = _binding_ipv4(local, role="local")
+    remote_address = _binding_ipv4(remote, role="remote")
+
+    known_local_addresses = sorted(set(local_addresses))
+    if not known_local_addresses:
+        raise RuntimeError(
+            "Network preflight failed: could not determine any local IPv4 addresses. "
+            "Verify that the `ip` command is installed and the required data-plane interface is up."
+        )
+    if local_address not in known_local_addresses:
+        raise RuntimeError(
+            f"Network preflight failed for identity {identity!r}: configured local address {local_address} "
+            f"is not assigned to this host (local IPv4s: {known_local_addresses}). "
+            "Verify --identity and the peer bindings; if the address belongs to a VPN or other data-plane "
+            "interface, bring that interface up before starting communication."
+        )
+
+    try:
+        route = subprocess.run(
+            ["ip", "-4", "route", "get", remote_address],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        raise RuntimeError("Network preflight failed: required command `ip` was not found.") from exc
+    route_output = (route.stdout or "").strip()
+    if route.returncode != 0 or not route_output:
+        detail = (route.stderr or route.stdout or "no route returned").strip()
+        raise RuntimeError(
+            f"Network preflight failed: no usable IPv4 route from {identity!r} ({local_address}) "
+            f"to {remote_identity!r} ({remote_address}): {detail}"
+        )
+    route_line = route_output.splitlines()[0]
+    source_match = re.search(r"\bsrc\s+(\d+\.\d+\.\d+\.\d+)\b", route_line)
+    interface_match = re.search(r"\bdev\s+(\S+)", route_line)
+    if source_match is None or interface_match is None:
+        raise RuntimeError(
+            f"Network preflight failed: could not determine source address and interface from route: {route_line}"
+        )
+    source_address = source_match.group(1)
+    interface = interface_match.group(1)
+    if source_address != local_address:
+        raise RuntimeError(
+            f"Network preflight failed: route to {remote_identity!r} ({remote_address}) uses source "
+            f"{source_address} on {interface}, but identity {identity!r} is bound to {local_address}. "
+            "Fix the route or peer binding before starting communication."
+        )
+
+    peer_reachable: bool | None = None
+    if require_peer_reachable:
+        try:
+            ping = subprocess.run(
+                ["ping", "-4", "-n", "-c", "3", "-W", "2", "-I", local_address, remote_address],
+                text=True,
+                capture_output=True,
+                check=False,
+                timeout=10,
+            )
+        except FileNotFoundError as exc:
+            raise RuntimeError(
+                "Network preflight failed: strict peer reachability was requested, but `ping` was not found."
+            ) from exc
+        except subprocess.TimeoutExpired as exc:
+            raise RuntimeError(
+                f"Network preflight failed: ICMP check from {local_address} to {remote_address} exceeded 10 seconds."
+            ) from exc
+        if ping.returncode != 0:
+            raise RuntimeError(
+                f"Network preflight failed: peer {remote_identity!r} ({remote_address}) did not answer "
+                f"3 ICMP echo requests sent from {local_address} via {interface}. This start requires an "
+                "already-reachable peer; verify the data plane, VPN, and firewall."
+            )
+        peer_reachable = True
+
+    return NetworkPreflightResult(
+        identity=identity,
+        local_address=local_address,
+        remote_identity=remote_identity,
+        remote_address=remote_address,
+        interface=interface,
+        source_address=source_address,
+        peer_reachable=peer_reachable,
+    )

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1743,12 +1743,13 @@ def test_positional_session_defaults_to_start(monkeypatch: pytest.MonkeyPatch) -
 
     monkeypatch.setattr(rosotacom, "start_session", fake_start_session)
 
-    result = rosotacom.main(["1_heartbeat", "--identity", "a"])
+    result = rosotacom.main(["1_heartbeat", "--identity", "a", "--require-peer-reachable"])
 
     assert result == 0
     assert calls
     assert calls[0].session_dir == "1_heartbeat"
     assert calls[0].identity == "a"
+    assert calls[0].require_peer_reachable is True
 
 
 def test_probe_verbs_dispatch_not_wrapped_in_start(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -2017,7 +2018,7 @@ def test_path_yaml_and_network_helpers(tmp_path: Path, monkeypatch: pytest.Monke
 
     def fake_check_output(command: list[str], *, text: bool) -> str:
         if command[:4] == ["ip", "-o", "-4", "addr"]:
-            return "1: lo inet 127.0.0.1/8\n2: eth0 inet 10.0.0.5/24\n"
+            return "1: lo inet 127.0.0.1/8\n2: eth0 inet 10.0.0.5/24 brd 10.0.0.255 scope global eth0\n"
         return "1.1.1.1 via 10.0.0.1 dev eth0 src 10.0.0.5 uid 1000"
 
     monkeypatch.setattr(rosotacom.subprocess, "check_output", fake_check_output)
@@ -2287,6 +2288,14 @@ def test_start_session_detached_dispatches_ros2docker(monkeypatch: pytest.Monkey
     monkeypatch.setattr(rosotacom, "_load_runtime_config", lambda args: runtime)
     monkeypatch.setattr(rosotacom, "_resolve_session", lambda session_dir, runtime: session)
     monkeypatch.setattr(rosotacom, "_effective_session_config", lambda *args, **kwargs: cfg)
+    monkeypatch.setattr(
+        rosotacom,
+        "_network_preflight",
+        lambda *args, **kwargs: rosotacom.NetworkPreflightResult(
+            "a", "127.0.0.1", "b", "127.0.0.2", "lo", "127.0.0.1", None
+        ),
+    )
+    monkeypatch.setattr(rosotacom, "_print_network_preflight", lambda result: None)
     monkeypatch.setattr(rosotacom, "_scoped_image_name", lambda runtime: "image:id")
     monkeypatch.setattr(
         rosotacom,
@@ -2334,6 +2343,14 @@ def test_start_session_attach_dispatches_command_run(monkeypatch: pytest.MonkeyP
     monkeypatch.setattr(rosotacom, "_resolve_session", lambda session_dir, runtime: session)
     monkeypatch.setattr(rosotacom, "_effective_session_config", lambda *args, **kwargs: cfg)
     monkeypatch.setattr(rosotacom, "_auto_identity", lambda *args: "a")
+    monkeypatch.setattr(
+        rosotacom,
+        "_network_preflight",
+        lambda *args, **kwargs: rosotacom.NetworkPreflightResult(
+            "a", "127.0.0.1", "b", "127.0.0.2", "lo", "127.0.0.1", None
+        ),
+    )
+    monkeypatch.setattr(rosotacom, "_print_network_preflight", lambda result: None)
     monkeypatch.setattr(rosotacom, "_scoped_image_name", lambda runtime: "image:id")
     monkeypatch.setattr(rosotacom, "_base_extra_run_args", lambda runtime, session, cfg, instance, **kwargs: [])
     monkeypatch.setattr(rosotacom, "_resolve_mode", lambda mode: "attach")

--- a/tests/unit/test_concurrency.py
+++ b/tests/unit/test_concurrency.py
@@ -190,6 +190,14 @@ def _patch_start_session_collaborators(
     monkeypatch.setattr(rosotacom, "_load_runtime_config", lambda args: runtime)
     monkeypatch.setattr(rosotacom, "_resolve_session", lambda session_dir, runtime: session)
     monkeypatch.setattr(rosotacom, "_effective_session_config", lambda *args, **kwargs: cfg)
+    monkeypatch.setattr(
+        rosotacom,
+        "_network_preflight",
+        lambda *args, **kwargs: rosotacom.NetworkPreflightResult(
+            "a", "127.0.0.1", "b", "127.0.0.2", "lo", "127.0.0.1", None
+        ),
+    )
+    monkeypatch.setattr(rosotacom, "_print_network_preflight", lambda result: None)
     monkeypatch.setattr(rosotacom, "_scoped_image_name", lambda runtime: "image:id")
     monkeypatch.setattr(rosotacom, "_base_extra_run_args", lambda runtime, session, cfg, instance, **kwargs: [])
     monkeypatch.setattr(rosotacom, "_resolve_mode", lambda mode: "detached")
@@ -236,16 +244,31 @@ def test_start_session_force_replaces_conflicting_identity_container(
     cfg = {"peers": {"a": {}, "b": {"com-name": "remote"}}}
     calls: list[tuple[str, dict[str, object]]] = []
     stopped: list[str] = []
+    events: list[str] = []
     _patch_start_session_collaborators(monkeypatch, runtime, session, cfg, calls)
+    monkeypatch.setattr(
+        rosotacom,
+        "_network_preflight",
+        lambda *args, **kwargs: (
+            events.append("preflight")
+            or rosotacom.NetworkPreflightResult("a", "127.0.0.1", "b", "127.0.0.2", "lo", "127.0.0.1", None)
+        ),
+    )
     monkeypatch.setattr(
         rosotacom,
         "_list_docker_containers",
         lambda all_states=False: [("rosotacom_id_other_com_to_remote", ["bridge"])],
     )
+
+    def record_stop(name: str, runtime: rosotacom.RuntimeConfig, **kwargs: object) -> bool:
+        events.append("stop")
+        stopped.append(name)
+        return True
+
     monkeypatch.setattr(
         rosotacom,
         "_stop_container_name",
-        lambda name, runtime, **kwargs: stopped.append(name) or True,
+        record_stop,
     )
 
     container = rosotacom.start_session(_start_session_args(force=True))
@@ -254,6 +277,7 @@ def test_start_session_force_replaces_conflicting_identity_container(
     # The conflicting other-instance container is stopped first; force also
     # keeps its pre-existing own-name replace for --instance-id rejoins.
     assert stopped == ["rosotacom_id_other_com_to_remote", "rosotacom_id_unit_com_to_remote"]
+    assert events == ["preflight", "stop", "stop"]
     assert [name for name, _ in calls] == ["build", "run", "exec"]
 
 

--- a/tests/unit/test_network_preflight.py
+++ b/tests/unit/test_network_preflight.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import argparse
+import subprocess
+
+import pytest
+
+import rosotacom.cli as rosotacom
+import rosotacom.network_preflight as network_preflight
+from rosotacom.deployment import PeerBinding
+
+
+def _bindings(
+    local: str = "10.254.0.39",
+    remote: str = "10.254.0.38",
+) -> dict[str, PeerBinding]:
+    return {
+        "center": PeerBinding("center", local, None, "center-host"),
+        "vehicle": PeerBinding("vehicle", remote, None, "vehicle-host"),
+    }
+
+
+def test_network_preflight_verifies_local_address_and_route_source(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[list[str], dict[str, object]]] = []
+    monkeypatch.setattr(rosotacom, "_get_local_ipv4s", lambda: ["127.0.0.1", "10.254.0.39"])
+
+    def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append((command, kwargs))
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            "10.254.0.38 dev tun1 src 10.254.0.39 uid 1000\n",
+            "",
+        )
+
+    monkeypatch.setattr(network_preflight.subprocess, "run", fake_run)
+
+    result = rosotacom._network_preflight(_bindings(), "center")
+
+    assert result == rosotacom.NetworkPreflightResult(
+        identity="center",
+        local_address="10.254.0.39",
+        remote_identity="vehicle",
+        remote_address="10.254.0.38",
+        interface="tun1",
+        source_address="10.254.0.39",
+        peer_reachable=None,
+    )
+    assert calls == [
+        (
+            ["ip", "-4", "route", "get", "10.254.0.38"],
+            {"text": True, "capture_output": True, "check": False},
+        )
+    ]
+
+
+def test_network_preflight_rejects_missing_local_binding_before_route_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(rosotacom, "_get_local_ipv4s", lambda: ["10.0.11.18"])
+
+    def fail_run(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        raise AssertionError("route lookup must not run when the local address is absent")
+
+    monkeypatch.setattr(network_preflight.subprocess, "run", fail_run)
+
+    with pytest.raises(RuntimeError, match="configured local address 10.254.0.39 is not assigned") as excinfo:
+        rosotacom._network_preflight(_bindings(), "center")
+
+    assert "VPN or other data-plane interface" in str(excinfo.value)
+
+
+def test_network_preflight_rejects_route_with_wrong_source(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(rosotacom, "_get_local_ipv4s", lambda: ["10.254.0.39", "192.168.10.12"])
+    monkeypatch.setattr(
+        network_preflight.subprocess,
+        "run",
+        lambda command, **kwargs: subprocess.CompletedProcess(
+            command,
+            0,
+            "10.254.0.38 via 192.168.10.1 dev eth0 src 192.168.10.12 uid 1000\n",
+            "",
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="uses source 192.168.10.12 on eth0") as excinfo:
+        rosotacom._network_preflight(_bindings(), "center")
+
+    assert "bound to 10.254.0.39" in str(excinfo.value)
+
+
+def test_network_preflight_can_require_bounded_peer_reachability(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[list[str], dict[str, object]]] = []
+    monkeypatch.setattr(rosotacom, "_get_local_ipv4s", lambda: ["10.254.0.39"])
+
+    def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append((command, kwargs))
+        if command[0] == "ip":
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                "10.254.0.38 dev tun1 src 10.254.0.39 uid 1000\n",
+                "",
+            )
+        return subprocess.CompletedProcess(command, 0, "3 packets transmitted, 3 received\n", "")
+
+    monkeypatch.setattr(network_preflight.subprocess, "run", fake_run)
+
+    result = rosotacom._network_preflight(_bindings(), "center", require_peer_reachable=True)
+
+    assert result.peer_reachable is True
+    assert calls[1] == (
+        ["ping", "-4", "-n", "-c", "3", "-W", "2", "-I", "10.254.0.39", "10.254.0.38"],
+        {"text": True, "capture_output": True, "check": False, "timeout": 10},
+    )
+
+
+def test_network_preflight_reports_required_peer_that_does_not_answer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(rosotacom, "_get_local_ipv4s", lambda: ["10.254.0.39"])
+
+    def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        if command[0] == "ip":
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                "10.254.0.38 dev tun1 src 10.254.0.39 uid 1000\n",
+                "",
+            )
+        return subprocess.CompletedProcess(command, 1, "3 packets transmitted, 0 received\n", "")
+
+    monkeypatch.setattr(network_preflight.subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError, match="did not answer 3 ICMP echo requests") as excinfo:
+        rosotacom._network_preflight(_bindings(), "center", require_peer_reachable=True)
+
+    assert "verify the data plane, VPN, and firewall" in str(excinfo.value)
+
+
+def test_preflight_command_exposes_session_binding_and_reachability_args(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen: list[argparse.Namespace] = []
+    monkeypatch.setattr(rosotacom, "preflight_session", lambda args: seen.append(args))
+
+    result = rosotacom.main(
+        [
+            "preflight",
+            "1_heartbeat",
+            "--identity",
+            "center",
+            "--peer",
+            "center=leitstand",
+            "--peer-address",
+            "vehicle=10.254.0.38",
+            "--require-peer-reachable",
+        ]
+    )
+
+    assert result == 0
+    assert len(seen) == 1
+    assert seen[0].session_dir == "1_heartbeat"
+    assert seen[0].identity == "center"
+    assert seen[0].peer == ["center=leitstand"]
+    assert seen[0].peer_address == ["vehicle=10.254.0.38"]
+    assert seen[0].require_peer_reachable is True


### PR DESCRIPTION
## Summary

- add a reusable host data-plane preflight for resolved two-peer bindings
- run local-address and route-source validation before `start` stops containers, writes an instance, or builds an image
- expose `rosotacom preflight` and opt-in bounded ICMP reachability for deployments that require an online peer
- preserve Docker-isolated local smoke networking and document the policy

Fixes #300

## Validation

- `just check` — passed (877 unit/contract tests, type checking, docs, package and wheel checks)
- focused CLI/preflight/concurrency tests — 187 passed
- `just test-e2e-smoke` — 18 passed, 5 skipped; 6 benchmark-only cases correctly refused because another rosotacom run was already active on the development host. All communication smoke scenarios executed by the run passed; CI will rerun the benchmark cases on an exclusive runner.
- installed-wheel CLI help exposes both `preflight` and `start --require-peer-reachable`

## Manual contract check

Verified that the preflight call precedes conflict replacement in the start path and that isolated smoke starts bypass host-interface validation.