### PR TITLE
Say why a peer has no project, not just that the file is missing

### DIFF
--- a/src/rosotacom/cli.py
+++ b/src/rosotacom/cli.py
@@ -3562,6 +3562,35 @@ def _ota_remote_package_dir(peer: OtaSmokePeer, plan: OtaSmokePlan, *, dry_run: 
     return located
 
 
+def _ota_missing_project_message(plan: OtaSmokePlan, peer: OtaSmokePeer) -> str:
+    """Why one peer has no project file, in the terms that make it fixable.
+
+    `test -f` failing is the single most common way a checkout-mode run stops,
+    and the bare "exit code 1" it used to raise says nothing about the contract
+    it broke. The path is not resolved per peer: `--project` is split once, on
+    the orchestrator, into (checkout root, path inside it), and that *relative*
+    path is then asserted inside every peer's own `--peer-checkout`. So the
+    peers do not merely need a rosotacom project each — they need the same
+    repository, with the project at the same place in it.
+
+    The failure therefore has two ordinary causes and they want opposite fixes:
+    the peer is behind (sync it), or the project lives in a repository this peer
+    does not have (move the project, or point the peer at the repository that
+    holds it). Naming both is the difference between a minute and an afternoon.
+    """
+    workdir = _ota_peer_workdir(plan, peer)
+    return (
+        f"{peer.name}: {workdir}/{plan.project} does not exist.\n"
+        f"  --install-mode checkout resolves the project once, on this machine, into a checkout root and "
+        f"the path {plan.project!r} inside it, and then asserts that same relative path inside every peer's "
+        f"--peer-checkout. Every peer therefore needs the same repository, with the project at the same "
+        f"place in it -- not a project of its own.\n"
+        f"  If {peer.name} has that repository, it is behind: sync it and run again.\n"
+        f"  If it does not, the project is in the wrong repository for this run. Move it into the one the "
+        f"peers actually have, or give this peer --peer-checkout for a checkout that holds it."
+    )
+
+
 def _ota_verify_checkouts(plan: OtaSmokePlan, *, dry_run: bool) -> None:
     """Checkout mode's replacement for staging: assert, do not install.
 
@@ -3583,13 +3612,16 @@ def _ota_verify_checkouts(plan: OtaSmokePlan, *, dry_run: bool) -> None:
             dry_run=dry_run,
             batch=True,
         )
-        _ota_run(
+        found = _ota_run(
             peer,
             f"test -f {checkout}/{project}",
             label=f"{peer.name}: project config {plan.project} inside the checkout",
             dry_run=dry_run,
+            check=False,
             batch=True,
         )
+        if found.returncode != 0:
+            raise RuntimeError(_ota_missing_project_message(plan, peer))
         _ota_run(
             peer,
             f"{OTA_CHECKOUT_PATH_PREFIX}command -v rosotacom >/dev/null 2>&1",

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -3506,6 +3506,32 @@ def test_ota_checkout_mode_runs_each_peer_from_its_own_checkout(tmp_path: Path) 
     assert "--rosotacom-config session/rosotacom.yaml" in command
 
 
+def test_ota_checkout_mode_names_the_shared_repository_when_a_peer_lacks_the_project(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The path is split once here and asserted on every peer, so a peer whose
+    # checkout is a *different* repository fails this probe -- and used to fail
+    # it as a bare "exit code 1", which reads as a broken machine rather than as
+    # the contract it is. Two runs were spent on that in one afternoon: a bench
+    # driven from the harness checkout, with a peer that only has the fleet
+    # repository, cannot resolve one relative path on both sides.
+    plan = _ota_checkout_plan(_write_checkout_project(tmp_path))
+
+    def fake_run(peer, script, *, label, **kwargs):
+        code = 1 if script.startswith("test -f") and peer.name == "b" else 0
+        return subprocess.CompletedProcess([], code, "", "")
+
+    monkeypatch.setattr(rosotacom, "_ota_run", fake_run)
+
+    with pytest.raises(RuntimeError) as error:
+        rosotacom._ota_verify_checkouts(plan, dry_run=False)
+
+    message = str(error.value)
+    assert "/home/other/fleet_mgmt/session/rosotacom.yaml does not exist" in message
+    assert "the same repository" in message
+    assert "it is behind: sync it" in message
+
+
 def test_ota_checkout_mode_puts_pipx_on_path_because_ssh_is_not_a_login_shell(tmp_path: Path) -> None:
     # `ssh host 'cmd'` skips the login profile, so a pipx install in
     # ~/.local/bin is invisible and the peer answers "command not found" —


### PR DESCRIPTION
Checkout mode splits `--project` once, on the orchestrator, into a checkout root and a path inside it, then asserts that same relative path inside every peer's `--peer-checkout`. The peers therefore need the same repository with the project in the same place — not a rosotacom project each.

Until now the probe that enforces this raised a bare `exit code 1`, which reads as a broken machine. It cost two runs in one afternoon: a bench driven from the harness checkout against a peer that only has the fleet repository cannot resolve one relative path on both sides, and nothing said so.

The message now names the absolute path it looked for and both ordinary causes, which want opposite fixes — a peer that is behind wants a sync, a peer without that repository wants the project moved or a different `--peer-checkout`. Regression test in `tests/unit/test_cli.py`.