### PR TITLE
Open the socket as root, because containeruser cannot

### DIFF
--- a/README.md
+++ b/README.md
@@ -644,7 +644,8 @@ is which fragment was lost, whether a retransmit followed, or how one sample's
 sub-messages were spaced, enable the [header-only OTA capture](docs/ota-pcap.md)
 next to them — `shared.ota_pcap.enabled`, off by default, roughly 1 % of payload
 volume, and every packet labelled uplink or downlink. It needs no capability,
-no image change and no extra container.
+no image change and no extra container — only the passwordless sudo the
+container already has, and only until its socket is open.
 
 Convert a recorded link trace into a profiles-file entry when you want to replay
 the same drive conditions in a repeatable benchmark:

--- a/docs/ota-pcap.md
+++ b/docs/ota-pcap.md
@@ -110,9 +110,25 @@ runs on. `shared.ota_pcap.enabled` therefore requires
 
 ## Privilege, containers, and what the option costs
 
-Nothing is added. The communication container already runs as root with
-`CAP_NET_RAW` in docker's default set, so the capture needs no `--cap-add`, no
-image change, no rebuild and no extra container in `docker ps`.
+No image change, no rebuild, no added capability and no extra container in
+`docker ps`. What it does need is `sudo`, and only until the socket is open.
+
+ros2docker's entrypoint runs this container's processes as `containeruser`,
+whose `CapEff` is `0000000000000000`. A non-root process cannot open an
+`AF_PACKET` socket however the container was started, so `--cap-add NET_RAW`
+would buy nothing. `containeruser` does have passwordless sudo here — the NET
+pane's `sudo iftop` already depends on it — so the capture is launched through
+it, and `--drop-to` hands the process back to `containeruser` the moment the
+socket exists. The pcap therefore belongs to the same user as
+`link_trace.jsonl` beside it, rather than to root.
+
+Two earlier attempts at this assumed root from a `docker run` that bypassed the
+entrypoint, and were wrong in the same way both times. If you change this,
+check the **running** container:
+
+```bash
+docker exec <com-container> bash -lc 'id; grep CapEff /proc/self/status'
+```
 
 `CAP_NET_ADMIN` is *not* taken and is not needed: it buys promiscuous mode,
 which this capture deliberately does not use. Everything of interest is

