### PR TITLE
Pin a peer to reserved CPUs, and judge those CPUs instead of the machine

### DIFF
--- a/src/rosotacom/cli.py
+++ b/src/rosotacom/cli.py
@@ -275,6 +275,13 @@ class OtaSmokePeer:
     #: list. Naming the transport lets the narrow thing be substituted without
     #: this file having to know what narrow means.
     exec_command: str | None = None
+    #: CPUs this peer's session containers are confined to, e.g. "0-3".
+    #:
+    #: The reason it is per peer: a reservation is a property of one machine's
+    #: contention, not of the run. A bench pair is usually one busy workstation
+    #: shared with somebody else and one idle machine, and pinning the idle one
+    #: would only take capacity away from the measurement.
+    cpuset: str | None = None
 
 
 @dataclass(frozen=True)
@@ -1189,6 +1196,11 @@ def _parse_peer_exec_overrides(overrides: list[str] | None) -> dict[str, str]:
     return parse_assignments(overrides, option="--peer-exec")
 
 
+def _parse_peer_cpuset_overrides(overrides: list[str] | None) -> dict[str, str]:
+    parsed = parse_assignments(overrides, option="--peer-cpuset")
+    return {name: validate_cpuset(value) for name, value in parsed.items()}
+
+
 def _deployment_config(runtime: RuntimeConfig) -> DeploymentConfig | None:
     return load_deployment(runtime.deployment)
 
@@ -1749,8 +1761,13 @@ def _ota_plan_from_bindings(
     checkouts: Mapping[str, str] | None = None,
     project: str | None = None,
     exec_commands: Mapping[str, str] | None = None,
+    cpusets: Mapping[str, str] | None = None,
 ) -> OtaSmokePlan:
     _ota_validate_install_mode(install_mode)
+    if cpusets:
+        unknown = sorted(set(cpusets) - set(bindings))
+        if unknown:
+            raise RuntimeError(f"--peer-cpuset names a peer the session does not have: {', '.join(unknown)}")
     if exec_commands:
         unknown = sorted(set(exec_commands) - set(bindings))
         if unknown:
@@ -1811,6 +1828,7 @@ def _ota_plan_from_bindings(
             address=binding.address,
             checkout=(checkouts or {}).get(name) if install_mode == "checkout" else None,
             exec_command=(exec_commands or {}).get(name),
+            cpuset=(cpusets or {}).get(name),
         )
         for name, binding in bindings.items()
     }
@@ -1839,6 +1857,7 @@ def _ota_write_state(instance: SessionInstance, plan: OtaSmokePlan) -> OtaSmokeP
                 "address": peer.address,
                 "ssh": peer.ssh,
                 "checkout": peer.checkout,
+                "cpuset": peer.cpuset,
                 "exec": peer.exec_command,
             }
             for name, peer in sorted(plan.peers.items())
@@ -1865,6 +1884,7 @@ def _ota_load_state(path_arg: str) -> OtaSmokePlan:
             address=str(peer_raw["address"]),
             ssh=str(peer_raw["ssh"]) if peer_raw.get("ssh") else None,
             checkout=str(peer_raw["checkout"]) if peer_raw.get("checkout") else None,
+            cpuset=str(peer_raw["cpuset"]) if peer_raw.get("cpuset") else None,
             exec_command=str(peer_raw["exec"]) if peer_raw.get("exec") else None,
         )
     install_pin = raw.get("install_pin")
@@ -2199,6 +2219,7 @@ def _ota_start_parts(
     mode: str,
     force: bool = True,
     link_trace_parts: list[str] | None = None,
+    cpuset: str | None = None,
 ) -> list[str]:
     if target.target_type == "scenario":
         parts = ["scenario", "start", target.name, "--identity", identity, "--mode", mode, "--instance-id", instance_id]
@@ -2215,6 +2236,8 @@ def _ota_start_parts(
         ]
     parts.append("--force" if force else "--no-force")
     parts.extend(link_trace_parts or [])
