### PR TITLE
Keep the link trace continuous instead of writing every other tick

### DIFF
--- a/docs/link-trace.md
+++ b/docs/link-trace.md
@@ -30,6 +30,16 @@ rosotacom ota-smoke 13_link_latency --link-trace
 `--link-trace-interval` and `--link-trace-modem-command` also enable the
 recorder and force `shared.use_status_overview: true` for the generated instance.
 
+`interval_s` is the period between rows, and the status-overview node is ticked
+at the same period when the trace is enabled. Those two being equal is what
+makes the trace continuous: each row's `passive_counter_delta` covers one tick,
+so consecutive rows meet rather than leaving traffic between them. The recorder
+therefore schedules against an advancing deadline with a small tolerance instead
+of a stopwatch since the last row — without that, a tick landing a hair early is
+rejected and waits a whole further period, which halves the trace and leaves
+every second interval described by no row at all (measured on a 5 h drive:
+1.984 s between rows carrying 1.002 s windows).
+
 ## Row Schema
 
 Each line is one JSON object:

--- a/src/rosotacom/resources/ws/ros2src/com_py/com_py/link_trace.py
+++ b/src/rosotacom/resources/ws/ros2src/com_py/com_py/link_trace.py
@@ -152,6 +152,12 @@ def build_link_trace_sample(
 class LinkTraceRecorder:
     """Write link trace rows as append-only JSONL."""
 
+    #: How early a tick may be and still count as on time. The caller ticks at
+    #: the same nominal period, so its jitter is the whole question; a tenth of
+    #: the interval absorbs that without ever letting rows run at half the
+    #: configured period.
+    _TOLERANCE_FRACTION = 0.1
+
     def __init__(
         self,
         path: str,
@@ -166,13 +172,37 @@ class LinkTraceRecorder:
         self.modem_metrics_command = modem_metrics_command
         self.modem_metrics_timeout_s = modem_metrics_timeout_s
         self._clock = clock
-        self._last_write: Optional[float] = None
+        self._due_at: Optional[float] = None
 
     def maybe_write(self, snapshot: Dict[str, Any], link_sample: Optional[Dict[str, Any]]) -> bool:
+        """Write one row if this tick is the one the schedule was waiting for.
+
+        The schedule is a *deadline that advances*, not a stopwatch since the
+        last row, and the tolerance is not cosmetic. The caller is deliberately
+        ticking at the same period as this one — `generate_session_files` sets
+        `status_write_interval_s` to the trace interval — so a plain
+        "never faster than interval_s" gate rejects every tick that lands a hair
+        early and, with no catch-up, makes it wait a whole further period.
+
+        That halves the trace, and it does not merely halve its resolution: the
+        passive counter delta in a row covers the caller's own tick, so with
+        rows twice as far apart every second of traffic is described by no row
+        at all. Measured on the 2026-08-19 drive before this fix: rows 1.984 s
+        apart carrying 1.002 s windows.
+        """
         now = self._clock()
-        if self._last_write is not None and now - self._last_write < self.interval_s:
+        if self._due_at is None:
+            self._due_at = now
+        if now < self._due_at - self._TOLERANCE_FRACTION * self.interval_s:
             return False
-        self._last_write = now
+        # Advance the deadline rather than restarting it from now, so the rows
+        # stay on one cadence instead of drifting by the jitter of every tick.
+        # After a stall long enough that the next deadline is already behind us,
+        # start a fresh interval from the present rather than bursting through
+        # the deadlines that were missed: the rows describe the link now, and a
+        # burst of them would describe nothing.
+        next_due = self._due_at + self.interval_s
+        self._due_at = next_due if next_due > now else now + self.interval_s
         modem = run_modem_metrics_hook(
             self.modem_metrics_command,
             timeout_s=self.modem_metrics_timeout_s,

--- a/tests/unit/test_link_trace.py
+++ b/tests/unit/test_link_trace.py
@@ -129,3 +129,75 @@ def test_link_trace_recorder_appends_jsonl_on_interval(tmp_path: Path) -> None:
 
     rows = [json.loads(line) for line in trace_path.read_text(encoding="utf-8").splitlines()]
     assert [row["kind"] for row in rows] == ["link_trace", "link_trace"]
+
+
+def _recorder(tmp_path: Path, ticks: list[float], interval_s: float = 1.0) -> tuple[LinkTraceRecorder, list[float]]:
+    remaining = iter(ticks)
+    path = tmp_path / "status" / "link_trace.jsonl"
+    return LinkTraceRecorder(str(path), interval_s=interval_s, clock=lambda: next(remaining)), ticks
+
+
+SNAPSHOT = {"generated_at": "2026-08-19T13:52:11.000", "peer": "a", "remote": "b", "topics": []}
+
+
+def test_a_caller_ticking_at_the_configured_period_gets_a_row_per_tick(tmp_path: Path) -> None:
+    """The caller ticks at exactly this period, so its jitter is the whole question.
+
+    `generate_session_files` sets `status_write_interval_s` to the trace
+    interval, so every tick lands one period after the last — sometimes a
+    millisecond early. A gate that rejects those outright makes each of them
+    wait a further full period, which is how the 2026-08-19 drive ended up with
+    rows 1.984 s apart at `interval_s: 1.0`.
+    """
+    ticks = [100.0, 100.999, 101.998, 102.997, 103.996]
+    recorder, _ = _recorder(tmp_path, ticks)
+
+    written = [recorder.maybe_write(SNAPSHOT, None) for _ in ticks]
+
+    assert written == [True] * len(ticks)
+
+
+def test_half_the_traffic_is_not_left_between_two_rows(tmp_path: Path) -> None:
+    """Why the tick above matters more than resolution.
+
+    A row's passive counter delta covers the caller's own tick. With rows twice
+    as far apart as the ticks, every second interval is described by no row at
+    all — so the trace undercounts the bytes it exists to account for.
+    """
+    ticks = [0.0, 0.999, 1.998, 2.997]
+    recorder, _ = _recorder(tmp_path, ticks)
+    for _ in ticks:
+        recorder.maybe_write(SNAPSHOT, {"passive_counter_delta": {"window_s": 1.0}})
+
+    rows = [
+        json.loads(line) for line in (tmp_path / "status" / "link_trace.jsonl").read_text(encoding="utf-8").splitlines()
+    ]
+    stamps = [row["monotonic_s"] for row in rows]
+    gaps = [b - a for a, b in zip(stamps, stamps[1:], strict=False)]
+    assert gaps, "more than one row"
+    assert max(gaps) < 1.5, "no second of the drive falls between two rows"
+
+
+def test_a_much_faster_caller_is_still_held_to_the_interval(tmp_path: Path) -> None:
+    """The tolerance must not turn the interval into a suggestion."""
+    ticks = [0.0, 0.2, 0.4, 0.6, 0.8, 1.0, 1.2]
+    recorder, _ = _recorder(tmp_path, ticks)
+
+    written = [recorder.maybe_write(SNAPSHOT, None) for _ in ticks]
+
+    assert written == [True, False, False, False, False, True, False]
+
+
+def test_a_stall_resynchronises_instead_of_bursting(tmp_path: Path) -> None:
+    """After a gap, the rows describe the link now.
+
+    Emitting the deadlines that were missed would produce a burst of rows that
+    describe nothing, and would make the trace's own timestamps disagree with
+    the counters in it.
+    """
+    ticks = [0.0, 30.0, 30.2, 31.0]
+    recorder, _ = _recorder(tmp_path, ticks)
+
+    written = [recorder.maybe_write(SNAPSHOT, None) for _ in ticks]
+
+    assert written == [True, True, False, True]


### PR DESCRIPTION
Closes #321.

## What was wrong

`LinkTraceRecorder.maybe_write` gated on "never faster than `interval_s`" while
its caller ticks at *exactly* `interval_s` — `generate_session_files` sets
`status_write_interval_s` to the trace interval when the trace is enabled. Every
tick landing a hair early was rejected, and with no catch-up it waited a whole
further period.

Measured on a 5 h 20 m two-machine drive (2026-08-19, 12 222 rows over 19 179 s):

| | |
|---|---|
| row period | median **1.984 s**, p95 2.004 s |
| … modem hook answered / timed out | 1.983 s / 1.991 s |
| `passive_counter_delta.window_s` | 1.002 s |

Identical with and without the modem hook, so the hook was never the cause.

## Why it is more than resolution

A row's counter delta covers one caller tick. With rows twice as far apart as
the ticks, **every second second of traffic was in no row at all** — so
integrating `observed_kbps` over the trace undercounted by about half, and the
question the trace exists for ("link had no capacity" vs "source sent nothing")
was answered from a stream with a hole in every other second.

## The fix

A deadline that advances by `interval_s`, with a tolerance of a tenth of it for
the caller's jitter. After a stall long enough that the next deadline is already
behind, it starts a fresh interval from the present rather than bursting through
the missed deadlines — a burst of rows would describe nothing and would put the
trace's timestamps at odds with the counters in it.

## Validation

Four new cases in `tests/unit/test_link_trace.py`:

- a caller ticking at exactly `interval_s`, each tick a millisecond early, gets
  a row per tick (this is the regression);
- no gap between consecutive rows exceeds 1.5x the interval, which is the
  property that keeps the counters contiguous;
- a caller ticking five times per interval is still held to the interval, so the
  tolerance is not a licence;
- a stall resynchronises instead of bursting.

The third of those caught a real defect in the first draft of this change, where
the resync left the next row immediately due.

```
.venv/bin/python -m pytest -q tests/unit
866 passed, 10 skipped, 1 failed
```

The failure is `test_catmux_pane_logging.py::test_the_hook_is_installed_once_even_if_sourced_twice`,
which fails identically on the unmodified base commit.

`ruff check`, `ruff format --check` and `mypy` are clean.