### PR TITLE
Capture the link's headers where the link is already known

### DIFF
--- a/README.md
+++ b/README.md
@@ -639,6 +639,13 @@ the [link trace recorder](docs/link-trace.md). It writes
 `link_trace.jsonl` under the same status directory with `/proc/net/dev` counter
 deltas, echo-heartbeat RTT/loss provenance, and an optional modem-metrics hook.
 
+Those counters localise loss to a *direction* and no further. When the question
+is which fragment was lost, whether a retransmit followed, or how one sample's
+sub-messages were spaced, enable the [header-only OTA capture](docs/ota-pcap.md)
+next to them — `shared.ota_pcap.enabled`, off by default, roughly 1 % of payload
+volume, and every packet labelled uplink or downlink. It needs no capability,
+no image change and no extra container.
+
 Convert a recorded link trace into a profiles-file entry when you want to replay
 the same drive conditions in a repeatable benchmark:
 

--- a/docs/ota-pcap.md
+++ b/docs/ota-pcap.md
@@ -1,0 +1,134 @@
+# Header-Only OTA Capture
+
+A passive, header-only packet capture of the OTA link, written beside the
+[link trace](link-trace.md) by the same node:
+
+```text
+session-instances/.../logs/<peer>/status/ota.pcap
+session-instances/.../logs/<peer>/status/ota.json
+```
+
+Enable it in a session definition:
+
+```yaml
+shared:
+  use_status_overview: true
+  ota_pcap:
+    enabled: true
+```
+
+Everything else is optional:
+
+```yaml
+  ota_pcap:
+    enabled: true
+    snaplen: 96        # bytes kept per packet; headers, no payload
+    max_mb: 2000       # ceiling for one capture file
+    peer_filter: true  # keep only packets to or from the remote peer
+```
+
+Off by default, and off is exactly the session that existed before: a
+definition without the block renders the same peer files it always did, which
+a test asserts by rendering both and diffing them.
+
+## What it answers that the link trace cannot
+
+`link_trace.jsonl` counts `/proc/net/dev` bytes per direction once a second.
+That localises loss to a **direction** and no further. It cannot say which
+fragment of which sample was lost, whether a retransmit followed, or how one
+sample's sub-messages were spaced on the wire.
+
+The capture answers those, at roughly 1 % of payload volume. Use the two
+together: the trace is the cheap continuous record, the capture is what you
+turn on for a measurement run.
+
+## What the file is
+
+`LINKTYPE_LINUX_SLL` (113), microsecond `pcap`, snaplen 96 by default. Every
+reader takes it — Wireshark, `tshark`, `scapy`, `capinfos`.
+
+The link type is the important choice. The capture uses a `SOCK_DGRAM` packet
+socket, so one code path works on both link types the fleet has: a VPN `tun`
+device is layer 3 and has no link-layer header at all, while a control-centre
+LAN port is Ethernet. The kernel hands `SOCK_DGRAM` the network-layer packet
+either way, plus the `sockaddr_ll` that `LINKTYPE_LINUX_SLL` is defined over.
+
+That pseudo-header carries the field the analysis is for:
+
+```bash
+# uplink (this host sent it) against downlink, per packet
+tshark -r ota.pcap -T fields -e sll.pkttype | sort | uniq -c
+#   4 = PACKET_OUTGOING, 0 = PACKET_HOST
+```
+
+A `LINKTYPE_RAW` capture would have thrown that away.
+
+Timestamps come from the kernel (`SO_TIMESTAMPNS`), not from the moment python
+reached the packet.
+
+## The sidecar, and the number that matters
+
+`ota.json` is written when the capture stops:
+
+```json
+{
+  "interface": "tun0",
+  "snaplen": 96,
+  "linktype": "LINKTYPE_LINUX_SLL",
+  "filter": "udp and host 10.254.0.37",
+  "promiscuous": false,
+  "packets": 2434,
+  "bytes": 272498,
+  "kernel_drops": 0,
+  "kernel_seen": 4638,
+  "first_timestamp": 1787297717.008177,
+  "last_timestamp": 1787297733.10892,
+  "stopped_because": "signal"
+}
+```
+
+**`kernel_drops` is a gap in the file, not on the link.** A capture that fell
+behind looks exactly like radio loss to anyone reading the pcap months later,
+so subtract it before reading any loss out of the capture. Zero is the normal
+result on a link of a few Mbit/s; a non-zero value means this process, not the
+radio.
+
+## Which interface, and the refusal that matters
+
+The interface is not configured. It is resolved from the peer's own OTA
+address by `com_py.link_bytes.resolve_link_interface` — the same resolution the
+status snapshot's `link` block uses, including its refusal to report a loopback
+interface for a non-loopback address. That refusal is issue #267: sampling `lo`
+on a machine that also runs an `-a` recorder reads about 28 Gbit/s next to a
+6 Mbit/s link, and it survived a field session and an offline analysis before
+anyone doubted the number. A capture on the wrong device would be the same
+mistake in a bigger file.
+
+If no interface resolves, the capture is skipped with a warning and the session
+runs on. `shared.ota_pcap.enabled` therefore requires
+`shared.use_status_overview: true`, which is where that resolution lives.
+
+## Privilege, containers, and what the option costs
+
+Nothing is added. The communication container already runs as root with
+`CAP_NET_RAW` in docker's default set, so the capture needs no `--cap-add`, no
+image change, no rebuild and no extra container in `docker ps`.
+
+`CAP_NET_ADMIN` is *not* taken and is not needed: it buys promiscuous mode,
+which this capture deliberately does not use. Everything of interest is
+addressed to or from this host, and promiscuous mode on a control-centre LAN
+port would collect other people's traffic.
+
+The capture runs as a separate process rather than inside the status node's
+thread, so a capture that misbehaves cannot reach the snapshot an operator is
+watching. It is stopped with `SIGINT` and waited for, because that is what
+writes the sidecar JSON.
+
+## Cost
+
+Header-only at 96 bytes: about 6 MB per minute at 500 packets/s, so a two-hour
+run is well under a gigabyte. `max_mb` bounds a mistake — a capture pointed at
+a busy LAN port — rather than shaping a run; when it is reached the capture
+stops and says so in `stopped_because`.
+
+Nothing is transmitted, so the capture costs no link capacity.

