### PR TITLE
Say which processing stages belong to this project (#325)

### DIFF
--- a/terminology.md
+++ b/terminology.md
@@ -305,6 +305,9 @@ Notes:
 - Preprocessing/postprocessing are just processing stages applied at different points:
   - outbound: native → processed (optional)
   - inbound: processed → native (optional)
+- Being postprocessing does **not** by itself make a transformation a processing
+  stage of this project. Which transformations belong here is decided by
+  §9.1, not by where or when they run.
 
 ---
 
@@ -322,6 +325,57 @@ Example: `/com/out/A/to_B/sensors/camera/image_raw/restamped/max20hz/bz2`
 ---
 
 ## 9. Module responsibilities
+
+### 9.1 Stage ownership (which transformations belong to this project)
+
+A **processing stage** (§7) belongs to this project when it either
+
+1. **undoes a stage this project applied** — decompression undoes compression,
+   the OTA unwrapper undoes the OTA wrapper, `global_to_local` undoes
+   `local_to_global`, `trickle` undoes `latch`; or
+2. **compensates for the medium** — the playout pacer against the arrival
+   jitter a link introduces.
+
+Everything else that happens to a stream after the inbound native topic
+belongs to whoever consumes it, and is that consumer's code in that
+consumer's repository. The inbound native topic (§3) is where this project's
+canonical lifecycle ends, and stage ownership ends with it.
+
+**Two criteria that do not decide it**, because both are true of stages on
+either side:
+
+- *Where it runs.* Decompression, the unwrapper, `trickle` and the pacer all
+  run at the receiving peer. So does an application transform that has nothing
+  to do with the link.
+- *That it is postprocessing.* §3 names inbound postprocessing as part of the
+  lifecycle, so the word describes a position, not an owner.
+
+`trickle` is the stage that makes the boundary feel ambiguous, and rule 1
+resolves it. It can be read as a fix for a consumer that expects a periodic
+stream — but the question is not what it is good for, it is why the value was
+latched in the first place: repeating a state at a fixed rate over a metered
+link is waste, so latching is a link decision and `trickle` is its inverse.
+Without the link there would be nothing to un-latch.
+
+**The quick test is a counterfactual.** Change the *link* — other radio, other
+route, other codec — and ask whether the stage has to change; then change the
+*consumer* — other display, other viewer, an automated pipeline instead of a
+person — and ask the same. A stage that survives every link change and breaks
+on a consumer change is the consumer's.
+
+**The falsifiable test, for cases the counterfactual leaves open.** A stage
+here becomes part of the session contract, so it must carry an `expect:` the
+harness can assert. If no `hz`, `loss_pct`, `latency_ms` or
+`completeness.vs_bag_ratio` on that stage would mean anything, the contract
+cannot check it — and a stage the contract cannot check does not belong in the
+contract.
+
+This is about **stages, not about code**. A generic operation — resampling an
+image, filtering a point cloud — may live here as a reusable node the day a
+second session needs it. What must not move here is the decision that a
+particular consumer wants a particular result.
+
+---
 
 ### App Relay
 The **App Relay** (application relay) maps between application topics and com topics.

--- a/tests/unit/test_terminology_stage_ownership.py
+++ b/tests/unit/test_terminology_stage_ownership.py
@@ -1,0 +1,103 @@
+"""The stage-ownership rule in `terminology.md` §9.1, against the code.
+
+The rule is normative — it decides what may be added to this project — and it
+argues from concrete pairs: decompression undoes compression, the unwrapper
+undoes the wrapper, `global_to_local` undoes `local_to_global`, `trickle`
+undoes `latch`, and the playout pacer compensates for the medium. A rule that
+reasons from examples is only as good as the examples, and a renamed node
+leaves it quietly arguing from things that are not there any more.
+
+This is a documentation test, not a behaviour test: there is no behaviour to
+run. What it pins is that every node the rule names still exists, that the two
+tests it offers still name assertions the session schema accepts, and that the
+section it belongs to is still where §7 sends the reader.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TERMINOLOGY = REPO_ROOT / "terminology.md"
+COM_PY = REPO_ROOT / "src" / "rosotacom" / "resources" / "ws" / "ros2src" / "com_py" / "com_py"
+STATUS_EVAL = REPO_ROOT / "src" / "rosotacom" / "status_eval.py"
+GENERATOR_PY = (
+    REPO_ROOT / "src" / "rosotacom" / "resources" / "ws" / "session" / "creation" / "generate_session_files.py"
+)
+
+#: The nodes §9.1 argues from, as module names in `com_py`.
+CITED_NODES = (
+    "universal_compressor",
+    "universal_decompressor",
+    "universal_ota_wrapper",
+    "universal_ota_unwrapper",
+    "local_global_frame_bridge",
+    "trickle",
+    "playout_pacer",
+)
+
+#: The processing keys §9.1's inverse pairs are stated in. A session has to
+#: still be able to declare each of them, or the pair argues from nothing.
+CITED_STAGE_KEYS = ("latch", "local_to_global", "global_to_local")
+
+#: The assertion keys §9.1 offers as its falsifiable test. They are only a
+#: test if a session may actually declare them, so each is checked against the
+#: evaluator that reads them. `vs_bag_ratio` sits under `completeness` and is
+#: named that way in the text for the same reason.
+CITED_EXPECTATIONS = ("hz", "loss_pct", "latency_ms", "completeness.vs_bag_ratio")
+
+
+#: `## 9.` and `### App Relay` are both headings, so a section has to run to
+#: the next heading of its own level or higher, not to the next heading.
+def section(title: str) -> str:
+    """The text of one `terminology.md` section, up to the next peer heading."""
+    text = TERMINOLOGY.read_text(encoding="utf-8")
+    match = re.search(
+        rf"^(#+) {re.escape(title)}\s*$",
+        text,
+        re.MULTILINE,
+    )
+    assert match is not None, f"terminology.md has no section '{title}'"
+    depth = len(match.group(1))
+    rest = text[match.end() :]
+    end = re.search(rf"^#{{1,{depth}}} ", rest, re.MULTILINE)
+    return rest[: end.start()] if end else rest
+
+
+def test_the_rule_is_where_the_stage_definition_sends_the_reader():
+    # §7 defers the ownership question rather than answering it twice.
+    assert "§9.1" in section("7. Processing and transformations")
+    assert section("9.1 Stage ownership (which transformations belong to this project)")
+
+
+def test_every_node_the_rule_argues_from_still_exists():
+    missing = [name for name in CITED_NODES if not (COM_PY / f"{name}.py").is_file()]
+
+    assert not missing, f"terminology.md §9.1 cites nodes that are gone: {missing}"
+
+
+def test_the_stage_keywords_the_rule_argues_from_are_still_session_vocabulary():
+    # The rule reasons from inverse pairs, so it breaks quietly when a session
+    # key is renamed: the prose keeps arguing from a `latch` or a
+    # `local_to_global` that no definition can declare any more.
+    body = section("9.1 Stage ownership (which transformations belong to this project)")
+    generator = GENERATOR_PY.read_text(encoding="utf-8")
+
+    for key in CITED_STAGE_KEYS:
+        assert f"`{key}`" in body, f"§9.1 no longer argues from '{key}'"
+        assert f'"{key}"' in generator, (
+            f"§9.1 argues from '{key}', which the session generator no longer knows as a processing key"
+        )
+
+
+def test_the_falsifiable_test_names_assertions_a_session_may_declare():
+    body = section("9.1 Stage ownership (which transformations belong to this project)")
+    evaluator = STATUS_EVAL.read_text(encoding="utf-8")
+
+    for key in CITED_EXPECTATIONS:
+        assert f"`{key}`" in body, f"§9.1 no longer offers '{key}'"
+        for part in key.split("."):
+            assert f'"{part}"' in evaluator, (
+                f"§9.1 offers '{key}' as an expectation, but status_eval does not know '{part}'"
+            )


### PR DESCRIPTION
Closes #325.

`terminology.md` §7 defines a processing stage and §9 defines the two modules,
but neither said which side of the repository boundary a given stage belongs
on — and the two criteria that look like they should decide it do not:

- *runs at the receiver* is true of `universal_decompressor`,
  `universal_ota_unwrapper`, `trickle` and `playout_pacer` alike;
- *is postprocessing* is a position in the §3 lifecycle, not an owner.

So an application transform that happens to run at the receiver reads as if it
belongs here.

## The rule (new §9.1)

A stage is this project's when it either **undoes one of this project's own** —
decompress/compress, unwrapper/wrapper, `global_to_local`/`local_to_global`,
`trickle`/`latch` — or **compensates for the medium**, as `playout_pacer` does
for arrival jitter. Everything after the inbound native topic belongs to
whoever consumes it.

`trickle` is the case that makes the boundary feel ambiguous. It can be read as
a fix for a consumer that wants a periodic stream; what settles it is why the
value was latched at all — repeating a state at a fixed rate over a metered
link is waste, so latching is a link decision and `trickle` is its inverse.

Two tests come with it. The **counterfactual**: change the link, then change
the consumer, and see which one forces the stage to change. The
**falsifiable** one, for what the first leaves open: a stage here joins the
session contract, so it must carry an `expect:` the harness can assert — and a
stage on which no `hz`, `loss_pct`, `latency_ms` or
`completeness.vs_bag_ratio` would mean anything is one the contract cannot
check.

The rule is about stages, not code: a generic operation may live here the day a
second session needs it. What must not move here is the decision that a
particular consumer wants a particular result.

## Where it came from

A consumer needed its delivered camera republished at its display's aspect
ratio. It is postprocessing, it runs at the receiver, and it would have been
easy to add as a session stage — but it undoes nothing this project did (the
camera had that ratio at the sensor) and compensates for a monitor. It became
the consumer's node. Writing the rule down is what makes that answerable
without re-deriving it.

## Validation

Documentation only, so what is verified is that the rule keeps arguing from
things that exist (`tests/unit/test_terminology_stage_ownership.py`):

- every node §9.1 cites is still a module in `com_py`;
- every processing key in its inverse pairs (`latch`, `local_to_global`,
  `global_to_local`) is still one `generate_session_files.py` accepts;
- every assertion in its falsifiable test is still one `status_eval` reads;
- §7 still sends the reader to §9.1 rather than answering it twice.

Each of the four was checked by breaking it and watching the test fail.

```
just lint        All checks passed / 97 files already formatted
just typecheck   Success: no issues found in 25 source files
just test-unit   918 passed, 1 failed
```

The one failure is `test_catmux_pane_logging.py::test_the_hook_is_installed_once_even_if_sourced_twice`,
which fails identically on `origin/develop` with this branch stashed — it reads
`PROMPT_COMMAND` out of a sourced shell and is environment-dependent. Unrelated
to this change and not touched here.