### PR TITLE
Start the capture by path, because sudo does not carry PYTHONPATH

### DIFF
--- a/docs/ota-pcap.md
+++ b/docs/ota-pcap.md
@@ -140,6 +140,13 @@ thread, so a capture that misbehaves cannot reach the snapshot an operator is
 watching. It is stopped with `SIGINT` and waited for, because that is what
 writes the sidecar JSON.
 
+It is launched by **file path**, not as `python3 -m com_py.ota_pcap`. sudo
+resets the environment, so `PYTHONPATH` does not survive it and the package is
+not importable on the other side — which is what a two-host run answered,
+`No module named 'com_py'`, once the permission problem was out of the way.
+`ota_pcap.py` imports nothing but the standard library, so a path needs no
+package at all, and a test pins that it stays that way.
+
 ## Cost
 
 Header-only at 96 bytes: about 6 MB per minute at 500 packets/s, so a two-hour

--- a/src/rosotacom/resources/ws/ros2src/com_py/com_py/status_overview.py
+++ b/src/rosotacom/resources/ws/ros2src/com_py/com_py/status_overview.py
@@ -58,6 +58,7 @@ import signal
 import subprocess
 import sys
 import threading
+from pathlib import Path
 from typing import Dict, Optional
 
 import yaml
@@ -558,8 +559,21 @@ class StatusOverview(Node):
             return
 
         path = os.path.join(output_dir, "ota.pcap")
+        # By file path, not `-m com_py.ota_pcap`. sudo resets the environment,
+        # so PYTHONPATH does not survive and the package is not importable on
+        # the other side of it — a two-host run answered exactly that,
+        # "No module named 'com_py'", after the permission problem was fixed.
+        # `ota_pcap.py` imports nothing but the standard library (a test pins
+        # that), so a path needs no package at all.
+        script = Path(__file__).resolve().with_name("ota_pcap.py")
+        if not script.is_file():
+            self.get_logger().warning(
+                f"status_overview: ota_pcap is enabled but {script} is not here; "
+                "capturing nothing"
+            )
+            return
         argv = [
-            sys.executable, "-m", "com_py.ota_pcap",
+            sys.executable, str(script),
             "--iface", interface,
             "--out", path,
             "--snaplen", str(int(self.get_parameter("ota_pcap_snaplen").value)),

--- a/tests/unit/test_ota_pcap.py
+++ b/tests/unit/test_ota_pcap.py
@@ -345,6 +345,10 @@ def test_the_node_launches_it_through_sudo_and_hands_root_straight_back() -> Non
     source because the node needs rclpy, which the host suite does not have."""
     source = (WS_PY / "com_py" / "status_overview.py").read_text(encoding="utf-8")
     assert 'argv = ["sudo", "-n", *argv]' in source
+    # By path, never `-m`: sudo resets the environment, so PYTHONPATH does not
+    # reach the other side of it and the package is not importable there.
+    assert '"-m", "com_py.ota_pcap"' not in source
+    assert 'Path(__file__).resolve().with_name("ota_pcap.py")' in source
     assert '"--drop-to", f"{os.getuid()}:{os.getgid()}"' in source
     # And the stop goes the same way: the child is root, so an ordinary kill
     # would be refused — and it must be SIGINT, which is what writes ota.json.


### PR DESCRIPTION
Third and last thing the two-host run found. With the permission problem out of the way (#327), the capture answered `No module named 'com_py'`: `sudo -n python3 -m com_py.ota_pcap` loses the environment that makes the package importable, and the workspace is on `PYTHONPATH` rather than installed into the interpreter's own site-packages.

`ota_pcap.py` imports nothing but the standard library — a test already pinned that, for the unrelated reason that it runs in an image nobody rebuilds for it — so a path needs no package at all. The node resolves it beside itself and says so if it is missing rather than failing silently.

**Verified in the running communication container on the bench vehicle**, against the live OTA tunnel:

```
sudo /opt/ros_venv/bin/python3 /ros2ws/build/com_py/com_py/ota_pcap.py \
  --iface tun0 --out /tmp/probe.pcap --snaplen 96 --drop-to 1000:1000
[ota_pcap] privileges dropped to 1000:1000; the socket stays open
[ota_pcap] 168 packets, 0.0 MB, 0 dropped by the kernel
-rw-r--r-- 1 containeruser containeruser /tmp/probe.pcap
```