### PR TITLE
Find a session's instances by its whole name, not by its prefix

### DIFF
--- a/src/rosotacom/cli.py
+++ b/src/rosotacom/cli.py
@@ -794,6 +794,31 @@ def _new_instance_id() -> str:
     return hashlib.sha1(seed.encode("utf-8")).hexdigest()[:8]
 
 
+#: The timestamp every instance directory carries between its session slug and
+#: its id: `<slug>_YYYY-MM-DD_HH-MM-SS_<id>`. Spelled out digit by digit rather
+#: than left as `*`, because a session's name may be a *prefix* of another
+#: session's name and `f"{slug}_*"` then collects the other session's instances
+#: too. `ccng_remote_assist_*` matches every `ccng_remote_assist_kilted_dds_*`,
+#: and because the matches are ordered by name, `[-1]` answers with the wrong
+#: session's run whenever the longer name sorts after a digit — which `k` does.
+#:
+#: That is not hypothetical. On 2026-08-21 it made `rosotacom status
+#: ccng_remote_assist` report a `ccng_remote_assist_kilted_dds` run that had
+#: been shut down 45 minutes earlier, so three two-host runs concluded their
+#: link never came up while it was in fact carrying traffic for eleven minutes.
+#: Nothing in the reading said it came from another session.
+_INSTANCE_STAMP_GLOB = "[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]_[0-9][0-9]-[0-9][0-9]-[0-9][0-9]"
+
+
+def _instance_glob(session_slug: str, instance_id: str | None = None) -> str:
+    """The pattern matching this session's instances, and no other session's.
+
+    With the stamp pinned, the names sort chronologically, so `sorted(...)[-1]`
+    is the newest instance rather than merely the last name.
+    """
+    return f"*/{session_slug}_{_INSTANCE_STAMP_GLOB}_{instance_id or '*'}"
+
+
 def _session_instances_root(runtime: RuntimeConfig) -> Path:
     return (runtime.session_instances_dir or (Path.cwd() / "session-instances")).resolve()
 