+    if cpuset:
+        parts.extend(["--cpuset", cpuset])
     for override in peer_args:
         parts.extend(["--peer-address", override])
     return parts
@@ -2229,6 +2252,7 @@ def _ota_communication_start_parts(
     mode: str,
     force: bool = True,
     link_trace_parts: list[str] | None = None,
+    cpuset: str | None = None,
 ) -> list[str]:
     parts = [
         "start",
@@ -2243,6 +2267,8 @@ def _ota_communication_start_parts(
     ]
     parts.append("--force" if force else "--no-force")
     parts.extend(link_trace_parts or [])
+    if cpuset:
+        parts.extend(["--cpuset", cpuset])
     for override in peer_args:
         parts.extend(["--peer-address", override])
     return parts
@@ -2658,6 +2684,7 @@ def _resolve_ota_smoke_context(
             checkouts=checkouts,
             project=project,
             exec_commands=exec_commands,
+            cpusets=_parse_peer_cpuset_overrides(getattr(args, "peer_cpuset", None)),
         )
     plan_peers = set(plan.peers)
     target_peers = set(_peer_keys_from_cfg(target.cfg))
@@ -2877,10 +2904,121 @@ def _ota_conflict_check(plan: OtaSmokePlan, *, dry_run: bool) -> None:
 _LOAD_WARN_PER_CPU = 0.7
 _LOAD_REFUSE_PER_CPU = 2.0
 
+# Thresholds for a peer whose containers are pinned to a CPU set. These are a
+# different quantity from the ones above and deliberately not the same numbers:
+# load-per-CPU counts runnable threads and is unbounded, while this is the busy
+# fraction of the pinned CPUs and cannot exceed 1.0. What it answers is the only
+# question a reservation raises — is anybody else on the cores this run was
+# given — so it is read before the run puts its own work there.
+_CPUSET_WARN_BUSY = 0.5
+_CPUSET_REFUSE_BUSY = 0.85
+
+
+#: Two snapshots of the per-CPU jiffy counters, a second apart. A busy fraction
+#: needs a delta -- the absolute counters describe the machine since boot, which
+#: says nothing about who is on those cores now.
+_CPU_BUSY_PROBE = "grep '^cpu[0-9]' /proc/stat; sleep 1; echo ---; grep '^cpu[0-9]' /proc/stat"
+
+
+def _parse_cpu_busy(stdout: str, cpus: Sequence[int]) -> dict[int, float] | None:
+    """Busy fraction per CPU between the two /proc/stat snapshots.
+
+    Busy is everything but idle and iowait: a core waiting on disk is not
+    competing for the runqueue this measurement cares about, and counting it
+    would refuse runs on a machine that is merely writing a bag.
+    """
+    before, sep, after = stdout.partition("---")
+    if not sep:
+        return None
+
+    def snapshot(text: str) -> dict[int, tuple[int, int]]:
+        out: dict[int, tuple[int, int]] = {}
+        for line in text.splitlines():
+            fields = line.split()
+            if len(fields) < 6 or not fields[0].startswith("cpu") or not fields[0][3:].isdigit():
+                continue
+            try:
+                values = [int(x) for x in fields[1:]]
+            except ValueError:
+                continue
+            total = sum(values)
+            idle = values[3] + values[4]  # idle + iowait
+            out[int(fields[0][3:])] = (total, idle)
+        return out
+
+    first, second = snapshot(before), snapshot(after)
+    busy: dict[int, float] = {}
+    for cpu in cpus:
+        if cpu not in first or cpu not in second:
+            return None
+        total_delta = second[cpu][0] - first[cpu][0]
+        idle_delta = second[cpu][1] - first[cpu][1]
+        if total_delta <= 0:
+            return None
+        busy[cpu] = max(0.0, min(1.0, 1.0 - idle_delta / total_delta))
+    return busy or None
+
+
+def _ota_cpuset_load_check(peer: OtaSmokePeer, *, dry_run: bool) -> bool:
+    """Judge the CPUs this peer is pinned to, not the machine around them.
+
+    A reservation makes a machine measurable without making it quiet: the other
+    account keeps every thread it had, they just queue on fewer cores, so
+    /proc/loadavg reads higher than before and says nothing about whether the
+    reserved cores are free. Reading those cores directly is the only way the
+    preflight can tell a partitioned workstation from a saturated one.
+
+    Returns False when the probe could not produce a number, so the caller can
+    fall back to the machine-wide check rather than silently skip it.
+    """
+    if not peer.cpuset:
+        return False
+    cpus = parse_cpuset_list(peer.cpuset)
+    result = _ota_run(
+        peer,
+        _CPU_BUSY_PROBE,
+        label=f"{peer.name}: load on CPUs {peer.cpuset}",
+        dry_run=dry_run,
+        batch=True,
+        check=False,
+    )
+    if dry_run:
+        return True
+    if result.returncode != 0:
+        return False
+    busy = _parse_cpu_busy(result.stdout or "", cpus)
+    if busy is None:
+        return False
+
+    worst_cpu = max(busy, key=lambda cpu: busy[cpu])
+    mean = sum(busy.values()) / len(busy)
+    detail = " ".join(f"cpu{cpu}={busy[cpu] * 100:.0f}%" for cpu in sorted(busy))
+    summary = (
+        f"CPUs {peer.cpuset} are {mean * 100:.0f}% busy on average "
+        f"(worst cpu{worst_cpu} at {busy[worst_cpu] * 100:.0f}%) — {detail}"
+    )
+    if mean >= _CPUSET_REFUSE_BUSY:
+        raise RuntimeError(
+            f"Peer {peer.name} is pinned to CPUs {peer.cpuset}, and they are not free: {summary}.\n"
+            "The reservation is either not in force or somebody else is inside it. Check it on that "
+            "machine, pin to different CPUs, or — if this load is yours and expected — pass "
+            "--skip-conflict-check."
+        )
+    if mean >= _CPUSET_WARN_BUSY:
+        print(f"! {peer.name}: {summary} — the run has less of its reservation than it looks")
+    else:
+        print(f"+ {peer.name}: {summary}")
+    return True
+
 
 def _ota_load_check(plan: OtaSmokePlan, *, dry_run: bool) -> None:
     """Refuse to measure on a peer that is busy with someone else's work."""
     for peer in plan.peers.values():
+        # A pinned peer is judged on its own CPUs. The machine-wide figure is the
+        # wrong question there: it is high by construction on exactly the shared
+        # workstation the pinning exists for.
+        if _ota_cpuset_load_check(peer, dry_run=dry_run):
+            continue
         result = _ota_run(
             peer,
             "cut -d' ' -f1-3 /proc/loadavg; nproc",
@@ -2910,7 +3048,9 @@ def _ota_load_check(plan: OtaSmokePlan, *, dry_run: bool) -> None:
                 f"Peer {peer.name} is carrying unrelated load: {summary}.\n"
                 "A measurement taken here would describe the contention, not the link.\n"
                 "Wait for the machine to go quiet, measure on another pair, or — if this "
-                "load is yours and expected — pass --skip-conflict-check."
+                "load is yours and expected — pass --skip-conflict-check.\n"
+                "If those CPUs were reserved away from another account, pin this peer to them "
+                "with --peer-cpuset and the check will read them instead of the whole machine."
             )
         if ratio >= _LOAD_WARN_PER_CPU:
             print(f"! {peer.name}: {summary} — comparisons survive if runs are interleaved, absolute latencies do not")
@@ -3692,7 +3832,15 @@ def _ota_start_peers(
         peer = plan.peers[peer_name]
         command = _ota_rosotacom_command(
             plan,
-            _ota_start_parts(target, peer_name, instance_id, peer_args, mode=mode, link_trace_parts=link_trace_parts),
+            _ota_start_parts(
+                target,
+                peer_name,
+                instance_id,
+                peer_args,
+                mode=mode,
+                link_trace_parts=link_trace_parts,
+                cpuset=peer.cpuset,
+            ),
             peer,
         )
         _ota_run(peer, command, label=f"{peer_name}: start {target.name}", dry_run=dry_run)
@@ -4089,6 +4237,7 @@ def _ota_create_tmux(
             peer_args,
             mode="attach",
             link_trace_parts=link_trace_parts,
+            cpuset=first_peer.cpuset,
         ),
         first_peer,
     )
@@ -4169,6 +4318,7 @@ def _ota_create_tmux(
                 peer_args,
                 mode="attach",
                 link_trace_parts=link_trace_parts,
+                cpuset=peer.cpuset,
             ),
             peer,
         )
