### PR TITLE
Add opt-in ROS 2 Lyrical validation matrix

### DIFF
--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -14,11 +14,19 @@ concurrency:
 
 jobs:
   trivy-image:
-    name: trivy-image
+    name: trivy-image-${{ matrix.variant }}
     runs-on: ubuntu-latest
     timeout-minutes: 180
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - variant: kilted
+            config: src/rosotacom/resources/ros2docker.json.example
+          - variant: lyrical
+            config: src/rosotacom/resources/ros2docker.lyrical.json.example
     env:
-      IMAGE_TAG: rosotacom:scan-${{ github.sha }}
+      IMAGE_TAG: rosotacom:scan-${{ matrix.variant }}-${{ github.sha }}
 
     steps:
       - name: Check out repository
@@ -41,10 +49,10 @@ jobs:
       - name: Show Docker environment
         run: docker info
 
-      - name: Build default rosotacom image
+      - name: Build rosotacom image
         run: |
           .venv/bin/ros2docker build \
-            -f src/rosotacom/resources/ros2docker.json.example \
+            -f "${{ matrix.config }}" \
             -o "{\"image_name\":\"${IMAGE_TAG}\"}"
 
       - name: Run Trivy vulnerability scanner
@@ -61,6 +69,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: trivy-image-report
+          name: trivy-image-report-${{ matrix.variant }}
           path: trivy-image-report.txt
           if-no-files-found: warn

--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -32,12 +32,13 @@ jobs:
     # nightly failed with nine "Timed out waiting for container readiness"
     # errors after 1h12m on one runner, while the same tests on the same commit
     # passed in the merge gate — where they were spread over six at the time.
-    name: smoke-e2e-${{ matrix.slice }}
+    name: smoke-e2e-${{ matrix.variant }}-${{ matrix.slice }}
     runs-on: ubuntu-latest
     timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:
+        variant: [kilted, lyrical]
         slice:
           - heartbeat
           - chatter
@@ -86,24 +87,27 @@ jobs:
         run: docker info
 
       - name: Run E2E slice
+        env:
+          ROSOTACOM_ROS2DOCKER_CONFIG: ${{ matrix.variant == 'lyrical' && format('{0}/src/rosotacom/resources/examples/ros2docker.lyrical.json', github.workspace) || '' }}
         run: just test-e2e-slice ${{ matrix.slice }}
 
       - name: Upload smoke session artifacts
         if: failure()
         uses: actions/upload-artifact@v7
         with:
-          name: session-instances-smoke-${{ matrix.slice }}
+          name: session-instances-smoke-${{ matrix.variant }}-${{ matrix.slice }}
           path: session-instances/
           if-no-files-found: ignore
 
   rmw-matrix:
-    name: rmw-${{ matrix.session }}
+    name: rmw-${{ matrix.variant }}-${{ matrix.session }}
     runs-on: ubuntu-latest
     timeout-minutes: 90
     if: github.event_name != 'schedule' || github.event.inputs.full-rmw-matrix != 'false'
     strategy:
       fail-fast: false
       matrix:
+        variant: [kilted, lyrical]
         session:
           - cyclone-local-zenoh-ros2dds-ota
           - cyclone-ota
@@ -139,12 +143,14 @@ jobs:
         run: docker info
 
       - name: Run generated RMW matrix session
+        env:
+          ROSOTACOM_ROS2DOCKER_CONFIG: ${{ matrix.variant == 'lyrical' && format('{0}/src/rosotacom/resources/examples/ros2docker.lyrical.json', github.workspace) || '' }}
         run: just test-e2e-rmw ${{ matrix.session }}
 
       - name: Upload RMW session artifacts
         if: failure()
         uses: actions/upload-artifact@v7
         with:
-          name: session-instances-rmw-${{ matrix.session }}
+          name: session-instances-rmw-${{ matrix.variant }}-${{ matrix.session }}
           path: session-instances/
           if-no-files-found: ignore

--- a/.github/workflows/pr-merge-gate.yml
+++ b/.github/workflows/pr-merge-gate.yml
@@ -159,7 +159,8 @@ jobs:
   quick-gate:
     # Everything `e2e` waits for that is not the image, and deliberately no
     # more. It exists to answer one question — is the tree obviously broken,
-    # such that seventeen slices would burn roughly 73 runner-minutes to say so.
+    # such that two variants across seventeen slices would burn roughly 146
+    # runner-minutes to say so.
     #
     # It replaced a `needs: preflight-success` edge that made e2e wait for the
     # whole five-version matrix. That barrier cost 2.15 min of every gate run
@@ -204,7 +205,8 @@ jobs:
     # ROS base from Docker Hub, 40s exporting layers, 47s of apt and pip. A pull
     # from GHCR — co-located with the runners, no Hub rate limit, one transfer
     # instead of a transfer plus a build — replaces all of it. The benefit
-    # grows with the diagnostic matrix; seventeen jobs still build only once.
+    # grows with the diagnostic matrix; both distribution variants still build
+    # only once each.
     #
     # The tag is a hash of everything that decides the image (base digest,
     # package lists, Dockerfile, entrypoint, ros2docker version, build UID):
@@ -255,18 +257,32 @@ jobs:
           # artifacts that live beside the checkout in the private harness, so it
           # does not resolve here.
           project="$(.venv/bin/rosotacom resources path examples)/rosotacom.yaml"
-          .venv/bin/rosotacom image references --project "$project" --repository "$repository" > references.txt
-          cat references.txt
-
-          while read -r reference; do
-            if docker manifest inspect "$reference" >/dev/null 2>&1; then
-              echo "present: $reference"
-              continue
+          lyrical_config="$(.venv/bin/rosotacom resources path ros2docker-lyrical)"
+          for variant in kilted lyrical; do
+            config=""
+            if [[ "$variant" == "lyrical" ]]; then
+              config="$lyrical_config"
             fi
-            echo "missing, building: $reference"
-            .venv/bin/rosotacom image build --project "$project" --reference "$reference"
-            docker push "$reference" || echo "::warning::could not push $reference"
-          done < references.txt
+            variant_references="references-${variant}.txt"
+            ROSOTACOM_ROS2DOCKER_CONFIG="$config" \
+              .venv/bin/rosotacom image references \
+              --project "$project" \
+              --repository "$repository" > "$variant_references"
+
+            while read -r reference; do
+              if docker manifest inspect "$reference" >/dev/null 2>&1; then
+                echo "present ($variant): $reference"
+                continue
+              fi
+              echo "missing ($variant), building: $reference"
+              ROSOTACOM_ROS2DOCKER_CONFIG="$config" \
+                .venv/bin/rosotacom image build --project "$project" --reference "$reference"
+              docker push "$reference" || echo "::warning::could not push $reference"
+            done < "$variant_references"
+          done
+
+          sort -u references-kilted.txt references-lyrical.txt > references.txt
+          cat references.txt
 
           # Report the repository only when every reference resolves. A
           # read-only GITHUB_TOKEN (a fork PR, Dependabot) can log in and pull
@@ -301,7 +317,7 @@ jobs:
     # reaches the measured floor: #253 split the four overloaded themes along
     # transport, stream, or concurrency semantics. Which tests a slice owns and
     # what each costs is E2E_SLICES in tests/e2e/conftest.py.
-    name: e2e-${{ matrix.slice }}
+    name: e2e-${{ matrix.variant }}-${{ matrix.slice }}
     runs-on: ubuntu-latest
     timeout-minutes: 90
     needs: [quick-gate, image]
@@ -312,6 +328,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        variant: [kilted, lyrical]
         slice:
           - heartbeat
           - chatter
@@ -371,13 +388,14 @@ jobs:
           # that tag itself and never accepts one, so it cannot be pointed at an
           # image built from something else.
           ROSOTACOM_IMAGE_CACHE: ${{ needs.image.outputs.repository }}
+          ROSOTACOM_ROS2DOCKER_CONFIG: ${{ matrix.variant == 'lyrical' && format('{0}/src/rosotacom/resources/examples/ros2docker.lyrical.json', github.workspace) || '' }}
         run: just test-e2e-slice ${{ matrix.slice }}
 
       - name: Upload session artifacts
         if: failure()
         uses: actions/upload-artifact@v7
         with:
-          name: session-instances-e2e-${{ matrix.slice }}
+          name: session-instances-e2e-${{ matrix.variant }}-${{ matrix.slice }}
           path: session-instances/
           if-no-files-found: ignore
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,12 +115,13 @@ jobs:
     # identical to nightly-e2e.yml's smoke-e2e job, so the release used to be
     # the third sequential run of the same tests against the same tree; it
     # dominated release wall-clock at roughly an hour. See issue #196.
-    name: e2e-${{ matrix.slice }}
+    name: e2e-${{ matrix.variant }}-${{ matrix.slice }}
     runs-on: ubuntu-latest
     timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:
+        variant: [kilted, lyrical]
         slice:
           - heartbeat
           - chatter
@@ -169,13 +170,15 @@ jobs:
         run: docker info
 
       - name: Run E2E slice
+        env:
+          ROSOTACOM_ROS2DOCKER_CONFIG: ${{ matrix.variant == 'lyrical' && format('{0}/src/rosotacom/resources/examples/ros2docker.lyrical.json', github.workspace) || '' }}
         run: just test-e2e-slice ${{ matrix.slice }}
 
       - name: Upload session artifacts
         if: failure()
         uses: actions/upload-artifact@v7
         with:
-          name: session-instances-e2e-${{ matrix.slice }}
+          name: session-instances-e2e-${{ matrix.variant }}-${{ matrix.slice }}
           path: session-instances/
           if-no-files-found: ignore
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
       - id: check-yaml
       - id: check-toml
       - id: check-json
-        exclude: ^src/rosotacom/resources/(examples/ros2docker\.json|ros2docker\.json\.example)$
+        exclude: ^src/rosotacom/resources/(examples/ros2docker(?:\.lyrical)?\.json|ros2docker(?:\.lyrical)?\.json\.example)$
       - id: check-merge-conflict
       - id: debug-statements
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The ROS Communication DevContainer is a Docker-based solution designed to stream
 - Git for configuration management
 - Python 3 with virtual environment support (`python3-venv` on Debian/Ubuntu;
   for versioned Python packages this may be named like `python3.14-venv`)
-- `ros2docker` v0.1.5.dev9 or newer (below v0.2). The local installer below installs the pinned
+- `ros2docker` v0.1.5.dev10 or newer (below v0.2). The local installer below installs the pinned
   supported range into this checkout's virtual environment.
 - `tmux` for the optional `rosotacom scenario` orchestration commands
 - Machines connected to the same network (VPN or local WLAN)

--- a/README.md
+++ b/README.md
@@ -236,10 +236,11 @@ commit with a pinned compatibility patch. The build fails closed outside
 Lyrical or if that patch no longer applies. Replace this fallback with
 `ros-lyrical-domain-bridge` once the official package is released.
 