@@ -818,7 +843,7 @@ def _resolve_session_instance(
     resolved_instance_id = _safe_path_token(instance_id or _new_instance_id())
 
     if instance_id:
-        matches = sorted(root.glob(f"*/{session_slug}_*_{resolved_instance_id}"))
+        matches = sorted(root.glob(_instance_glob(session_slug, resolved_instance_id)))
         if matches:
             host_dir = matches[-1].resolve()
         else:
@@ -8781,10 +8806,7 @@ def smoke(args: argparse.Namespace) -> int:
 def _find_latest_instance_dir(runtime: RuntimeConfig, session: ResolvedSession, instance_id: str | None) -> Path:
     root = _session_instances_root(runtime)
     session_slug = _session_instance_slug(session, runtime)
-    if instance_id:
-        pattern = f"*/{session_slug}_*_{_safe_path_token(instance_id)}"
-    else:
-        pattern = f"*/{session_slug}_*"
+    pattern = _instance_glob(session_slug, _safe_path_token(instance_id) if instance_id else None)
     matches = sorted(p for p in root.glob(pattern) if p.is_dir())
     if not matches:
         raise RuntimeError(

--- a/tests/unit/test_concurrency.py
+++ b/tests/unit/test_concurrency.py
@@ -943,3 +943,76 @@ def test_a_pinned_peer_confines_its_containers(tmp_path: Path) -> None:
     # And without one, nothing is added: the flag must not appear on a peer that
     # was never pinned, or every unpinned run changes shape too.
     assert "--cpuset" not in rosotacom._ota_start_parts(target, "a", "id-1", [], mode="detached")
+
+
+# --------------------------------------------------- instance resolution by name
+#
+# A session's instances are found by globbing its slug. The slug of one session
+# can be a prefix of another's — `ccng_remote_assist` and
+# `ccng_remote_assist_kilted_dds` are the pair that exposed it — and a pattern
+# that ends the slug with `*` then matches both. The matches are ordered by
+# name, so the answer is whichever sorts last, and a letter sorts after a digit:
+# the *other* session's run wins over this session's own newest one.
+#
+# What that cost: on 2026-08-21 `rosotacom status ccng_remote_assist` reported a
+# `ccng_remote_assist_kilted_dds` run that had been shut down 45 minutes
+# earlier. Three two-host runs waited ten minutes each and concluded their link
+# never came up, while their own status file said it had been OK the whole time.
+
+
+def _session(tmp_path: Path, name: str) -> rosotacom.ResolvedSession:
+    host_dir = tmp_path / "sessions" / name
+    host_dir.mkdir(parents=True, exist_ok=True)
+    return rosotacom.ResolvedSession(host_dir, f"/session/{name}", "test")
+
+
+def _instance(root: Path, slug: str, stamp: str, instance_id: str) -> Path:
+    day, _, _ = stamp.partition("_")
+    path = root / day / f"{slug}_{stamp}_{instance_id}"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def test_a_longer_session_name_does_not_capture_this_session_s_instances(tmp_path: Path) -> None:
+    runtime = _runtime(tmp_path)
+    root = tmp_path / "instances"
+    mine = _instance(root, "ccng_remote_assist", "2026-08-21_21-42-01", "35285739")
+    # Older, another session, and its name sorts after mine because 'k' > '2'.
+    _instance(root, "ccng_remote_assist_kilted_dds", "2026-08-21_20-57-05", "52a752d6")
+
+    found = rosotacom._find_latest_instance_dir(runtime, _session(tmp_path, "ccng_remote_assist"), None)
+
+    assert found == mine.resolve()
+
+
+def test_the_longer_name_still_finds_its_own_newest(tmp_path: Path) -> None:
+    runtime = _runtime(tmp_path)
+    root = tmp_path / "instances"
+    _instance(root, "ccng_remote_assist", "2026-08-21_21-42-01", "35285739")
+    _instance(root, "ccng_remote_assist_kilted_dds", "2026-08-21_20-48-37", "643792ab")
+    newest = _instance(root, "ccng_remote_assist_kilted_dds", "2026-08-21_20-57-05", "52a752d6")
+
+    found = rosotacom._find_latest_instance_dir(runtime, _session(tmp_path, "ccng_remote_assist_kilted_dds"), None)
+
+    assert found == newest.resolve()
+
+
+def test_instances_are_ordered_by_their_stamp(tmp_path: Path) -> None:
+    runtime = _runtime(tmp_path)
+    root = tmp_path / "instances"
+    _instance(root, "link", "2026-08-20_23-59-59", "aaaaaaaa")
+    newest = _instance(root, "link", "2026-08-21_00-00-01", "00000000")
+
+    found = rosotacom._find_latest_instance_dir(runtime, _session(tmp_path, "link"), None)
+
+    # The id sorts first among these two; the stamp is what has to decide.
+    assert found == newest.resolve()
+
+
+def test_a_named_instance_of_another_session_is_not_answered(tmp_path: Path) -> None:
+    runtime = _runtime(tmp_path)
+    root = tmp_path / "instances"
+    _instance(root, "ccng_remote_assist_kilted_dds", "2026-08-21_20-57-05", "52a752d6")
+
+    with pytest.raises(RuntimeError, match="No session instance found"):
+        rosotacom._find_latest_instance_dir(runtime, _session(tmp_path, "ccng_remote_assist"), "52a752d6")


### PR DESCRIPTION
A session name may be a prefix of another session name. `_find_latest_instance_dir` globs `<slug>_*` and takes `sorted(...)[-1]`, so `ccng_remote_assist` also matches every `ccng_remote_assist_kilted_dds_*` — and since `k` sorts after a digit, the *other* session's run wins over this session's own newest one.

## What it cost

On 2026-08-21, `rosotacom status ccng_remote_assist` answered with a `ccng_remote_assist_kilted_dds` instance that had been shut down 45 minutes earlier. Three two-host runs each waited the full 600 s and reported `link never came up`, while:

- their own `status.json` recorded the inbound heartbeat as **OK** from 13 s after start until shutdown,
- `events.jsonl` held the `STALLED -> OK` transition and no transition back,
- `link_trace.jsonl` showed the peer's traffic arriving at ~1680 B/s for the whole 684 s,
- `startup_check.json` said `verdict: ok`.

The tell was the diagnosis text: the failing run reported `stopped 11.0s ago`, which is the value in the *other* run's status file — its own said `11.3s`.

## The change

Pin the `YYYY-MM-DD_HH-MM-SS` stamp the directory name always carries between the slug and the id, so the pattern ends the slug instead of leaving it open. With the stamp pinned the names sort chronologically as well, so `[-1]` is genuinely the newest instance. Both call sites share one helper.

## Tests

Four cases in `tests/unit/test_concurrency.py`. Two of them fail on the old pattern (verified by reverting the helper body): the prefix collision, and a named instance of another session being answered. The other two pin behaviour that was already correct — the longer name finding its own newest, and ordering by stamp rather than by id.