### PR TITLE
Let the pacer's delay floor rise again

### DIFF
--- a/src/rosotacom/resources/ws/ros2src/com_py/com_py/playout_pacer_core.py
+++ b/src/rosotacom/resources/ws/ros2src/com_py/com_py/playout_pacer_core.py
@@ -32,7 +32,10 @@ class PacerConfig:
     adaptive: bool = True
     percentile: float = 0.95  # of (arrival - stamp), window-local
     margin_ms: float = 40.0  # headroom above the tracked percentile
-    window: int = 400  # samples (~40 s at 10 Hz)
+    #: Samples (~40 s at 10 Hz). Bounds both the tracked percentile and the
+    #: delay floor, so how fast the schedule re-anchors after the path changes
+    #: is this number: a longer window is steadier and slower to recover.
+    window: int = 400
 
     def __post_init__(self) -> None:
         if not 0.0 < self.percentile < 1.0:
@@ -72,8 +75,18 @@ class PlayoutSchedule:
         """
         d = arrival_s - stamp_s
         self._d.append(d)
-        if self._d_floor is None or d < self._d_floor:
-            self._d_floor = d
+        # The minimum over the *window*, not over all time. An all-time floor
+        # can only fall, so any upward shift in `arrival - stamp` -- a clock
+        # step, an NTP correction, a route change, a looping replay -- leaves
+        # every later message past `stamp + floor + budget`, and the pacer
+        # degrades to a pass-through it can never come back from. Found on the
+        # fleet e2e, where a bag loop moved the delay by the bag's length and
+        # the centre's camera ran unpaced for the rest of the run with every
+        # panel healthy. Windowed, the same shift re-anchors within one window.
+        #
+        # O(window) per message: 400 floats at 10 Hz. A monotonic deque would
+        # make it O(1) and is not worth the machinery at these rates.
+        self._d_floor = min(self._d)
         release = stamp_s + self._d_floor + self.budget_ms / 1000.0
         if release < arrival_s:  # already late: pass through immediately
             release = arrival_s

--- a/tests/unit/test_playout_pacer.py
+++ b/tests/unit/test_playout_pacer.py
@@ -111,3 +111,57 @@ def test_a_late_message_is_reported_as_held_for_nothing() -> None:
     _hold_ms(schedule, 0.0, 0.030)
 
     assert _hold_ms(schedule, 1.0, 1.400) == 0.0
+
+
+# The floor has to be able to rise again (#312).
+#
+# Every budget is anchored to `d_floor`, the fastest path observed. Taking that
+# over all time rather than over the window means it can only fall, so one
+# upward shift in `arrival - stamp` puts every later message past its release
+# time and the pacer becomes a pass-through it never recovers from. A clock step
+# on either peer is enough; the fleet e2e's looping bag replay does it every
+# lap, and until #301 the symptom was invisible -- node up, topic flowing,
+# nothing re-timed.
+
+
+def _hold_p50(schedule: PlayoutSchedule, count: int, stamp0: float, offset: float) -> float:
+    holds = []
+    for index in range(count):
+        stamp = stamp0 + index * 0.1
+        # 10 ms most of the time, 50 ms every third message: enough jitter for
+        # an adaptive budget to have something to track.
+        arrival = stamp + offset + (0.05 if index % 3 == 0 else 0.01)
+        holds.append(max(0.0, (schedule.on_message(stamp, arrival) - arrival) * 1000.0))
+    return sorted(holds)[len(holds) // 2]
+
+
+def test_a_delay_step_up_is_re_anchored_within_one_window() -> None:
+    schedule = PlayoutSchedule(PacerConfig(adaptive=True, min_ms=100.0, max_ms=300.0))
+    window = schedule.config.window
+
+    assert _hold_p50(schedule, 500, 0.0, 0.20) == pytest.approx(100.0, abs=5.0)
+    # The step itself is absorbed, not smoothed: those messages are genuinely
+    # late relative to what was known, and pass through.
+    _hold_p50(schedule, window, 1000.0, 161.20)
+    # One window later the floor describes the new path again.
+    assert _hold_p50(schedule, 500, 2000.0, 161.20) == pytest.approx(100.0, abs=5.0)
+
+
+def test_a_constant_offset_is_still_absorbed_entirely() -> None:
+    """The property the floor exists for: no clock synchronization needed."""
+    near = PlayoutSchedule(PacerConfig(adaptive=True, min_ms=100.0, max_ms=300.0))
+    far = PlayoutSchedule(PacerConfig(adaptive=True, min_ms=100.0, max_ms=300.0))
+
+    assert _hold_p50(near, 500, 0.0, 0.20) == pytest.approx(_hold_p50(far, 500, 0.0, 3600.20), abs=1.0)
+
+
+def test_the_step_neither_drops_nor_reorders() -> None:
+    schedule = PlayoutSchedule(PacerConfig(adaptive=True, min_ms=100.0, max_ms=300.0))
+    releases = []
+    for index in range(600):
+        stamp = index * 0.1
+        offset = 0.20 if index < 300 else 161.20
+        releases.append(schedule.on_message(stamp, stamp + offset + 0.01))
+
+    assert len(releases) == 600
+    assert releases == sorted(releases)


### PR DESCRIPTION
Closes #312.

`d_floor` is what every budget is measured against, and the docstring calls it a
rolling minimum. It was an all-time minimum — `window: 400` bounds the
percentile samples, nothing bounded the floor — so it could only fall.

`release = stamp + d_floor + budget`, so any upward shift in `arrival - stamp`
leaves every later message past its release time and the pacer becomes a
pass-through **it never recovers from**. A clock step on either peer is enough.

## How it was found

On the fleet e2e, whose bag replay loops: the delay jumps by the bag's length
and from that lap the centre's camera ran unpaced for the rest of the run — node
up, topic flowing, panels healthy, nothing re-timed.

It was findable only because of #301, one release old: `hold_ms` read `0.0` for
every message and `budget_ms` sat pinned at its `max_ms` clamp. That is the
whole argument for reporting what a node actually did rather than what it was
configured to do.

Offline against the installed 2.5.dev57, 10 Hz with 40 ms of jitter:

| phase | hold p50 | budget |
|---|---:|---:|
| steady state, 500 messages | 100.0 ms | 100.0 ms |
| after a +161 s step | **0.0 ms** | 300.0 ms (clamped) |
| 500 more, five full windows later | **0.0 ms** | 300.0 ms |

## The change

```python
self._d.append(d)
self._d_floor = min(self._d)
```

A shift re-anchors within one window instead of never. The forward jump in
release times stays monotonic through `_last_release`, so order is preserved and
nothing is dropped. `min()` over 400 floats per message is ~4k comparisons/s at
10 Hz; a monotonic deque would be O(1) and is not worth the machinery here.

`window`'s comment now says what it decides — how fast the schedule recovers
after the path changes — because that is no longer only about the percentile.

## Validation

- `just check`: **exit 0**, "All checks passed!", **935** host tests.
- 3 new tests in `test_playout_pacer.py`: a step up is re-anchored within one
  window; a *constant* offset is still absorbed entirely (the property the floor
  exists for, i.e. no clock synchronization needed); the step neither drops nor
  reorders.
- Mutation check: `test_a_delay_step_up_is_re_anchored_within_one_window` fails
  on the old floor and passes on the new one.

## Owner smoke

```bash
python3 -m pytest tests/unit/test_playout_pacer.py -q
```

Expected: `10 passed`. On a live paced link, `ros2 topic echo <encoded>/paced/hold_ms`
should read a non-zero hold in steady state; a run of `0.0` with `budget_ms` at
its clamp is this defect's signature and should no longer survive a path change.