-The communication container follows this variant selection. Scenario
-application containers retain their own explicit ros2docker configs; mixed ROS
-distributions across the application/communication boundary therefore remain
-part of the tested shape.
+The communication container and any scenario application with a matching
+`ros2docker_config_by_distro` entry follow this variant selection together.
+The packaged chatter scenario supplies Lyrical application configs, because
+[ROS 2 does not guarantee cross-distribution communication](https://docs.ros.org/en/ros2_documentation/rolling/Releases.html#cross-distribution-communications).
+Applications without a matching entry retain their explicit default config.
 
 The default switch is intentionally not part of this change. Before promoting
 Lyrical, keep the two-variant E2E and RMW matrices green, point the packaged
@@ -356,9 +357,13 @@ applications:
   a:
     - name: native_application
       ros2docker_config: ../../scripts/2_native_chatter/machine_a/external.ros2docker.json
+      ros2docker_config_by_distro:
+        lyrical: ../../scripts/2_native_chatter/machine_a/external.lyrical.ros2docker.json
   b:
     - name: native_application
       ros2docker_config: ../../scripts/2_native_chatter/machine_b/external.ros2docker.json
+      ros2docker_config_by_distro:
+        lyrical: ../../scripts/2_native_chatter/machine_b/external.lyrical.ros2docker.json
 ```
 
 Start one identity's communication and local application together:
@@ -373,7 +378,11 @@ rosotacom scenario stop
 `scenario list` shows both configured scenarios and currently active
 scenario/identity pairs. `attach` and `stop` infer omitted values when exactly
 one active choice exists; otherwise their completions and error messages show
-the eligible active choices.
+the eligible active choices. `ros2docker_config` is always the fallback;
+`ros2docker_config_by_distro` selects a matching application image from the
+communication config's `BASE_IMAGE` distro, so changing the project between
+Kilted and Lyrical changes the complete scenario rather than creating an
+unsupported mixed-distro data path.
 
 The outer view uses an isolated host tmux server with one full window for
 communication and one full window per local application. Its prefix remains

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The ROS Communication DevContainer is a Docker-based solution designed to stream
 - Git for configuration management
 - Python 3 with virtual environment support (`python3-venv` on Debian/Ubuntu;
   for versioned Python packages this may be named like `python3.14-venv`)
-- `ros2docker` v0.1.4 or newer. The local installer below installs the pinned
+- `ros2docker` v0.1.5.dev9 or newer (below v0.2). The local installer below installs the pinned
   supported range into this checkout's virtual environment.
 - `tmux` for the optional `rosotacom scenario` orchestration commands
 - Machines connected to the same network (VPN or local WLAN)
@@ -171,6 +171,7 @@ The copied packaged example project uses this layout:
 ```text
 rosotacom.yaml
 ros2docker.json
+ros2docker.lyrical.json
 deployment.example.yaml
 sessions/
 scenarios/
@@ -201,12 +202,50 @@ composes directly in a shell:
 ```bash
 rosotacom resources path com_msgs   # the ROS 2 message package
 rosotacom resources path ws         # the packaged runtime workspace
+rosotacom resources path ros2docker-lyrical  # the opt-in ROS 2 Lyrical image config
 ```
 
 Use this wherever another project needs rosotacom's files on the host, for
 example to bake `com_msgs` into its own container image. Ask for the resource by
 name rather than reconstructing a path: the names are part of the CLI contract,
 the layout behind them is not.
+
+### ROS 2 distribution variants
+
+ROS 2 Kilted remains the default. The packaged Lyrical/Ubuntu Resolute image is
+an explicit opt-in and uses a separate image name, so trying it does not replace
+the default image. To select it for one command, including the built-in example:
+
+```bash
+ROSOTACOM_ROS2DOCKER_CONFIG="$(rosotacom resources path ros2docker-lyrical)" \
+  rosotacom smoke
+```
+
+An example project copied with `rosotacom examples create` also contains
+`ros2docker.lyrical.json`. To opt that project in persistently, select it in
+`rosotacom.yaml`:
+
+```yaml
+ros2docker_config: ros2docker.lyrical.json
+```
+
+The Lyrical config keeps every available ROS dependency on the official binary
+packages. `domain_bridge` is the current exception: because no Lyrical binary
+package exists, ros2docker's `domain-bridge` profile builds a pinned upstream
+commit with a pinned compatibility patch. The build fails closed outside
+Lyrical or if that patch no longer applies. Replace this fallback with
+`ros-lyrical-domain-bridge` once the official package is released.
+
+The communication container follows this variant selection. Scenario
+application containers retain their own explicit ros2docker configs; mixed ROS
+distributions across the application/communication boundary therefore remain
+part of the tested shape.
+
+The default switch is intentionally not part of this change. Before promoting
+Lyrical, keep the two-variant E2E and RMW matrices green, point the packaged
+default and example project at the Lyrical configs, and recalibrate the
+distribution-specific performance budgets. Existing copied projects continue
+to name their own config and do not change when the package default changes.
 
 ### Reusing an image instead of rebuilding it
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -43,22 +43,25 @@ check is:
 ci-success
 ```
 
-The merge gate runs workflow lint, dependency/security review, runtime/build asset lint, Python 3.10 through 3.14 non-Docker checks, package validation, and the Docker single-machine smoke matrix (one matrix job per slice, seventeen in parallel):
+The merge gate runs workflow lint, dependency/security review, runtime/build
+asset lint, Python 3.10 through 3.14 non-Docker checks, package validation, and
+the Docker single-machine smoke matrix: seventeen diagnostic slices for each of
+the `kilted` and `lyrical` variants, 34 jobs in parallel.
 
 Python 3.10–3.14 are supported for the host CLI; Python 3.12 is the reference
 interpreter for packaging and Docker E2E jobs.
 
 ### What the e2e slices wait for
 
-The only explicit barriers before the seventeen slices are their `needs`. They
-wait for exactly two jobs:
+The only explicit barriers before the 34 variant/slice jobs are their `needs`.
+They wait for exactly two jobs:
 
 - **`image`**, because a slice adopts the published image rather than building
   it, so it cannot start before that image is known to exist. On a hit this is
   two manifest inspections, and it is what sets the floor.
 - **`quick-gate`**, `just lint && just typecheck` on one interpreter: the
-  cheapest signal that the tree is not obviously broken, so seventeen runners
-  do not spend roughly 73 minutes discovering a syntax error. Four seconds of work,
+  cheapest signal that the tree is not obviously broken, so 34 runners do not
+  spend roughly 146 minutes discovering a syntax error. Four seconds of work,
   sized to finish inside `image` and therefore free.
 
 They used to wait for `preflight-success`, which meant the whole five-version
@@ -105,19 +108,23 @@ Docker E2E is not collected for coverage.
 
 ## Docker E2E
 
-`just test-e2e-smoke` runs the entire local single-machine smoke matrix through Docker. In the CI merge gate, the same collection runs as seventeen parallel
-jobs, one per slice, named `e2e-<slice>`. Each smoke run writes generated
-config, catmux pane logs, Docker logs when available, and the smoke verification
-log under `session-instances/`; collect that directory as the first debugging
-artifact when an E2E job fails.
+`just test-e2e-smoke` runs the entire local single-machine smoke matrix through
+Docker using the selected config (Kilted by default). In the CI merge gate, the
+same collection runs for both Kilted and Lyrical as 34 parallel jobs, one per
+variant/slice pair, named `e2e-<variant>-<slice>`. Each smoke run writes
+generated config, catmux pane logs, Docker logs when available, and the smoke
+verification log under `session-instances/`; collect that directory as the
+first debugging artifact when an E2E job fails.
 
 ### The e2e image is published once, not rebuilt per job
 
 Every e2e job used to build the project image from scratch. #236 measured that
 at 154s per job — 57s pulling the multi-GB ROS base from Docker Hub, 40s
 exporting layers, 47s of apt and pip — which was 33 minutes of runner time and
-thirteen Hub pulls with the matrix at that time. The image is still published
-only once now that the diagnostic matrix has seventeen jobs.
+thirteen Hub pulls with the matrix at that time. Each distribution-specific
+communication image is now published once, despite the 17 consumers per
+variant; scenario application images common to both variants are deduplicated
+by their content-addressed references.
 
 The `image` job now publishes those images to
 `ghcr.io/<owner>/rosotacom-e2e` and each slice pulls instead of building. GHCR
@@ -161,6 +168,9 @@ Two properties are worth keeping in mind when changing this:
   image from a different package list, so `rosotacom image references` walks the
   project config *and* every scenario application. Publishing only the project
   image would leave that slice adopting something nobody published.
+- **Both ROS variants are published.** The publisher resolves the project once
+  with the default Kilted config and once with the opt-in Lyrical config. A
+  variant's reference is built under the same selection that derived it.
 - **The release and nightly lanes still build from scratch**, as does the
   nightly `image-scan`. That is deliberate: they are what would notice if a
   published image and a fresh build ever stopped agreeing.
@@ -256,10 +266,12 @@ The deterministic benchmark rows gate against committed two-sided bands
 ## Nightly And Maintenance Checks
 
 `.github/workflows/nightly-e2e.yml` runs the local smoke slice plus the generated
-RMW matrix nightly on GitHub-hosted infrastructure and also supports manual
-dispatch. It is not the private OTA promotion gate.
-`.github/workflows/image-scan.yml` builds the default communication image and
-uploads an advisory Trivy report.
+RMW matrix for both Kilted and Lyrical nightly on GitHub-hosted infrastructure
+and also supports manual dispatch. It is not the private OTA promotion gate.
+`.github/workflows/image-scan.yml` builds both communication variants and
+uploads one advisory Trivy report per image. The dedicated performance gate
+remains on the default Kilted config because its committed budgets are
+distribution-specific; switching the default requires a fresh calibration.
 
 Dependabot is configured for weekly grouped GitHub Actions and Python dependency
 updates.

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -46,7 +46,10 @@ ci-success
 The merge gate runs workflow lint, dependency/security review, runtime/build
 asset lint, Python 3.10 through 3.14 non-Docker checks, package validation, and
 the Docker single-machine smoke matrix: seventeen diagnostic slices for each of
-the `kilted` and `lyrical` variants, 34 jobs in parallel.
+the `kilted` and `lyrical` variants, 34 jobs in parallel. Scenario application
+images follow the selected communication distro through
+`ros2docker_config_by_distro`, so each variant is end-to-end rather than a
+cross-distro combination.
 
 Python 3.10–3.14 are supported for the host CLI; Python 3.12 is the reference
 interpreter for packaging and Docker E2E jobs.

--- a/install.sh
+++ b/install.sh
@@ -9,13 +9,13 @@ set -euo pipefail
 #
 # Optional env vars:
 #   VENV_DIR=.venv
-#   ROS2DOCKER_SPEC='ros2docker==0.1.4'
+#   ROS2DOCKER_SPEC='ros2docker==0.1.5.dev9'
 #   BIN_DIR=~/.local/bin
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$SCRIPT_DIR"
 VENV_DIR="${VENV_DIR:-"$ROOT_DIR/.venv"}"
-ROS2DOCKER_SPEC="${ROS2DOCKER_SPEC:-"ros2docker==0.1.4"}"
+ROS2DOCKER_SPEC="${ROS2DOCKER_SPEC:-"ros2docker==0.1.5.dev9"}"
 BIN_DIR="${BIN_DIR:-"$HOME/.local/bin"}"
 
 INSTALL_GLOBAL_SYMLINKS=false

--- a/install.sh
+++ b/install.sh
@@ -9,13 +9,13 @@ set -euo pipefail
 #
 # Optional env vars:
 #   VENV_DIR=.venv
-#   ROS2DOCKER_SPEC='ros2docker==0.1.5.dev9'
+#   ROS2DOCKER_SPEC='ros2docker==0.1.5.dev10'
 #   BIN_DIR=~/.local/bin
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$SCRIPT_DIR"
 VENV_DIR="${VENV_DIR:-"$ROOT_DIR/.venv"}"
-ROS2DOCKER_SPEC="${ROS2DOCKER_SPEC:-"ros2docker==0.1.5.dev9"}"
+ROS2DOCKER_SPEC="${ROS2DOCKER_SPEC:-"ros2docker==0.1.5.dev10"}"
 BIN_DIR="${BIN_DIR:-"$HOME/.local/bin"}"
 
 INSTALL_GLOBAL_SYMLINKS=false

--- a/justfile
+++ b/justfile
@@ -92,7 +92,9 @@ _package-smoke:
 	expected = (
 	    "py.typed",
 	    "resources/ros2docker.json.example",
+	    "resources/ros2docker.lyrical.json.example",
 	    "resources/examples/rosotacom.yaml",
+	    "resources/examples/ros2docker.lyrical.json",
 	    "resources/examples/sessions/1_heartbeat/session-definition.yaml",
 	    "resources/examples/scenarios/2_native_chatter/scenario-definition.yaml",
 	    "resources/ws/session/creation/run_session.py",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
   "mcap>=1.4,<2",
   "Pillow>=10,<13",
   "PyYAML>=6",
-  "ros2docker>=0.1.5.dev9,<0.2",
+  "ros2docker>=0.1.5.dev10,<0.2",
 ]
 classifiers = [
   "Development Status :: 3 - Alpha",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
   "mcap>=1.4,<2",
   "Pillow>=10,<13",
   "PyYAML>=6",
-  "ros2docker>=0.1.5.dev8,<0.2",
+  "ros2docker>=0.1.5.dev9,<0.2",
 ]
 classifiers = [
   "Development Status :: 3 - Alpha",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-ros2docker==0.1.5.dev8
+ros2docker==0.1.5.dev9

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-ros2docker==0.1.5.dev9
+ros2docker==0.1.5.dev10

--- a/src/rosotacom/cli.py
+++ b/src/rosotacom/cli.py
@@ -91,6 +91,7 @@ RESOURCE_DIR = PACKAGE_DIR / "resources"
 PROJECT_DIR = RESOURCE_DIR
 WS_DIR = RESOURCE_DIR / "ws"
 DEFAULT_ROS2DOCKER_CONFIG = RESOURCE_DIR / "ros2docker.json.example"
+LYRICAL_ROS2DOCKER_CONFIG = RESOURCE_DIR / "ros2docker.lyrical.json.example"
 EXAMPLE_PROJECT_DIR = RESOURCE_DIR / "examples"
 
 # Packaged resources external tooling may need to locate on the host. rosotacom
@@ -103,6 +104,7 @@ NAMED_RESOURCES = {
     "ws": WS_DIR,
     "com_msgs": WS_DIR / "ros2src" / "com_msgs",
     "examples": EXAMPLE_PROJECT_DIR,
+    "ros2docker-lyrical": LYRICAL_ROS2DOCKER_CONFIG,
 }
 SESSION_CONFIG_CONTAINER_DIR = "/session/configs"
 SESSION_DEFINITION_CONTAINER_DIR = "/session/definitions"

--- a/src/rosotacom/cli.py
+++ b/src/rosotacom/cli.py
@@ -8919,7 +8919,8 @@ def anonymize_command(args: argparse.Namespace) -> int:
 
     _require_ros2docker()
     ros2docker_cfg = load_config(runtime.ros2docker_config)
-    image_name = ros2docker_cfg.get("image_name", "ros2docker")
+    base_image_name = str(ros2docker_cfg.get("image_name", "ros2docker"))
+    image_name = _scoped_image_name_from_base(base_image_name, runtime.install_id)
 
     input_parent = input_bag_path.parent.resolve()
     input_name = input_bag_path.name
@@ -8951,11 +8952,15 @@ def anonymize_command(args: argparse.Namespace) -> int:
 
     print("Running anonymization inside ROS 2 docker container...")
     try:
+        common_override = {
+            "container_name": container_name,
+            "image_name": image_name,
+        }
+        _build_image(runtime.ros2docker_config, common_override)
         ros2docker_run(
             config_file=runtime.ros2docker_config,
             override={
-                "container_name": container_name,
-                "image_name": image_name,
+                **common_override,
                 "run_type": "command",
                 "command": " ".join(container_command),
                 # Batch job: a TTY would make headless runs (CI, agents) abort
@@ -9005,7 +9010,9 @@ def anonymize_command(args: argparse.Namespace) -> int:
             play_run_args.extend(["-v", "./qos-overrides.yaml:/scenario/qos-overrides.yaml:ro"])
         play_bag_cfg = {
             "container_name": f"play_bag_{peer}",
-            "image_name": image_name,
+            # Keep generated scenarios portable. Their normal launch path
+            # applies the installation scope when it runs the application.
+            "image_name": base_image_name,
             "run_type": "command",
             "command": " ".join(play_command_parts),
             "run_args": play_run_args,

--- a/src/rosotacom/cli.py
+++ b/src/rosotacom/cli.py
@@ -214,6 +214,7 @@ class ResolvedScenario:
 class ScenarioApplication:
     name: str
     ros2docker_config: Path
+    ros2docker_config_by_distro: tuple[tuple[str, Path], ...] = ()
 
 
 @dataclass(frozen=True)
@@ -679,7 +680,7 @@ def _project_build_inputs(runtime: RuntimeConfig) -> list[tuple[str, Path]]:
         definition = _load_scenario_definition(_resolve_scenario(scenario_name, runtime))
         for identity, applications in sorted(definition.applications.items()):
             for application in applications:
-                config = application.ros2docker_config.resolve()
+                config = _scenario_application_config(runtime, application).resolve()
                 if config in seen:
                     continue
                 seen.add(config)
@@ -964,6 +965,9 @@ def _write_scenario_manifest(
     manifest["updated_at"] = now
     manifest["effective_config_sha256"] = _effective_config_sha256(cfg)
     scenario_runs = manifest.setdefault("scenario_runs", {})
+    selected_applications = [
+        (application, _scenario_application_config(runtime, application)) for application in applications
+    ]
     scenario_runs[run_key] = {
         "started_at": now,
         "stopped_at": None,
@@ -976,13 +980,13 @@ def _write_scenario_manifest(
         "applications": [
             {
                 "name": application.name,
-                "ros2docker_config": str(application.ros2docker_config),
+                "ros2docker_config": str(config_path),
                 "container_name": _scenario_container_name(
                     runtime, resolved.name, identity, application.name, instance.instance_id
                 ),
                 "image_name": _scenario_application_image_name(runtime, application),
             }
-            for application in applications
+            for application, config_path in selected_applications
         ],
     }
     manifest_path.write_text(
@@ -1047,7 +1051,7 @@ def _write_interactive_smoke_manifest(
             {
                 "identity": identity,
                 "name": application.name,
-                "ros2docker_config": str(application.ros2docker_config),
+                "ros2docker_config": str(_scenario_application_config(runtime, application)),
                 "container_name": _scenario_container_name(
                     runtime, target.scenario.name, identity, application.name, instance.instance_id
                 ),
@@ -4579,7 +4583,7 @@ def _load_scenario_definition(resolved: ResolvedScenario) -> ScenarioDefinition:
             context = f"scenario applications.{identity}[{index}]"
             if not isinstance(entry, dict):
                 raise RuntimeError(f"{context} must be a mapping.")
-            allowed_entry = {"name", "ros2docker_config"}
+            allowed_entry = {"name", "ros2docker_config", "ros2docker_config_by_distro"}
             extra_entry = sorted(set(entry) - allowed_entry)
             if extra_entry:
                 raise RuntimeError(
@@ -4605,8 +4609,35 @@ def _load_scenario_definition(resolved: ResolvedScenario) -> ScenarioDefinition:
             # Resolving run args here would make every peer demand every other
             # peer's machine-local artifacts (#249).
             load_config(config_path, resolve_run_args=False)
+            by_distro_raw = entry.get("ros2docker_config_by_distro", {})
+            if not isinstance(by_distro_raw, dict):
+                raise RuntimeError(f"{context}.ros2docker_config_by_distro must be a mapping.")
+            by_distro: list[tuple[str, Path]] = []
+            for distro_raw, distro_config_raw in sorted(by_distro_raw.items()):
+                if not isinstance(distro_raw, str) or not re.fullmatch(r"[a-z][a-z0-9_]*", distro_raw):
+                    raise RuntimeError(
+                        f"{context}.ros2docker_config_by_distro keys must be lowercase ROS distro names."
+                    )
+                if not isinstance(distro_config_raw, str) or not distro_config_raw.strip():
+                    raise RuntimeError(
+                        f"{context}.ros2docker_config_by_distro.{distro_raw} must be a non-empty string."
+                    )
+                distro_config = _resolve_path(distro_config_raw, resolved.host_dir, must_exist=True)
+                assert distro_config is not None
+                if not distro_config.is_file():
+                    raise RuntimeError(
+                        f"{context}.ros2docker_config_by_distro.{distro_raw} must resolve to a file: {distro_config}"
+                    )
+                load_config(distro_config, resolve_run_args=False)
+                by_distro.append((distro_raw, distro_config))
             seen_names.add(name)
-            parsed_entries.append(ScenarioApplication(name=name, ros2docker_config=config_path))
+            parsed_entries.append(
+                ScenarioApplication(
+                    name=name,
+                    ros2docker_config=config_path,
+                    ros2docker_config_by_distro=tuple(by_distro),
+                )
+            )
         applications[identity] = tuple(parsed_entries)
 
     return ScenarioDefinition(session=session.strip(), applications=applications)
@@ -4663,8 +4694,27 @@ def _matching_scenario_containers(
     return sorted(names)
 
 
+def _ros_distro_from_ros2docker_config(config_path: Path) -> str | None:
+    config = load_config(config_path, resolve_run_args=False)
+    build_args = config.get("build_args", {}) or {}
+    if not isinstance(build_args, dict):
+        return None
+    base_image = str(build_args.get("BASE_IMAGE", ""))
+    match = re.search(r"(?:^|/)ros:([a-z][a-z0-9_]*)-", base_image)
+    return match.group(1) if match else None
+
+
+def _scenario_application_config(runtime: RuntimeConfig, application: ScenarioApplication) -> Path:
+    distro = _ros_distro_from_ros2docker_config(runtime.ros2docker_config)
+    if distro is not None:
+        by_distro = dict(application.ros2docker_config_by_distro)
+        if distro in by_distro:
+            return by_distro[distro]
+    return application.ros2docker_config
+
+
 def _scenario_application_image_name(runtime: RuntimeConfig, application: ScenarioApplication) -> str:
-    config = load_config(application.ros2docker_config, resolve_run_args=False)
+    config = load_config(_scenario_application_config(runtime, application), resolve_run_args=False)
     base = str(config.get("image_name") or "ros2docker")
     return _scoped_image_name_from_base(base, runtime.install_id)
 
@@ -5423,9 +5473,10 @@ def _stop_scenario_application(
         containers = [name for name in containers if _container_exists(name)]
     else:
         containers = _matching_scenario_containers(runtime, resolved.name, identity, application.name, all_states=True)
+    config_path = _scenario_application_config(runtime, application)
     for container_name in containers:
         ros2docker_stop(
-            config_file=application.ros2docker_config,
+            config_file=config_path,
             override={"container_name": container_name},
         )
     return bool(containers)
@@ -5587,11 +5638,12 @@ def run_scenario_application(args: argparse.Namespace) -> int:
     resolved = _resolve_scenario(args.scenario, runtime)
     definition = _load_scenario_definition(resolved)
     application = _scenario_application(definition, args.identity, args.application)
+    config_path = _scenario_application_config(runtime, application)
     instance_id = getattr(args, "instance_id", None) or _new_instance_id()
     container_name = _scenario_container_name(runtime, resolved.name, args.identity, application.name, instance_id)
     if _container_exists(container_name):
         ros2docker_stop(
-            config_file=application.ros2docker_config,
+            config_file=config_path,
             override={"container_name": container_name},
         )
     override: dict[str, object] = {
@@ -5600,14 +5652,14 @@ def run_scenario_application(args: argparse.Namespace) -> int:
     }
     network_name = getattr(args, "network_name", None)
     if network_name:
-        base_run_args = load_config(application.ros2docker_config).get("run_args", []) or []
+        base_run_args = load_config(config_path).get("run_args", []) or []
         override["run_args"] = _isolated_network_run_args(
             [str(arg) for arg in base_run_args],
             network_name,
             getattr(args, "network_ip", None),
         )
-    _build_image(application.ros2docker_config, override)
-    ros2docker_run(config_file=application.ros2docker_config, override=override)
+    _build_image(config_path, override)
+    ros2docker_run(config_file=config_path, override=override)
     return 0
 
 

--- a/src/rosotacom/resources/examples/README.md
+++ b/src/rosotacom/resources/examples/README.md
@@ -73,6 +73,20 @@ Expected result:
 session definitions contain only logical peers, so local testing never depends
 on physical-machine configuration.
 
+### Opt in to ROS 2 Lyrical
+
+Kilted remains this project's default. The copied project includes a second,
+independent `ros2docker.lyrical.json`; select it for one command with:
+
+```bash
+ROSOTACOM_ROS2DOCKER_CONFIG="$PWD/ros2docker.lyrical.json" rosotacom smoke
+```
+
+For a persistent project opt-in, set
+`ros2docker_config: ros2docker.lyrical.json` in `rosotacom.yaml`. The Lyrical
+image uses ros2docker's pinned `domain_bridge` source fallback until an official
+Lyrical binary package is available.
+
 For an interactive local end-to-end debug session, use the same smoke target
 with `--interactive`:
 
@@ -151,6 +165,7 @@ Use `--identity b` on the second host. Alternatively copy
 
 - `rosotacom.yaml`: project-local rosotacom setup
 - `ros2docker.json`: Docker runtime defaults used by the communication containers
+- `ros2docker.lyrical.json`: opt-in ROS 2 Lyrical runtime configuration
 - `deployment.example.yaml`: optional named-host deployment example
 - `bags/`: small rosbag metadata fixtures used by documentation and host tests
 - `sessions/`: tracked static session definitions/templates

--- a/src/rosotacom/resources/examples/README.md
+++ b/src/rosotacom/resources/examples/README.md
@@ -85,7 +85,9 @@ ROSOTACOM_ROS2DOCKER_CONFIG="$PWD/ros2docker.lyrical.json" rosotacom smoke
 For a persistent project opt-in, set
 `ros2docker_config: ros2docker.lyrical.json` in `rosotacom.yaml`. The Lyrical
 image uses ros2docker's pinned `domain_bridge` source fallback until an official
-Lyrical binary package is available.
+Lyrical binary package is available. Scenario applications with a
+`ros2docker_config_by_distro.lyrical` entry switch to their Lyrical image at the
+same time; the default application config remains Kilted.
 
 For an interactive local end-to-end debug session, use the same smoke target
 with `--interactive`:

--- a/src/rosotacom/resources/examples/ros2docker.lyrical.json
+++ b/src/rosotacom/resources/examples/ros2docker.lyrical.json
@@ -1,0 +1,37 @@
+{
+  "image_name":     "ros-communication-lyrical", // Separate cache/image namespace from the Kilted default
+
+  // Lyrical is opt-in. Kilted remains rosotacom's default until this complete
+  // configuration and the E2E matrix are intentionally promoted.
+  "profile": "domain-bridge",
+
+  // rosotacom mounts its packaged runtime workspace into /ws dynamically.
+  "mount_ws": false,
+
+  // Enable X11/Wayland GUI forwarding
+  "enable_gui_forwarding": false,
+
+  // Extra docker run arguments
+  "run_args": [
+    "-e", "ROS_DOMAIN_ID=48",
+    "-e", "BUILD_ROS2WS=1",
+    "--network", "host"
+  ],
+
+  // Forward your local SSH agent into the container
+  "forward_ssh_agent": false,
+
+  // Build-time arguments. domain_bridge has no Lyrical binary package yet;
+  // ros2docker's domain-bridge profile builds a pinned upstream revision with
+  // a pinned Lyrical compatibility patch. All other ROS packages stay on APT.
+  //
+  // Resolute ships Python 3.14, which requires NumPy 2; the Kilted config keeps
+  // its existing NumPy 1 constraint and is not changed by this opt-in.
+  "build_args": {
+    "BASE_IMAGE":                    "ros:lyrical-ros-base-resolute",
+    "DIGEST":                        "@sha256:0eea195bb91662a7dfbd6c6b026c209aef1d091e55ce37733e54509580ddf2c8",
+    "INSTALL_ZENOH":                 "1",
+    "APT_PACKAGES":                  "iputils-ping psmisc net-tools snmp iw nload iftop iproute2 tshark ros-lyrical-rmw-cyclonedds-cpp ros-lyrical-rmw-zenoh-cpp ros-lyrical-topic-tools ros-lyrical-image-transport ros-lyrical-compressed-image-transport ros-lyrical-ffmpeg-image-transport ros-lyrical-ffmpeg-image-transport-msgs ros-lyrical-gps-msgs",
+    "PIP_PACKAGES":                  "numpy>=2,<3 lz4 pysnmp speedtest-cli psutil zstandard opencv-python"
+  }
+}

--- a/src/rosotacom/resources/examples/scenarios/2_native_chatter/scenario-definition.yaml
+++ b/src/rosotacom/resources/examples/scenarios/2_native_chatter/scenario-definition.yaml
@@ -5,6 +5,10 @@ applications:
   a:
     - name: native_application
       ros2docker_config: ../../scripts/2_native_chatter/machine_a/external.ros2docker.json
+      ros2docker_config_by_distro:
+        lyrical: ../../scripts/2_native_chatter/machine_a/external.lyrical.ros2docker.json
   b:
     - name: native_application
       ros2docker_config: ../../scripts/2_native_chatter/machine_b/external.ros2docker.json
+      ros2docker_config_by_distro:
+        lyrical: ../../scripts/2_native_chatter/machine_b/external.lyrical.ros2docker.json

--- a/src/rosotacom/resources/examples/scripts/2_native_chatter/machine_a/external.lyrical.ros2docker.json
+++ b/src/rosotacom/resources/examples/scripts/2_native_chatter/machine_a/external.lyrical.ros2docker.json
@@ -1,0 +1,20 @@
+{
+  "container_name": "machine_a_logic_lyrical",
+  "image_name": "rosotacom-native-chatter-lyrical",
+
+  "run_type": "command",
+  "command": "/wait_for_echo_topic.sh",
+
+  "run_args": [
+    "--network", "host",
+    "-v", "./wait_for_echo_topic.sh:/wait_for_echo_topic.sh",
+    "-e", "RMW_IMPLEMENTATION=rmw_cyclonedds_cpp",
+    "-e", "ROS_DOMAIN_ID=46"
+  ],
+
+  "build_args": {
+    "BASE_IMAGE": "ros:lyrical-ros-base-resolute",
+    "DIGEST": "@sha256:0eea195bb91662a7dfbd6c6b026c209aef1d091e55ce37733e54509580ddf2c8",
+    "APT_PACKAGES": "ros-lyrical-rmw-cyclonedds-cpp"
+  }
+}

--- a/src/rosotacom/resources/examples/scripts/2_native_chatter/machine_b/external.lyrical.ros2docker.json
+++ b/src/rosotacom/resources/examples/scripts/2_native_chatter/machine_b/external.lyrical.ros2docker.json
@@ -1,0 +1,19 @@
+{
+  "container_name": "machine_b_logic_lyrical",
+  "image_name": "rosotacom-native-chatter-lyrical",
+
+  "run_type": "command",
+  "command": ["ros2", "topic", "pub", "-r", "1", "/chatter", "std_msgs/String", "data: 'hello from talker'"],
+
+  "run_args": [
+    "--network", "host",
+    "-e", "RMW_IMPLEMENTATION=rmw_cyclonedds_cpp",
+    "-e", "ROS_DOMAIN_ID=47"
+  ],
+
+  "build_args": {
+    "BASE_IMAGE": "ros:lyrical-ros-base-resolute",
+    "DIGEST": "@sha256:0eea195bb91662a7dfbd6c6b026c209aef1d091e55ce37733e54509580ddf2c8",
+    "APT_PACKAGES": "ros-lyrical-rmw-cyclonedds-cpp"
+  }
+}

--- a/src/rosotacom/resources/ros2docker.lyrical.json.example
+++ b/src/rosotacom/resources/ros2docker.lyrical.json.example
@@ -1,0 +1,37 @@
+{
+  "image_name":     "ros-communication-lyrical", // Separate cache/image namespace from the Kilted default
+
+  // Lyrical is opt-in. Kilted remains rosotacom's default until this complete
+  // configuration and the E2E matrix are intentionally promoted.
+  "profile": "domain-bridge",
+
+  // rosotacom mounts its packaged runtime workspace into /ws dynamically.
+  "mount_ws": false,
+
+  // Enable X11/Wayland GUI forwarding
+  "enable_gui_forwarding": false,
+
+  // Extra docker run arguments
+  "run_args": [
+    "-e", "ROS_DOMAIN_ID=47",
+    "-e", "BUILD_ROS2WS=1",
+    "--network", "host"
+  ],
+
+  // Forward your local SSH agent into the container
+  "forward_ssh_agent": false,
+
+  // Build-time arguments. domain_bridge has no Lyrical binary package yet;
+  // ros2docker's domain-bridge profile builds a pinned upstream revision with
+  // a pinned Lyrical compatibility patch. All other ROS packages stay on APT.
+  //
+  // Resolute ships Python 3.14, which requires NumPy 2; the Kilted config keeps
+  // its existing NumPy 1 constraint and is not changed by this opt-in.
+  "build_args": {
+    "BASE_IMAGE":                    "ros:lyrical-ros-base-resolute",
+    "DIGEST":                        "@sha256:0eea195bb91662a7dfbd6c6b026c209aef1d091e55ce37733e54509580ddf2c8",
+    "INSTALL_ZENOH":                 "1",
+    "APT_PACKAGES":                  "iputils-ping psmisc net-tools snmp iw nload iftop iproute2 tshark ros-lyrical-rmw-cyclonedds-cpp ros-lyrical-rmw-zenoh-cpp ros-lyrical-topic-tools ros-lyrical-image-transport ros-lyrical-compressed-image-transport ros-lyrical-ffmpeg-image-transport ros-lyrical-ffmpeg-image-transport-msgs ros-lyrical-gps-msgs",
+    "PIP_PACKAGES":                  "numpy>=2,<3 lz4 pysnmp speedtest-cli psutil zstandard opencv-python"
+  }
+}

--- a/src/rosotacom/resources/ws/ros2src/com_py/com_py/universal_decompressor.py
+++ b/src/rosotacom/resources/ws/ros2src/com_py/com_py/universal_decompressor.py
@@ -138,9 +138,10 @@ class UniversalDecompressorNode(Node):
 
         # 4) Keep track of what compressed topics we have already subscribed to
         self.subscribed_topics = set()
-        # Keep ROS entity objects alive explicitly.
-        self._subscriptions = []
-        self._publishers = []
+        # Keep our own references without shadowing rclpy.Node private fields.
+        # The create_* methods own and update those internal lists themselves.
+        self._owned_subscriptions = []
+        self._owned_publishers = []
 
         # 4b) Cache per compressed topic: created typed publisher + message class.
         #     We create these lazily on the first received message because msg_type now comes
@@ -234,7 +235,7 @@ class UniversalDecompressorNode(Node):
                             qos_profile=sub_qos,
                             callback_group=self.cb_subs,
                         )
-                        self._subscriptions.append(sub)
+                        self._owned_subscriptions.append(sub)
 
                         self.subscribed_topics.add(tname)
                         self.get_logger().info(
@@ -282,7 +283,7 @@ class UniversalDecompressorNode(Node):
 
             pub_qos = get_topic_qos(self.get_logger(), self.qos_config, out_topic, self.pub_role)
             pub = self.create_publisher(typed_cls, out_topic, qos_profile=pub_qos)
-            self._publishers.append(pub)
+            self._owned_publishers.append(pub)
             self._typed_pub_cache[compressed_topic] = {
                 'pub': pub,
                 'typed_cls': typed_cls,

--- a/src/rosotacom/resources/ws/ros2src/com_py/com_py/universal_ota_unwrapper.py
+++ b/src/rosotacom/resources/ws/ros2src/com_py/com_py/universal_ota_unwrapper.py
@@ -45,7 +45,9 @@ class UniversalOtaUnwrapperNode(Node):
         self.subscribe_lock = Lock()
         self.cache_lock = Lock()
         self.subscribed_topics = set()
-        self._subscriptions = []
+        # Keep our own references without shadowing rclpy.Node._subscriptions.
+        # Node.create_subscription() owns and updates that private list itself.
+        self._owned_subscriptions = []
         self._typed_pub_cache = {}
         self._last_seq = {}
 
@@ -101,7 +103,7 @@ class UniversalOtaUnwrapperNode(Node):
                                ),
                         qos_profile=sub_qos,
                     )
-                    self._subscriptions.append(subscription)
+                    self._owned_subscriptions.append(subscription)
                     self.subscribed_topics.add(topic_name)
 
                     self.get_logger().info(

--- a/src/rosotacom/resources/ws/ros2src/com_py/com_py/universal_ota_wrapper.py
+++ b/src/rosotacom/resources/ws/ros2src/com_py/com_py/universal_ota_wrapper.py
@@ -44,7 +44,9 @@ class UniversalOtaWrapperNode(Node):
         self.sequence_lock = Lock()
         self.subscribed_topics = set()
         self.sequence_by_topic = {}
-        self._subscriptions = []
+        # Keep our own references without shadowing rclpy.Node._subscriptions.
+        # Node.create_subscription() owns and updates that private list itself.
+        self._owned_subscriptions = []
 
         self.config = self.load_config(config_file)
 
@@ -107,7 +109,7 @@ class UniversalOtaWrapperNode(Node):
                                ),
                         qos_profile=sub_qos,
                     )
-                    self._subscriptions.append(subscription)
+                    self._owned_subscriptions.append(subscription)
                     self.subscribed_topics.add(out_topic)
 
                     self.get_logger().info(

--- a/src/rosotacom/resources/ws/session/content/base/session_plugin_base.yaml
+++ b/src/rosotacom/resources/ws/session/content/base/session_plugin_base.yaml
@@ -436,7 +436,7 @@ windows:
       - commands:
         - metric_dir="$(dirname "${ROSOTACOM_CATMUX_LOG_DIR:-/tmp/rosotacom_logs/catmux}")/metrics"
         - mkdir -p "$metric_dir"
-        - topics="${metric_stage_topics}"; ros2 bag record -s mcap -o "$metric_dir/stages_$(date +%Y%m%d_%H%M%S)" ${topics//,/ }
+        - topics="${metric_stage_topics}"; ros2 bag record -s mcap -o "$metric_dir/stages_$(date +%Y%m%d_%H%M%S)" --topics ${topics//,/ }
   - name: BEAT
     if: heartbeat
     layout: even-vertical
@@ -599,6 +599,11 @@ windows:
   # A peer then reported `STARTUP CHECK FAILED ... 4 pane(s) exited` on every
   # start while nothing was wrong, which is the one thing that check must not
   # do: it exists to make a genuinely dead pane visible in seconds.
+  #
+  # Kilted's republish node declares output-plugin parameters below `ut.*`;
+  # Lyrical declares the same parameters below `out.*`. Each version ignores
+  # the namespace it does not declare, so pass both while both distros are in
+  # the validation matrix.
   - name: IT
     if: it
     layout: even-vertical
@@ -608,14 +613,14 @@ windows:
         - if [[ "${it_1_topic}" == *"/compressed"* ]]; then it_in_transport="compressed"; else it_in_transport="raw"; fi
         - args=(ros2 run image_transport republish --ros-args -r __node:=republish1 -p in_transport:=${it_in_transport})
         - 'if [[ "${it_1_transport}" != "None" ]]; then args+=(-p "out_transport:=${it_1_transport}"); fi'
-        - 'if [[ "${it_1_compressed_jpeg_quality}" != "None" ]]; then args+=(-p "ut.compressed.jpeg_quality:=${it_1_compressed_jpeg_quality}"); fi'
-        - 'if [[ "${it_1_ffmpeg_gop_size}" != "None" ]]; then args+=(-p "ut.ffmpeg.gop_size:=${it_1_ffmpeg_gop_size}"); fi'
-        - 'if [[ "${it_1_ffmpeg_encoder_av_options}" != "None" ]]; then args+=(-p "ut.ffmpeg.encoder_av_options:=${it_1_ffmpeg_encoder_av_options}"); fi'
-        - 'if [[ "${it_1_ffmpeg_bit_rate}" != "None" ]]; then args+=(-p "ut.ffmpeg.bit_rate:=${it_1_ffmpeg_bit_rate}"); fi'
-        - 'if [[ "${it_1_foxglove_gop_size}" != "None" ]]; then args+=(-p "ut.foxglove.gop_size:=${it_1_foxglove_gop_size}"); fi'
-        - 'if [[ "${it_1_foxglove_encoder_av_options}" != "None" ]]; then args+=(-p "ut.foxglove.encoder_av_options:=${it_1_foxglove_encoder_av_options}"); fi'
-        - 'if [[ "${it_1_foxglove_bit_rate}" != "None" ]]; then args+=(-p "ut.foxglove.bit_rate:=${it_1_foxglove_bit_rate}"); fi'
-        - 'if [[ "${it_1_foxglove_qmax}" != "None" ]]; then args+=(-p "ut.foxglove.qmax:=${it_1_foxglove_qmax}"); fi'
+        - 'if [[ "${it_1_compressed_jpeg_quality}" != "None" ]]; then args+=(-p "ut.compressed.jpeg_quality:=${it_1_compressed_jpeg_quality}" -p "out.compressed.jpeg_quality:=${it_1_compressed_jpeg_quality}"); fi'
+        - 'if [[ "${it_1_ffmpeg_gop_size}" != "None" ]]; then args+=(-p "ut.ffmpeg.gop_size:=${it_1_ffmpeg_gop_size}" -p "out.ffmpeg.gop_size:=${it_1_ffmpeg_gop_size}"); fi'
+        - 'if [[ "${it_1_ffmpeg_encoder_av_options}" != "None" ]]; then args+=(-p "ut.ffmpeg.encoder_av_options:=${it_1_ffmpeg_encoder_av_options}" -p "out.ffmpeg.encoder_av_options:=${it_1_ffmpeg_encoder_av_options}"); fi'
+        - 'if [[ "${it_1_ffmpeg_bit_rate}" != "None" ]]; then args+=(-p "ut.ffmpeg.bit_rate:=${it_1_ffmpeg_bit_rate}" -p "out.ffmpeg.bit_rate:=${it_1_ffmpeg_bit_rate}"); fi'
+        - 'if [[ "${it_1_foxglove_gop_size}" != "None" ]]; then args+=(-p "ut.foxglove.gop_size:=${it_1_foxglove_gop_size}" -p "out.foxglove.gop_size:=${it_1_foxglove_gop_size}"); fi'
+        - 'if [[ "${it_1_foxglove_encoder_av_options}" != "None" ]]; then args+=(-p "ut.foxglove.encoder_av_options:=${it_1_foxglove_encoder_av_options}" -p "out.foxglove.encoder_av_options:=${it_1_foxglove_encoder_av_options}"); fi'
+        - 'if [[ "${it_1_foxglove_bit_rate}" != "None" ]]; then args+=(-p "ut.foxglove.bit_rate:=${it_1_foxglove_bit_rate}" -p "out.foxglove.bit_rate:=${it_1_foxglove_bit_rate}"); fi'
+        - 'if [[ "${it_1_foxglove_qmax}" != "None" ]]; then args+=(-p "ut.foxglove.qmax:=${it_1_foxglove_qmax}" -p "out.foxglove.qmax:=${it_1_foxglove_qmax}"); fi'
         - if [[ "${it_1_outgoing_suffix}" != "None" ]]; then outgoing_suffix="${it_1_outgoing_suffix}"; else outgoing_suffix="${it_1_transport}"; fi
         - if [[ "${it_in_transport}" == "raw" ]]; then in_remap="in"; else in_remap="in/${it_in_transport}"; fi
         - args+=(--remap "${in_remap}:=${it_1_topic}" --remap "out/${it_1_transport}:=${it_1_topic}/${outgoing_suffix}")
@@ -626,14 +631,14 @@ windows:
         - if [[ "${it_2_topic}" == *"/compressed"* ]]; then it_in_transport="compressed"; else it_in_transport="raw"; fi
         - args=(ros2 run image_transport republish --ros-args -r __node:=republish2 -p in_transport:=${it_in_transport})
         - 'if [[ "${it_2_transport}" != "None" ]]; then args+=(-p "out_transport:=${it_2_transport}"); fi'
-        - 'if [[ "${it_2_compressed_jpeg_quality}" != "None" ]]; then args+=(-p "ut.compressed.jpeg_quality:=${it_2_compressed_jpeg_quality}"); fi'
-        - 'if [[ "${it_2_ffmpeg_gop_size}" != "None" ]]; then args+=(-p "ut.ffmpeg.gop_size:=${it_2_ffmpeg_gop_size}"); fi'
-        - 'if [[ "${it_2_ffmpeg_encoder_av_options}" != "None" ]]; then args+=(-p "ut.ffmpeg.encoder_av_options:=${it_2_ffmpeg_encoder_av_options}"); fi'
-        - 'if [[ "${it_2_ffmpeg_bit_rate}" != "None" ]]; then args+=(-p "ut.ffmpeg.bit_rate:=${it_2_ffmpeg_bit_rate}"); fi'
-        - 'if [[ "${it_2_foxglove_gop_size}" != "None" ]]; then args+=(-p "ut.foxglove.gop_size:=${it_2_foxglove_gop_size}"); fi'
-        - 'if [[ "${it_2_foxglove_encoder_av_options}" != "None" ]]; then args+=(-p "ut.foxglove.encoder_av_options:=${it_2_foxglove_encoder_av_options}"); fi'
-        - 'if [[ "${it_2_foxglove_bit_rate}" != "None" ]]; then args+=(-p "ut.foxglove.bit_rate:=${it_2_foxglove_bit_rate}"); fi'
-        - 'if [[ "${it_2_foxglove_qmax}" != "None" ]]; then args+=(-p "ut.foxglove.qmax:=${it_2_foxglove_qmax}"); fi'
+        - 'if [[ "${it_2_compressed_jpeg_quality}" != "None" ]]; then args+=(-p "ut.compressed.jpeg_quality:=${it_2_compressed_jpeg_quality}" -p "out.compressed.jpeg_quality:=${it_2_compressed_jpeg_quality}"); fi'
+        - 'if [[ "${it_2_ffmpeg_gop_size}" != "None" ]]; then args+=(-p "ut.ffmpeg.gop_size:=${it_2_ffmpeg_gop_size}" -p "out.ffmpeg.gop_size:=${it_2_ffmpeg_gop_size}"); fi'
+        - 'if [[ "${it_2_ffmpeg_encoder_av_options}" != "None" ]]; then args+=(-p "ut.ffmpeg.encoder_av_options:=${it_2_ffmpeg_encoder_av_options}" -p "out.ffmpeg.encoder_av_options:=${it_2_ffmpeg_encoder_av_options}"); fi'
+        - 'if [[ "${it_2_ffmpeg_bit_rate}" != "None" ]]; then args+=(-p "ut.ffmpeg.bit_rate:=${it_2_ffmpeg_bit_rate}" -p "out.ffmpeg.bit_rate:=${it_2_ffmpeg_bit_rate}"); fi'
+        - 'if [[ "${it_2_foxglove_gop_size}" != "None" ]]; then args+=(-p "ut.foxglove.gop_size:=${it_2_foxglove_gop_size}" -p "out.foxglove.gop_size:=${it_2_foxglove_gop_size}"); fi'
+        - 'if [[ "${it_2_foxglove_encoder_av_options}" != "None" ]]; then args+=(-p "ut.foxglove.encoder_av_options:=${it_2_foxglove_encoder_av_options}" -p "out.foxglove.encoder_av_options:=${it_2_foxglove_encoder_av_options}"); fi'
+        - 'if [[ "${it_2_foxglove_bit_rate}" != "None" ]]; then args+=(-p "ut.foxglove.bit_rate:=${it_2_foxglove_bit_rate}" -p "out.foxglove.bit_rate:=${it_2_foxglove_bit_rate}"); fi'
+        - 'if [[ "${it_2_foxglove_qmax}" != "None" ]]; then args+=(-p "ut.foxglove.qmax:=${it_2_foxglove_qmax}" -p "out.foxglove.qmax:=${it_2_foxglove_qmax}"); fi'
         - if [[ "${it_2_outgoing_suffix}" != "None" ]]; then outgoing_suffix="${it_2_outgoing_suffix}"; else outgoing_suffix="${it_2_transport}"; fi
         - if [[ "${it_in_transport}" == "raw" ]]; then in_remap="in"; else in_remap="in/${it_in_transport}"; fi
         - args+=(--remap "${in_remap}:=${it_2_topic}" --remap "out/${it_2_transport}:=${it_2_topic}/${outgoing_suffix}")
@@ -644,14 +649,14 @@ windows:
         - if [[ "${it_3_topic}" == *"/compressed"* ]]; then it_in_transport="compressed"; else it_in_transport="raw"; fi
         - args=(ros2 run image_transport republish --ros-args -r __node:=republish3 -p in_transport:=${it_in_transport})
         - 'if [[ "${it_3_transport}" != "None" ]]; then args+=(-p "out_transport:=${it_3_transport}"); fi'
-        - 'if [[ "${it_3_compressed_jpeg_quality}" != "None" ]]; then args+=(-p "ut.compressed.jpeg_quality:=${it_3_compressed_jpeg_quality}"); fi'
-        - 'if [[ "${it_3_ffmpeg_gop_size}" != "None" ]]; then args+=(-p "ut.ffmpeg.gop_size:=${it_3_ffmpeg_gop_size}"); fi'
-        - 'if [[ "${it_3_ffmpeg_encoder_av_options}" != "None" ]]; then args+=(-p "ut.ffmpeg.encoder_av_options:=${it_3_ffmpeg_encoder_av_options}"); fi'
-        - 'if [[ "${it_3_ffmpeg_bit_rate}" != "None" ]]; then args+=(-p "ut.ffmpeg.bit_rate:=${it_3_ffmpeg_bit_rate}"); fi'
-        - 'if [[ "${it_3_foxglove_gop_size}" != "None" ]]; then args+=(-p "ut.foxglove.gop_size:=${it_3_foxglove_gop_size}"); fi'
-        - 'if [[ "${it_3_foxglove_encoder_av_options}" != "None" ]]; then args+=(-p "ut.foxglove.encoder_av_options:=${it_3_foxglove_encoder_av_options}"); fi'
-        - 'if [[ "${it_3_foxglove_bit_rate}" != "None" ]]; then args+=(-p "ut.foxglove.bit_rate:=${it_3_foxglove_bit_rate}"); fi'
-        - 'if [[ "${it_3_foxglove_qmax}" != "None" ]]; then args+=(-p "ut.foxglove.qmax:=${it_3_foxglove_qmax}"); fi'
+        - 'if [[ "${it_3_compressed_jpeg_quality}" != "None" ]]; then args+=(-p "ut.compressed.jpeg_quality:=${it_3_compressed_jpeg_quality}" -p "out.compressed.jpeg_quality:=${it_3_compressed_jpeg_quality}"); fi'
+        - 'if [[ "${it_3_ffmpeg_gop_size}" != "None" ]]; then args+=(-p "ut.ffmpeg.gop_size:=${it_3_ffmpeg_gop_size}" -p "out.ffmpeg.gop_size:=${it_3_ffmpeg_gop_size}"); fi'
+        - 'if [[ "${it_3_ffmpeg_encoder_av_options}" != "None" ]]; then args+=(-p "ut.ffmpeg.encoder_av_options:=${it_3_ffmpeg_encoder_av_options}" -p "out.ffmpeg.encoder_av_options:=${it_3_ffmpeg_encoder_av_options}"); fi'
+        - 'if [[ "${it_3_ffmpeg_bit_rate}" != "None" ]]; then args+=(-p "ut.ffmpeg.bit_rate:=${it_3_ffmpeg_bit_rate}" -p "out.ffmpeg.bit_rate:=${it_3_ffmpeg_bit_rate}"); fi'
+        - 'if [[ "${it_3_foxglove_gop_size}" != "None" ]]; then args+=(-p "ut.foxglove.gop_size:=${it_3_foxglove_gop_size}" -p "out.foxglove.gop_size:=${it_3_foxglove_gop_size}"); fi'
+        - 'if [[ "${it_3_foxglove_encoder_av_options}" != "None" ]]; then args+=(-p "ut.foxglove.encoder_av_options:=${it_3_foxglove_encoder_av_options}" -p "out.foxglove.encoder_av_options:=${it_3_foxglove_encoder_av_options}"); fi'
+        - 'if [[ "${it_3_foxglove_bit_rate}" != "None" ]]; then args+=(-p "ut.foxglove.bit_rate:=${it_3_foxglove_bit_rate}" -p "out.foxglove.bit_rate:=${it_3_foxglove_bit_rate}"); fi'
+        - 'if [[ "${it_3_foxglove_qmax}" != "None" ]]; then args+=(-p "ut.foxglove.qmax:=${it_3_foxglove_qmax}" -p "out.foxglove.qmax:=${it_3_foxglove_qmax}"); fi'
         - if [[ "${it_3_outgoing_suffix}" != "None" ]]; then outgoing_suffix="${it_3_outgoing_suffix}"; else outgoing_suffix="${it_3_transport}"; fi
         - if [[ "${it_in_transport}" == "raw" ]]; then in_remap="in"; else in_remap="in/${it_in_transport}"; fi
         - args+=(--remap "${in_remap}:=${it_3_topic}" --remap "out/${it_3_transport}:=${it_3_topic}/${outgoing_suffix}")
@@ -662,14 +667,14 @@ windows:
         - if [[ "${it_4_topic}" == *"/compressed"* ]]; then it_in_transport="compressed"; else it_in_transport="raw"; fi
         - args=(ros2 run image_transport republish --ros-args -r __node:=republish4 -p in_transport:=${it_in_transport})
         - 'if [[ "${it_4_transport}" != "None" ]]; then args+=(-p "out_transport:=${it_4_transport}"); fi'
-        - 'if [[ "${it_4_compressed_jpeg_quality}" != "None" ]]; then args+=(-p "ut.compressed.jpeg_quality:=${it_4_compressed_jpeg_quality}"); fi'
-        - 'if [[ "${it_4_ffmpeg_gop_size}" != "None" ]]; then args+=(-p "ut.ffmpeg.gop_size:=${it_4_ffmpeg_gop_size}"); fi'
-        - 'if [[ "${it_4_ffmpeg_encoder_av_options}" != "None" ]]; then args+=(-p "ut.ffmpeg.encoder_av_options:=${it_4_ffmpeg_encoder_av_options}"); fi'
-        - 'if [[ "${it_4_ffmpeg_bit_rate}" != "None" ]]; then args+=(-p "ut.ffmpeg.bit_rate:=${it_4_ffmpeg_bit_rate}"); fi'
-        - 'if [[ "${it_4_foxglove_gop_size}" != "None" ]]; then args+=(-p "ut.foxglove.gop_size:=${it_4_foxglove_gop_size}"); fi'
-        - 'if [[ "${it_4_foxglove_encoder_av_options}" != "None" ]]; then args+=(-p "ut.foxglove.encoder_av_options:=${it_4_foxglove_encoder_av_options}"); fi'
-        - 'if [[ "${it_4_foxglove_bit_rate}" != "None" ]]; then args+=(-p "ut.foxglove.bit_rate:=${it_4_foxglove_bit_rate}"); fi'
-        - 'if [[ "${it_4_foxglove_qmax}" != "None" ]]; then args+=(-p "ut.foxglove.qmax:=${it_4_foxglove_qmax}"); fi'
+        - 'if [[ "${it_4_compressed_jpeg_quality}" != "None" ]]; then args+=(-p "ut.compressed.jpeg_quality:=${it_4_compressed_jpeg_quality}" -p "out.compressed.jpeg_quality:=${it_4_compressed_jpeg_quality}"); fi'
+        - 'if [[ "${it_4_ffmpeg_gop_size}" != "None" ]]; then args+=(-p "ut.ffmpeg.gop_size:=${it_4_ffmpeg_gop_size}" -p "out.ffmpeg.gop_size:=${it_4_ffmpeg_gop_size}"); fi'
+        - 'if [[ "${it_4_ffmpeg_encoder_av_options}" != "None" ]]; then args+=(-p "ut.ffmpeg.encoder_av_options:=${it_4_ffmpeg_encoder_av_options}" -p "out.ffmpeg.encoder_av_options:=${it_4_ffmpeg_encoder_av_options}"); fi'
+        - 'if [[ "${it_4_ffmpeg_bit_rate}" != "None" ]]; then args+=(-p "ut.ffmpeg.bit_rate:=${it_4_ffmpeg_bit_rate}" -p "out.ffmpeg.bit_rate:=${it_4_ffmpeg_bit_rate}"); fi'
+        - 'if [[ "${it_4_foxglove_gop_size}" != "None" ]]; then args+=(-p "ut.foxglove.gop_size:=${it_4_foxglove_gop_size}" -p "out.foxglove.gop_size:=${it_4_foxglove_gop_size}"); fi'
+        - 'if [[ "${it_4_foxglove_encoder_av_options}" != "None" ]]; then args+=(-p "ut.foxglove.encoder_av_options:=${it_4_foxglove_encoder_av_options}" -p "out.foxglove.encoder_av_options:=${it_4_foxglove_encoder_av_options}"); fi'
+        - 'if [[ "${it_4_foxglove_bit_rate}" != "None" ]]; then args+=(-p "ut.foxglove.bit_rate:=${it_4_foxglove_bit_rate}" -p "out.foxglove.bit_rate:=${it_4_foxglove_bit_rate}"); fi'
+        - 'if [[ "${it_4_foxglove_qmax}" != "None" ]]; then args+=(-p "ut.foxglove.qmax:=${it_4_foxglove_qmax}" -p "out.foxglove.qmax:=${it_4_foxglove_qmax}"); fi'
         - if [[ "${it_4_outgoing_suffix}" != "None" ]]; then outgoing_suffix="${it_4_outgoing_suffix}"; else outgoing_suffix="${it_4_transport}"; fi
         - if [[ "${it_in_transport}" == "raw" ]]; then in_remap="in"; else in_remap="in/${it_in_transport}"; fi
         - args+=(--remap "${in_remap}:=${it_4_topic}" --remap "out/${it_4_transport}:=${it_4_topic}/${outgoing_suffix}")

--- a/tests/contract/test_lyrical_runtime_compat.py
+++ b/tests/contract/test_lyrical_runtime_compat.py
@@ -1,0 +1,30 @@
+"""Contracts for command-line changes made by ROS 2 Lyrical."""
+
+from __future__ import annotations
+
+import re
+from collections import Counter
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SESSION_TEMPLATE = (
+    REPO_ROOT / "src" / "rosotacom" / "resources" / "ws" / "session" / "content" / "base" / "session_plugin_base.yaml"
+)
+
+
+def test_metric_bag_uses_explicit_topics_option() -> None:
+    template = SESSION_TEMPLATE.read_text(encoding="utf-8")
+    assert "ros2 bag record -s mcap" in template
+    assert "--topics ${topics//,/ }" in template
+
+
+def test_image_transport_sets_kilted_and_lyrical_parameter_namespaces() -> None:
+    template = SESSION_TEMPLATE.read_text(encoding="utf-8")
+    parameter_commands = "\n".join(
+        line for line in template.splitlines() if line.lstrip().startswith("- 'if") and "args+=(-p" in line
+    )
+    kilted = Counter(re.findall(r'"ut\.([a-z_.]+):=', parameter_commands))
+    lyrical = Counter(re.findall(r'"out\.([a-z_.]+):=', parameter_commands))
+
+    assert kilted
+    assert lyrical == kilted

--- a/tests/contract/test_packaged_resources.py
+++ b/tests/contract/test_packaged_resources.py
@@ -13,6 +13,13 @@ import yaml
 import rosotacom.cli as cli
 
 PACKAGE_ROOT = Path(__file__).resolve().parents[2]
+LYRICAL_EXAMPLE_CONFIG = cli.EXAMPLE_PROJECT_DIR / "ros2docker.lyrical.json"
+PACKAGED_COMMUNICATION_CONFIGS = (
+    cli.DEFAULT_ROS2DOCKER_CONFIG,
+    cli.LYRICAL_ROS2DOCKER_CONFIG,
+    cli.EXAMPLE_PROJECT_DIR / "ros2docker.json",
+    LYRICAL_EXAMPLE_CONFIG,
+)
 
 
 def test_packaged_resources_include_curated_examples_and_runtime_workspace() -> None:
@@ -21,9 +28,11 @@ def test_packaged_resources_include_curated_examples_and_runtime_workspace() -> 
     expected = (
         "py.typed",
         "resources/ros2docker.json.example",
+        "resources/ros2docker.lyrical.json.example",
         "resources/examples/rosotacom.yaml",
         "resources/examples/.gitignore",
         "resources/examples/ros2docker.json",
+        "resources/examples/ros2docker.lyrical.json",
         "resources/examples/profiles.yaml",
         "resources/examples/deployment.example.yaml",
         "resources/examples/bags/8_drop_reference/metadata.yaml",
@@ -72,6 +81,7 @@ def test_cli_resource_constants_point_inside_package_resources() -> None:
     assert cli.RESOURCE_DIR == PACKAGE_ROOT / "src" / "rosotacom" / "resources"
     assert cli.WS_DIR == cli.RESOURCE_DIR / "ws"
     assert cli.DEFAULT_ROS2DOCKER_CONFIG == cli.RESOURCE_DIR / "ros2docker.json.example"
+    assert cli.LYRICAL_ROS2DOCKER_CONFIG == cli.RESOURCE_DIR / "ros2docker.lyrical.json.example"
     assert cli.EXAMPLE_PROJECT_DIR == cli.RESOURCE_DIR / "examples"
 
 
@@ -112,14 +122,56 @@ def test_default_ros2docker_config_pins_supported_kilted_noble_image() -> None:
         assert "ros-kilted-gps-msgs" in apt_packages
 
 
+def test_opt_in_lyrical_config_pins_resolute_and_source_domain_bridge() -> None:
+    root_config = cli.load_config(cli.LYRICAL_ROS2DOCKER_CONFIG)
+    example_config = cli.load_config(LYRICAL_EXAMPLE_CONFIG)
+
+    for config in (root_config, example_config):
+        assert config["image_name"] == "ros-communication-lyrical"
+        assert config["profile"] == "domain-bridge"
+        build_args = config["build_args"]
+        assert build_args["BASE_IMAGE"] == "ros:lyrical-ros-base-resolute"
+        assert build_args["DIGEST"].startswith("@sha256:")
+        assert build_args["INSTALL_DOMAIN_BRIDGE"] == "1"
+        assert build_args["INSTALL_ZENOH"] == "1"
+
+        apt_packages = set(str(build_args["APT_PACKAGES"]).split())
+        assert "ros-lyrical-domain-bridge" not in apt_packages
+        for package in (
+            "ros-lyrical-rmw-cyclonedds-cpp",
+            "ros-lyrical-rmw-zenoh-cpp",
+            "ros-lyrical-topic-tools",
+            "ros-lyrical-image-transport",
+            "ros-lyrical-compressed-image-transport",
+            "ros-lyrical-ffmpeg-image-transport",
+            "ros-lyrical-ffmpeg-image-transport-msgs",
+            "ros-lyrical-gps-msgs",
+        ):
+            assert package in apt_packages
+
+        pip_packages = str(build_args["PIP_PACKAGES"]).split()
+        assert "numpy>=2,<3" in pip_packages
+
+    assert root_config["build_args"] == example_config["build_args"]
+
+
+def test_packaged_example_keeps_kilted_as_the_default_variant() -> None:
+    project = yaml.safe_load((cli.EXAMPLE_PROJECT_DIR / "rosotacom.yaml").read_text(encoding="utf-8"))
+
+    assert project["ros2docker_config"] == "ros2docker.json"
+    assert cli.load_config(cli.EXAMPLE_PROJECT_DIR / project["ros2docker_config"])["build_args"][
+        "BASE_IMAGE"
+    ].startswith("ros:kilted-")
+
+
 # `image_transport republish` resolves a transport name to a pluginlib class at
 # runtime, so a transport nobody installed is not a build failure — it is a
 # container that starts fine and aborts on the first image message. `raw` ships
 # with image_transport itself; every other transport needs its own package.
-IMAGE_TRANSPORT_APT_PACKAGES = {
-    "raw": "ros-kilted-image-transport",
-    "compressed": "ros-kilted-compressed-image-transport",
-    "ffmpeg": "ros-kilted-ffmpeg-image-transport",
+IMAGE_TRANSPORT_APT_SUFFIXES = {
+    "raw": "image-transport",
+    "compressed": "compressed-image-transport",
+    "ffmpeg": "ffmpeg-image-transport",
 }
 
 
@@ -157,12 +209,15 @@ def test_every_image_transport_the_session_plugin_can_select_is_installed() -> N
     # Both branches of that choice, so a rewrite that drops one is visible here.
     assert {"raw", "compressed"} <= selected
 
-    unknown = selected - set(IMAGE_TRANSPORT_APT_PACKAGES)
+    unknown = selected - set(IMAGE_TRANSPORT_APT_SUFFIXES)
     assert not unknown, f"no apt package recorded for image transport(s): {sorted(unknown)}"
 
-    required = {IMAGE_TRANSPORT_APT_PACKAGES[transport] for transport in selected}
-    for config_path in (cli.DEFAULT_ROS2DOCKER_CONFIG, cli.EXAMPLE_PROJECT_DIR / "ros2docker.json"):
-        apt_packages = set(str(cli.load_config(config_path)["build_args"]["APT_PACKAGES"]).split())
+    for config_path in PACKAGED_COMMUNICATION_CONFIGS:
+        config = cli.load_config(config_path)
+        base_image = str(config["build_args"]["BASE_IMAGE"])
+        distro = base_image.split(":", 1)[1].split("-", 1)[0]
+        required = {f"ros-{distro}-{IMAGE_TRANSPORT_APT_SUFFIXES[transport]}" for transport in selected}
+        apt_packages = set(str(config["build_args"]["APT_PACKAGES"]).split())
         missing = required - apt_packages
         assert not missing, f"{config_path.name} does not install {sorted(missing)}"
 
@@ -176,12 +231,7 @@ def test_packaged_configs_do_not_fetch_rosdep_on_container_start() -> None:
     communication container before that small build and make readiness depend
     on raw.githubusercontent.com.
     """
-    configs = (
-        cli.DEFAULT_ROS2DOCKER_CONFIG,
-        cli.EXAMPLE_PROJECT_DIR / "ros2docker.json",
-    )
-
-    for config_path in configs:
+    for config_path in PACKAGED_COMMUNICATION_CONFIGS:
         config = cli.load_config(config_path)
         run_args = [str(value) for value in config["run_args"]]
 
@@ -228,6 +278,10 @@ def test_all_owned_configs_parse_and_validate() -> None:
 
     # 1. ros2docker.json.example
     load_config(cli.DEFAULT_ROS2DOCKER_CONFIG)
+
+    # 1b. opt-in Lyrical configs
+    load_config(cli.LYRICAL_ROS2DOCKER_CONFIG)
+    load_config(LYRICAL_EXAMPLE_CONFIG)
 
     # 2. rosotacom.yaml example
     yaml.safe_load(cli.EXAMPLE_PROJECT_DIR.joinpath("rosotacom.yaml").read_text(encoding="utf-8"))
@@ -363,9 +417,11 @@ def test_every_registered_subcommand_is_exempt_from_implicit_start(
     assert "resources" in registered
 
 
-def test_named_resources_point_at_real_packaged_directories() -> None:
+def test_named_resources_point_at_real_packaged_paths() -> None:
     for name, path in cli.NAMED_RESOURCES.items():
-        assert path.is_dir(), f"packaged resource {name!r} is not a directory: {path}"
+        assert path.exists(), f"packaged resource {name!r} does not exist: {path}"
+
+    assert cli.NAMED_RESOURCES["ros2docker-lyrical"].is_file()
 
     # com_msgs is consumed by external builds (fleet_mgmt bakes it into its
     # container images), so it must be a usable ROS 2 package, not just a folder.

--- a/tests/contract/test_packaged_resources.py
+++ b/tests/contract/test_packaged_resources.py
@@ -43,6 +43,8 @@ def test_packaged_resources_include_curated_examples_and_runtime_workspace() -> 
         "resources/examples/sessions/16_remote_assist_anonymized_camera/session-definition.yaml",
         "resources/examples/sessions/17_synthetic_camera_quality/session-definition.yaml",
         "resources/examples/scenarios/2_native_chatter/scenario-definition.yaml",
+        "resources/examples/scripts/2_native_chatter/machine_a/external.lyrical.ros2docker.json",
+        "resources/examples/scripts/2_native_chatter/machine_b/external.lyrical.ros2docker.json",
         "resources/ws/session/creation/run_session.py",
         "resources/ws/session/creation/catmux_log_setup.sh",
         "resources/ws/session/creation/strip_ansi.py",
@@ -240,7 +242,7 @@ def test_packaged_configs_do_not_fetch_rosdep_on_container_start() -> None:
 
 
 def test_external_ros2docker_configs_install_selected_rmw_implementations() -> None:
-    configs = sorted(cli.EXAMPLE_PROJECT_DIR.glob("scripts/**/external.ros2docker.json"))
+    configs = sorted(cli.EXAMPLE_PROJECT_DIR.glob("scripts/**/external*.ros2docker.json"))
     assert configs
 
     offenders: list[str] = []
@@ -252,9 +254,12 @@ def test_external_ros2docker_configs_install_selected_rmw_implementations() -> N
 
         build_args = config.get("build_args", {}) or {}
         apt_packages = set(str(build_args.get("APT_PACKAGES", "")).split())
-        if "ros-kilted-rmw-cyclonedds-cpp" not in apt_packages:
+        base_image = str(build_args.get("BASE_IMAGE", ""))
+        match = re.search(r"ros:([a-z][a-z0-9_]*)-", base_image)
+        expected_package = f"ros-{match.group(1)}-rmw-cyclonedds-cpp" if match else None
+        if expected_package is None or expected_package not in apt_packages:
             rel = config_path.relative_to(cli.EXAMPLE_PROJECT_DIR)
-            offenders.append(f"{rel} selects rmw_cyclonedds_cpp but does not install its package")
+            offenders.append(f"{rel} selects rmw_cyclonedds_cpp but does not install its distro-matched package")
 
     assert not offenders
 

--- a/tests/contract/test_profile_covers_generated_commands.py
+++ b/tests/contract/test_profile_covers_generated_commands.py
@@ -21,12 +21,16 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
+import pytest
 from ros2docker.config import load_config
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 RESOURCES = REPO_ROOT / "src" / "rosotacom" / "resources"
 SESSION_CONTENT = RESOURCES / "ws" / "session" / "content"
-PROFILE = RESOURCES / "examples" / "ros2docker.json"
+PROFILES = (
+    RESOURCES / "examples" / "ros2docker.json",
+    RESOURCES / "examples" / "ros2docker.lyrical.json",
+)
 
 #: `ros2 run <package> <executable>` in a template.
 ROS2_RUN = re.compile(r"\bros2\s+run\s+([A-Za-z_][A-Za-z0-9_]*)\b")
@@ -51,10 +55,12 @@ def _invoked_packages() -> dict[str, set[str]]:
     return found
 
 
-def test_profile_installs_every_package_the_sessions_run() -> None:
+@pytest.mark.parametrize("profile", PROFILES, ids=("kilted", "lyrical"))
+def test_profile_installs_every_package_the_sessions_run(profile: Path) -> None:
     # Read it through ros2docker itself, so the test sees exactly what the
     # tool that builds the image sees rather than a second parser's idea of it.
-    installed = str(load_config(PROFILE)["build_args"]["APT_PACKAGES"]).split()
+    build_args = load_config(profile)["build_args"]
+    installed = str(build_args["APT_PACKAGES"]).split()
     # `ros-<distro>-topic-tools` installs the `topic_tools` package; compare on
     # the ROS package name rather than the apt name so a distro bump does not
     # silently turn this test green.
@@ -63,6 +69,10 @@ def test_profile_installs_every_package_the_sessions_run() -> None:
         for name in installed
         if name.startswith("ros-") and name.count("-") >= 2
     }
+    # Lyrical's domain_bridge is provided by ros2docker's pinned source profile
+    # until an official binary package exists.
+    if build_args.get("INSTALL_DOMAIN_BRIDGE") == "1":
+        installed_ros_packages.add("domain_bridge")
 
     missing = {
         package: sorted(where)

--- a/tests/contract/test_security_maintenance_config.py
+++ b/tests/contract/test_security_maintenance_config.py
@@ -37,11 +37,18 @@ def test_image_scan_is_advisory_and_not_a_pr_check() -> None:
     assert '- cron: "23 3 * * *"' in image_scan
     assert "workflow_dispatch:" in image_scan
     assert "pull_request:" not in image_scan
-    assert "IMAGE_TAG: rosotacom:scan-${{ github.sha }}" in image_scan
+    assert "IMAGE_TAG: rosotacom:scan-${{ matrix.variant }}-${{ github.sha }}" in image_scan
     assert "aquasecurity/trivy-action@v0.36.0" in image_scan
     assert 'exit-code: "0"' in image_scan
     assert "image-scan" not in merge_gate
     assert "trivy" not in merge_gate.lower()
+
+    scan_job = yaml.safe_load(image_scan)["jobs"]["trivy-image"]
+    variants = {entry["variant"]: entry["config"] for entry in scan_job["strategy"]["matrix"]["include"]}
+    assert variants == {
+        "kilted": "src/rosotacom/resources/ros2docker.json.example",
+        "lyrical": "src/rosotacom/resources/ros2docker.lyrical.json.example",
+    }
 
 
 def test_merge_gate_requires_non_docker_package_and_docker_smoke() -> None:
@@ -201,6 +208,10 @@ def test_full_e2e_workflow_runs_nightly_and_supports_manual_dispatch() -> None:
     assert "name: smoke-e2e" in full_e2e
     assert "rmw-matrix:" in full_e2e
     assert "just test-e2e-rmw" in full_e2e
+
+    jobs = yaml.safe_load(full_e2e)["jobs"]
+    assert jobs["smoke-e2e"]["strategy"]["matrix"]["variant"] == ["kilted", "lyrical"]
+    assert jobs["rmw-matrix"]["strategy"]["matrix"]["variant"] == ["kilted", "lyrical"]
 
 
 def test_nightly_rmw_matrix_matches_local_checkable_smoke_params() -> None:

--- a/tests/contract/test_workflow_contracts.py
+++ b/tests/contract/test_workflow_contracts.py
@@ -137,6 +137,11 @@ def _e2e_slices(workflow_name: str, job: str) -> list[str]:
     return list(workflow["jobs"][job]["strategy"]["matrix"]["slice"])
 
 
+def _e2e_variants(workflow_name: str, job: str) -> list[str]:
+    workflow = yaml.safe_load((WORKFLOWS_DIR / workflow_name).read_text(encoding="utf-8"))
+    return list(workflow["jobs"][job]["strategy"]["matrix"]["variant"])
+
+
 def _release_e2e_slices() -> list[str]:
     """The slice names the release matrix expands to."""
     return _e2e_slices("release.yml", E2E_SLICE_MATRICES["release.yml"])
@@ -157,6 +162,25 @@ def test_every_e2e_workflow_runs_the_same_slices() -> None:
     assert not mismatched, f"e2e slice lists disagree; release.yml has {reference} but: " + "; ".join(
         f"{name} has {value}" for name, value in sorted(mismatched.items())
     )
+
+
+def test_every_e2e_workflow_gates_kilted_and_lyrical() -> None:
+    expected = ["kilted", "lyrical"]
+    for workflow_name, job_name in sorted(E2E_SLICE_MATRICES.items()):
+        workflow = yaml.safe_load((WORKFLOWS_DIR / workflow_name).read_text(encoding="utf-8"))
+        job = workflow["jobs"][job_name]
+        assert _e2e_variants(workflow_name, job_name) == expected
+        assert "matrix.variant" in job["name"]
+
+        run_step = next(step for step in job["steps"] if "test-e2e-slice" in step.get("run", ""))
+        selected_config = run_step["env"]["ROSOTACOM_ROS2DOCKER_CONFIG"]
+        assert "matrix.variant == 'lyrical'" in selected_config
+        assert "ros2docker.lyrical.json" in selected_config
+
+    merge_gate = (WORKFLOWS_DIR / "pr-merge-gate.yml").read_text(encoding="utf-8")
+    assert "references-kilted.txt" in merge_gate
+    assert "references-lyrical.txt" in merge_gate
+    assert 'ROSOTACOM_ROS2DOCKER_CONFIG="$config"' in merge_gate
 
 
 def test_ci_success_checks_every_job_it_waits_for() -> None:

--- a/tests/unit/test_anonymize.py
+++ b/tests/unit/test_anonymize.py
@@ -306,11 +306,17 @@ def test_anonymize_cli_subcommand(tmp_path: Path, monkeypatch: pytest.MonkeyPatc
 
     # Mock docker running api
     container_runs = []
+    image_builds = []
 
     def mock_ros2docker_run(config_file, override, extra_run_args):
         container_runs.append((override, extra_run_args))
 
     monkeypatch.setattr(cli, "ros2docker_run", mock_ros2docker_run, raising=False)
+    monkeypatch.setattr(
+        cli,
+        "_build_image",
+        lambda config_file, override: image_builds.append((config_file, override)),
+    )
     monkeypatch.setattr(cli, "_stop_container_name", lambda *args, **kwargs: None)
     monkeypatch.setattr(cli, "_require_ros2docker", lambda: None)
 
@@ -369,6 +375,17 @@ def test_anonymize_cli_subcommand(tmp_path: Path, monkeypatch: pytest.MonkeyPatc
     assert len(container_runs) == 1
     override, extra_args = container_runs[0]
     assert override["container_name"] == "rosotacom_anonymizer"
+    assert override["image_name"] == "ros2docker-test-image-test_install"
+    assert image_builds == [
+        (
+            runtime.ros2docker_config,
+            {
+                "container_name": "rosotacom_anonymizer",
+                "image_name": "ros2docker-test-image-test_install",
+            },
+        )
+    ]
+    assert play_cfg["image_name"] == "ros2docker-test-image"
     # Batch job must stay headless-safe: a TTY aborts without a terminal.
     assert override["tty"] is False
     assert override["stdin_open"] is False

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -217,6 +217,7 @@ def test_examples_create_copies_project_and_refuses_overwrite(
 
     assert (target / "rosotacom.yaml").is_file()
     assert (target / "ros2docker.json").is_file()
+    assert (target / "ros2docker.lyrical.json").is_file()
     assert (target / "deployment.example.yaml").is_file()
     assert "session-instances/" in (target / ".gitignore").read_text(encoding="utf-8")
     assert (target / "sessions" / "1_heartbeat" / "session-definition.yaml").is_file()
@@ -3211,8 +3212,10 @@ def test_resources_path_prints_an_absolute_existing_path(capsys: pytest.CaptureF
         assert out.endswith("\n")
         printed = Path(out.strip())
         assert printed.is_absolute()
-        assert printed.is_dir()
+        assert printed.exists()
         assert len(out.splitlines()) == 1
+
+    assert Path(rosotacom.NAMED_RESOURCES["ros2docker-lyrical"]).is_file()
 
 
 def test_resources_path_rejects_an_unknown_resource_name() -> None:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -371,6 +371,17 @@ def _write_test_scenario_project(tmp_path: Path) -> tuple[rosotacom.RuntimeConfi
             ),
             encoding="utf-8",
         )
+        app_dir.joinpath(f"{identity}.lyrical.json").write_text(
+            json.dumps(
+                {
+                    "image_name": "lyrical-app",
+                    "run_type": "command",
+                    "command": ["true"],
+                    "build_args": {"BASE_IMAGE": "ros:lyrical-ros-base-resolute"},
+                }
+            ),
+            encoding="utf-8",
+        )
     scenario_dir = tmp_path / "scenarios" / "demo"
     scenario_dir.mkdir(parents=True)
     scenario_dir.joinpath("scenario-definition.yaml").write_text(
@@ -382,9 +393,13 @@ def _write_test_scenario_project(tmp_path: Path) -> tuple[rosotacom.RuntimeConfi
                 "  a:",
                 "    - name: local_app",
                 "      ros2docker_config: ../../apps/a.json",
+                "      ros2docker_config_by_distro:",
+                "        lyrical: ../../apps/a.lyrical.json",
                 "  b:",
                 "    - name: local_app",
                 "      ros2docker_config: ../../apps/b.json",
+                "      ros2docker_config_by_distro:",
+                "        lyrical: ../../apps/b.lyrical.json",
                 "",
             ]
         ),
@@ -423,11 +438,26 @@ def test_scenario_definition_resolves_and_validates_strictly(tmp_path: Path) -> 
     assert definition.session == "demo"
     assert definition.applications["a"][0].name == "local_app"
     assert definition.applications["a"][0].ros2docker_config == tmp_path / "apps" / "a.json"
+    assert definition.applications["a"][0].ros2docker_config_by_distro == (
+        ("lyrical", tmp_path / "apps" / "a.lyrical.json"),
+    )
     assert rosotacom._scenario_names(runtime) == ["demo"]
     assert rosotacom._scenario_container_name(runtime, "demo", "a", "local_app", "run1") == (
         "rosotacom_test_run1_scenario_demo_a_local_app"
     )
     assert rosotacom._scenario_application_image_name(runtime, definition.applications["a"][0]) == "ros2docker-test"
+
+    lyrical_config = tmp_path / "ros2docker.lyrical.json"
+    lyrical_config.write_text(
+        json.dumps({"build_args": {"BASE_IMAGE": "ros:lyrical-ros-base-resolute"}}),
+        encoding="utf-8",
+    )
+    lyrical_runtime = replace(runtime, ros2docker_config=lyrical_config)
+    application = definition.applications["a"][0]
+    assert rosotacom._scenario_application_config(lyrical_runtime, application) == (
+        tmp_path / "apps" / "a.lyrical.json"
+    )
+    assert rosotacom._scenario_application_image_name(lyrical_runtime, application) == "lyrical-app-test"
 
     resolved.definition_path.write_text(
         "schema_version: 1\nsession: demo\napplications: {}\nunknown: true\n",

--- a/tests/unit/test_image_cache.py
+++ b/tests/unit/test_image_cache.py
@@ -215,6 +215,32 @@ def test_references_lists_every_image_the_project_builds(
     assert all(reference.startswith("ghcr.io/owner/name:") for reference in references)
 
 
+def test_references_selects_scenario_image_for_active_ros_distro(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    project = _example_project(tmp_path, monkeypatch)
+    capsys.readouterr()
+    lyrical_project_config = project / "ros2docker.lyrical.json"
+    monkeypatch.setenv("ROSOTACOM_ROS2DOCKER_CONFIG", str(lyrical_project_config))
+
+    rosotacom.image_references_command(
+        argparse.Namespace(rosotacom_config=str(project / "rosotacom.yaml"), repository="ghcr.io/owner/name")
+    )
+
+    references = set(capsys.readouterr().out.split())
+    lyrical_application = project / "scripts/2_native_chatter/machine_b/external.lyrical.ros2docker.json"
+    kilted_application = project / "scripts/2_native_chatter/machine_b/external.ros2docker.json"
+    expected_lyrical = image_cache.cached_reference(
+        "ghcr.io/owner/name", image_cache.image_fingerprint(lyrical_application)
+    )
+    default_kilted = image_cache.cached_reference(
+        "ghcr.io/owner/name", image_cache.image_fingerprint(kilted_application)
+    )
+
+    assert expected_lyrical in references
+    assert default_kilted not in references
+
+
 def test_build_refuses_a_reference_no_input_hashes_to(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """The publisher may push only what its own inputs produced."""
     project = _example_project(tmp_path, monkeypatch)

--- a/tests/unit/test_ros_node_entity_ownership.py
+++ b/tests/unit/test_ros_node_entity_ownership.py
@@ -1,0 +1,40 @@
+"""Guard against shadowing rclpy.Node's private ROS entity collections."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+COM_PY = REPO_ROOT / "src" / "rosotacom" / "resources" / "ws" / "ros2src" / "com_py" / "com_py"
+
+# rclpy.Node.create_*() appends entities to these collections itself. Assigning
+# either name in a subclass discards Node-owned state, and appending the returned
+# entity again makes it appear twice in the executor wait set on ROS 2 Lyrical.
+RCLPY_NODE_ENTITY_FIELDS = {"_subscriptions", "_publishers"}
+
+
+@pytest.mark.parametrize("source", sorted(COM_PY.glob("*.py")), ids=lambda path: path.name)
+def test_nodes_do_not_shadow_rclpy_entity_collections(source: Path) -> None:
+    tree = ast.parse(source.read_text(encoding="utf-8"), filename=str(source))
+
+    collisions = []
+    for node in ast.walk(tree):
+        targets = []
+        if isinstance(node, (ast.Assign, ast.AnnAssign, ast.AugAssign)):
+            targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+        for target in targets:
+            if (
+                isinstance(target, ast.Attribute)
+                and isinstance(target.value, ast.Name)
+                and target.value.id == "self"
+                and target.attr in RCLPY_NODE_ENTITY_FIELDS
+            ):
+                collisions.append((target.attr, target.lineno))
+
+    assert collisions == [], (
+        "rclpy.Node owns these private entity collections; use a component-specific "
+        f"_owned_* list instead: {collisions}"
+    )


### PR DESCRIPTION
## Summary

- keep ROS 2 Kilted as the unchanged default for the upcoming demo
- add named Lyrical ros2docker resources and an explicit `ros2docker-lyrical` opt-in
- build Lyrical with the source-built, commit-pinned `domain_bridge` profile from ros2docker
- validate Kilted and Lyrical across PR, nightly, release, image-scan, and image-publish workflows
- document the later default-promotion checklist
- depend on the published `ros2docker==0.1.5.dev10` from develNor/ros2docker#179

## Linked Issue

- Fixes #305

## Release Notes

- [ ] Release PR: includes `docs/release-notes/vX.Y.Z.md`
- [ ] Release PR: summarizes user-facing changes since the previous release
- [ ] Release PR: documents compatibility, migration, and validation notes
- [ ] Release PR: records the intended `main` commit and previous release tag
- [x] Not a release PR

## Public Behavior

- [x] Changes public CLI/config/API/Docker behavior
- [ ] Does not change public behavior

The change is additive and opt-in; existing installs and the default Kilted image remain unchanged.

## Checks

- [x] `just lint-workflows`
- [x] `just lint-build`
- [x] `just lint`
- [x] `just typecheck`
- [x] `just test-unit`
- [x] `just test-contract`
- [x] `just docs`
- [x] `just package`
- [x] `just check`
- [x] targeted Kilted and Lyrical heartbeat E2E, plus Lyrical CycloneDDS OTA and Zenoh endpoint slices

## Test Integrity

- [x] Tests/CI were not skipped, weakened, or removed to make this pass

## Maintainer Evidence

- Required CI links: this PR and develNor/ros2docker#179
- Manual/runtime evidence: Kilted and Lyrical heartbeat passed locally; Lyrical Fast DDS, CycloneDDS OTA, and Zenoh endpoints passed; domain bridge forwarded across isolated domains
- External OTA evidence, if this PR is part of a `main` promotion: not applicable; this is the opt-in preparation, not the default promotion
