### PR TITLE
Record the revision of the session an instance was built from

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ Peer reachability is opt-in because some valid networks block ICMP and peers may
 be started in either order. `rosotacom start` accepts the same
 `--require-peer-reachable` policy when a deployment does require it.
 
-`rosotacom` reads the static session input and creates generated files under `session-instances/<date>/<session>_<timestamp>_<id>/config/`, including per-peer plugin/session specs, topic lists, optional QoS, and optional `domain_bridge.yaml`. Catmux pane output is logged under the same instance in `logs/<peer>/catmux/`.
+`rosotacom` reads the static session input and creates generated files under `session-instances/<date>/<session>_<timestamp>_<id>/config/`, including per-peer plugin/session specs, topic lists, optional QoS, and optional `domain_bridge.yaml`. The instance's `manifest.yaml` records what produced it: `rosotacom_version`, the effective config SHA, and `source_revision` — the commit, branch and tracked-dirtiness of the session source directory at creation time, so a recording stays attributable to a revision after the checkout has moved on (`null` when the source is not a git repository). Catmux pane output is logged under the same instance in `logs/<peer>/catmux/`.
 
 What else a run leaves under `logs/<peer>/`, and which file to open first when a
 peer looked healthy but did nothing:

--- a/docs/forensics-report.md
+++ b/docs/forensics-report.md
@@ -37,7 +37,7 @@ gracefully when absent:
 |---|---|
 | `status.json` | declared topic types (FFMPEGPacket detection) |
 | `link_trace.jsonl` ([link trace recorder](link-trace.md)) | link state around each incident |
-| `manifest.yaml` | instance id + config SHA provenance |
+| `manifest.yaml` | instance id, config SHA, and `source_revision` — the commit of the session source at instance creation |
 | `--profile NAME --profiles-file FILE` | RFC 0004 environment context (static params or timeline steps) |
 | `state_transition` rows in `events.jsonl` | pipeline diagnoses around each incident |
 

--- a/src/rosotacom/cli.py
+++ b/src/rosotacom/cli.py
@@ -882,6 +882,61 @@ def _append_log(path: Path, text: str) -> None:
             fp.write("\n")
 
 