--- a/src/rosotacom/resources/ws/ros2src/com_py/com_py/ota_pcap.py
+++ b/src/rosotacom/resources/ws/ros2src/com_py/com_py/ota_pcap.py
@@ -35,9 +35,22 @@ to a 6 Mbit/s link and survived a field session (#267). A capture that has to
 re-derive link knowledge is in the wrong place; this one asks the same
 resolution the status snapshot's own link block uses.
 
-It also needs no privilege here. This container already runs as root with
-`CAP_NET_RAW` in the default docker set, so the option adds no capability, no
-image change and no container.
+WHAT IT NEEDS, MEASURED RATHER THAN ASSUMED
+-------------------------------------------
+`sudo`, and only until the socket is open. ros2docker's entrypoint runs this
+container's processes as `containeruser`, whose `CapEff` is
+0000000000000000 — a non-root process cannot open an `AF_PACKET` socket
+however the container was started, so `--cap-add` buys nothing. `containeruser`
+does have passwordless sudo here, which the NET pane's `sudo iftop` already
+relies on, so the capture is launched through it and `--drop-to` hands the
+process back to `containeruser` the moment the socket exists. The pcap in
+`logs/<peer>/status/` therefore belongs to the same user as `link_trace.jsonl`
+beside it.
+
+That is the whole cost: no image change, no rebuild, no added capability and no
+extra container. Two earlier attempts at this assumed root from a `docker run`
+that bypassed the entrypoint, and both were wrong in the same way — check the
+*running* container, not the image.
 
 THE FILE
 --------
@@ -72,6 +85,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import signal
 import socket
 import struct
@@ -240,6 +254,40 @@ def open_socket(iface: str) -> socket.socket:
     return sock
 
 
+def drop_privileges(spec: str | None) -> str | None:
+    """Hand the process back to the user that started it.
+
+    The capture is launched through `sudo` — see the module header — because a
+    non-root process cannot open an `AF_PACKET` socket. Nothing after that call
+    needs root, and the artifacts in `logs/<peer>/status/` belong to
+    `containeruser` like `link_trace.jsonl` beside them: a root-owned file in
+    that directory is a `sudo rm` waiting to happen months later, and
+    `gather_drive.py` would copy it without noticing.
+
+    `spec` is "uid:gid". An argument rather than an environment variable
+    because sudo does not pass the environment through. Returns what it did, or
+    None when there was nothing to do.
+    """
+    if not spec:
+        return None
+    try:
+        uid_text, _, gid_text = spec.partition(":")
+        uid, gid = int(uid_text), int(gid_text or uid_text)
+    except ValueError:
+        log(f"WARN --drop-to {spec!r} is not uid:gid — staying as I am")
+        return None
+    if os.geteuid() != 0:
+        return None
+    try:
+        os.setgroups([])
+        os.setgid(gid)
+        os.setuid(uid)
+    except OSError as error:
+        log(f"WARN could not drop to {uid}:{gid} ({error}) — the file will be root's")
+        return None
+    return f"{uid}:{gid}"
+
+
 def kernel_timestamp(ancdata) -> tuple[int, int] | None:
     """(seconds, microseconds) out of SCM_TIMESTAMPNS, if the kernel sent it."""
     for level, kind, data in ancdata:
@@ -264,7 +312,9 @@ class Capture:
     """One pcap file, and the counts needed to trust it."""
 
     def __init__(self, iface: str, out: Path, *, snaplen: int = DEFAULT_SNAPLEN,
-                 peer: str | None = None, max_bytes: int = DEFAULT_MAX_MB * 1000 * 1000):
+                 peer: str | None = None, max_bytes: int = DEFAULT_MAX_MB * 1000 * 1000,
+                 drop_to: str | None = None):
+        self.drop_to = drop_to
         self.iface = iface
         self.out = out
         self.snaplen = snaplen
@@ -300,6 +350,10 @@ class Capture:
 
     def run(self, stop: list) -> None:
         sock = open_socket(self.iface)
+        # Root was needed for that one call and for nothing after it.
+        dropped = drop_privileges(self.drop_to)
+        if dropped:
+            log(f"privileges dropped to {dropped}; the socket stays open")
         packet_statistics(sock)  # zero the counters; the run owns them from here
         ancillary = socket.CMSG_SPACE(16)
         self.out.parent.mkdir(parents=True, exist_ok=True)
@@ -365,10 +419,13 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--peer", help="keep only packets to or from this address")
     parser.add_argument("--max-mb", type=int, default=DEFAULT_MAX_MB,
                         help=f"stop after this many MB (default {DEFAULT_MAX_MB})")
+    parser.add_argument("--drop-to", metavar="UID:GID",
+                        help="give root back once the socket is open, so the pcap "
+                             "belongs to the user that started the session")
     args = parser.parse_args(argv)
 
     capture = Capture(args.iface, args.out, snaplen=args.snaplen, peer=args.peer,
-                      max_bytes=args.max_mb * 1000 * 1000)
+                      max_bytes=args.max_mb * 1000 * 1000, drop_to=args.drop_to)
 
     stop: list = []
     for name in (signal.SIGINT, signal.SIGTERM):
@@ -379,9 +436,10 @@ def main(argv: list[str] | None = None) -> int:
     try:
         capture.run(stop)
     except PermissionError:
-        log("FAIL no permission to open a packet socket. Inside the recorder "
-            "container this should not happen — CAP_NET_RAW is in docker's "
-            "default set. Outside it, run as root.")
+        log("FAIL no permission to open a packet socket. This is meant to run "
+            "through `sudo` from inside the communication container, where "
+            "containeruser has passwordless sudo; a non-root process cannot "
+            "open AF_PACKET whatever capabilities the container was given.")
         return 3
     except OSError as error:
         log(f"FAIL {error}")

