### PR TITLE
Retry the one preflight step whose failure can only be the transport

### DIFF
--- a/src/rosotacom/cli.py
+++ b/src/rosotacom/cli.py
@@ -2912,6 +2912,66 @@ def _ota_load_check(plan: OtaSmokePlan, *, dry_run: bool) -> None:
             print(f"+ {peer.name}: {summary}")
 
 
+_REACH_ATTEMPTS = 3
+_REACH_BACKOFF_SECONDS = 2.0
+_REACH_TIMEOUT_SECONDS = 20.0
+
+
+def _ota_reach_check(peer: OtaSmokePeer, *, dry_run: bool) -> None:
+    """Open the control channel to a peer, retrying a transport that flaked.
+
+    This is the only preflight step that retries, and the reason is the probe
+    itself: the remote command is ``true``. It cannot fail. Every non-zero exit
+    and every timeout here is therefore the transport — an ssh handshake that
+    timed out because the peer was loaded, a link that had not come up yet —
+    and never a condition on the machine that a second look would paper over.
+
+    The checks after this one deliberately do not retry. A container that is
+    already running is still running a moment later, and a peer somebody else is
+    saturating is still saturated; retrying those would convert a real refusal
+    into a delayed one. Retrying is right where the answer is stateless and the
+    failure is transient, and that is here alone.
+
+    Each attempt is printed. A run that needed three tries to reach a peer was
+    taken under conditions worth knowing about, so the artefact says so rather
+    than reporting a clean first-try connection.
+    """
+    if dry_run:
+        _ota_run(peer, "true", label=f"{peer.name}: reachable", dry_run=True, batch=True)
+        return
+
+    last_detail = ""
+    for attempt in range(1, _REACH_ATTEMPTS + 1):
+        suffix = "" if attempt == 1 else f" (attempt {attempt} of {_REACH_ATTEMPTS})"
+        try:
+            result = _ota_run(
+                peer,
+                "true",
+                label=f"{peer.name}: reachable{suffix}",
+                batch=True,
+                check=False,
+                timeout=_REACH_TIMEOUT_SECONDS,
+            )
+        except subprocess.TimeoutExpired:
+            last_detail = f"no answer within {_REACH_TIMEOUT_SECONDS:.0f}s"
+        else:
+            if result.returncode == 0:
+                if attempt > 1:
+                    print(
+                        f"! {peer.name}: reachable on attempt {attempt} of {_REACH_ATTEMPTS} — the transport was flaky"
+                    )
+                return
+            last_detail = ((result.stdout or "") + (result.stderr or "")).strip() or f"exit code {result.returncode}"
+        if attempt < _REACH_ATTEMPTS:
+            print(f"! {peer.name}: not reachable ({last_detail}); retrying")
+            time.sleep(_REACH_BACKOFF_SECONDS * attempt)
+
+    raise RuntimeError(
+        f"{peer.name}: not reachable via {_ota_peer_target(peer)} after "
+        f"{_REACH_ATTEMPTS} attempts.\nLast failure: {last_detail}"
+    )
+
+
 def _ota_preflight(
     plan: OtaSmokePlan,
     *,
@@ -2928,7 +2988,7 @@ def _ota_preflight(
     sudo_passwords = sudo_passwords or {}
     for peer in plan.peers.values():
         if _ota_peer_is_remote(peer):
-            _ota_run(peer, "true", label=f"{peer.name}: reachable", dry_run=dry_run, batch=True)
+            _ota_reach_check(peer, dry_run=dry_run)
         required = ["python3", "docker", "tar"]
         if require_tmux:
             required.append("tmux")

--- a/tests/unit/test_concurrency.py
+++ b/tests/unit/test_concurrency.py
@@ -702,3 +702,97 @@ def test_sigterm_disposition_is_restored() -> None:
     with rosotacom._terminate_via_exception():
         assert signal.getsignal(signal.SIGTERM) is not before
     assert signal.getsignal(signal.SIGTERM) is before
+
+
+def _reach_peer() -> rosotacom.OtaSmokePeer:
+    return rosotacom.OtaSmokePeer("a", "robot-a", "10.0.0.10")
+
+
+def test_reach_check_retries_a_transport_that_flaked(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """An ssh handshake that times out under load is not a verdict about the peer.
+
+    The probe is `true`, so a non-zero exit can only be the transport. That is
+    what makes retrying safe here and nowhere else in the preflight.
+    """
+    attempts: list[str] = []
+
+    def fake_ota_run(peer: object, script: str, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        attempts.append(script)
+        if len(attempts) < 3:
+            return subprocess.CompletedProcess([script], 255, "", "ssh: connect to host port 22: Connection timed out")
+        return subprocess.CompletedProcess([script], 0, "", "")
+
+    monkeypatch.setattr(rosotacom, "_ota_run", fake_ota_run)
+    monkeypatch.setattr(rosotacom.time, "sleep", lambda _seconds: None)
+
+    rosotacom._ota_reach_check(_reach_peer(), dry_run=False)
+
+    assert len(attempts) == 3
+    out = capsys.readouterr().out
+    # The run must not read as a clean first-try connection.
+    assert "attempt 3 of 3" in out
+    assert "flaky" in out
+
+
+def test_reach_check_retries_a_timeout_too(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[int] = []
+
+    def fake_ota_run(peer: object, script: str, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append(1)
+        if len(calls) == 1:
+            raise subprocess.TimeoutExpired(cmd=["ssh"], timeout=20.0)
+        return subprocess.CompletedProcess([script], 0, "", "")
+
+    monkeypatch.setattr(rosotacom, "_ota_run", fake_ota_run)
+    monkeypatch.setattr(rosotacom.time, "sleep", lambda _seconds: None)
+
+    rosotacom._ota_reach_check(_reach_peer(), dry_run=False)
+    assert len(calls) == 2
+
+
+def test_reach_check_gives_up_and_says_how_often_it_tried(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[int] = []
+
+    def fake_ota_run(peer: object, script: str, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append(1)
+        return subprocess.CompletedProcess([script], 255, "", "ssh: Could not resolve hostname robot-a")
+
+    monkeypatch.setattr(rosotacom, "_ota_run", fake_ota_run)
+    monkeypatch.setattr(rosotacom.time, "sleep", lambda _seconds: None)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        rosotacom._ota_reach_check(_reach_peer(), dry_run=False)
+
+    assert len(calls) == rosotacom._REACH_ATTEMPTS
+    message = str(excinfo.value)
+    assert "after 3 attempts" in message
+    assert "Could not resolve hostname" in message
+
+
+def test_the_load_check_does_not_retry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Only the reachability probe retries.
+
+    A peer somebody else is saturating is still saturated a moment later, and a
+    container that is already running is still running. Retrying those would
+    turn a real refusal into a delayed one, which is the failure mode the load
+    check exists to prevent.
+    """
+    calls: list[str] = []
+
+    def fake_ota_run(peer: object, script: str, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append(script)
+        return subprocess.CompletedProcess([script], 0, "78.24 81.86 81.28\n32\n", "")
+
+    monkeypatch.setattr(rosotacom, "_ota_run", fake_ota_run)
+    monkeypatch.setattr(rosotacom.time, "sleep", lambda _seconds: pytest.fail("the load check must not sleep"))
+
+    with pytest.raises(RuntimeError):
+        rosotacom._ota_load_check(_load_plan(tmp_path), dry_run=False)
+
+    assert len(calls) == 1


### PR DESCRIPTION
`ssh host true` cannot fail on the peer's account: `true` has no way to return
non-zero. Every non-zero exit and every timeout at that step is the transport —
a handshake that timed out under load, a link that had not come up yet — so a
second attempt cannot mask a real condition, because there is no condition it
could hide.

Three attempts, 2 s and 4 s apart, 20 s each. Every attempt is printed, and a
run that needed more than one says so, so an artefact does not read as a clean
first-try connection when it was not.

**Nothing else retries, and a test pins that.** A peer somebody else is
saturating is still saturated a moment later; a container that is already
running is still running. Retrying those would turn a refusal into a delayed
refusal — the failure mode the load check added in #303 exists to prevent.

This is deliberately sequenced after #303: without the load check, a retry here
would have rescued the measurement one should not take at all.

922 unit and contract tests pass.