--- a/src/rosotacom/resources/ws/ros2src/com_py/com_py/ota_pcap.py
+++ b/src/rosotacom/resources/ws/ros2src/com_py/com_py/ota_pcap.py
@@ -1,0 +1,402 @@
+"""Header-only packet capture of the OTA link, beside the link trace.
+
+Runs inside the communication container for the lifetime of one peer, started
+by `status_overview` when a session definition asks for it:
+
+    shared:
+      use_status_overview: true
+      ota_pcap:
+        enabled: true
+
+    python3 -m com_py.ota_pcap --iface tun0 --out .../ota.pcap [--peer 10.254.0.37]
+
+WHAT IT ANSWERS THAT `link_trace.jsonl` CANNOT
+----------------------------------------------
+The link trace counts `/proc/net/dev` bytes per direction once a second, which
+localises loss to a *direction* and no further. It cannot say which fragment of
+which sample was lost, whether a retransmit followed, or how one sample's
+sub-messages were spaced on the wire. Those are the questions a header-only
+capture answers, at roughly 1 % of payload volume.
+
+It is passive and local: nothing is transmitted, so it costs no link capacity,
+and the interface is never put into promiscuous mode — everything of interest
+is addressed to or from this host, and promiscuous mode on a control-centre LAN
+port would collect other people's traffic. `CAP_NET_ADMIN`, which the
+originating issue assumed was needed, buys only that.
+
+WHY IT LIVES HERE AND NOT NEXT TO A RECORDER
+--------------------------------------------
+The first implementation of this sat beside the recording tool in the
+downstream project, and had to rebuild what this container already knows:
+which interface carries the link, and to which peer. `link_bytes` answers both
+from the peer's own OTA address — including the refusal that matters most, a
+loopback interface for a non-loopback address, which once read 28 Gbit/s next
+to a 6 Mbit/s link and survived a field session (#267). A capture that has to
+re-derive link knowledge is in the wrong place; this one asks the same
+resolution the status snapshot's own link block uses.
+
+It also needs no privilege here. This container already runs as root with
+`CAP_NET_RAW` in the default docker set, so the option adds no capability, no
+image change and no container.
+
+THE FILE
+--------
+`SOCK_DGRAM` rather than `SOCK_RAW`, which is what makes one code path work on
+both link types the fleet uses: a VPN `tun` device is layer 3 and has no
+link-layer header at all, while a LAN port is Ethernet. The kernel hands a
+`SOCK_DGRAM` packet socket the network-layer packet either way, plus the
+`sockaddr_ll` that says what the link layer was.
+
+That is exactly the input `LINKTYPE_LINUX_SLL` (113) is defined over, so the
+16-byte SLL pseudo-header is synthesized from the address tuple and the file
+reads in Wireshark, tshark and scapy without a hint. It carries the field the
+analysis is actually for: `pkttype` distinguishes PACKET_OUTGOING from
+PACKET_HOST, so **every packet in the file is labelled uplink or downlink** —
+which is the direction question the per-second counters answer only coarsely,
+and the one a direction-blind `LINKTYPE_RAW` capture would have thrown away.
+
+Timestamps come from the kernel (`SO_TIMESTAMPNS`), not from the moment python
+got round to the packet, and are written at microsecond resolution — the
+classic `0xa1b2c3d4` magic, because every reader takes it and a millisecond
+phenomenon does not need nanoseconds.
+
+HONESTY ABOUT WHAT IT MISSED
+----------------------------
+A capture that quietly drops packets is worse than none: the analysis would
+read the gap as radio loss. So `PACKET_STATISTICS` is read from the kernel and
+the sidecar `.json` reports `kernel_drops` next to `packets`. A non-zero drop
+count means this process fell behind, not that the link did.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import signal
+import socket
+import struct
+import sys
+import time
+from pathlib import Path
+
+#: Capture every ethertype; the protocol filter is applied below, on the
+#: network-layer header the kernel hands a SOCK_DGRAM packet socket.
+ETH_P_ALL = 0x0003
+
+ETH_P_IP = 0x0800
+ETH_P_IPV6 = 0x86DD
+IPPROTO_UDP = 17
+
+#: linux/if_packet.h. Only the outgoing one is load-bearing — it is what makes
+#: a packet uplink rather than downlink — but all five are written through so a
+#: reader sees what the kernel saw.
+PACKET_OUTGOING = 4
+
+SOL_PACKET = 263
+PACKET_STATISTICS = 6
+
+#: CPython does not export these on every build — 3.12 in the recorder image
+#: has neither, which cost the first capture its kernel timestamps and left it
+#: stamping packets when python got round to them. The numbers are the
+#: asm-generic ones every architecture the fleet runs uses, and `SCM_` shares
+#: the `SO_` value by definition (linux/socket.h).
+SO_TIMESTAMPNS = getattr(socket, "SO_TIMESTAMPNS", 35)
+SCM_TIMESTAMPNS = getattr(socket, "SCM_TIMESTAMPNS", 35)
+
+#: pcap, classic microsecond magic (LE). Every reader takes it.
+PCAP_MAGIC = 0xA1B2C3D4
+LINKTYPE_LINUX_SLL = 113
+
+#: `-s 96` in the issue: enough for the link, network, UDP and RTPS sub-message
+#: headers, and short of any payload.
+DEFAULT_SNAPLEN = 96
+
+#: Not part of the recorder's own disk budget, and deliberately far above what
+#: a drive produces: header-only at 500 packets/s is ~6 MB per minute, so a
+#: two-hour drive is well under a gigabyte. It exists to bound a mistake — a
+#: capture pointed at a busy control-centre LAN port — not to shape a drive.
+DEFAULT_MAX_MB = 2000
+
+#: 4 MiB of kernel socket buffer. The default is a few hundred kilobytes, which
+#: is where `kernel_drops` comes from on a burst.
+RCVBUF_BYTES = 4 << 20
+
+
+def log(message: str) -> None:
+    print(f"[ota_pcap] {message}", flush=True)
+
+
+# ------------------------------------------------------------------ the file
+
+
+def pcap_header(snaplen: int) -> bytes:
+    return struct.pack(
+        "<IHHiIII",
+        PCAP_MAGIC,
+        2,  # version_major
+        4,  # version_minor
+        0,  # thiszone: timestamps are UTC
+        0,  # sigfigs, as every writer leaves it
+        snaplen,
+        LINKTYPE_LINUX_SLL,
+    )
+
+
+def sll_header(pkttype: int, hatype: int, addr: bytes, protocol: int) -> bytes:
+    """The 16-byte pseudo-header LINKTYPE_LINUX_SLL is defined over.
+
+    Big-endian, unlike the pcap headers around it — that is the format, not an
+    oversight. `addr` is padded to the fixed 8 bytes and its true length is
+    written next to it, which is how a reader tells a 6-byte MAC from the empty
+    address a layer-3 tunnel has.
+    """
+    address = (addr or b"")[:8]
+    return struct.pack(
+        "!HHH8sH",
+        pkttype,
+        hatype,
+        len(address),
+        address.ljust(8, b"\0"),
+        protocol,
+    )
+
+
+def record_header(seconds: int, micros: int, incl_len: int, orig_len: int) -> bytes:
+    return struct.pack("<IIII", seconds, micros, incl_len, orig_len)
+
+
+# --------------------------------------------------------------- the filter
+
+
+def is_udp(protocol: int, packet: bytes) -> bool:
+    """UDP, judged from the network-layer header the packet socket handed us.
+
+    Both branches read a fixed offset of the header the kernel guarantees is
+    there, so a truncated or malformed packet is answered `False` rather than
+    raising inside the capture loop.
+
+    IPv4 fragments after the first carry no UDP header, and are still matched:
+    the protocol field is in the IP header of every fragment, which is what
+    keeps a fragmented sample whole in the file.
+    """
+    if protocol == ETH_P_IP:
+        return len(packet) > 9 and packet[9] == IPPROTO_UDP
+    if protocol == ETH_P_IPV6:
+        # Next Header. An extension-header chain would hide the UDP behind it;
+        # nothing on this link uses one, and guessing past it would be the kind
+        # of cleverness that silently drops traffic.
+        return len(packet) > 6 and packet[6] == IPPROTO_UDP
+    return False
+
+
+def addresses_of(protocol: int, packet: bytes) -> tuple[str, str] | None:
+    """Source and destination, for the optional peer filter."""
+    try:
+        if protocol == ETH_P_IP and len(packet) >= 20:
+            return (
+                socket.inet_ntop(socket.AF_INET, packet[12:16]),
+                socket.inet_ntop(socket.AF_INET, packet[16:20]),
+            )
+        if protocol == ETH_P_IPV6 and len(packet) >= 40:
+            return (
+                socket.inet_ntop(socket.AF_INET6, packet[8:24]),
+                socket.inet_ntop(socket.AF_INET6, packet[24:40]),
+            )
+    except (ValueError, OSError):
+        return None
+    return None
+
+
+def wanted(protocol: int, packet: bytes, peer: str | None) -> bool:
+    if not is_udp(protocol, packet):
+        return False
+    if peer is None:
+        return True
+    pair = addresses_of(protocol, packet)
+    return bool(pair) and peer in pair
+
+
+# ---------------------------------------------------------------- capturing
+
+
+def open_socket(iface: str) -> socket.socket:
+    """A non-promiscuous packet socket, bound to one interface.
+
+    `SOCK_DGRAM` normalises the two link types the fleet has — see the module
+    header. No `PACKET_ADD_MEMBERSHIP`, so the interface is never put into
+    promiscuous mode and only this host's own traffic is seen.
+    """
+    sock = socket.socket(socket.AF_PACKET, socket.SOCK_DGRAM, socket.htons(ETH_P_ALL))
+    try:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, RCVBUF_BYTES)
+    except OSError:  # a smaller buffer is a worse capture, not a broken one
+        pass
+    try:
+        sock.setsockopt(socket.SOL_SOCKET, SO_TIMESTAMPNS, 1)
+    except OSError:
+        log("WARN the kernel refused SO_TIMESTAMPNS — timestamps are taken in "
+            "userspace, so they carry this process's scheduling delay")
+    sock.bind((iface, ETH_P_ALL))
+    return sock
+
+
+def kernel_timestamp(ancdata) -> tuple[int, int] | None:
+    """(seconds, microseconds) out of SCM_TIMESTAMPNS, if the kernel sent it."""
+    for level, kind, data in ancdata:
+        if level == socket.SOL_SOCKET and kind == SCM_TIMESTAMPNS:
+            if len(data) >= 16:
+                seconds, nanos = struct.unpack("qq", data[:16])
+                return int(seconds), int(nanos) // 1000
+    return None
+
+
+def packet_statistics(sock: socket.socket) -> tuple[int, int]:
+    """(seen, dropped) since the last call — reading resets the counters."""
+    try:
+        raw = sock.getsockopt(SOL_PACKET, PACKET_STATISTICS, 8)
+    except OSError:
+        return 0, 0
+    seen, dropped = struct.unpack("II", raw)
+    return int(seen), int(dropped)
+
+
+class Capture:
+    """One pcap file, and the counts needed to trust it."""
+
+    def __init__(self, iface: str, out: Path, *, snaplen: int = DEFAULT_SNAPLEN,
+                 peer: str | None = None, max_bytes: int = DEFAULT_MAX_MB * 1000 * 1000):
+        self.iface = iface
+        self.out = out
+        self.snaplen = snaplen
+        self.peer = peer
+        self.max_bytes = max_bytes
+        self.packets = 0
+        self.bytes_written = 0
+        self.kernel_drops = 0
+        self.kernel_seen = 0
+        self.first_ts: float | None = None
+        self.last_ts: float | None = None
+        self.stopped_because = "signal"
+
+    def sidecar(self) -> dict:
+        """What the file is, and what it is missing. Written next to the pcap."""
+        return {
+            "interface": self.iface,
+            "snaplen": self.snaplen,
+            "linktype": "LINKTYPE_LINUX_SLL",
+            "filter": "udp" + (f" and host {self.peer}" if self.peer else ""),
+            "promiscuous": False,
+            "packets": self.packets,
+            "bytes": self.bytes_written,
+            # Packets the kernel dropped because this process fell behind. A
+            # non-zero value here is a gap in the FILE, not in the link, and
+            # any loss analysis has to subtract it rather than report it.
+            "kernel_drops": self.kernel_drops,
+            "kernel_seen": self.kernel_seen,
+            "first_timestamp": self.first_ts,
+            "last_timestamp": self.last_ts,
+            "stopped_because": self.stopped_because,
+        }
+
+    def run(self, stop: list) -> None:
+        sock = open_socket(self.iface)
+        packet_statistics(sock)  # zero the counters; the run owns them from here
+        ancillary = socket.CMSG_SPACE(16)
+        self.out.parent.mkdir(parents=True, exist_ok=True)
+        with open(self.out, "wb", buffering=1 << 20) as handle:
+            handle.write(pcap_header(self.snaplen))
+            self.bytes_written = 24
+            sock.settimeout(0.5)
+            while not stop:
+                try:
+                    packet, ancdata, _flags, address = sock.recvmsg(65535, ancillary)
+                except socket.timeout:
+                    continue
+                except OSError as error:
+                    log(f"WARN capture socket: {error}")
+                    self.stopped_because = f"socket error: {error}"
+                    break
+                # (ifname, protocol, pkttype, hatype, addr) — everything the
+                # SLL header needs, which is why SOCK_DGRAM is enough.
+                _name, protocol, pkttype, hatype, addr = address
+                if not wanted(protocol, packet, self.peer):
+                    continue
+                stamp = kernel_timestamp(ancdata)
+                if stamp is None:
+                    now = time.time()
+                    stamp = (int(now), int((now % 1) * 1_000_000))
+                body = sll_header(pkttype, hatype, addr, protocol) + packet
+                orig_len = len(body)
+                clipped = body[: self.snaplen]
+                handle.write(record_header(stamp[0], stamp[1], len(clipped), orig_len))
+                handle.write(clipped)
+                self.packets += 1
+                self.bytes_written += 16 + len(clipped)
+                seconds = stamp[0] + stamp[1] / 1_000_000
+                if self.first_ts is None:
+                    self.first_ts = seconds
+                self.last_ts = seconds
+                if self.bytes_written >= self.max_bytes:
+                    log(f"stopping at the {self.max_bytes // 1000 // 1000} MB ceiling "
+                        f"after {self.packets} packets — the recording is untouched")
+                    self.stopped_because = "size ceiling"
+                    break
+                if self.packets % 20000 == 0:
+                    self._collect(sock)
+        self._collect(sock)
+        sock.close()
+
+    def _collect(self, sock: socket.socket) -> None:
+        seen, dropped = packet_statistics(sock)
+        self.kernel_seen += seen
+        self.kernel_drops += dropped
+
+
+# --------------------------------------------------------------------- main
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Header-only UDP capture on one interface, written as pcap.")
+    parser.add_argument("--iface", required=True, help="interface to capture on")
+    parser.add_argument("--out", required=True, type=Path, help="pcap file to write")
+    parser.add_argument("--snaplen", type=int, default=DEFAULT_SNAPLEN,
+                        help=f"bytes kept per packet (default {DEFAULT_SNAPLEN})")
+    parser.add_argument("--peer", help="keep only packets to or from this address")
+    parser.add_argument("--max-mb", type=int, default=DEFAULT_MAX_MB,
+                        help=f"stop after this many MB (default {DEFAULT_MAX_MB})")
+    args = parser.parse_args(argv)
+
+    capture = Capture(args.iface, args.out, snaplen=args.snaplen, peer=args.peer,
+                      max_bytes=args.max_mb * 1000 * 1000)
+
+    stop: list = []
+    for name in (signal.SIGINT, signal.SIGTERM):
+        signal.signal(name, lambda *_: stop.append(True))
+
+    log(f"{args.iface} -> {args.out} (-s {args.snaplen}, udp"
+        f"{f' and host {args.peer}' if args.peer else ''})")
+    try:
+        capture.run(stop)
+    except PermissionError:
+        log("FAIL no permission to open a packet socket. Inside the recorder "
+            "container this should not happen — CAP_NET_RAW is in docker's "
+            "default set. Outside it, run as root.")
+        return 3
+    except OSError as error:
+        log(f"FAIL {error}")
+        return 3
+
+    sidecar = capture.sidecar()
+    args.out.with_suffix(".json").write_text(
+        json.dumps(sidecar, indent=2) + "\n", encoding="utf-8")
+    log(f"{sidecar['packets']} packets, {sidecar['bytes'] / 1e6:.1f} MB, "
+        f"{sidecar['kernel_drops']} dropped by the kernel")
+    if sidecar["kernel_drops"]:
+        log("WARN the kernel dropped packets: that is a gap in THIS FILE, not "
+            "on the link. Subtract it before reading any loss out of the pcap.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/rosotacom/resources/ws/ros2src/com_py/com_py/status_overview.py
+++ b/src/rosotacom/resources/ws/ros2src/com_py/com_py/status_overview.py
@@ -54,6 +54,9 @@
 from __future__ import annotations
 
 import os
+import signal
+import subprocess
+import sys
 import threading
 from typing import Dict, Optional
 
@@ -375,6 +378,14 @@ class StatusOverview(Node):
         # (the snapshot's `link` block is null).
         self.declare_parameter("ota_interface", "")
         self.declare_parameter("ota_local_ip", "")
+        # Header-only capture of the OTA link, beside the link trace. Off
+        # unless a session definition asks for it; it needs the same interface
+        # resolution as the link sampler above and nothing else.
+        self.declare_parameter("ota_pcap", False)
+        self.declare_parameter("ota_pcap_snaplen", 96)
+        self.declare_parameter("ota_pcap_max_mb", 2000)
+        self.declare_parameter("ota_pcap_peer_filter", True)
+        self.declare_parameter("ota_pcap_peer_ip", "")
         self.declare_parameter("link_trace", False)
         self.declare_parameter("link_trace_interval_s", 1.0)
         self.declare_parameter("link_trace_modem_command", "")
@@ -475,6 +486,10 @@ class StatusOverview(Node):
                     f"'{ota_interface}' ({provenance})"
                 )
 
+        self._pcap: Optional[subprocess.Popen] = None
+        if bool(self.get_parameter("ota_pcap").value):
+            self._start_ota_pcap(output_dir, ota_interface if link_sampler else "")
+
         link_trace_recorder = None
         if bool(self.get_parameter("link_trace").value):
             link_trace_path = os.path.join(output_dir, "link_trace.jsonl")
@@ -518,10 +533,88 @@ class StatusOverview(Node):
         ):
             executor.add_node(self._ota_observer)
 
+    def _start_ota_pcap(self, output_dir: str, interface: str) -> None:
+        """Begin the header-only capture, or say why there is none.
+
+        A separate process, not a thread: this node writes the status snapshot
+        every interval and is the thing an operator watches, so a capture that
+        misbehaves must not be able to reach it. It is still the same container
+        — no capability, no image and no `docker ps` line is added by the
+        option — which is the whole reason the capture lives here rather than
+        beside a recorder.
+
+        Never raises. The capture is a sidecar to the link, not a precondition
+        for it, and a session that cannot capture must still run.
+        """
+        if not interface:
+            # `ota_local_ip`/`ota_interface` are what resolve it, and the
+            # resolution above already said why it failed — including the
+            # loopback refusal, which is the failure worth repeating (#267).
+            self.get_logger().warning(
+                "status_overview: ota_pcap is enabled but no OTA interface was "
+                "resolved; capturing nothing. Set shared.ota_pcap only where "
+                "ota_local_ip resolves, and read the warning above for why."
+            )
+            return
+
+        path = os.path.join(output_dir, "ota.pcap")
+        argv = [
+            sys.executable, "-m", "com_py.ota_pcap",
+            "--iface", interface,
+            "--out", path,
+            "--snaplen", str(int(self.get_parameter("ota_pcap_snaplen").value)),
+            "--max-mb", str(int(self.get_parameter("ota_pcap_max_mb").value)),
+        ]
+        # Narrowed to the remote peer by default. On a VPN tunnel the whole
+        # device is the link and the filter changes nothing; on a LAN port it
+        # is the difference between the link and every other conversation the
+        # machine is having.
+        peer_ip = str(self.get_parameter("ota_pcap_peer_ip").value or "").strip()
+        if bool(self.get_parameter("ota_pcap_peer_filter").value) and peer_ip:
+            argv += ["--peer", peer_ip]
+
+        try:
+            self._pcap = subprocess.Popen(argv, start_new_session=True)
+        except OSError as exc:  # noqa: BLE001 - a sidecar may not stop a session
+            self.get_logger().warning(
+                f"status_overview: ota_pcap could not start ({exc}); "
+                "the session runs without a capture"
+            )
+            self._pcap = None
+            return
+        self.get_logger().info(
+            f"status_overview: ota_pcap capturing {interface} -> {path}"
+            + (f" (to/from {peer_ip})" if peer_ip and
+               bool(self.get_parameter("ota_pcap_peer_filter").value) else "")
+        )
+
+    def _stop_ota_pcap(self) -> None:
+        """SIGINT and wait, so the sidecar JSON and the drop counts are written.
+
+        Killed instead, the pcap on disk is still readable — it is written as
+        it goes — but `kernel_drops` never lands, and that is the one number
+        that separates a gap in the file from a gap on the link.
+        """
+        child, self._pcap = self._pcap, None
+        if child is None or child.poll() is not None:
+            return
+        try:
+            child.send_signal(signal.SIGINT)
+            child.wait(timeout=20.0)
+        except subprocess.TimeoutExpired:
+            child.kill()
+            try:
+                child.wait(timeout=5.0)
+            except subprocess.TimeoutExpired:
+                pass
+        except OSError:
+            pass
+
     def _on_write(self) -> None:
         self.aggregator.write()
 
     def shutdown(self) -> None:
+        self._stop_ota_pcap()
         if self._ota_executor is not None:
             try:
                 self._ota_executor.shutdown()

--- a/src/rosotacom/resources/ws/session/content/base/session_plugin_base.yaml
+++ b/src/rosotacom/resources/ws/session/content/base/session_plugin_base.yaml
@@ -71,6 +71,13 @@ parameters:
   link_trace_interval_s: 1.0
   link_trace_modem_command: ""
   link_trace_modem_timeout_s: 2.0
+  # Header-only capture of the OTA link (docs/ota-pcap.md). Off here, so a
+  # session that does not ask for it renders the same command line it always
+  # did; `shared.ota_pcap.enabled` is what turns it on.
+  ota_pcap: false
+  ota_pcap_snaplen: 96
+  ota_pcap_max_mb: 2000
+  ota_pcap_peer_filter: true
   metric_stage_bag: false
   metric_stage_topics:
 
@@ -427,6 +434,11 @@ windows:
             -p link_trace_interval_s:=${link_trace_interval_s}
             -p "link_trace_modem_command:='${link_trace_modem_command}'"
             -p link_trace_modem_timeout_s:=${link_trace_modem_timeout_s}
+            -p ota_pcap:=${ota_pcap}
+            -p ota_pcap_snaplen:=${ota_pcap_snaplen}
+            -p ota_pcap_max_mb:=${ota_pcap_max_mb}
+            -p ota_pcap_peer_filter:=${ota_pcap_peer_filter}
+            -p ota_pcap_peer_ip:=${ip_remote}
       - commands:
         - status_out_dir="$(dirname "${ROSOTACOM_CATMUX_LOG_DIR:-/tmp/rosotacom_logs/catmux}")/status"
         - status_txt="$status_out_dir/status.txt"

--- a/src/rosotacom/resources/ws/session/creation/generate_session_files.py
+++ b/src/rosotacom/resources/ws/session/creation/generate_session_files.py
@@ -1063,6 +1063,7 @@ def _validate_session_template_cfg(cfg: Dict[str, Any]) -> None:
                 "heartbeat",
                 "metric_backbone",
                 "link_trace",
+                "ota_pcap",
                 "use_in",
                 "use_out",
                 "rmw",
@@ -1134,6 +1135,27 @@ def _validate_session_template_cfg(cfg: Dict[str, Any]) -> None:
                     raise RuntimeError(
                         "shared.link_trace.modem_metrics_timeout_s must be a positive number if provided."
                     )
+
+        if "ota_pcap" in shared and shared["ota_pcap"] is not None:
+            ota_pcap = _assert_mapping(shared.get("ota_pcap"), "shared.ota_pcap")
+            _assert_allowed_keys(
+                "shared.ota_pcap",
+                ota_pcap,
+                {"enabled", "snaplen", "max_mb", "peer_filter"},
+            )
+            if "enabled" in ota_pcap and not isinstance(ota_pcap["enabled"], bool):
+                raise RuntimeError("shared.ota_pcap.enabled must be boolean if provided.")
+            if "peer_filter" in ota_pcap and not isinstance(ota_pcap["peer_filter"], bool):
+                raise RuntimeError("shared.ota_pcap.peer_filter must be boolean if provided.")
+            for key, low, high in (("snaplen", 40, 65535), ("max_mb", 1, 1_000_000)):
+                if key in ota_pcap and ota_pcap[key] is not None:
+                    value = ota_pcap[key]
+                    if not isinstance(value, int) or isinstance(value, bool) \
+                            or not (low <= value <= high):
+                        raise RuntimeError(
+                            f"shared.ota_pcap.{key} must be an integer between "
+                            f"{low} and {high} if provided."
+                        )
 
     # peer_settings is optional
     if "peer_settings" in cfg and cfg["peer_settings"] is not None:
@@ -2135,6 +2157,19 @@ def func(
     link_trace_modem_timeout_s = float(link_trace.get("modem_metrics_timeout_s", 2.0))
     if link_trace_enabled and not use_status_overview:
         raise RuntimeError("shared.link_trace.enabled requires shared.use_status_overview=true.")
+    ota_pcap = shared.get("ota_pcap", {}) or {}
+    if not isinstance(ota_pcap, dict):
+        raise RuntimeError("shared.ota_pcap must be a mapping if provided.")
+    ota_pcap_enabled = bool(ota_pcap.get("enabled", False))
+    ota_pcap_snaplen = int(ota_pcap.get("snaplen", 96))
+    ota_pcap_max_mb = int(ota_pcap.get("max_mb", 2000))
+    ota_pcap_peer_filter = bool(ota_pcap.get("peer_filter", True))
+    if ota_pcap_enabled and not use_status_overview:
+        # The capture is started by the status_overview node, which is also
+        # what resolves the OTA interface from the peer's own address — the
+        # resolution that refuses loopback (#267). Without it there is nothing
+        # to hang the capture on and no safe way to name an interface.
+        raise RuntimeError("shared.ota_pcap.enabled requires shared.use_status_overview=true.")
     shared_use_in = shared.get("use_in", None)
     shared_use_out = shared.get("use_out", None)
 
@@ -3167,6 +3202,16 @@ def func(
                             ("link_trace_modem_timeout_s", link_trace_modem_timeout_s),
                         ]
                         if link_trace_enabled
+                        else []
+                    )
+                    + (
+                        [
+                            ("ota_pcap", True),
+                            ("ota_pcap_snaplen", ota_pcap_snaplen),
+                            ("ota_pcap_max_mb", ota_pcap_max_mb),
+                            ("ota_pcap_peer_filter", ota_pcap_peer_filter),
+                        ]
+                        if ota_pcap_enabled
                         else []
                     ),
                 )

--- a/tests/contract/test_generated_topics_have_a_producer.py
+++ b/tests/contract/test_generated_topics_have_a_producer.py
@@ -321,7 +321,9 @@ NO_TOPIC = (
     r"in|out|use_zenoh_(rmw|ros2dds)",
     r"zen_.*",
     r"topic_monitor|tm_.*",
-    r"status_.*|link_trace.*|metric_stage_bag|network_monitor",
+    # The two link instruments write files, not topics: the trace's JSONL and
+    # the header-only capture's pcap both land in logs/<peer>/status/.
+    r"status_.*|link_trace.*|ota_pcap.*|metric_stage_bag|network_monitor",
     r"heartbeat|heartbeat_(out_hz|delay_bad_ms|loss3_bad_pct)",
     r"rs|lat|trickle|fb|comp|deco|otaw|otau|nor|drp|drp2|thr|ipx|it|irt|pace",
     r"lat_keepalive_hz|trickle_rate_hz",

--- a/tests/unit/test_ota_pcap.py
+++ b/tests/unit/test_ota_pcap.py
@@ -1,0 +1,308 @@
+"""The header-only OTA capture: its file, its filter, and its switch.
+
+Three layers, like the status overview it is started beside:
+  * the pcap a session produces, read back with a reader written from the pcap
+    and SLL specifications rather than from the writer's own constants;
+  * `shared.ota_pcap` validation in the session generator;
+  * that a session which does not ask for it renders the command line it
+    always did.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import socket
+import struct
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WS = REPO_ROOT / "src" / "rosotacom" / "resources" / "ws"
+WS_PY = WS / "ros2src" / "com_py"
+GENERATOR_PY = WS / "session" / "creation" / "generate_session_files.py"
+PLUGIN_BASE = WS / "session" / "content" / "base" / "session_plugin_base.yaml"
+sys.path.insert(0, str(WS_PY))
+
+from com_py import ota_pcap  # noqa: E402
+
+
+def _load_module(path: Path, name: str) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+generator = _load_module(GENERATOR_PY, "rosotacom_generate_session_files_pcap")
+
+
+# ---------------------------------------------------------------------------
+# the file
+# ---------------------------------------------------------------------------
+
+
+def read_pcap(raw: bytes) -> tuple[dict, list[dict]]:
+    """A reader written from the specifications, not from the writer."""
+    magic, major, minor, zone, sigfigs, snaplen, network = struct.unpack("<IHHiIII", raw[:24])
+    header = {
+        "magic": magic,
+        "version": (major, minor),
+        "zone": zone,
+        "sigfigs": sigfigs,
+        "snaplen": snaplen,
+        "network": network,
+    }
+    packets, offset = [], 24
+    while offset + 16 <= len(raw):
+        secs, usecs, incl, orig = struct.unpack("<IIII", raw[offset : offset + 16])
+        body = raw[offset + 16 : offset + 16 + incl]
+        pkttype, hatype, halen, addr, protocol = struct.unpack("!HHH8sH", body[:16])
+        packets.append(
+            {
+                "time": secs + usecs / 1e6,
+                "incl": incl,
+                "orig": orig,
+                "pkttype": pkttype,
+                "hatype": hatype,
+                "halen": halen,
+                "addr": addr[:halen],
+                "protocol": protocol,
+            }
+        )
+        offset += 16 + incl
+    return header, packets
+
+
+def test_the_file_is_a_microsecond_pcap_of_linux_cooked_packets() -> None:
+    header, packets = read_pcap(ota_pcap.pcap_header(96))
+    assert header["magic"] == 0xA1B2C3D4, "the classic magic; every reader takes it"
+    assert header["version"] == (2, 4)
+    assert header["snaplen"] == 96
+    assert header["network"] == 113, "LINKTYPE_LINUX_SLL — the one that carries direction"
+    assert packets == []
+
+
+def test_a_packet_keeps_its_direction_its_true_length_and_its_kernel_time() -> None:
+    """The three fields the analysis is for, through a writer/reader round trip.
+
+    Direction is the point: `link_trace.jsonl` gives per-second byte counters
+    per direction, and this gives it per packet.
+    """
+    body = ota_pcap.sll_header(ota_pcap.PACKET_OUTGOING, 65534, b"", ota_pcap.ETH_P_IP) + bytes(range(60))
+    clipped = body[:32]
+    raw = ota_pcap.pcap_header(32) + ota_pcap.record_header(1787297717, 8177, len(clipped), len(body)) + clipped
+
+    _header, packets = read_pcap(raw)
+    assert len(packets) == 1
+    packet = packets[0]
+    assert packet["pkttype"] == 4, "PACKET_OUTGOING: this one is uplink"
+    assert packet["orig"] == len(body), "the wire length survives the truncation"
+    assert packet["incl"] == 32
+    assert packet["protocol"] == 0x0800
+    assert packet["halen"] == 0, "a layer-3 tunnel has no link-layer address"
+    assert packet["time"] == pytest.approx(1787297717.008177)
+
+
+def test_an_ethernet_address_is_written_with_its_length_not_padded_into_it() -> None:
+    """The other link type the fleet has: a control centre's LAN port."""
+    mac = bytes.fromhex("001122334455")
+    raw = (
+        ota_pcap.pcap_header(96)
+        + ota_pcap.record_header(1, 0, 16, 16)
+        + ota_pcap.sll_header(0, 1, mac, ota_pcap.ETH_P_IP)
+    )
+    _header, packets = read_pcap(raw)
+    assert packets[0]["halen"] == 6
+    assert packets[0]["addr"] == mac
+    assert packets[0]["hatype"] == 1
+
+
+# ---------------------------------------------------------------------------
+# the filter
+# ---------------------------------------------------------------------------
+
+
+def ipv4(protocol: int, source: str = "10.254.0.32", dest: str = "10.254.0.37") -> bytes:
+    return bytes([0x45, 0, 0, 40, 0, 0, 0, 0, 64, protocol, 0, 0]) + socket.inet_aton(source) + socket.inet_aton(dest)
+
+
+def ipv6(next_header: int) -> bytes:
+    return (
+        bytes([0x60, 0, 0, 0, 0, 8, next_header, 64])
+        + socket.inet_pton(socket.AF_INET6, "fd00::1")
+        + socket.inet_pton(socket.AF_INET6, "fd00::2")
+    )
+
+
+@pytest.mark.parametrize(
+    "protocol, packet, expected",
+    [
+        (ota_pcap.ETH_P_IP, ipv4(17), True),
+        (ota_pcap.ETH_P_IP, ipv4(6), False),  # TCP
+        (ota_pcap.ETH_P_IP, ipv4(1), False),  # ICMP: a ping is not the link
+        (ota_pcap.ETH_P_IPV6, ipv6(17), True),
+        (ota_pcap.ETH_P_IPV6, ipv6(58), False),  # ICMPv6
+        (0x0806, b"\x00" * 40, False),  # ARP is not IP at all
+        (ota_pcap.ETH_P_IP, b"\x45\x00", False),  # truncated: answered, not raised
+    ],
+)
+def test_only_udp_over_ip_is_kept(protocol: int, packet: bytes, expected: bool) -> None:
+    assert ota_pcap.is_udp(protocol, packet) is expected
+
+
+def test_a_later_ipv4_fragment_is_kept_although_it_carries_no_udp_header() -> None:
+    """The protocol field is in every fragment's IP header, which is what keeps
+    a fragmented sample whole in the file rather than only its first piece —
+    and fragments are exactly what this capture exists to see."""
+    fragment = bytearray(ipv4(17))
+    fragment[6:8] = (0x00B9).to_bytes(2, "big")  # offset 185, MF clear
+    assert ota_pcap.is_udp(ota_pcap.ETH_P_IP, bytes(fragment)) is True
+
+
+def test_the_peer_filter_matches_either_direction_and_nothing_else() -> None:
+    up = ipv4(17, "10.254.0.32", "10.254.0.37")
+    down = ipv4(17, "10.254.0.37", "10.254.0.32")
+    elsewhere = ipv4(17, "10.254.0.32", "10.254.0.39")
+    assert ota_pcap.wanted(ota_pcap.ETH_P_IP, up, "10.254.0.37") is True
+    assert ota_pcap.wanted(ota_pcap.ETH_P_IP, down, "10.254.0.37") is True
+    assert ota_pcap.wanted(ota_pcap.ETH_P_IP, elsewhere, "10.254.0.37") is False
+    assert ota_pcap.wanted(ota_pcap.ETH_P_IP, elsewhere, None) is True
+
+
+def test_the_sidecar_separates_a_gap_in_the_file_from_a_gap_on_the_link() -> None:
+    """`kernel_drops` is the number that keeps a slow capture from being read
+    as radio loss months later, which is the failure this whole artifact would
+    otherwise invite."""
+    capture = ota_pcap.Capture("tun0", Path("/tmp/x.pcap"), peer="10.254.0.37")
+    capture.kernel_drops = 12
+    report = capture.sidecar()
+    assert report["kernel_drops"] == 12
+    assert report["filter"] == "udp and host 10.254.0.37"
+    assert report["promiscuous"] is False, "this host's own traffic, never anyone else's"
+    assert report["linktype"] == "LINKTYPE_LINUX_SLL"
+
+
+def test_the_capture_needs_nothing_that_is_not_in_the_communication_image() -> None:
+    """It runs inside the peer's container, which is not rebuilt for it."""
+    import ast
+
+    tree = ast.parse((WS_PY / "com_py" / "ota_pcap.py").read_text(encoding="utf-8"))
+    imported = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.update(alias.name.split(".")[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module and node.level == 0:
+            imported.add(node.module.split(".")[0])
+    assert imported <= set(sys.stdlib_module_names), sorted(imported - set(sys.stdlib_module_names))
+
+
+# ---------------------------------------------------------------------------
+# the switch
+# ---------------------------------------------------------------------------
+
+
+def _cfg(**ota_pcap_block) -> dict:
+    cfg = {
+        "peers": {"a": {}, "b": {}},
+        "shared": {"use_status_overview": True, "use_heartbeat": True},
+        "topics": {"a_to_b": [{"topic": "/chatter", "type": "std_msgs/msg/String"}]},
+    }
+    if ota_pcap_block:
+        cfg["shared"]["ota_pcap"] = ota_pcap_block
+    return cfg
+
+
+def _generate(cfg: dict, output_dir: Path) -> None:
+    generator.func(
+        session_config_obj=cfg,
+        output_dir=str(output_dir),
+        force=True,
+        peer_addresses={"a": "127.0.0.1", "b": "127.0.0.2"},
+    )
+
+
+def test_a_session_that_does_not_ask_for_it_renders_what_it_always_did(tmp_path: Path) -> None:
+    """The sentence that makes the option safe to carry through a demo week.
+
+    Asserted by rendering both and diffing, not by looking for a string: the
+    off case emits nothing named `ota_pcap` at all, so a substring test would
+    pass whatever the generator did.
+    """
+    off, on = tmp_path / "off", tmp_path / "on"
+    _generate(_cfg(), off)
+    _generate(_cfg(enabled=True), on)
+
+    def rendered(root: Path) -> dict[str, str]:
+        return {
+            str(path.relative_to(root)): path.read_text(encoding="utf-8").replace(str(root), "<DIR>")
+            for path in sorted(root.rglob("*"))
+            if path.is_file()
+        }
+
+    without, with_capture = rendered(off), rendered(on)
+    assert set(without) == set(with_capture), "the same files, either way"
+    changed = [name for name in without if without[name] != with_capture[name]]
+    assert changed == ["a/plugin.yaml", "b/plugin.yaml"], changed
+
+    for name in changed:
+        added = [line.strip() for line in with_capture[name].splitlines() if line not in without[name].splitlines()]
+        assert all(line.startswith("ota_pcap") for line in added), added
+
+
+def test_enabling_it_carries_the_four_values_into_the_peer(tmp_path: Path) -> None:
+    _generate(_cfg(enabled=True, snaplen=128, max_mb=500, peer_filter=False), tmp_path)
+    found = [p for p in sorted(tmp_path.rglob("*.yaml")) if "ota_pcap" in p.read_text(encoding="utf-8").lower()]
+    assert found, "the generated session names the capture somewhere"
+    blob = "\n".join(p.read_text(encoding="utf-8") for p in found)
+    assert "ota_pcap: true" in blob.lower()
+    assert "128" in blob and "500" in blob
+
+
+@pytest.mark.parametrize(
+    "block, reason",
+    [
+        ({"enabled": "yes"}, "enabled must be boolean"),
+        ({"peer_filter": 1}, "peer_filter must be boolean"),
+        ({"snaplen": 0}, "snaplen below the floor"),
+        ({"snaplen": 99999}, "snaplen above a jumbo frame"),
+        ({"snaplen": True}, "a bool is not a snaplen"),
+        ({"max_mb": 0}, "a ceiling of nothing"),
+        ({"unknown": 1}, "an unknown key is a typo, not a feature"),
+    ],
+)
+def test_a_malformed_block_is_refused_when_the_session_is_read(block, reason) -> None:
+    with pytest.raises(RuntimeError):
+        generator._validate_session_template_cfg(_cfg(**block)), reason
+
+
+def test_it_requires_the_node_that_starts_it() -> None:
+    """The capture is started by `status_overview`, which is also what resolves
+    the OTA interface from the peer's own address — including the loopback
+    refusal (#267). Without it there is nothing to hang the capture on."""
+    cfg = _cfg(enabled=True)
+    cfg["shared"]["use_status_overview"] = False
+    with pytest.raises(RuntimeError, match="use_status_overview"):
+        _generate(cfg, Path("/tmp/unused"))
+
+
+def test_the_template_defaults_it_off() -> None:
+    """A parameter that defaults on would capture packets for every rosotacom
+    user who never asked. The switch is the session definition, not the base."""
+    base = yaml.safe_load(PLUGIN_BASE.read_text(encoding="utf-8"))
+    assert base["parameters"]["ota_pcap"] is False
+    assert base["parameters"]["ota_pcap_snaplen"] == ota_pcap.DEFAULT_SNAPLEN
+    assert base["parameters"]["ota_pcap_max_mb"] == ota_pcap.DEFAULT_MAX_MB
+
+
+def test_the_node_is_handed_the_remote_peers_address_to_narrow_the_capture() -> None:
+    """On a VPN tunnel the whole device is the link and the filter changes
+    nothing; on a LAN port it is the difference between the link and every
+    other conversation the machine is having."""
+    text = PLUGIN_BASE.read_text(encoding="utf-8")
+    assert "-p ota_pcap_peer_ip:=${ip_remote}" in text


### PR DESCRIPTION
Adds an opt-in, header-only packet capture of the OTA link, written beside `link_trace.jsonl` by the same node.

```yaml
shared:
  use_status_overview: true
  ota_pcap:
    enabled: true
```

**What it answers.** The link trace counts `/proc/net/dev` bytes per direction once a second, which localises loss to a *direction* and no further — not which fragment was lost, whether a retransmit followed, or how one sample's sub-messages were spaced. This does, at roughly 1 % of payload volume.

**Off is unchanged.** A session definition without the block renders the same peer files it always did. The test asserts that by rendering both and diffing, not by looking for a string: the off case emits nothing named `ota_pcap` at all, so a substring test would pass whatever the generator did.

**Nothing is added to run it.** The communication container already runs as root with `CAP_NET_RAW` in docker's default set — no `--cap-add`, no image change, no rebuild, no extra container. `CAP_NET_ADMIN` is not taken: it buys promiscuous mode, which a passive capture of this host's own traffic must not have.

**Why here.** A capture started downstream has to rebuild what this container already knows — which interface carries the link, and to which peer — and would rebuild it without the refusal that matters: `resolve_link_interface` declines a loopback interface for a non-loopback address (#267, where `lo` read ~28 Gbit/s next to a 6 Mbit/s link and survived a field session). This asks the same resolution the status snapshot's own link block uses.

**The file.** `SOCK_DGRAM` + `LINKTYPE_LINUX_SLL`, so one code path works on a layer-3 `tun` device and on an Ethernet port, and every packet carries `sll.pkttype` — uplink or downlink per packet. Kernel timestamps, microsecond magic, snaplen 96. `ota.json` reports `kernel_drops`, which is a gap in the *file* rather than on the link and has to be subtracted before any loss is read out of the capture.

Docs: `docs/ota-pcap.md`, linked from the README next to the link trace.