### PR TITLE
Make a two-host benchmark measure what it was asked for

### DIFF
--- a/src/rosotacom/cli.py
+++ b/src/rosotacom/cli.py
@@ -293,6 +293,12 @@ class OtaSmokePlan:
     peers: dict[str, OtaSmokePeer]
     install_mode: str = "source"
     install_pin: str | None = None
+    #: Where the peers write session instances, relative to the project file's
+    #: own directory. `session-instances` is the default a project that says
+    #: nothing gets; a project that sets `session_instances_dir` to anything
+    #: else -- `../instances`, say -- used to have its artifacts looked for in a
+    #: directory nothing writes to, and the miss was silent.
+    instances_rel: str = "session-instances"
 
 
 @dataclass(frozen=True)
@@ -1835,6 +1841,26 @@ def _ota_checkout_project_path(project_config: Path) -> tuple[Path, str]:
     )
 
 
+def _ota_instances_rel(runtime: RuntimeConfig) -> str:
+    """Where this project writes session instances, relative to its own file.
+
+    The peers resolve the project from their own checkout, so the *relative*
+    answer is the one that travels; an absolute path is the orchestrator's and
+    means nothing on the far side. A project that says nothing gets
+    `session-instances`, which is what the collection used to assume for every
+    project -- and a project that says `../instances` had its artifacts looked
+    for in a directory nothing writes to.
+    """
+    default = "session-instances"
+    if not runtime.rosotacom_config:
+        return default
+    raw = _load_yaml_file(runtime.rosotacom_config)
+    value = raw.get("session_instances_dir")
+    if not value:
+        return default
+    return str(value)
+
+
 def _ota_plan_from_bindings(
     bindings: dict[str, PeerBinding],
     *,
@@ -1845,6 +1871,7 @@ def _ota_plan_from_bindings(
     project: str | None = None,
     exec_commands: Mapping[str, str] | None = None,
     cpusets: Mapping[str, str] | None = None,
+    instances_rel: str = "session-instances",
 ) -> OtaSmokePlan:
     _ota_validate_install_mode(install_mode)
     if cpusets:
@@ -1923,6 +1950,7 @@ def _ota_plan_from_bindings(
         peers=peers,
         install_mode=install_mode,
         install_pin=install_pin,
+        instances_rel=instances_rel,
     )
 
 
@@ -1935,6 +1963,7 @@ def _ota_write_state(instance: SessionInstance, plan: OtaSmokePlan) -> OtaSmokeP
         "project": plan.project,
         "install_mode": plan.install_mode,
         "install_pin": plan.install_pin,
+        "instances_rel": plan.instances_rel,
         "peers": {
             name: {
                 "address": peer.address,
@@ -1979,6 +2008,7 @@ def _ota_load_state(path_arg: str) -> OtaSmokePlan:
         peers=peers,
         install_mode=_ota_validate_install_mode(str(raw["install_mode"])),
         install_pin=str(install_pin) if install_pin else None,
+        instances_rel=str(raw.get("instances_rel") or "session-instances"),
     )
 
 
@@ -2404,12 +2434,26 @@ def _ota_stop_parts(
     return parts
 
 
+#: How a benchmark's load maps onto `publish-test-topics` flags. The keys are
+#: `_sized_publisher_param_args`'s own, so a load dict travels from the
+#: benchmark to the peer's publisher without being rewritten on the way.
+_OTA_LOAD_FLAGS: tuple[tuple[str, str], ...] = (
+    ("size", "--load-size"),
+    ("pattern", "--load-size-pattern"),
+    ("rate", "--load-rate-hz"),
+    ("streams", "--load-streams"),
+    ("interval_jitter_ms", "--load-interval-jitter-ms"),
+    ("interval_jitter_seed", "--load-interval-jitter-seed"),
+)
+
+
 def _ota_publish_parts(
     target: InteractiveSmokeTarget,
     identity: str,
     peer_args: list[str],
     *,
     stop: bool = False,
+    load: Mapping[str, Any] | None = None,
 ) -> list[str]:
     parts = [
         "publish-test-topics",
@@ -2421,6 +2465,13 @@ def _ota_publish_parts(
     ]
     if stop:
         parts.append("--stop")
+    else:
+        merged = dict(load or {})
+        if "size" not in merged and merged.get("size_a") is not None:
+            merged["size"] = merged["size_a"]
+        for key, flag in _OTA_LOAD_FLAGS:
+            if merged.get(key) is not None:
+                parts.extend([flag, str(merged[key])])
     for override in peer_args:
         parts.extend(["--peer-address", override])
     return parts
@@ -2769,6 +2820,7 @@ def _resolve_ota_smoke_context(
             project=project,
             exec_commands=exec_commands,
             cpusets=_parse_peer_cpuset_overrides(getattr(args, "peer_cpuset", None)),
+            instances_rel=_ota_instances_rel(runtime),
         )
     plan_peers = set(plan.peers)
     target_peers = set(_peer_keys_from_cfg(target.cfg))
@@ -3732,14 +3784,41 @@ def _resolve_ota_profile(
     return name, profile
 
 
-def _profile_directions(plan: OtaSmokePlan, cfg: dict[str, Any]) -> dict[str, str]:
+def _loaded_peer(cfg: dict[str, Any]) -> str | None:
+    """Which peer's egress carries this session's dominant direction.
+
+    A profile's ``uplink`` leg is the impaired one in almost every profile this
+    project ships, so which peer it lands on decides what the run measures. The
+    session already says: `topics.a_to_b` and `topics.b_to_a` are its two
+    directions, and the one with more topics is the one the load runs over.
+    Reading it here is what keeps a one-host and a two-host run of the *same*
+    session under the *same* profile from shaping opposite directions -- which
+    they did, silently, until 2026-08-31.
+    """
+    topics = cfg.get("topics")
+    if not isinstance(topics, dict):
+        return None
+    a_to_b = len(topics.get("a_to_b") or ())
+    b_to_a = len(topics.get("b_to_a") or ())
+    if a_to_b == b_to_a:
+        return None
+    return "a" if a_to_b > b_to_a else "b"
+
+
+def _profile_directions_for(peers: list[str], cfg: dict[str, Any]) -> dict[str, str]:
     """Map each peer to the profile direction its egress carries (RFC 0004).
 
-    Default for the a/b convention: the first peer (center / receiver) shapes
-    ``downlink``, the second (vehicle / sender) shapes ``uplink`` — the dominant
-    telemetry direction. Override with ``shared.profile_directions: { a: …, b: … }``."""
-    peers = sorted(plan.peers)
-    directions: dict[str, str] = {peers[0]: "downlink", peers[1]: "uplink"} if len(peers) == 2 else {}
+    The sender of the session's dominant direction shapes ``uplink``; the other
+    peer shapes ``downlink``. Where the two directions carry the same number of
+    topics the session does not say, and the a/b convention decides: the first
+    peer is the centre and receives, the second is the vehicle and sends.
+    ``shared.profile_directions: { a: …, b: … }`` overrides either.
+    """
+    directions: dict[str, str] = {}
+    if len(peers) == 2:
+        sender = _loaded_peer(cfg) or peers[1]
+        other = next(name for name in peers if name != sender)
+        directions = {sender: "uplink", other: "downlink"}
     shared = cfg.get("shared")
     override = shared.get("profile_directions") if isinstance(shared, dict) else None
     if isinstance(override, dict):
@@ -3749,6 +3828,11 @@ def _profile_directions(plan: OtaSmokePlan, cfg: dict[str, Any]) -> dict[str, st
     if invalid:
         raise RuntimeError(f"shared.profile_directions values must be 'uplink' or 'downlink'; got {invalid}")
     return directions
+
+
+def _profile_directions(plan: OtaSmokePlan, cfg: dict[str, Any]) -> dict[str, str]:
+    """`_profile_directions_for` against a plan's peers."""
+    return _profile_directions_for(sorted(plan.peers), cfg)
 
 
 def _ota_resolve_interfaces(peer: OtaSmokePeer, peer_addr: str, *, dry_run: bool) -> tuple[str, str | None]:
@@ -3935,6 +4019,7 @@ def _ota_start_session_publishers(
     plan: OtaSmokePlan,
     *,
     dry_run: bool,
+    load: Mapping[str, Any] | None = None,
 ) -> None:
     if target.target_type != "session":
         print("OTA smoke: target is a scenario; using its application publishers.")
@@ -3942,7 +4027,7 @@ def _ota_start_session_publishers(
     peer_args = _ota_peer_address_args(plan)
     for peer_name in sorted(plan.peers):
         peer = plan.peers[peer_name]
-        command = _ota_rosotacom_command(plan, _ota_publish_parts(target, peer_name, peer_args), peer)
+        command = _ota_rosotacom_command(plan, _ota_publish_parts(target, peer_name, peer_args, load=load), peer)
         result = _ota_run(peer, command, label=f"{peer_name}: start synthetic publishers", dry_run=dry_run, check=False)
         _print_completed_output(result)
         if result.returncode != 0:
@@ -4068,21 +4153,44 @@ def _ota_collect_logs(
     dry_run: bool,
 ) -> None:
     project = shlex.quote(plan.project)
+    instances_rel = shlex.quote(plan.instances_rel)
     instance_suffix = shlex.quote(f"*_{instance.instance_id}")
+    collected = 0
     for peer in plan.peers.values():
         script = (
             f"cd {shlex.quote(_ota_peer_workdir(plan, peer))} && "
             f"project_dir=$(dirname {project}) && "
-            f'instance_dir=$(find "$project_dir/session-instances" -mindepth 2 -maxdepth 2 '
+            f'instances_root=$(cd "$project_dir" && cd "$(dirname {instances_rel})" 2>/dev/null '
+            f'&& printf %s "$PWD/$(basename {instances_rel})") && '
+            f'instance_dir=$(find "$instances_root" -mindepth 2 -maxdepth 2 '
             f"-type d -name {instance_suffix} -print -quit 2>/dev/null) && "
             'if [ -n "$instance_dir" ]; then '
-            'relative=${instance_dir#"$project_dir"/}; '
-            'tar cz -C "$project_dir" "$relative" 2>/dev/null | base64; fi'
+            'root=$(dirname "$(dirname "$instance_dir")"); '
+            'relative=${instance_dir#"$root"/}; '
+            'tar cz -C "$root" "$relative" 2>/dev/null | base64; fi'
         )
         result = _ota_run(peer, script, label=f"{peer.name}: collect session-instances", dry_run=dry_run, check=False)
-        if dry_run or not result.stdout.strip():
+        if dry_run:
+            continue
+        if not result.stdout.strip():
+            # Silence here used to end as "no status/events.jsonl files found"
+            # after the run was already over, which describes the symptom and
+            # not the cause. Say which peer, and where it was looked for.
+            print(
+                f"OTA smoke: peer {peer.name} returned no session instance matching "
+                f"*_{instance.instance_id} under its {plan.instances_rel!r} "
+                f"(relative to {plan.project!r}).",
+                file=sys.stderr,
+            )
             continue
         _ota_extract_peer_artifacts(instance, peer, result.stdout)
+        collected += 1
+    if not dry_run and not collected:
+        print(
+            "OTA smoke: nothing was collected from any peer -- the run produced no local records. "
+            "Check that the project's session_instances_dir is the one the peers write to.",
+            file=sys.stderr,
+        )
 
 
 def _ota_extract_peer_artifacts(instance: SessionInstance, peer: OtaSmokePeer, encoded: str) -> None:
@@ -7372,9 +7480,30 @@ def _smoke_topic_pub_qos_args(qos: dict[str, Any] | None) -> str:
     return " ".join(shlex.quote(arg) for arg in args) + (" " if args else "")
 
 
-def _smoke_publisher_command(spec: SmokeTopicSpec, ros_setup: str, duration: float) -> str:
+def _smoke_publisher_command(
+    spec: SmokeTopicSpec,
+    ros_setup: str,
+    duration: float,
+    load: Mapping[str, Any] | None = None,
+) -> str:
+    """The publisher command for one crossed topic.
+
+    `load` overrides what the session's own `expect` says, and only for a
+    `SizedPayload` stream: a benchmark chooses its load, and a session that also
+    declares one is describing what it expects to see rather than what a
+    measurement should offer. Without this the benchmark's `--size` and
+    `--rate-hz` reached the local runner and stopped there, so a two-host run
+    measured the session's defaults while reporting the load that was asked for.
+    """
     assert spec.publish_topic is not None and spec.publish_type is not None
     if spec.publish_type == "com_msgs/msg/SizedPayload":
+        from .cli_benchmark import _sized_publisher_param_args
+
+        if load:
+            args = " ".join(
+                shlex.quote(str(part)) for part in _sized_publisher_param_args(spec.publish_topic, dict(load))
+            )
+            return f"{ros_setup} && timeout {duration} ros2 run com_py sized_publisher --ros-args {args}"
         size = spec.expected_size or SMOKE_SIZED_PAYLOAD_BYTES
         return (
             f"{ros_setup} && timeout {duration} ros2 run com_py sized_publisher --ros-args "
@@ -7427,16 +7556,18 @@ def _start_smoke_topic_publishers(
     log_line: Callable[[str], None] = print,
     duration: float = 180.0,
     source_peer_key: str | None = None,
+    load: Mapping[str, Any] | None = None,
 ) -> list[SmokeTopicSpec]:
     started: list[SmokeTopicSpec] = []
     for spec in _smoke_publish_specs(cfg, source_peer_key=source_peer_key):
         assert spec.publish_topic is not None and spec.publish_type is not None
         container = containers[spec.source_peer_key]
         ros_setup = ros_setups[spec.source_peer_key]
-        cmd = _smoke_publisher_command(spec, ros_setup, duration)
+        cmd = _smoke_publisher_command(spec, ros_setup, duration, load)
+        offered = f" at {load.get('rate', spec.publish_rate)} Hz (benchmark load)" if load else ""
         log_line(
             f"Starting smoke publisher {spec.source_peer_key}->{spec.receiver_peer_key} "
-            f"{spec.publish_topic} ({spec.publish_type}) in {container}"
+            f"{spec.publish_topic} ({spec.publish_type}) in {container}{offered}"
         )
         subprocess.run(
             ["docker", "exec", "-d", container, "bash", "-c", cmd],
@@ -7801,6 +7932,30 @@ def probe_content_command(args: argparse.Namespace) -> int:
     return 0 if ok else 1
 
 
+def _publish_load_override(args: argparse.Namespace) -> dict[str, Any] | None:
+    """The benchmark's load as `_sized_publisher_param_args` wants it, or None.
+
+    None means "use what the session expects", which is what an ordinary smoke
+    run wants. A benchmark always passes something, because choosing the load is
+    the whole point of it.
+    """
+    load: dict[str, Any] = {}
+    if getattr(args, "load_size", None) is not None:
+        load["size"] = int(args.load_size)
+        load["size_a"] = int(args.load_size)
+    if getattr(args, "load_size_pattern", None):
+        load["pattern"] = args.load_size_pattern
+    if getattr(args, "load_rate_hz", None) is not None:
+        load["rate"] = float(args.load_rate_hz)
+    if getattr(args, "load_streams", None) is not None:
+        load["streams"] = int(args.load_streams)
+    if getattr(args, "load_interval_jitter_ms", None) is not None:
+        load["interval_jitter_ms"] = float(args.load_interval_jitter_ms)
+    if getattr(args, "load_interval_jitter_seed", None) is not None:
+        load["interval_jitter_seed"] = int(args.load_interval_jitter_seed)
+    return load or None
+
+
 def publish_test_topics_command(args: argparse.Namespace) -> int:
     """Start or stop synthetic local app publishers for the peer's crossed topics.
 
@@ -7826,6 +7981,7 @@ def publish_test_topics_command(args: argparse.Namespace) -> int:
             cfg,
             duration=args.duration,
             source_peer_key=args.identity,
+            load=_publish_load_override(args),
         )
     except RuntimeError as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
@@ -10357,6 +10513,16 @@ def main(argv: list[str] | None = None) -> int:
     publish_test_topics_parser.add_argument(
         "--stop", action="store_true", help="Stop running synthetic test topic publishers."
     )
+    # The benchmark's load, for the peer that publishes it. Without these a
+    # two-host benchmark offered the session's own expected load and reported
+    # the one that was asked for -- a run that reads as a success and measures
+    # something else.
+    publish_test_topics_parser.add_argument("--load-size", type=int, help=argparse.SUPPRESS)
+    publish_test_topics_parser.add_argument("--load-size-pattern", help=argparse.SUPPRESS)
+    publish_test_topics_parser.add_argument("--load-rate-hz", type=float, help=argparse.SUPPRESS)
+    publish_test_topics_parser.add_argument("--load-streams", type=int, help=argparse.SUPPRESS)
+    publish_test_topics_parser.add_argument("--load-interval-jitter-ms", type=float, help=argparse.SUPPRESS)
+    publish_test_topics_parser.add_argument("--load-interval-jitter-seed", type=int, help=argparse.SUPPRESS)
     publish_test_topics_parser.set_defaults(func=publish_test_topics_command)
 
     list_parser = subparsers.add_parser("list-sessions", help="List configured sessions.")

--- a/src/rosotacom/cli_benchmark.py
+++ b/src/rosotacom/cli_benchmark.py
@@ -5163,6 +5163,7 @@ def _make_live_run_point(args: argparse.Namespace, session_name: str) -> RunPoin
         _peer_command_runner,
         _peer_watchdog_launcher,
         _profile_directions,
+        _profile_directions_for,
         _remove_smoke_network,
         _resolve_ota_profile,
         _resolve_ota_smoke_context,
@@ -5327,7 +5328,10 @@ def _make_live_run_point(args: argparse.Namespace, session_name: str) -> RunPoin
                 _ota_start_peers(target, plan, instance.instance_id, dry_run=dry_run)
                 if not dry_run:
                     time.sleep(12)
-                _ota_start_session_publishers(target, plan, dry_run=dry_run)
+                # The load is the benchmark's, not the session's expectation:
+                # without this the peer published what its own `expect` declares
+                # and the run reported the load that was asked for.
+                _ota_start_session_publishers(target, plan, dry_run=dry_run, load=load)
 
                 if not dry_run:
                     if profile_obj is not None and profile_obj.is_timeline:
@@ -5651,34 +5655,36 @@ def _make_live_run_point(args: argparse.Namespace, session_name: str) -> RunPoin
                                 print(
                                     f"  netem distribution {table_name!r} installed in {dist_container}: {dist_target}"
                                 )
+                    # Which peer's egress carries `uplink` is the session's
+                    # answer, not the runner's: the same session under the same
+                    # profile must be shaped identically here and across two
+                    # machines, and hard-coding a=uplink here while the OTA path
+                    # hard-coded b=uplink meant it was not.
+                    lab_directions = _profile_directions_for(["a", "b"], cfg)
+                    lab_containers = {"a": a_container, "b": b_container}
                     if profile_obj.is_timeline:
-                        # Peer A shapes uplink (egress to B)
-                        shaper_a = ProfileShaper("eth0", make_container_runner(a_container))
-                        lab_shapers.append(shaper_a)
-                        steps_a = expand_timeline(profile_obj, "eth0", direction="uplink")
-                        lab_peer_steps["a"] = (shaper_a, steps_a)
-
-                        # Peer B shapes downlink (egress to A)
-                        shaper_b = ProfileShaper("eth0", make_container_runner(b_container))
-                        lab_shapers.append(shaper_b)
-                        steps_b = expand_timeline(profile_obj, "eth0", direction="downlink")
-                        lab_peer_steps["b"] = (shaper_b, steps_b)
+                        for peer_name in ("a", "b"):
+                            shaper = ProfileShaper("eth0", make_container_runner(lab_containers[peer_name]))
+                            lab_shapers.append(shaper)
+                            steps = expand_timeline(profile_obj, "eth0", direction=lab_directions[peer_name])
+                            lab_peer_steps[peer_name] = (shaper, steps)
 
                         for shaper in lab_shapers:
                             shaper.arm([])
                     else:
-                        if profile_obj.uplink and not profile_obj.uplink.is_empty:
-                            shaper_a = ProfileShaper("eth0", make_container_runner(a_container))
-                            lab_shapers.append(shaper_a)
-                            shaper_a.arm(shaping_commands("eth0", profile_obj.uplink))
-                        if profile_obj.downlink and not profile_obj.downlink.is_empty:
-                            shaper_b = ProfileShaper("eth0", make_container_runner(b_container))
-                            lab_shapers.append(shaper_b)
-                            shaper_b.arm(shaping_commands("eth0", profile_obj.downlink))
+                        for peer_name in ("a", "b"):
+                            leg = profile_obj.uplink if lab_directions[peer_name] == "uplink" else profile_obj.downlink
+                            if leg is None or leg.is_empty:
+                                continue
+                            shaper = ProfileShaper("eth0", make_container_runner(lab_containers[peer_name]))
+                            lab_shapers.append(shaper)
+                            shaper.arm(shaping_commands("eth0", leg))
 
                 # 4. Verify shaping was applied (diagnostic)
                 if profile_obj is not None and not getattr(args, "dry_run", False):
-                    for label, container in [("A (uplink)", a_container), ("B (downlink)", b_container)]:
+                    for peer_name in ("a", "b"):
+                        label = f"{peer_name.upper()} ({lab_directions[peer_name]})"
+                        container = lab_containers[peer_name]
                         tc_binary = container_tc_overrides.get(container, "tc")
                         res = subprocess.run(
                             ["docker", "exec", "-u", "root", container, tc_binary, "qdisc", "show", "dev", "eth0"],

--- a/tests/unit/test_cli_benchmark.py
+++ b/tests/unit/test_cli_benchmark.py
@@ -2309,7 +2309,15 @@ def test_live_lab_run_point_uses_instance_scoped_smoke_network(
     monkeypatch.setattr(cli, "_load_runtime_config", lambda args: runtime)
     monkeypatch.setattr(cli, "_resolve_session", lambda session_name, runtime: session)
     monkeypatch.setattr(cli, "_resolve_session_instance", lambda runtime, session, instance_id=None: instance)
-    monkeypatch.setattr(cli, "_effective_session_config", lambda *args, **kwargs: {"topics": {"a_to_b": []}})
+    # One a->b topic, as every benchmark session has: which container meets the
+    # profile's `uplink` leg follows the session's own loaded direction, so a
+    # fixture with no topics would be asserting an arbitrary default rather than
+    # the rule.
+    monkeypatch.setattr(
+        cli,
+        "_effective_session_config",
+        lambda *args, **kwargs: {"topics": {"a_to_b": [{"topic": "/bench_capacity"}], "b_to_a": []}},
+    )
     monkeypatch.setattr(cli, "_list_docker_containers", lambda all_states=False: [])
     monkeypatch.setattr(
         cli, "_ensure_smoke_network", lambda name, subnet, labels=None: networks_created.append((name, subnet))

--- a/tests/unit/test_ota_benchmark_peer_exec.py
+++ b/tests/unit/test_ota_benchmark_peer_exec.py
@@ -1,0 +1,134 @@
+"""What a two-host benchmark must carry to its peers, and where it looks after.
+
+Three defects this pins, all found by running one: the same session under the
+same profile was shaped in opposite directions on one host and on two; the
+benchmark's load never left the orchestrator; and the collection looked for the
+peer's artifacts in a directory the project does not use, then reported the
+symptom rather than the cause.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from rosotacom.cli import (
+    _ota_instances_rel,
+    _ota_publish_parts,
+    _profile_directions_for,
+    _publish_load_override,
+)
+
+
+class _Target:
+    target_type = "session"
+    name = "bench_1_1_capacity"
+
+
+def _cfg(a_to_b: int, b_to_a: int, **shared) -> dict:
+    return {
+        "topics": {
+            "a_to_b": [{"topic": f"/a{i}"} for i in range(a_to_b)],
+            "b_to_a": [{"topic": f"/b{i}"} for i in range(b_to_a)],
+        },
+        "shared": shared,
+    }
+
+
+# ------------------------------------------------- which peer meets `uplink`
+
+
+def test_the_sender_of_the_loaded_direction_shapes_uplink():
+    """A profile's impaired leg must land on the egress that carries the load.
+
+    `bench_1_1_capacity` sends a->b. The OTA runner used to hand `uplink` to b
+    on the a=centre/b=vehicle convention, so a run under a loss profile shaped
+    the idle direction and delivered every message -- a green run measuring
+    nothing.
+    """
+    assert _profile_directions_for(["a", "b"], _cfg(1, 0)) == {"a": "uplink", "b": "downlink"}
+
+
+def test_a_vehicle_to_centre_session_still_shapes_the_vehicle():
+    assert _profile_directions_for(["a", "b"], _cfg(0, 1)) == {"b": "uplink", "a": "downlink"}
+
+
+def test_a_symmetric_session_falls_back_to_the_a_b_convention():
+    """Neither direction dominates, so the session does not say; b sends."""
+    assert _profile_directions_for(["a", "b"], _cfg(2, 2)) == {"b": "uplink", "a": "downlink"}
+
+
+def test_an_explicit_declaration_wins_over_both():
+    cfg = _cfg(1, 0, profile_directions={"a": "downlink", "b": "uplink"})
+    assert _profile_directions_for(["a", "b"], cfg) == {"a": "downlink", "b": "uplink"}
+
+
+# ------------------------------------------------------- the load must travel
+
+
+def test_the_benchmark_load_reaches_the_peer_command():
+    parts = _ota_publish_parts(_Target(), "a", [], load={"size": 12000, "rate": 10.0, "streams": 2})
+    assert "--load-size" in parts and parts[parts.index("--load-size") + 1] == "12000"
+    assert "--load-rate-hz" in parts and parts[parts.index("--load-rate-hz") + 1] == "10.0"
+    assert "--load-streams" in parts and parts[parts.index("--load-streams") + 1] == "2"
+
+
+def test_a_size_pattern_travels_as_itself():
+    parts = _ota_publish_parts(_Target(), "a", [], load={"pattern": "a*4,b*1", "size_a": 5000})
+    assert parts[parts.index("--load-size-pattern") + 1] == "a*4,b*1"
+    # `size_a` is the pattern's own base size and must reach the peer as --load-size.
+    assert parts[parts.index("--load-size") + 1] == "5000"
+
+
+def test_no_load_leaves_the_session_to_say_what_it_expects():
+    parts = _ota_publish_parts(_Target(), "a", [])
+    assert not [p for p in parts if p.startswith("--load-")]
+
+
+def test_stopping_carries_no_load():
+    parts = _ota_publish_parts(_Target(), "a", [], stop=True, load={"size": 1})
+    assert "--stop" in parts
+    assert not [p for p in parts if p.startswith("--load-")]
+
+
+def test_the_peer_turns_the_flags_back_into_a_load():
+    args = argparse.Namespace(
+        load_size=12000,
+        load_size_pattern=None,
+        load_rate_hz=10.0,
+        load_streams=None,
+        load_interval_jitter_ms=None,
+        load_interval_jitter_seed=None,
+    )
+    assert _publish_load_override(args) == {"size": 12000, "size_a": 12000, "rate": 10.0}
+
+
+def test_an_empty_namespace_means_use_the_session():
+    args = argparse.Namespace(
+        load_size=None,
+        load_size_pattern=None,
+        load_rate_hz=None,
+        load_streams=None,
+        load_interval_jitter_ms=None,
+        load_interval_jitter_seed=None,
+    )
+    assert _publish_load_override(args) is None
+
+
+# --------------------------------------------- where the artifacts are looked for
+
+
+class _Runtime:
+    def __init__(self, path):
+        self.rosotacom_config = path
+
+
+def test_the_collection_follows_the_project_not_a_convention(tmp_path):
+    project = tmp_path / "rosotacom.yaml"
+    project.write_text("session_instances_dir: ../instances\n", encoding="utf-8")
+    assert _ota_instances_rel(_Runtime(project)) == "../instances"
+
+
+def test_a_project_that_says_nothing_gets_the_default(tmp_path):
+    project = tmp_path / "rosotacom.yaml"
+    project.write_text("session_configs_dir:\n  - sessions\n", encoding="utf-8")
+    assert _ota_instances_rel(_Runtime(project)) == "session-instances"


### PR DESCRIPTION
Closes #338.

A two-host `ota-benchmark probe` starts on both peers, writes transit records on both and tears itself down. Three things did not arrive, and the result was **a run that reads as a success in the log while measuring something nobody asked for.** Found by running one; every number below is from that run.

### 1. The two runners shaped opposite directions

The local path hard-coded *"peer A shapes uplink"*. The OTA path hard-coded `a=downlink, b=uplink` on the a=centre/b=vehicle convention. `bench_1_1_capacity` sends **a→b**, so on two machines the impaired leg landed on the idle direction:

> 609 of 609 delivered, under a profile asking 1 % per-packet loss on a 65-packet message — where about half should have been lost.

Which peer meets `uplink` is now **the session's answer, in both runners**: the sender of the dominant direction in `topics`, with the a/b convention only as the tie-break and `shared.profile_directions` still winning over both.

### 2. The benchmark's load never left the orchestrator

The OTA path starts the peers' publishers with `publish-test-topics`, which builds its command from the session's own `expect`. So `--size 12000 --rate-hz 10` produced **66100 B at 5 Hz** — the session's defaults — while `result.json` reported the load that was asked for.

`publish-test-topics` now takes the load, `_ota_publish_parts` forwards it, and `_smoke_publisher_command` applies it to `SizedPayload` streams only. An ordinary smoke run passes nothing and keeps using what the session expects.

### 3. Collection looked in a directory the project does not use

It assumed `session-instances` beside the project file. A project setting `session_instances_dir` to anything else (`../instances`, say) had its artifacts looked for where nothing writes, found nothing, and said so only later as *"No status/events.jsonl files found"* — the symptom, not the cause. The path now comes from the project, relative so it resolves on each peer's own checkout, and a peer that returns nothing is named at the moment it returns nothing.

### Verified

Same command, before and after:

```
before:  OTA profile: arming 'tilt-iid-nodist' downlink on a   uplink on b
after:   OTA profile: arming 'tilt-iid-nodist' uplink on a     downlink on b

after:   publish-test-topics bench_1_1_capacity --identity a --duration 3600 \
           --load-size 12000 --load-rate-hz 10.0
```

Twelve tests, one per rule. The local-lab fixture gains the one `a_to_b` topic every benchmark session has: with no topics it was pinning an arbitrary default rather than the rule, which is what let the two paths disagree in the first place.

The whole `tests/unit` + `tests/contract` set has the same 49 failures as untouched `develop` on this machine (missing `ros2docker` in the system python), and no new ones.