--- a/src/rosotacom/resources/ws/ros2src/com_py/com_py/status_overview.py
+++ b/src/rosotacom/resources/ws/ros2src/com_py/com_py/status_overview.py
@@ -564,6 +564,9 @@ class StatusOverview(Node):
             "--out", path,
             "--snaplen", str(int(self.get_parameter("ota_pcap_snaplen").value)),
             "--max-mb", str(int(self.get_parameter("ota_pcap_max_mb").value)),
+            # Root opens the socket; this hands it straight back, so the pcap
+            # belongs to the same user as link_trace.jsonl beside it.
+            "--drop-to", f"{os.getuid()}:{os.getgid()}",
         ]
         # Narrowed to the remote peer by default. On a VPN tunnel the whole
         # device is the link and the filter changes nothing; on a LAN port it
@@ -572,6 +575,16 @@ class StatusOverview(Node):
         peer_ip = str(self.get_parameter("ota_pcap_peer_ip").value or "").strip()
         if bool(self.get_parameter("ota_pcap_peer_filter").value) and peer_ip:
             argv += ["--peer", peer_ip]
+
+        # An `AF_PACKET` socket needs root, and this node is `containeruser`:
+        # its `CapEff` is zero, so no `--cap-add` on the container would help.
+        # `containeruser` has passwordless sudo here — the NET pane's
+        # `sudo iftop` already depends on it — so the capture goes through it
+        # and gives root back as soon as the socket exists. Where there is no
+        # sudo (this module run somewhere else, or already as root) the plain
+        # command is tried instead rather than refused.
+        if os.geteuid() != 0 and self._sudo_available():
+            argv = ["sudo", "-n", *argv]
 
         try:
             self._pcap = subprocess.Popen(argv, start_new_session=True)
@@ -588,6 +601,16 @@ class StatusOverview(Node):
                bool(self.get_parameter("ota_pcap_peer_filter").value) else "")
         )
 
+    @staticmethod
+    def _sudo_available() -> bool:
+        """Can this process become root without being asked for a password?"""
+        try:
+            return subprocess.run(
+                ["sudo", "-n", "true"], capture_output=True, timeout=5.0
+            ).returncode == 0
+        except (OSError, subprocess.SubprocessError):
+            return False
+
     def _stop_ota_pcap(self) -> None:
         """SIGINT and wait, so the sidecar JSON and the drop counts are written.
 
@@ -599,7 +622,15 @@ class StatusOverview(Node):
         if child is None or child.poll() is not None:
             return
         try:
-            child.send_signal(signal.SIGINT)
+            # Through sudo the child is root, so an ordinary kill would be
+            # refused; `sudo -n kill` is how a non-root parent signals it.
+            # SIGINT and not SIGTERM, because SIGINT is what makes the capture
+            # write ota.json on the way out.
+            if os.geteuid() != 0:
+                subprocess.run(["sudo", "-n", "kill", "-INT", str(child.pid)],
+                               capture_output=True, timeout=5.0)
+            else:
+                child.send_signal(signal.SIGINT)
             child.wait(timeout=20.0)
         except subprocess.TimeoutExpired:
             child.kill()

--- a/tests/unit/test_ota_pcap.py
+++ b/tests/unit/test_ota_pcap.py
@@ -306,3 +306,52 @@ def test_the_node_is_handed_the_remote_peers_address_to_narrow_the_capture() -> 
     other conversation the machine is having."""
     text = PLUGIN_BASE.read_text(encoding="utf-8")
     assert "-p ota_pcap_peer_ip:=${ip_remote}" in text