@@ -5235,6 +5385,43 @@ def _local_ipc_run_args(network_isolated: bool) -> list[str]:
     return [] if network_isolated else ["--ipc", "host"]
 
 
+_CPUSET_RE = re.compile(r"^\d+(-\d+)?(,\d+(-\d+)?)*$")
+
+
+def validate_cpuset(cpuset: str) -> str:
+    """Accept a docker `--cpuset-cpus` list, and nothing else.
+
+    This string is handed to `docker run` and travels to a peer over ssh, so it
+    is validated rather than trusted: only decimal CPU numbers and ranges, the
+    exact grammar docker documents. Anything else — a shell metacharacter, a
+    negative number, an empty element — is a caller error and says so here
+    instead of at the far end of an ssh pipe.
+    """
+    cleaned = cpuset.strip()
+    if not _CPUSET_RE.match(cleaned):
+        raise RuntimeError(
+            f"--cpuset {cpuset!r} is not a CPU list: expected decimal numbers and ranges like '0-3' or '0,2,4-7'."
+        )
+    for part in cleaned.split(","):
+        if "-" in part:
+            low, high = (int(x) for x in part.split("-", 1))
+            if high < low:
+                raise RuntimeError(f"--cpuset {cpuset!r}: range {part!r} counts backwards.")
+    return cleaned
+
+
+def parse_cpuset_list(cpuset: str) -> list[int]:
+    """Expand a validated CPU list into the individual CPU numbers."""
+    cpus: list[int] = []
+    for part in validate_cpuset(cpuset).split(","):
+        if "-" in part:
+            low, high = (int(x) for x in part.split("-", 1))
+            cpus.extend(range(low, high + 1))
+        else:
+            cpus.append(int(part))
+    return sorted(set(cpus))
+
+
 def _base_extra_run_args(
     runtime: RuntimeConfig,
     session: ResolvedSession,
@@ -5242,8 +5429,15 @@ def _base_extra_run_args(
     instance: SessionInstance,
     *,
     network_isolated: bool = False,
+    cpuset: str | None = None,
 ) -> list[str]:
     args: list[str] = _local_ipc_run_args(network_isolated)
+    if cpuset:
+        # Confine every container of this session to the given CPUs. On a shared
+        # workstation the point is not to slow this session down: it is to put it
+        # on the cores that were reserved away from whoever else is on the
+        # machine, so a latency measurement stops competing for a runqueue.
+        args.extend(["--cpuset-cpus", validate_cpuset(cpuset)])
     ros2docker_cfg = load_config(runtime.ros2docker_config)
 
     if not ros2docker_cfg.get("mount_ws"):
@@ -5427,7 +5621,9 @@ def start_session(args: argparse.Namespace) -> str:
                 " (or pass --force to replace it, --skip-conflict-check to ignore it).",
             )
     image_name = _scoped_image_name(runtime)
