### PR TITLE
Say the rate the publisher was given, not the one the session expects

### DIFF
--- a/src/rosotacom/cli.py
+++ b/src/rosotacom/cli.py
@@ -7564,7 +7564,12 @@ def _start_smoke_topic_publishers(
         container = containers[spec.source_peer_key]
         ros_setup = ros_setups[spec.source_peer_key]
         cmd = _smoke_publisher_command(spec, ros_setup, duration, load)
-        offered = f" at {load.get('rate', spec.publish_rate)} Hz (benchmark load)" if load else ""
+        # The rate the publisher was actually given, not the one the session
+        # expects: they differ exactly when a benchmark chose the load, and a
+        # log that reports the session's number there is how a run that measured
+        # the wrong load reads as one that measured the right one.
+        rate = (load or {}).get("rate", spec.publish_rate)
+        offered = f" at {rate:g} Hz" + (" (benchmark load)" if load else "")
         log_line(
             f"Starting smoke publisher {spec.source_peer_key}->{spec.receiver_peer_key} "
             f"{spec.publish_topic} ({spec.publish_type}) in {container}{offered}"
@@ -7580,7 +7585,7 @@ def _start_smoke_topic_publishers(
                 log_line(
                     f"OK: smoke publisher {spec.source_peer_key}->{spec.receiver_peer_key} "
                     f"{spec.publish_topic} ({spec.publish_type}) is advertising in {container} "
-                    f"at {spec.publish_rate:g} Hz"
+                    f"at {rate:g} Hz"
                 )
                 started.append(spec)
                 break


### PR DESCRIPTION
#339 made a benchmark's load reach the peers' publishers and left the two log lines reporting `spec.publish_rate` — the session's own expectation. A verified 10 Hz run therefore still printed

```
OK: smoke publisher a->b /bench_capacity (com_msgs/msg/SizedPayload) is advertising in ... at 5 Hz
```

while the records showed 1226 messages in 120 s. That is the exact shape of the defect #339 fixed: a log that agrees with the session while the run does something else.

Both lines now report what the publisher was actually given, and say `(benchmark load)` when it came from a benchmark rather than from `expect`.