+#: A provenance read must never be what makes an instance fail to start.
+_SOURCE_REVISION_TIMEOUT_S = 5.0
+
+
+def _source_revision(path: Path | str) -> dict[str, Any] | None:
+    """The VCS revision of the directory this session was taken from.
+
+    `rosotacom_version` pins the tool. This pins its *input*: the session source
+    is normally a checkout of a deployment repository, and that checkout moves.
+    A consumer reading the manifest later cannot recover the revision by looking
+    at the machine, because looking at the machine answers a different question —
+    on one two-machine drive the vehicle had been synced by the time the
+    recording was consolidated the next morning, so the only commit anybody
+    could still read was not the commit that ran. The manifest is written once
+    at creation and never rewritten, which is exactly what such a fact needs.
+
+    `dirty` deliberately ignores untracked files: deployment checkouts routinely
+    carry recordings, logs and scratch files that are not the code, so counting
+    them would make every real deployment permanently dirty and the flag
+    meaningless. What it reports is tracked content differing from the commit.
+
+    Best effort throughout — not a directory, no git, not a repository, a git
+    that hangs: all yield None.
+    """
+    directory = Path(path)
+    if not directory.is_dir():
+        return None
+
+    def git(*args: str) -> str | None:
+        try:
+            result = subprocess.run(
+                ["git", "-C", str(directory), *args],
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=_SOURCE_REVISION_TIMEOUT_S,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return None
+        return result.stdout.strip() if result.returncode == 0 else None
+
+    commit = git("rev-parse", "HEAD")
+    if not commit:
+        return None
+    branch = git("rev-parse", "--abbrev-ref", "HEAD")
+    tracked_changes = git("status", "--porcelain", "--untracked-files=no")
+    return {
+        "vcs": "git",
+        "commit": commit,
+        "branch": None if branch in (None, "HEAD") else branch,
+        "dirty": None if tracked_changes is None else bool(tracked_changes),
+        "root": git("rev-parse", "--show-toplevel"),
+    }
+
+
 def _effective_config_sha256(cfg: dict[str, Any]) -> str:
     text = yaml.safe_dump(cfg, sort_keys=True, default_flow_style=False, allow_unicode=True)
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
@@ -908,6 +963,7 @@ def _write_instance_manifest(
             "instance_id": instance.instance_id,
             "rosotacom_version": __version__,
             "source_session_host_dir": str(session.host_dir),
+            "source_revision": _source_revision(session.host_dir),
             "source_session_container_dir": session.container_dir,
             "source": session.source,
             "config_dir": str(instance.config_host_dir),
@@ -962,6 +1018,7 @@ def _write_scenario_manifest(
             "instance_id": instance.instance_id,
             "rosotacom_version": __version__,
             "source_session_host_dir": str(session.host_dir),
+            "source_revision": _source_revision(session.host_dir),
             "source_session_container_dir": session.container_dir,
             "source": session.source,
             "config_dir": str(instance.config_host_dir),
@@ -1028,6 +1085,7 @@ def _write_interactive_smoke_manifest(
             "instance_id": instance.instance_id,
             "rosotacom_version": __version__,
             "source_session_host_dir": str(target.session.host_dir),
+            "source_revision": _source_revision(target.session.host_dir),
             "source_session_container_dir": target.session.container_dir,
             "source": target.session.source,
             "config_dir": str(instance.config_host_dir),
@@ -2445,6 +2503,7 @@ def _ota_write_manifest(
             "instance_id": instance.instance_id,
             "rosotacom_version": __version__,
             "source_session_host_dir": str(target.session.host_dir),
+            "source_revision": _source_revision(target.session.host_dir),
             "source_session_container_dir": target.session.container_dir,
             "source": target.session.source,
             "config_dir": str(instance.config_host_dir),

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -3721,3 +3721,81 @@ def test_ota_cleanup_refuses_to_act_on_a_guessed_plan(capsys: pytest.CaptureFixt
 
     assert calls == []
     assert "no deployment state" in capsys.readouterr().out
+
+
+def _git_repo(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    env = {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "t",
+        "GIT_AUTHOR_EMAIL": "t@example.invalid",
+        "GIT_COMMITTER_NAME": "t",
+        "GIT_COMMITTER_EMAIL": "t@example.invalid",
+    }
+    for args in (
+        ["init", "--initial-branch", "main"],
+        ["config", "commit.gpgsign", "false"],
+    ):
+        subprocess.run(["git", "-C", str(path), *args], check=True, capture_output=True, env=env)
+    (path / "session-definition.yaml").write_text("shared: {}\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(path), "add", "-A"], check=True, capture_output=True, env=env)
+    subprocess.run(["git", "-C", str(path), "commit", "-m", "seed"], check=True, capture_output=True, env=env)
+
+
+def test_the_manifest_records_the_revision_of_the_session_it_was_built_from(
+    tmp_path: Path,
+) -> None:
+    """rosotacom_version pins the tool; this pins its input.
+
+    Without it the only recoverable commit is whatever the machine holds when
+    somebody looks, which is a different fact — and a wrong one as soon as the
+    machine has been synced in between.
+    """
+    session = tmp_path / "sessions" / "demo"
+    _git_repo(session)
+
+    revision = rosotacom._source_revision(session)
+
+    assert revision is not None
+    assert revision["vcs"] == "git"
+    assert re.fullmatch(r"[0-9a-f]{40}", revision["commit"])
+    assert revision["branch"] == "main"
+    assert revision["dirty"] is False
+    assert Path(revision["root"]).resolve() == session.resolve()
+
+
+def test_a_session_source_that_differs_from_its_commit_says_so(tmp_path: Path) -> None:
+    session = tmp_path / "sessions" / "demo"
+    _git_repo(session)
+    (session / "session-definition.yaml").write_text("shared: {changed: true}\n", encoding="utf-8")
+
+    assert rosotacom._source_revision(session)["dirty"] is True
+
+
+def test_untracked_files_beside_a_session_do_not_make_it_dirty(tmp_path: Path) -> None:
+    """A deployment checkout carries recordings, logs and scratch files.
+
+    Counting those would leave every real deployment permanently dirty, which is
+    the same as reporting nothing.
+    """
+    session = tmp_path / "sessions" / "demo"
+    _git_repo(session)
+    (session / "rosbag2_2026_01_01-00_00_00").mkdir()
+    (session / "rosbag2_2026_01_01-00_00_00" / "metadata.yaml").write_text("x\n", encoding="utf-8")
+
+    assert rosotacom._source_revision(session)["dirty"] is False
+
+
+@pytest.mark.parametrize("case", ["not_a_repository", "not_a_directory", "missing"])
+def test_a_source_without_a_revision_is_null_and_not_an_error(tmp_path: Path, case: str) -> None:
+    """An instance must never fail to start over a provenance read."""
+    if case == "not_a_repository":
+        target = tmp_path / "plain"
+        target.mkdir()
+    elif case == "not_a_directory":
+        target = tmp_path / "file"
+        target.write_text("x\n", encoding="utf-8")
+    else:
+        target = tmp_path / "gone"
+
+    assert rosotacom._source_revision(target) is None


### PR DESCRIPTION
Closes #318.

## What

Every manifest writer now records `source_revision` next to
`source_session_host_dir`:

```yaml
source_revision:
  vcs: git
  commit: 0941a44c5c4d…
  branch: main
  dirty: false
  root: /home/carpc/remote-assist
```

`rosotacom_version` pins the tool; this pins its input.

## Why it is written at creation and not read later

Reading the checkout later answers a different question. A two-machine drive on
2026-08-19 was consolidated the next morning, after the vehicle's checkout had
been synced at 09:22 — so the commit a consumer could still read was not the
commit that drove, and nothing said so. The manifest is written once when the
instance is created and never rewritten, which is the only artifact in the
instance with that property.

## Decisions worth reviewing

- **Untracked files do not count as dirty** (`git status --porcelain
  --untracked-files=no`). Deployment checkouts carry recordings, logs and
  scratch files; counting those leaves every real deployment permanently dirty,
  which is the same as reporting nothing.
- **Never fatal.** Not a directory, no git, not a repository, a git that hangs
  past 5 s — all yield `null`, like `rollout` does today. An instance start must
  not fail over a provenance read.
- Applied to all four manifest writers (instance, scenario, interactive smoke,
  OTA), because they share the same base dict and the same gap.

## Validation

`tests/unit/test_cli.py`, four new cases: a git checkout yields commit/branch,
a modified tracked file reports `dirty: true`, an untracked bag directory does
not, and a non-repository / missing path yields `null` rather than an error.

```
.venv/bin/python -m pytest -q tests/unit
868 passed, 10 skipped, 1 failed
```

The one failure is `test_catmux_pane_logging.py::test_the_hook_is_installed_once_even_if_sourced_twice`,
which fails identically on the unmodified base commit — pre-existing, not from
this change.

`ruff check`, `ruff format --check` and `mypy` are clean.