-    extra_run_args = _base_extra_run_args(runtime, session, cfg, instance, network_isolated=network_isolated)
+    extra_run_args = _base_extra_run_args(
+        runtime, session, cfg, instance, network_isolated=network_isolated, cpuset=getattr(args, "cpuset", None)
+    )
     run_override: dict[str, object] = {}
     network_name = getattr(args, "network_name", None)
     if network_name:
@@ -8913,6 +9109,18 @@ def _add_ota_install_args(parser: argparse.ArgumentParser) -> None:
         ),
     )
     parser.add_argument(
+        "--peer-cpuset",
+        action="append",
+        default=[],
+        metavar="PEER=CPUS",
+        help=(
+            "Confine this peer's session containers to these CPUs, e.g. 'a=0-3'. For a shared "
+            "workstation whose CPUs were reserved away from another account: the run then measures "
+            "on cores nobody else can take, and the load preflight judges those cores instead of "
+            "the whole machine."
+        ),
+    )
+    parser.add_argument(
         "--peer-exec",
         action="append",
         default=[],
@@ -8980,6 +9188,14 @@ def _add_start_args(parser: argparse.ArgumentParser) -> None:
         help="Require three bounded ICMP probes to the peer to succeed before starting.",
     )
     parser.add_argument("--instance-id", help="Join or create a named runtime session instance.")