+
+
+# ---------------------------------------------------------------------------
+# root for one system call
+# ---------------------------------------------------------------------------
+
+
+def test_the_capture_gives_root_back_as_soon_as_the_socket_exists(monkeypatch) -> None:
+    """Launched through sudo, dropped straight after — so the pcap belongs to
+    the same user as `link_trace.jsonl` beside it, not to root."""
+    calls = {}
+    monkeypatch.setattr(ota_pcap.os, "geteuid", lambda: 0)
+    monkeypatch.setattr(ota_pcap.os, "setgroups", lambda g: calls.setdefault("groups", g))
+    monkeypatch.setattr(ota_pcap.os, "setgid", lambda gid: calls.setdefault("gid", gid))
+    monkeypatch.setattr(ota_pcap.os, "setuid", lambda uid: calls.setdefault("uid", uid))
+
+    assert ota_pcap.drop_privileges("1000:1001") == "1000:1001"
+    assert calls == {"groups": [], "gid": 1001, "uid": 1000}
+
+
+def test_a_capture_that_is_not_root_leaves_the_ids_alone(monkeypatch) -> None:
+    monkeypatch.setattr(ota_pcap.os, "geteuid", lambda: 1000)
+    monkeypatch.setattr(ota_pcap.os, "setuid", lambda uid: pytest.fail("must not be called"))
+    assert ota_pcap.drop_privileges("1000:1000") is None
+
+
+@pytest.mark.parametrize("spec", [None, "", "root", "1000:nobody"])
+def test_a_spec_that_is_not_uid_gid_never_changes_the_process(spec, monkeypatch) -> None:
+    monkeypatch.setattr(ota_pcap.os, "geteuid", lambda: 0)
+    monkeypatch.setattr(ota_pcap.os, "setuid", lambda uid: pytest.fail("must not be called"))
+    assert ota_pcap.drop_privileges(spec) is None
+
+
+def test_the_node_launches_it_through_sudo_and_hands_root_straight_back() -> None:
+    """The node runs as `containeruser`, whose CapEff is zero, so no `--cap-add`
+    on the container would let it open an AF_PACKET socket. Asserted over the
+    source because the node needs rclpy, which the host suite does not have."""
+    source = (WS_PY / "com_py" / "status_overview.py").read_text(encoding="utf-8")
+    assert 'argv = ["sudo", "-n", *argv]' in source
+    assert '"--drop-to", f"{os.getuid()}:{os.getgid()}"' in source
+    # And the stop goes the same way: the child is root, so an ordinary kill
+    # would be refused — and it must be SIGINT, which is what writes ota.json.
+    assert '"sudo", "-n", "kill", "-INT"' in source
+
+
+def test_the_capture_is_a_process_not_a_thread_in_the_status_node() -> None:
+    """A capture that misbehaves must not reach the snapshot an operator watches."""
+    source = (WS_PY / "com_py" / "status_overview.py").read_text(encoding="utf-8")
+    assert "subprocess.Popen(argv, start_new_session=True)" in source


### PR DESCRIPTION
Follow-up to #324, found by a two-host run: the capture started, resolved `tun0` correctly, and then failed with *no permission to open a packet socket* while the session carried on beside it.

**Why.** ros2docker's entrypoint runs this container's processes as `containeruser`, whose `CapEff` is `0000000000000000`. A non-root process cannot open an `AF_PACKET` socket however the container was started, so `--cap-add NET_RAW` would buy nothing. #324 claimed the container ran as root — that reading came from a `docker run --entrypoint`, which skips the privilege drop and reports root. The doc now says to check the *running* container, with the command.

**Fix.** `containeruser` has passwordless sudo here (the NET pane's `sudo iftop` already depends on it), so the capture is launched through it and `--drop-to` hands the process back the moment the socket exists. The pcap and its sidecar then belong to the same user as `link_trace.jsonl` beside them. The stop goes the same way — through sudo, because the child is root until it drops, and `SIGINT` rather than `SIGTERM` because SIGINT is what writes `ota.json`.

Still no image change, no rebuild, no added capability, no extra container.

**Verified inside the real communication image**, not against it: sudo opens AF_PACKET on `tun0`, the drop keeps the socket, `sudo kill -INT` is relayed through sudo to the capture, `ota.json` is written, and both files land owned by `containeruser`.