+    parser.add_argument(
+        "--cpuset",
+        help=(
+            "Confine this session's containers to these CPUs, e.g. '0-3'. Use on a shared "
+            "workstation where those CPUs were reserved away from another account: the "
+            "session then measures on cores nobody else can take."
+        ),
+    )
     parser.add_argument(
         "--skip-conflict-check",
         action="store_true",

--- a/src/rosotacom/cli_benchmark.py
+++ b/src/rosotacom/cli_benchmark.py
@@ -5214,6 +5214,7 @@ def _make_live_run_point(args: argparse.Namespace, session_name: str) -> RunPoin
                 peer_address=getattr(args, "peer_address", None),
                 peer_ssh=getattr(args, "peer_ssh", None),
                 peer_checkout=getattr(args, "peer_checkout", None),
+                peer_cpuset=getattr(args, "peer_cpuset", None),
                 peer_exec=getattr(args, "peer_exec", None),
                 install_mode=getattr(args, "install_mode", None),
                 install_pin=getattr(args, "install_pin", None),

--- a/tests/contract/test_packaged_resources.py
+++ b/tests/contract/test_packaged_resources.py
@@ -537,3 +537,36 @@ def test_every_default_ota_profile_template_is_packaged() -> None:
     defaults = list(gsf._DDS_OTA_DEFAULT_CONFIG.values()) + list(gsf._DDS_LOCAL_DEFAULT_CONFIG.values())
     missing = [name for name in defaults if name and not (ota_configs / f"{name}.template").exists()]
     assert not missing, f"default profile templates absent from the package: {missing}"
+
+
+def test_benchmark_forwards_every_shared_ota_peer_option() -> None:
+    """A hand-copied field list drops new options silently, and did.
+
+    `cli_benchmark` builds an `argparse.Namespace` for the OTA layer by naming
+    each field it forwards. `--peer-cpuset` was added to the shared OTA argument
+    group, reached the parser, and was accepted on the command line — and then
+    never arrived, because this list did not mention it. Every unit test passed
+    and the feature was inert on the machine it was built for.
+
+    So the list is checked against the parser rather than maintained by hand:
+    whatever `_add_ota_install_args` defines has to appear here too.
+    """
+    import argparse
+    import inspect
+
+    import rosotacom.cli as cli
+    import rosotacom.cli_benchmark as cli_benchmark
+
+    parser = argparse.ArgumentParser()
+    cli._add_ota_install_args(parser)
+    peer_dests = {
+        action.dest for action in parser._actions if action.dest.startswith("peer_") and action.dest != "help"
+    }
+    assert peer_dests, "the shared OTA argument group defines no --peer-* options"
+
+    forwarded = inspect.getsource(cli_benchmark)
+    missing = sorted(dest for dest in peer_dests if f"{dest}=getattr(args" not in forwarded)
+    assert not missing, (
+        f"cli_benchmark does not forward {', '.join(missing)} into the OTA namespace, "
+        "so the option is accepted on the command line and then ignored"
+    )

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -2258,6 +2258,19 @@ def test_resolve_session_and_base_extra_run_args(tmp_path: Path, monkeypatch: py
     assert resolved.container_dir == "/session/definitions/1_heartbeat"
     assert f"{rosotacom.WS_DIR.resolve()}:/ws" in args
     assert f"{runtime.session_configs_dir[0]}:/session/definitions:ro" in args
+    assert "--cpuset-cpus" not in args
+
+    # A cpuset confines every container of the session. Without this the CPUs a
+    # shared workstation reserved are merely idle, not used by the run.
+    pinned = rosotacom._base_extra_run_args(runtime, resolved, {"peers": {"a": {}, "b": {}}}, instance, cpuset=" 0-3 ")
+    assert pinned[pinned.index("--cpuset-cpus") + 1] == "0-3"
+
+    # It is validated here too, not only where it is parsed: this is the last
+    # place before the string becomes part of a docker command line.
+    with pytest.raises(RuntimeError):
+        rosotacom._base_extra_run_args(
+            runtime, resolved, {"peers": {"a": {}, "b": {}}}, instance, cpuset="0-3; rm -rf /"
+        )
     assert f"{runtime.session_instances_dir}:/session/instances" in args
     assert "Configured sessions:" in rosotacom._format_available_sessions(runtime)
     # A peer shares the host IPC namespace, so it can exchange local-domain

--- a/tests/unit/test_concurrency.py
+++ b/tests/unit/test_concurrency.py
@@ -796,3 +796,150 @@ def test_the_load_check_does_not_retry(
         rosotacom._ota_load_check(_load_plan(tmp_path), dry_run=False)
 
     assert len(calls) == 1
+
+
+def test_validate_cpuset_accepts_a_cpu_list_and_nothing_else() -> None:
+    assert rosotacom.validate_cpuset("0-3") == "0-3"
+    assert rosotacom.validate_cpuset(" 0,2,4-7 ") == "0,2,4-7"
+    assert rosotacom.parse_cpuset_list("0-3,8") == [0, 1, 2, 3, 8]
+
+    # The string reaches `docker run` and travels over ssh, so it is validated
+    # rather than trusted.
+    for bad in ("0-3; rm -rf /", "$(id)", "0..3", "-1", "", "0-", "a-b"):
+        with pytest.raises(RuntimeError):
+            rosotacom.validate_cpuset(bad)
+    with pytest.raises(RuntimeError) as excinfo:
+        rosotacom.validate_cpuset("7-2")
+    assert "backwards" in str(excinfo.value)
+
+
+def test_cpu_busy_is_read_from_two_snapshots() -> None:
+    """A busy fraction needs the delta; the absolute counters describe boot onward."""
+    stdout = (
+        "cpu0 100 0 100 800 0 0 0 0 0 0\n"
+        "cpu1 100 0 100 800 0 0 0 0 0 0\n"
+        "---\n"
+        # cpu0 gains 100 busy and 900 idle -> 10% busy.
+        "cpu0 150 0 150 1700 0 0 0 0 0 0\n"
+        # cpu1 gains 900 busy and 100 idle -> 90% busy.
+        "cpu1 550 0 550 900 0 0 0 0 0 0\n"
+    )
+    busy = rosotacom._parse_cpu_busy(stdout, [0, 1])
+    assert busy is not None
+    assert busy[0] == pytest.approx(0.10, abs=0.01)
+    assert busy[1] == pytest.approx(0.90, abs=0.01)
+
+    # iowait does not count as competition for the runqueue: a peer writing a
+    # bag must not read as a peer that cannot be measured on.
+    io = "cpu0 0 0 0 100 0 0 0 0 0 0\n---\ncpu0 0 0 0 100 900 0 0 0 0 0\n"
+    busy_io = rosotacom._parse_cpu_busy(io, [0])
+    assert busy_io is not None
+    assert busy_io[0] == pytest.approx(0.0, abs=0.01)
+
+    assert rosotacom._parse_cpu_busy("no separator here", [0]) is None
+    assert rosotacom._parse_cpu_busy(stdout, [9]) is None  # a CPU the peer does not have
+
+
+def _pinned_peer(cpuset: str = "0-3") -> rosotacom.OtaSmokePeer:
+    return rosotacom.OtaSmokePeer("a", "robot-a", "10.0.0.10", cpuset=cpuset)
+
+
+def _busy_probe(fraction: float) -> str:
+    """Two snapshots in which every CPU is `fraction` busy."""
+    lines = [f"cpu{cpu} 0 0 0 0 0 0 0 0 0 0" for cpu in range(4)]
+    after = [f"cpu{cpu} {int(1000 * fraction)} 0 0 {int(1000 * (1 - fraction))} 0 0 0 0 0 0" for cpu in range(4)]
+    return "\n".join(lines) + "\n---\n" + "\n".join(after) + "\n"
+
+
+def test_cpuset_check_refuses_when_the_reserved_cpus_are_not_free(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A reservation that is not in force must not read as a quiet machine."""
+    monkeypatch.setattr(
+        rosotacom,
+        "_ota_run",
+        lambda peer, script, **kw: subprocess.CompletedProcess([script], 0, _busy_probe(0.95), ""),
+    )
+    with pytest.raises(RuntimeError) as excinfo:
+        rosotacom._ota_cpuset_load_check(_pinned_peer(), dry_run=False)
+    message = str(excinfo.value)
+    assert "not free" in message
+    assert "0-3" in message
+
+
+def test_cpuset_check_passes_on_reserved_cpus_that_are_idle(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(
+        rosotacom,
+        "_ota_run",
+        lambda peer, script, **kw: subprocess.CompletedProcess([script], 0, _busy_probe(0.02), ""),
+    )
+    assert rosotacom._ota_cpuset_load_check(_pinned_peer(), dry_run=False) is True
+    assert "CPUs 0-3 are 2% busy" in capsys.readouterr().out
+
+
+def test_a_pinned_peer_is_not_judged_by_the_machine_wide_load(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The whole point: a reserved workstation reads high and is still measurable.
+
+    Measured on majestic on 2026-08-19: 68-75 on 32 CPUs with four cores reserved
+    away from the account carrying that load. loadavg cannot see the reservation
+    — the other account's threads all stayed runnable, they just queue on fewer
+    cores — so judging the machine refuses a run the reservation made possible.
+    """
+    scripts: list[str] = []
+
+    def fake_ota_run(peer: object, script: str, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        scripts.append(script)
+        if "/proc/stat" in script:
+            return subprocess.CompletedProcess([script], 0, _busy_probe(0.01), "")
+        return subprocess.CompletedProcess([script], 0, "75.68 68.49 67.20\n32\n", "")
+
+    monkeypatch.setattr(rosotacom, "_ota_run", fake_ota_run)
+    plan = rosotacom.OtaSmokePlan(
+        state_path=tmp_path / "ota-deployment.yaml",
+        workdir="/tmp/rosotacom_ota",
+        rosotacom="rosotacom",
+        project="rosotacom.yaml",
+        peers={"a": _pinned_peer()},
+    )
+
+    rosotacom._ota_load_check(plan, dry_run=False)  # must not raise
+
+    assert any("/proc/stat" in s for s in scripts)
+    assert not any("loadavg" in s for s in scripts), "a pinned peer must not fall back to loadavg"
+
+
+def test_an_unpinned_peer_still_uses_the_machine_wide_load(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        rosotacom,
+        "_ota_run",
+        _fake_ota_run_factory({"/proc/loadavg": "78.24 81.86 81.28\n32\n"}),
+    )
+    with pytest.raises(RuntimeError) as excinfo:
+        rosotacom._ota_load_check(_load_plan(tmp_path), dry_run=False)
+    assert "--peer-cpuset" in str(excinfo.value), "the refusal should name the way out"
+
+
+def test_a_pinned_peer_confines_its_containers(tmp_path: Path) -> None:
+    """The reservation only buys anything if the containers actually land on it."""
+    target = rosotacom.InteractiveSmokeTarget(
+        name="s",
+        target_type="session",
+        session=rosotacom.ResolvedSession(host_dir=tmp_path, container_dir="/s", source="test"),
+        cfg={},
+    )
+    parts = rosotacom._ota_start_parts(target, "a", "id-1", [], mode="detached", cpuset="0-3")
+    assert "--cpuset" in parts
+    assert parts[parts.index("--cpuset") + 1] == "0-3"
+
+    # And without one, nothing is added: the flag must not appear on a peer that
+    # was never pinned, or every unpinned run changes shape too.
+    assert "--cpuset" not in rosotacom._ota_start_parts(target, "a", "id-1", [], mode="detached")


### PR DESCRIPTION
A CPU reservation makes a shared workstation **measurable** without making it
**quiet**, and the load preflight could not tell those apart. Reserving cores
away from another account leaves every one of its threads runnable — they just
queue on fewer cores — so `/proc/loadavg` reads the same or higher while the
reserved cores sit idle.

Measured on the bench workstation on 2026-08-19: load 68–75 on 32 CPUs with
CPUs 0-3 reserved, which #303's load check refuses at 2.0 per CPU. The run it
refused was the one the reservation had just made possible.

### Two halves, neither works alone

**`--cpuset` on `start`, `--peer-cpuset PEER=CPUS` on every OTA command** adds
`--cpuset-cpus` to the session's containers. Without it a reservation only means
the cores are idle; nothing puts the run on them. Per peer, because a reservation
is a property of one machine's contention: a bench pair is usually one shared
workstation and one idle machine, and pinning the idle one would only take
capacity away.

**The load check then reads those CPUs.** Two `/proc/stat` snapshots a second
apart; busy is everything but idle and iowait, so a peer writing a bag does not
read as a peer that cannot be measured on. Refuses above 85% mean busy, warns
above 50% — a different quantity from load-per-CPU and deliberately not the same
numbers, since a busy fraction cannot exceed 1.0. An unpinned peer keeps the old
check unchanged, and its refusal now names `--peer-cpuset` as the way out.

The cpuset string is validated where it is parsed and again where it becomes part
of a docker command line: it travels over ssh, so `0-3; rm -rf /` is a caller
error that says so locally rather than at the far end of a pipe.

### The second commit is why end-to-end validation earns its keep

`--peer-cpuset` reached the parser, was accepted on the command line, and never
arrived — `cli_benchmark` builds its OTA namespace by naming each field it
forwards, and the list did not mention it. Every unit test passed and the feature
was inert. The list is now checked against the parser, and the test was verified
by deleting the fix and watching it fail.

### End to end, on the workstation that refused the same run minutes earlier

```
+ a: CPUs 0-3 are 0% busy on average (worst cpu0 at 1%) — cpu0=1% cpu1=1% cpu2=0% cpu3=0%
+ b: host load: running remote command
  probe(attempt=1/1): delivered=69/103 loss=32.353% p50=88.698ms
```

986 unit and contract tests pass. The 6 failures in this tree are pre-existing on
develop (`Profile 'domain-bridge' not found`, an installed ros2docker older than
#308 expects) and reproduce with this branch stashed.